### PR TITLE
CS-973 Fix token refresh issue

### DIFF
--- a/apps/tenant-management-webapp/src/app/store/session/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/session/reducers.ts
@@ -3,12 +3,18 @@ import { Session, SESSION_INIT } from './models';
 
 export default function (state: Session = SESSION_INIT, action: ActionType): Session {
   switch (action.type) {
-    case 'session/login/success':
-      return {
-        ...state,
-        ...action.payload,
-      };
+    case 'session/login/success': {
+      const payloadKeys = Object.keys(action.payload);
+      let returnObject = state;
 
+      for (let i = 0; i < payloadKeys.length; i++) {
+        if (JSON.stringify(state[payloadKeys[i]]) !== JSON.stringify(action.payload[payloadKeys[i]])) {
+          returnObject = { ...returnObject, [payloadKeys[i]]: action.payload[payloadKeys[i]] };
+        }
+      }
+
+      return returnObject;
+    }
     case 'credential/refresh':
       return {
         ...state,
@@ -22,8 +28,8 @@ export default function (state: Session = SESSION_INIT, action: ActionType): Ses
       return {
         ...state,
         indicator: {
-          ...action.payload
-        }
+          ...action.payload,
+        },
       };
 
     case 'session/logout':


### PR DESCRIPTION
make updates to token much more granular - we use the session
  information in certain places, but if we update all of it every time
  there is a token refresh, every place where we need parts of it that aren't
  normally changed will will cause a page refresh.

  For example, sidebar.tsx uses state.session.realm, which was
  previously updated on a token refresh because eveything inside of
  state.session was automatically updated on a token refresh. This would
  then trigger a page refresh. But now we only update
  state.session.whatever elmennts that acually change on a token
  refresh, for example .token. Since we don't need those variables
  inside the /pages/admin/..., they don't trigger a page refresh.