### PR TITLE
Prevent modification of subscriber itself when creating subscription

### DIFF
--- a/apps/notification-service/src/notification/router/subscription.ts
+++ b/apps/notification-service/src/notification/router/subscription.ts
@@ -125,6 +125,11 @@ export function createTypeSubscription(apiId: AdspId, repository: SubscriptionRe
         subscriberEntity = await repository.getSubscriber(tenantId, subscriber.userId, true);
       }
 
+      if (subscriber.id) {
+        // Try to find an existing subscriber based on existing subscriber ID.
+        subscriberEntity = await repository.getSubscriber(tenantId, subscriber.id, false);
+      }
+
       if (!subscriberEntity) {
         subscriberEntity = await SubscriberEntity.create(user, repository, subscriber);
       }
@@ -524,11 +529,7 @@ export const createSubscriptionRouter = ({
   subscriptionRouter.get('/subscribers/:subscriber', getSubscriber(subscriptionRepository), (req, res) =>
     res.send(mapSubscriber(apiId, req[SUBSCRIBER_KEY]))
   );
-  subscriptionRouter.patch(
-    '/subscribers/:subscriber',
-    getSubscriber(subscriptionRepository),
-    updateSubscriber(apiId)
-  );
+  subscriptionRouter.patch('/subscribers/:subscriber', getSubscriber(subscriptionRepository), updateSubscriber(apiId));
   subscriptionRouter.post(
     '/subscribers/:subscriber',
     getSubscriber(subscriptionRepository),


### PR DESCRIPTION
We want to make sure we don't update the subscriber itself when creating a new subscription, if we are given the id of an existing subscriber (this isn't used currently by an app afaik)