### PR TITLE
Fix/cs 1087 review fixes

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/emailPreviewEditor/config.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/emailPreviewEditor/config.ts
@@ -21,11 +21,9 @@ export const subjectEditorConfig = {
 
 export const bodyEditorConfig = {
   'data-testid': 'templateForm-body',
-  height: 250,
   language: 'handlebars',
   options: {
     tabSize: 2,
-
     minimap: { enabled: false },
     overviewRulerBorder: false,
     lineHeight: 25,


### PR DESCRIPTION
The template body editor now spans the height of the parent div rather than having a fixed height

<img width="691" alt="Screen Shot 2022-03-02 at 2 49 34 PM" src="https://user-images.githubusercontent.com/31360331/156455413-8ca27afa-3559-4bb3-9f57-3484f4523010.png">
