### PR TITLE
CS-1040 - Prevent Unsubscribe if you don't have permission

### DIFF
--- a/apps/notification-service/src/notification/router/mappers.ts
+++ b/apps/notification-service/src/notification/router/mappers.ts
@@ -20,12 +20,17 @@ export const mapSubscription = (apiId: AdspId, subscription: SubscriptionEntity)
   criteria: subscription.criteria,
 });
 
-export const mapType = (type: NotificationTypeEntity, lean?: boolean): Record<string, unknown> =>
+export const mapType = (
+  type: NotificationTypeEntity,
+  lean?: boolean,
+  canSubscribe?: boolean
+): Record<string, unknown> =>
   lean
     ? {
         id: type.id,
         name: type.name,
         description: type.description,
+        canSubscribe: canSubscribe,
       }
     : {
         id: type.id,
@@ -35,4 +40,5 @@ export const mapType = (type: NotificationTypeEntity, lean?: boolean): Record<st
         manageSubscribe: type.manageSubscribe,
         subscriberRoles: type.subscriberRoles,
         events: type.events,
+        canSubscribe: canSubscribe,
       };

--- a/apps/subscriber-app/src/app/pages/private/Subscriptions/Subscriptions.tsx
+++ b/apps/subscriber-app/src/app/pages/private/Subscriptions/Subscriptions.tsx
@@ -4,6 +4,8 @@ import Container from '@components/Container';
 import styled from 'styled-components';
 import DataTable from '@components/DataTable';
 import { GoAButton, GoACard, GoAPageLoader } from '@abgov/react-components';
