### PR TITLE
CS-970 / CS-971

### DIFF
--- a/apps/status-app/src/app/pages/status.spec.tsx
+++ b/apps/status-app/src/app/pages/status.spec.tsx
@@ -55,11 +55,7 @@ describe('Service statuses', () => {
         <ServiceStatuses />
       </Provider>
     );
-    await waitFor(() =>
-      expect(
-        getByText('Either there are no services available by this provider, or you have an incorrect ID')
-      ).toBeTruthy()
-    );
+    await waitFor(() => expect(getByText('Cannot find a provider at this url')).toBeTruthy());
   });
 });
 

--- a/apps/status-app/src/app/pages/status.tsx
+++ b/apps/status-app/src/app/pages/status.tsx
@@ -14,6 +14,7 @@ import { fetchApplications } from '@store/status/actions';
 import { RootState } from '@store/index';
 import { PageLoader } from '@components/PageLoader';
 import { LocalTime } from '@components/Date';
+import { GoAPageLoader } from '@abgov/react-components';
 import moment from 'moment';
 
 function capitalizeFirstLetter(string) {
@@ -32,8 +33,9 @@ const ServiceStatusPage = (): JSX.Element => {
     applications: state.application?.applications,
   }));
 
-  const { tenantName } = useSelector((state: RootState) => ({
+  const { tenantName, loaded } = useSelector((state: RootState) => ({
     tenantName: state.session?.tenant?.name,
+    loaded: state.session?.isLoadingReady,
   }));
 
   const { allApplicationsNotices } = useSelector((state: RootState) => ({
@@ -54,8 +56,8 @@ const ServiceStatusPage = (): JSX.Element => {
         <br />
         <p>
           These are the services currently being offered by{' '}
-          {location.pathname.slice(1) ? capitalizeFirstLetter(tenantName) : 'the Alberta Digital Service Platform'}. All statuses are
-          in real time and reflect current states of the individual services. Please{' '}
+          {location.pathname.slice(1) ? capitalizeFirstLetter(tenantName) : 'the Alberta Digital Service Platform'}. All
+          statuses are in real time and reflect current states of the individual services. Please{' '}
           <a href="mailto: DIO@gov.ab.ca">contact support</a> for additional information or any other inquiries
           regarding service statuses.
         </p>
@@ -65,6 +67,7 @@ const ServiceStatusPage = (): JSX.Element => {
         <br />
         {allApplicationsNotices.length > 0 && <AllApplicationsNotices />}
         <br />
+        {applications?.length === 0 && <div>There are no services available by this provider</div>}
         <Grid>
           {applications.map((app, index) => {
             return (
@@ -85,17 +88,24 @@ const ServiceStatusPage = (): JSX.Element => {
     );
   };
 
-  const noServices = () => {
+  const noProvider = () => {
     return (
       <div className="small-container">
-        <h2>No services at this address</h2>
-        <p>Either there are no services available by this provider, or you have an incorrect ID</p>
+        <h2>Provider not found</h2>
+        <p>Cannot find a provider at this url</p>
       </div>
     );
   };
 
   const SectionView = () => {
-    return <div>{applications && (applications?.length > 0 || allApplicationsNotices?.length > 0) ? services() : noServices()}</div>;
+    if (!applications) {
+      if (loaded) {
+        return noProvider();
+      }
+      return <GoAPageLoader visible={true} message="Loading..." type="infinite" pagelock={false} />;
+    } else {
+      return services();
+    }
   };
 
   const AllApplicationsNotices = () => {
@@ -140,7 +150,7 @@ const ServiceStatusPage = (): JSX.Element => {
           <section>
             <SectionView />
           </section>
-          <section>{ }</section>
+          <br />
         </ServiceStatusesCss>
       </main>
       <Footer>

--- a/apps/status-app/src/app/store/config/sagas.ts
+++ b/apps/status-app/src/app/store/config/sagas.ts
@@ -8,7 +8,6 @@ import { ConfigState } from './models';
 export function* fetchConfig(): SagaIterator {
   try {
     const config = (yield call(axios.get, '/config/config.json')).data as ConfigState;
-    config.serviceUrls.serviceStatusApiUrl = 'http://localhost:3338';
     yield put(fetchConfigSuccess({ ...config, envLoaded: true }));
   } catch (e) {
     console.error(e.message);

--- a/apps/status-app/src/app/store/status/models.ts
+++ b/apps/status-app/src/app/store/status/models.ts
@@ -73,11 +73,11 @@ export interface Notices {
 
 export const NoticeInit: Notices = {
   notices: [],
-  allApplicationsNotices: []
+  allApplicationsNotices: [],
 };
 
 export const ApplicationInit: ServiceStatus = {
-  applications: [],
+  applications: null,
 };
 
 // Helper functions
@@ -100,7 +100,10 @@ export const bindApplicationsWithNotices = (
   });
   for (const application of applications) {
     const noticesOfApplication = notices.filter((notice) => {
-      return notice.isAllApplications !== true && notice.tennantServRef.find((applicationRef) => applicationRef.id === application._id);
+      return (
+        notice.isAllApplications !== true &&
+        notice.tennantServRef.find((applicationRef) => applicationRef.id === application._id)
+      );
     });
 
     application.notices = sortNotices(noticesOfApplication);
@@ -131,4 +134,4 @@ export const sortApplications = (applications: ServiceStatusApplication[]): Serv
 
 export const toTenantName = (nameInUrl: string): string => {
   return nameInUrl.replace(/-/g, ' ');
-}
+};

--- a/apps/status-service/src/app/router/notice.ts
+++ b/apps/status-service/src/app/router/notice.ts
@@ -16,24 +16,24 @@ export interface NoticeRouterProps {
 interface NoticeFilter {
   mode?: NoticeModeType;
   tenantName?: string;
-  tenantId?: string
+  tenantId?: string;
 }
 
 interface applicationRef {
   name?: string;
-  id?: UrlWithStringQuery
+  id?: UrlWithStringQuery;
 }
 
 const parseTenantServRef = (tennantServRef?: string | applicationRef[] | null): string => {
   if (!tennantServRef) {
-    return JSON.stringify([])
+    return JSON.stringify([]);
   } else {
     if (typeof tennantServRef !== 'string') {
-      return JSON.stringify(tennantServRef)
+      return JSON.stringify(tennantServRef);
     }
   }
-  return tennantServRef
-}
+  return tennantServRef;
+};
 
 export function createNoticeRouter({ logger, tenantService, noticeRepository }: NoticeRouterProps): Router {
   const router = Router();
@@ -41,7 +41,7 @@ export function createNoticeRouter({ logger, tenantService, noticeRepository }: 
   // Get notices by query
   router.get('/notices', async (req, res, next) => {
     const { top, after, mode } = req.query;
-    const tenantName = req.query.name
+    const tenantName = req.query.name as string;
     const user = req.user as Express.User;
 
     logger.info(req.method, req.url);
@@ -56,10 +56,11 @@ export function createNoticeRouter({ logger, tenantService, noticeRepository }: 
       } else {
         if (tenantName) {
           // tenant is an array, but it shall only contain 1 or 0 element
-          const tenant = (await tenantService.getTenants())
-            .filter((tenant) => { return tenant.name === tenantName });
+          const tenant = (await tenantService.getTenants()).filter((tenant) => {
+            return tenant.name.toLowerCase() === tenantName.toLowerCase();
+          });
           if (tenant) {
-            filter.tenantId = tenant[0].id.toString()
+            filter.tenantId = tenant[0].id.toString();
           }
         }
       }
@@ -77,7 +78,8 @@ export function createNoticeRouter({ logger, tenantService, noticeRepository }: 
       res.json({
         page: applications.page,
         results: applications.results.map((result) => ({
-          ...result, tennantServRef: JSON.parse(result.tennantServRef),
+          ...result,
+          tennantServRef: JSON.parse(result.tennantServRef),
         })),
       });
     } catch (err) {
@@ -167,7 +169,7 @@ export function createNoticeRouter({ logger, tenantService, noticeRepository }: 
     const { message, startDate, endDate, mode, isAllApplications } = req.body;
     const { id } = req.params;
     const user = req.user as Express.User;
-    const tennantServRef = parseTenantServRef(req.body.tennantServRef)
+    const tennantServRef = parseTenantServRef(req.body.tennantServRef);
 
     try {
       // TODO: this needs to be moved to a service
@@ -185,11 +187,10 @@ export function createNoticeRouter({ logger, tenantService, noticeRepository }: 
         isAllApplications,
       });
 
-      res.status(200).json(
-        {
-          ...updatedApplication,
-          tennantServRef: JSON.parse(updatedApplication.tennantServRef)
-        });
+      res.status(200).json({
+        ...updatedApplication,
+        tennantServRef: JSON.parse(updatedApplication.tennantServRef),
+      });
     } catch (err) {
       const errMessage = `Error updating notice: ${err.message}`;
       logger.error(errMessage);

--- a/apps/status-service/src/app/router/publicServiceStatus.ts
+++ b/apps/status-service/src/app/router/publicServiceStatus.ts
@@ -10,7 +10,11 @@ export interface ServiceStatusRouterProps {
   serviceStatusRepository: ServiceStatusRepository;
 }
 
-export function createPublicServiceStatusRouter({ logger, tenantService, serviceStatusRepository }: ServiceStatusRouterProps): Router {
+export function createPublicServiceStatusRouter({
+  logger,
+  tenantService,
+  serviceStatusRepository,
+}: ServiceStatusRouterProps): Router {
   const router = Router();
 
   // Get the public service for the tenant
@@ -51,10 +55,13 @@ export function createPublicServiceStatusRouter({ logger, tenantService, service
     let applications: ServiceStatusApplicationEntity[] = [];
     try {
       applications = await serviceStatusRepository.find({
-        tenantId: (await tenantService
-          .getTenants())
-          .filter((tenant) => { return tenant.name === searchName })[0]
-          .id.toString()
+        tenantId: (
+          await tenantService.getTenants()
+        )
+          .filter((tenant) => {
+            return tenant.name.toLowerCase() === searchName.toLowerCase();
+          })[0]
+          .id.toString(),
       });
       res.json(applications);
     } catch (err) {


### PR DESCRIPTION
CS-970 - routes are no longer case sensitive - this was a regression
that was fixed

CS-971 - status app now loads with a spinner and shows all existing
applications if the app exists, and only shows non-existing message if
the tenant does not exist

Revert an accidental commit of a local setup change