### PR TITLE
fix(notification-service, tenant-management-webapp): throw error if s…

### DIFF
--- a/apps/notification-service/src/provider/router/slack.ts
+++ b/apps/notification-service/src/provider/router/slack.ts
@@ -101,6 +101,10 @@ export const createSlackProviderRouter = ({ slackInstaller, slackRepository, get
           teamId,
         });
 
+        if (!botToken) {
+          throw new Error('Failed to get Slack API bot token.');
+        }
+
         const client = new WebClient(botToken);
         const teamInfo = await client.team.info({ team: teamId });
 

--- a/apps/tenant-management-webapp/src/app/store/notification/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/notification/reducers.ts
@@ -78,7 +78,7 @@ export default function (state = NOTIFICATION_INIT, action: ActionTypes): Notifi
         providers: {
           ...state.providers,
           slack: {
-            installedTeams: action.teams,
+            installedTeams: action.teams || state.providers.slack.installedTeams,
             authorizationUrl: action.authorizationUrl,
           },
         },


### PR DESCRIPTION
…lack bot token is null and handle failure to retrieve team information in tenant admin.