### PR TITLE
CS-1110 - fix regex matching and error messages

### DIFF
--- a/apps/tenant-management-api/src/tenant/router/tenant.ts
+++ b/apps/tenant-management-api/src/tenant/router/tenant.ts
@@ -167,7 +167,7 @@ export const createTenantRouter = ({ tenantRepository, eventService }: TenantRou
       res.status(HttpStatusCodes.OK).json(data);
     } catch (err) {
       logger.error(`Error creating new tenant ${err.message}`);
-      res.status(err.response?.status || err.errorCode || 400).json({ error: err.message });
+      next(err);
     }
   }
 

--- a/apps/tenant-management-webapp/src/app/store/tenant/api.ts
+++ b/apps/tenant-management-webapp/src/app/store/tenant/api.ts
@@ -38,7 +38,7 @@ export class TenantApi {
         name: name,
       })
       .catch(function (error) {
-        throw new Error(error?.response?.data?.error);
+        throw new Error(error?.response?.data.errorMessage);
       });
     return res.data;
   }


### PR DESCRIPTION
^ to $ matches everything in between

^ to \b does a whole word match

This is to fix the following

"When there is an existing tenant with the name of "autotest signup
deleted", creating a new tenant with a name of "autotest signup"
generates an error of invalid tenant name (tenant name being used).
Looks like name validation has a flaw of dealing with names with
spaces."

Also, error messages were no longer showing up because they were not
being passed through anymore

![image](https://user-images.githubusercontent.com/11400938/152278162-9341e676-f1c7-4e70-9b7d-507a02b6ad6c.png)