### PR TITLE
fix(notification-service): change notification generation to use the …

### DIFF
--- a/apps/notification-service/src/notification/model/type.spec.ts
+++ b/apps/notification-service/src/notification/model/type.spec.ts
@@ -520,7 +520,7 @@ describe('NotificationTypeEntity', () => {
       expect(notification.message).toBe(message);
     });
 
-    it('can return notification for criteria match without tenantid', () => {
+    it('can return notification for criteria match without notification type tenant Id', () => {
       const tenantId = null;
 
       const entity = new NotificationTypeEntity(
@@ -572,7 +572,7 @@ describe('NotificationTypeEntity', () => {
       templateServiceMock.generateMessage.mockReturnValueOnce(message);
 
       const event: DomainEvent = {
-        tenantId,
+        tenantId: adspId`urn:ads:platform:tenant-service:v2:/tenants/test`,
         namespace: 'test-service',
         name: 'test-started',
         timestamp: new Date(),

--- a/apps/notification-service/src/notification/model/type.ts
+++ b/apps/notification-service/src/notification/model/type.ts
@@ -112,7 +112,7 @@ export class NotificationTypeEntity implements NotificationType {
       return null;
     } else {
       return {
-        tenantId: this.tenantId?.toString() || subscription.subscriber.tenantId?.toString(),
+        tenantId: event.tenantId.toString(),
         type: {
           id: this.id,
           name: this.name,


### PR DESCRIPTION
…tenant context of the event instead of using tenant context of the type or the subscriber.

notification type can be in a core context (no tenant).