### PR TITLE
Notification type configuration includes access configuration of who …

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationTypes.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationTypes.spec.tsx
@@ -44,6 +44,9 @@ describe('NotificationTypes Page', () => {
     },
     user: { jwt: { token: '' } },
     session: { realm: 'core' },
+    tenant: {
+      realmRoles: ['uma_auth'],
+    },
   });
 
   it('renders', () => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationTypes.tsx
@@ -11,6 +11,7 @@ import {
   GoAModalTitle,
   GoAIcon,
 } from '@abgov/react-components/experimental';
+import { FetchRealmRoles } from '@store/tenant/actions';
 
 import {
   UpdateNotificationTypeService,
@@ -53,6 +54,7 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
   useEffect(() => {
     dispatch(FetchNotificationTypeService());
     dispatch(FetchCoreNotificationTypeService());
+    dispatch(FetchRealmRoles());
   }, [dispatch]);
 
   function reset() {
@@ -113,37 +115,52 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
           <div className="topBottomMargin" key={notificationType.name}>
             <GoACard
               title={
-                <div className="rowFlex">
-                  <h2 className="flex1">{notificationType.name}</h2>
-                  <MaxHeight height={30} className="rowFlex">
-                    <a
-                      className="flex1"
-                      data-testid={`edit-notification-type-${notificationType.id}`}
-                      onClick={() => {
-                        setSelectedType(notificationType);
-                        setEditType(true);
-                      }}
-                    >
-                      <NotificationBorder className="smallPadding">
-                        <GoAIcon type="create" />
-                      </NotificationBorder>
-                    </a>
-                    <a
-                      className="flex1"
-                      onClick={() => {
-                        setSelectedType(notificationType);
-                        setShowDeleteConfirmation(true);
-                      }}
-                      data-testid={`delete-notification-type-${notificationType.id}`}
-                    >
-                      <NotificationBorder className="smallPadding">
-                        <GoAIcon type="trash" />
-                      </NotificationBorder>
-                    </a>
-                  </MaxHeight>
+                <div>
+                  <div className="rowFlex">
+                    <h2 className="flex1">{notificationType.name}</h2>
+                    <MaxHeight height={30} className="rowFlex">
+                      <a
+                        className="flex1"
+                        data-testid={`edit-notification-type-${notificationType.id}`}
+                        onClick={() => {
+                          setSelectedType(notificationType);
+                          setEditType(true);
+                        }}
+                      >
+                        <NotificationBorder className="smallPadding">
+                          <GoAIcon type="create" />
+                        </NotificationBorder>
+                      </a>
+                      <a
+                        className="flex1"
+                        onClick={() => {
+                          setSelectedType(notificationType);
+                          setShowDeleteConfirmation(true);
+                        }}
+                        data-testid={`delete-notification-type-${notificationType.id}`}
+                      >
+                        <NotificationBorder className="smallPadding">
+                          <GoAIcon type="trash" />
+                        </NotificationBorder>
+                      </a>
+                    </MaxHeight>
+                  </div>
+                  <div className="rowFlex smallFont">
+                    <div className="flex1">
+                      Subscriber Roles:{' '}
+                      <b>
+                        {notificationType.subscriberRoles
+                          .filter((value) => value !== 'anonymousRead')
+                          .map(
+                            (roles, ix) => roles + (notificationType.subscriberRoles.length - 1 === ix ? '' : ', ')
+                          )}{' '}
+                      </b>
+                    </div>
+                    <div>Public Subscription: {notificationType.publicSubscribe ? 'yes' : 'no'}</div>
+                  </div>
                 </div>
               }
-              description={notificationType.description}
+              description={`Description: ${notificationType.description}`}
             >
               <Grid>
                 {notificationType.events.map((event, key) => (
@@ -419,9 +436,17 @@ const MaxHeight = styled.div`
 `;
 
 const NotficationStyles = styled.div`
+  .smallFont {
+    font-size: 12px;
+  }
+
   svg {
     fill: #56a0d8;
     color: #56a0d8;
+  }
+
+  .goa-title {
+    margin-bottom: 14px !important;
   }
 
   .topBottomMargin {

--- a/apps/tenant-management-webapp/src/app/store/notification/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/notification/models.ts
@@ -2,7 +2,7 @@ export interface NotificationItem {
   name: string;
   description?: string;
   events: Array<EventItem>;
-  subscriberRoles: [];
+  subscriberRoles: string[];
   id: string;
   publicSubscribe: boolean;
 }


### PR DESCRIPTION
…is permitted to subscribe to the type. This is configured via a subscriberRoles property and a publicSubscribe property.

When creating or editing a notification type, the user is able to configure the subscriber roles and the public subscribe properties.

Subscriber roles is configured as a multi-select combobox

The values are populated with the realm roles of the tenant realm

User can select 0 or more roles to include

User is able to deselect role

Public subscribe is configured using an ‘Anyone (Anonymous)’ selection

![image](https://user-images.githubusercontent.com/11400938/143142640-00c2f5a3-c42e-4bfa-b7b1-4142ea983836.png)
![image](https://user-images.githubusercontent.com/11400938/143143589-0422a851-6b1a-459a-a12e-fe15705b3477.png)
