### PR TITLE
change state to use sagas instead because of forced dispatch refresh

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/form.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/form.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, FC } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { RootState } from '@store/index';
-import { saveApplication } from '@store/status/actions';
+import { saveApplication, updateFormData } from '@store/status/actions';
 import { ServiceStatusApplication } from '@store/status/models';
 import { GoAButton } from '@abgov/react-components';
 import {
@@ -28,36 +28,43 @@ export const ApplicationFormModal: FC<Props> = ({ isOpen, title }: Props) => {
 
   const [isModalOpen, setIsModalOpen] = useState(true);
 
-  const [application, setApplication] = useState<ServiceStatusApplication>({
-    name: '',
-    tenantId: '',
-    enabled: false,
-    description: '',
-    endpoint: { url: '', status: 'offline' },
-  });
+  const application = serviceStatus.currentFormData;
 
   useEffect(() => {
     if (applicationId) {
       const app = serviceStatus.applications.find((app) => applicationId === app._id);
-      setApplication(app);
+      const cloneApp = Object.assign({}, app);
+      dispatch(updateFormData(cloneApp));
+    } else {
+      const app: ServiceStatusApplication = {
+        name: '',
+        tenantId: '',
+        enabled: false,
+        description: '',
+        endpoint: { url: '', status: 'offline' },
+      };
+      dispatch(updateFormData(app));
     }
-  }, [applicationId, serviceStatus]);
+  }, []);
 
   function setValue(name: string, value: string) {
+    const formData = serviceStatus.currentFormData;
+
     switch (name) {
       case 'name':
       case 'description':
-        setApplication({ ...application, [name]: value });
+        formData[name] = value;
         break;
       case 'endpoint':
-        setApplication({ ...application, [name]: { url: value, status: 'offline' } });
+        formData[name] = { url: value, status: 'offline' };
         break;
     }
+    dispatch(updateFormData(formData));
   }
 
   function isFormValid(): boolean {
-    if (!application.name) return false;
-    if (!application.endpoint.url) return false;
+    if (!application?.name) return false;
+    if (!application?.endpoint.url) return false;
     return true;
   }
 

--- a/apps/tenant-management-webapp/src/app/store/status/actions/index.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/actions/index.ts
@@ -4,6 +4,7 @@ import * as save from './saveApplication';
 import * as destroy from './deleteApplication';
 import * as status from './setApplicationStatus';
 import * as toggle from './toggleApplication';
+import * as form from './updateFormData';
 
 export * from './fetchApplications';
 export * from './getApplication';
@@ -11,6 +12,7 @@ export * from './saveApplication';
 export * from './deleteApplication';
 export * from './setApplicationStatus';
 export * from './toggleApplication';
+export * from './updateFormData';
 
 export type ActionTypes =
   | toggle.ToggleApplicationStatusSuccessAction
@@ -20,4 +22,5 @@ export type ActionTypes =
   | save.SaveApplicationSuccessAction
   | get.GetApplicationSuccessAction
   | destroy.DeleteApplicationSuccessAction
-  | status.SetApplicationStatusSuccessAction;
+  | status.SetApplicationStatusSuccessAction
+  | form.UpdateFormDataAction;

--- a/apps/tenant-management-webapp/src/app/store/status/actions/updateFormData.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/actions/updateFormData.ts
@@ -1,0 +1,13 @@
+import { ServiceStatusApplication } from '../models';
+
+export const UPDATE_FORM_DATA_ACTION = 'status/UPDATE_FORM_DATA';
+
+export interface UpdateFormDataAction {
+  type: typeof UPDATE_FORM_DATA_ACTION;
+  payload: ServiceStatusApplication;
+}
+
+export const updateFormData = (payload: ServiceStatusApplication): UpdateFormDataAction => ({
+  type: 'status/UPDATE_FORM_DATA',
+  payload,
+});

--- a/apps/tenant-management-webapp/src/app/store/status/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/models.ts
@@ -6,7 +6,14 @@ export type EndpointStatusType = 'offline' | 'online' | 'pending';
 
 export interface ServiceStatus {
   applications: ServiceStatusApplication[];
+  currentFormData: ServiceStatusApplication;
   endpointHealth: Record<string, { url: string; entries: EndpointStatusEntry[] }>;
+}
+
+export interface FormData {
+  name: string;
+  description: string;
+  endpoint: { url: string; status: string };
 }
 
 export interface ServiceStatusApplication {

--- a/apps/tenant-management-webapp/src/app/store/status/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/reducers.ts
@@ -6,16 +6,23 @@ import {
   SAVE_APPLICATION_SUCCESS_ACTION,
   SET_APPLICATION_SUCCESS_STATUS_ACTION,
   TOGGLE_APPLICATION_SUCCESS_STATUS_ACTION,
+  UPDATE_FORM_DATA_ACTION,
 } from './actions';
 import { ServiceStatus } from './models';
 
 const initialState: ServiceStatus = {
   applications: [],
   endpointHealth: {},
+  currentFormData: {
+    name: '',
+    tenantId: '',
+    enabled: false,
+    description: '',
+    endpoint: { url: '', status: 'offline' },
+  },
 };
 
 const compareIds = (a: { _id?: string }, b: { _id?: string }): number => (a._id <= b._id ? 1 : -1);
-
 
 export default function statusReducer(state: ServiceStatus = initialState, action: ActionTypes): ServiceStatus {
   switch (action.type) {
@@ -41,12 +48,13 @@ export default function statusReducer(state: ServiceStatus = initialState, actio
     case SAVE_APPLICATION_SUCCESS_ACTION:
     case SET_APPLICATION_SUCCESS_STATUS_ACTION: {
       // After toggle set the application internalStatus to pending
-      const index = state.applications.findIndex((app) => { return app._id === action.payload._id });
+      const index = state.applications.findIndex((app) => {
+        return app._id === action.payload._id;
+      });
       if (index !== -1) {
-        console.log(action.payload)
         state.applications[index] = action.payload;
       }
-      return { ...state }
+      return { ...state };
     }
     case TOGGLE_APPLICATION_SUCCESS_STATUS_ACTION:
       return {
@@ -54,6 +62,12 @@ export default function statusReducer(state: ServiceStatus = initialState, actio
         applications: [...state.applications.filter((app) => app._id !== action.payload._id), action.payload].sort(
           compareIds
         ),
+      };
+
+    case UPDATE_FORM_DATA_ACTION:
+      return {
+        ...state,
+        currentFormData: action.payload,
       };
 
     default:


### PR DESCRIPTION
Functionality should be the same, but it no longer refreshes every 30 seconds

State is refreshed every 30 seconds because new data needs to be displayed in the status bars. I stored the current edit inputs in the store to prevent it from changing when the refresh occurs