### PR TITLE
clear notifications when on file page

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypes.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
 import './file.css';
 import { FetchFileTypeService } from '@store/file/actions';
+import { ClearNotifications } from '@store/notifications/actions';
 import { FetchRealmRoles } from '@store/tenant/actions';
 import { RootState } from '@store/index';
 import { FileTypeTable } from './fileTypesTable';
@@ -20,6 +21,7 @@ export default function FileTypes(): JSX.Element {
   useEffect(() => {
     dispatch(FetchRealmRoles());
     dispatch(FetchFileTypeService());
+    dispatch(ClearNotifications());
   }, []);
 
   useEffect(() => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypesTable.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypesTable.tsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { v4 as uuid4 } from 'uuid';
 import { RootState } from '@store/index';
 import { Role } from '@store/tenant/models';
+import { ClearNotifications } from '@store/notifications/actions';
 
 import {
   DeleteFileTypeService,
@@ -210,6 +211,7 @@ export const FileTypeTable = (props: FileTypeTableProps): JSX.Element => {
           buttonType="secondary"
           key={`${props.id}-confirm-button`}
           onClick={() => {
+            dispatch(ClearNotifications());
             dispatch(CreateFileTypeService({ ...newFileType, id }));
 
             setNewFileType(null);
@@ -230,6 +232,7 @@ export const FileTypeTable = (props: FileTypeTableProps): JSX.Element => {
           data-testid="confirm-update"
           disabled={newFileType}
           onClick={() => {
+            dispatch(ClearNotifications());
             dispatch(UpdateFileTypeService({ ...updateFileType, id }));
 
             setUpdateFileType(null);
@@ -469,6 +472,7 @@ export const FileTypeTable = (props: FileTypeTableProps): JSX.Element => {
               <GoAButton
                 data-testid="delete-modal-delete-button"
                 onClick={() => {
+                  dispatch(ClearNotifications());
                   dispatch(DeleteFileTypeService(props));
                 }}
               >

--- a/apps/tenant-management-webapp/src/app/store/notifications/actions.ts
+++ b/apps/tenant-management-webapp/src/app/store/notifications/actions.ts
@@ -3,9 +3,15 @@ import { Notification } from './models';
 export const ERROR_NOTIFICATION = 'notifications/error';
 export const SUCCESS_NOTIFICATION = 'notifications/success';
 
+export const CLEAR_NOTIFICATION = 'notifications/clear';
+
 export const BASIC_NOTIFICATION = 'notifications/basic';
 
-export type ActionTypes = ErrorNotificationAction | SuccessNotificationAction | BasicNotificationAction;
+export type ActionTypes =
+  | ErrorNotificationAction
+  | SuccessNotificationAction
+  | BasicNotificationAction
+  | ClearNotificationAction;
 
 interface ErrorNotificationAction {
   type: typeof ERROR_NOTIFICATION;
@@ -22,6 +28,10 @@ interface BasicNotificationAction {
   payload: Notification;
 }
 
+interface ClearNotificationAction {
+  type: typeof CLEAR_NOTIFICATION;
+}
+
 export const ErrorNotification = (payload: Notification): ErrorNotificationAction => ({
   type: 'notifications/error',
   payload,
@@ -35,4 +45,8 @@ export const SuccessNotification = (payload: Notification): SuccessNotificationA
 export const BasicNotification = (payload: Notification): BasicNotificationAction => ({
   type: 'notifications/basic',
   payload,
+});
+
+export const ClearNotifications = (): ClearNotificationAction => ({
+  type: 'notifications/clear',
 });

--- a/apps/tenant-management-webapp/src/app/store/notifications/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/notifications/reducers.ts
@@ -17,6 +17,10 @@ export default function (state: NotificationState = NOTIFICATION_INIT, action: A
           },
         ],
       };
+    case 'notifications/clear':
+      return {
+        notifications: [],
+      };
     default:
       return state;
   }


### PR DESCRIPTION
It used to look like this. Now It only shows notifications that you generate with the current action

![Status Service Public Page Link](https://user-images.githubusercontent.com/11400938/135931292-b58063e7-cc5b-489a-ac59-aaac908030f5.png)

* All notifications before you arrive at the page are not relevant to the
  user
* Also clear notifications before any changes are made, so only relevant
  notifications are visible

Probably need to only save current notifications in the future, and not old ones, but I didn't want to make the change universal in case we need multiple notifications somewhere