### PR TITLE
CS-905 - Fix subscriber flow

### DIFF
--- a/apps/notification-service/src/mongo/subscription.ts
+++ b/apps/notification-service/src/mongo/subscription.ts
@@ -39,6 +39,19 @@ export class MongoSubscriptionRepository implements SubscriptionRepository {
     );
   }
 
+  getSubscriberByEmail(tenantId: AdspId, email: string): Promise<SubscriberEntity> {
+    const criteria: Record<string, string> = {
+      tenantId: tenantId?.toString(),
+      addressAs: email,
+    };
+
+    return new Promise<SubscriberEntity>((resolve, reject) =>
+      this.subscriberModel.findOne(criteria, null, { lean: true }, (err, doc) =>
+        err ? reject(err) : resolve(this.fromDoc(doc))
+      )
+    );
+  }
+
   getSubscription(type: NotificationTypeEntity, subscriberId: string): Promise<SubscriptionEntity> {
     return new Promise<SubscriptionEntity>((resolve, reject) =>
       this.subscriptionModel

--- a/apps/notification-service/src/notification/model/subscriber.spec.ts
+++ b/apps/notification-service/src/notification/model/subscriber.spec.ts
@@ -7,6 +7,7 @@ import { SubscriberEntity } from './subscriber';
 describe('SubscriberEntity', () => {
   const repositoryMock = {
     getSubscriber: jest.fn(),
+    getSubscriberByEmail: jest.fn(),
     getSubscriptions: jest.fn(),
     getSubscription: jest.fn(),
     findSubscribers: jest.fn(),

--- a/apps/notification-service/src/notification/repository/subscription.ts
+++ b/apps/notification-service/src/notification/repository/subscription.ts
@@ -5,6 +5,7 @@ import { SubscriberCriteria, SubscriptionSearchCriteria } from '../types';
 
 export interface SubscriptionRepository {
   getSubscriber(tenantId: AdspId, subscriberId: string, byUserId?: boolean): Promise<SubscriberEntity>;
+  getSubscriberByEmail(tenantId: AdspId, email: string): Promise<SubscriberEntity>;
 
   getSubscription(type: NotificationTypeEntity, subscriberId: string): Promise<SubscriptionEntity>;
   getSubscriptions(

--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -34,6 +34,7 @@ describe('subscription router', () => {
 
   const repositoryMock = {
     getSubscriber: jest.fn(),
+    getSubscriberByEmail: jest.fn(),
     getSubscriptions: jest.fn(),
     getSubscription: jest.fn(),
     findSubscribers: jest.fn(),
@@ -60,6 +61,7 @@ describe('subscription router', () => {
   beforeEach(() => {
     repositoryMock.findSubscribers.mockReset();
     repositoryMock.getSubscriber.mockReset();
+    repositoryMock.getSubscriberByEmail.mockReset();
     repositoryMock.getSubscriptions.mockReset();
     repositoryMock.saveSubscriber.mockClear();
     repositoryMock.saveSubscription.mockReset();

--- a/apps/notification-service/src/notification/router/subscription.ts
+++ b/apps/notification-service/src/notification/router/subscription.ts
@@ -238,10 +238,9 @@ export function getSubscribers(apiId: AdspId, repository: SubscriptionRepository
 
 export function createSubscriber(apiId: AdspId, repository: SubscriptionRepository): RequestHandler {
   return async (req, res) => {
+    let tenantId;
+    const user = req.user;
     try {
-      let tenantId;
-      const user = req.user;
-
       if (req.tenant?.id) {
         tenantId = req.tenant?.id;
       } else {
@@ -283,6 +282,8 @@ export function createSubscriber(apiId: AdspId, repository: SubscriptionReposito
       const subscriberEntity = await SubscriberEntity.create(user, repository, subscriber);
       res.send(mapSubscriber(apiId, subscriberEntity));
     } catch (err) {
+      const entity = await repository.getSubscriberByEmail(tenantId, req.body?.email);
+      err.id = entity?.id;
       res.status(400).json({ error: JSON.stringify(err) });
     }
   };

--- a/apps/status-app/src/app/store/status/serviceTokenApi.ts
+++ b/apps/status-app/src/app/store/status/serviceTokenApi.ts
@@ -42,7 +42,11 @@ export class ServiceTokenApi {
         }
       )
       .catch(function (error) {
-        throw new Error(error?.response?.data?.error);
+        if (JSON.parse(error?.response?.data?.error).id) {
+          return { data: { id: JSON.parse(error?.response?.data?.error).id } };
+        } else {
+          throw new Error(error?.response?.data?.error);
+        }
       });
 
     const res2 = await this.http


### PR DESCRIPTION
Ensure we can subscribe if we previously created a subscriber if for some reason a subscription was not created in the same step -  previously, this would leave the email in limbo