+import { GoACallout } from '@abgov/react-components';
+import { FetchNotificationTypeService } from '@store/notification/actions';
 import {
   GoAInputEmail,
   GoAForm,
@@ -26,6 +28,7 @@ const Subscriptions = (): JSX.Element => {
   const { subscriber } = useSelector((state: RootState) => ({
     subscriber: state.subscription.subscriber,
   }));
+  const contact = useSelector((state: RootState) => state.notification.notificationTypes?.contact);
   const [formErrors, setFormErrors] = useState({});
   const subscriberEmail = subscriber?.channels.filter((chn: SubscriberChannel) => chn.channel === EMAIL)[0]?.address;
   const [emailContactInformation, setEmailContactInformation] = useState(subscriberEmail);
@@ -33,8 +36,19 @@ const Subscriptions = (): JSX.Element => {
   const [showUnSubscribeModal, setShowUnSubscribeModal] = useState(false);
   const [selectedUnsubscribeSub, setSelectedUnsubscribeSub] = useState<Subscription>();
 
+  const phoneWrapper = (phoneNumber) => {
+    if (phoneNumber) {
+      return (
+        '1 (' + phoneNumber.substring(0, 3) + ') ' + phoneNumber.substring(3, 6) + '-' + phoneNumber.substring(6, 10)
+      );
+    }
+  };
   useEffect(() => {
     dispatch(getMySubscriberDetails());
+  }, []);
+
+  useEffect(() => {
+    dispatch(FetchNotificationTypeService());
   }, []);
 
   const unSubscribe = (typeId: string) => {
@@ -199,6 +213,19 @@ const Subscriptions = (): JSX.Element => {
               </tbody>
             </DataTable>
           </SubscriptionListContainer>
+          <div id="contactSupport">
+            <GoACallout title="Need help? Contact your service admin" type="information">
+              <div>{contact?.supportInstructions}</div>
+              <div>
+                Email:{' '}
+                <a rel="noopener noreferrer" target="_blank" href={`mailto:${contact?.contactEmail}`}>
+                  {contact?.contactEmail}
+                </a>
+              </div>
+              <div>Phone: {phoneWrapper(contact?.phoneNumber)}</div>
+              <div data-testid="service-notice-date-range"></div>
+            </GoACallout>
+          </div>
         </Container>
       </Container>
     </Main>

--- a/apps/subscriber-app/src/app/pages/private/Subscriptions/SubscriptionsList.tsx
+++ b/apps/subscriber-app/src/app/pages/private/Subscriptions/SubscriptionsList.tsx
@@ -19,17 +19,21 @@ const SubscriptionsList = (props: SubscriptionsListProps): JSX.Element => {
               <GoAIcon data-testid="mail-icon" size="medium" type="mail" />
             </IconsCell>
             <ButtonsCell>
-              <GoAButton
-                buttonSize="small"
-                buttonType="tertiary"
-                key={`${subscription.typeId}`}
-                onClick={() => {
-                  props.onUnsubscribe(subscription.typeId);
-                }}
-                data-testid="unsubscribe-button"
-              >
-                Unsubscribe
-              </GoAButton>
+              {subscription.type?.canSubscribe ? (
+                <GoAButton
+                  buttonSize="small"
+                  buttonType="tertiary"
+                  key={`${subscription.typeId}`}
+                  onClick={() => {
+                    props.onUnsubscribe(subscription.typeId);
+                  }}
+                  data-testid="unsubscribe-button"
+                >
+                  Unsubscribe
+                </GoAButton>
+              ) : (
+                <a href={`${window.location.pathname}#contactSupport`}>Contact support to unsubscribe</a>
+              )}
             </ButtonsCell>
           </tr>
         );

--- a/apps/subscriber-app/src/app/store/notification/actions.ts
+++ b/apps/subscriber-app/src/app/store/notification/actions.ts
@@ -1,0 +1,38 @@
+import { NotificationType } from './models';
+
+export const FETCH_NOTIFICATION_TYPE = 'tenant/notification-service/notificationType/fetch';
+export const FETCH_NOTIFICATION_TYPE_SUCCEEDED = 'notification-service/space/notificationType/succeeded';
+
+// =============
+// Actions Types
+// =============
+
+export type ActionTypes = FetchNotificationTypeSucceededAction | FetchNotificationTypeAction;
+
+interface FetchNotificationTypeSucceededAction {
+  type: typeof FETCH_NOTIFICATION_TYPE_SUCCEEDED;
+  payload: {
+    notificationInfo: { data: NotificationType };
+  };
+}
+
+interface FetchNotificationTypeAction {
+  type: typeof FETCH_NOTIFICATION_TYPE;
+}
+
+// ==============
+// Action Methods
+// ==============
+
+export const FetchNotificationTypeSucceededService = (notificationInfo: {
+  data: NotificationType;
+}): FetchNotificationTypeSucceededAction => ({
+  type: FETCH_NOTIFICATION_TYPE_SUCCEEDED,
+  payload: {
+    notificationInfo,
+  },
+});
+
+export const FetchNotificationTypeService = (): FetchNotificationTypeAction => ({
+  type: FETCH_NOTIFICATION_TYPE,
+});

--- a/apps/subscriber-app/src/app/store/notification/models.ts
+++ b/apps/subscriber-app/src/app/store/notification/models.ts
@@ -1,0 +1,66 @@
+export interface NotificationItem {
+  name: string;
+  description?: string;
+  events: Array<EventItem>;
+  subscriberRoles: string[];
+  id: string;
+  publicSubscribe: boolean;
+  customized?: boolean;
+  manageSubscribe?: boolean;
+}
+
+export interface ContactInformation {
+  contactEmail?: string;
+  phoneNumber?: string;
+  supportInstructions?: string;
+}
+
+export type NotificationType = Record<string, ContactInformation & NotificationItem>;
+
+export interface EventItem {
+  name: string;
+  namespace?: string;
+  templates?: Template;
+  channels?: string[];
+  customized?: boolean;
+}
+
+export interface Template {
+  email?: notifyText;
+  sms?: notifyText;
+}
+
+export interface notifyText {
+  subject: string;
+  body: string;
+}
+
+export interface RequestBodyProperties {
+  type?: string;
+  description?: string;
+  format?: string;
+}
+export interface RequestBodySchema {
+  schema: {
+    properties: Record<string, RequestBodyProperties>;
+  };
+}
+
+export interface NotificationMetrics {
+  notificationsSent?: number;
+  notificationsFailed?: number;
+}
+
+export interface NotificationState {
+  notificationList: NotificationType;
+  notificationTypes: NotificationType | undefined;
+  core: NotificationType;
+  metrics: NotificationMetrics;
+}
+
+export const NOTIFICATION_INIT: NotificationState = {
+  notificationList: {},
+  notificationTypes: undefined,
+  core: {},
+  metrics: {},
+};

--- a/apps/subscriber-app/src/app/store/notification/reducers.ts
+++ b/apps/subscriber-app/src/app/store/notification/reducers.ts
@@ -1,0 +1,17 @@
+import { ActionTypes, FETCH_NOTIFICATION_TYPE_SUCCEEDED } from './actions';
+import { NOTIFICATION_INIT, NotificationState } from './models';
+
+export default function (state = NOTIFICATION_INIT, action: ActionTypes): NotificationState {
+  switch (action.type) {
+    case FETCH_NOTIFICATION_TYPE_SUCCEEDED: {
+      const notificationTypes = action.payload.notificationInfo.data;
+
+      return {
+        ...state,
+        notificationTypes: notificationTypes,
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/apps/subscriber-app/src/app/store/notification/sagas.ts
+++ b/apps/subscriber-app/src/app/store/notification/sagas.ts
@@ -1,0 +1,34 @@
+import { put, select, call, takeEvery } from 'redux-saga/effects';
+import { ErrorNotification } from '@store/notifications/actions';
+import { SagaIterator } from '@redux-saga/core';
+import { FetchNotificationTypeSucceededService, FETCH_NOTIFICATION_TYPE } from './actions';
+import { RootState } from '../index';
+import axios from 'axios';
+
+export function* fetchNotificationTypes(): SagaIterator {
+  const configBaseUrl: string = yield select(
+    (state: RootState) => state.config.serviceUrls?.configurationServiceApiUrl
+  );
+  const token: string = yield select((state: RootState) => state.session.credentials?.token);
+
+  if (configBaseUrl && token) {
+    try {
+      const { data: configuration } = yield call(
+        axios.get,
+        `${configBaseUrl}/configuration/v2/configuration/platform/notification-service`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+
+      const notificationTypeInfo = configuration.latest && configuration.latest.configuration;
+      yield put(FetchNotificationTypeSucceededService({ data: notificationTypeInfo }));
+    } catch (e) {
+      yield put(ErrorNotification({ message: `${e.message} - fetchNotificationTypes` }));
+    }
+  }
+}
+
+export function* watchNotificationSagas(): Generator {
+  yield takeEvery(FETCH_NOTIFICATION_TYPE, fetchNotificationTypes);
+}

--- a/apps/subscriber-app/src/app/store/reducers.ts
+++ b/apps/subscriber-app/src/app/store/reducers.ts
@@ -3,10 +3,12 @@ import Config from './config/reducers';
 import Session from './session/reducers';
 import Subscription from './subscription/reducers';
 import Notifications from './notifications/reducers';
+import Notification from './notification/reducers';
 
 export const rootReducer = combineReducers({
   session: Session,
   config: Config,
   subscription: Subscription,
   notifications: Notifications,
+  notification: Notification,
 });

--- a/apps/subscriber-app/src/app/store/sagas.ts
+++ b/apps/subscriber-app/src/app/store/sagas.ts
@@ -9,6 +9,7 @@ import {
   keycloakRefreshToken,
   tenantLogout,
 } from './tenant/sagas';
+import { watchNotificationSagas } from './notification/sagas';
 import { watchSubscriptionSagas } from './subscription/sagas';
 
 // Actions
@@ -35,5 +36,6 @@ export function* watchSagas() {
   yield all([
     // subscription
     watchSubscriptionSagas(),
+    watchNotificationSagas(),
   ]);
 }

--- a/apps/subscriber-app/src/app/store/subscription/models.ts
+++ b/apps/subscriber-app/src/app/store/subscription/models.ts
@@ -14,6 +14,7 @@ export interface SubscriptionType {
   description: string;
   id: string;
   name: string;
+  canSubscribe: boolean;
 }
 export interface SubscriberChannel {
   address: string;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11400938/156072766-68db58a5-3310-4ac7-9b5f-7632af418603.png)

A list of subscriptions that I cannot unsubscribe without the help of my tenant admin

Subscription management shows tenant specific notification admin contact information, so user knows where to reach out for help
Subscription list does not show unsubscribe for types that don’t allow self-serve
Subscription list provides information about how user can address those subscriptions.
Provides link to see the contact instructions.

