### PR TITLE
Adding fonts and some styles to match event email template with keycloak email template

### DIFF
--- a/libs/notification-shared/src/templates/email-wrapper.hbs
+++ b/libs/notification-shared/src/templates/email-wrapper.hbs
@@ -140,7 +140,7 @@
       .goa-footer-event {
         background-color: #f1f1f1;
         padding-top: 2.5rem;
-        padding-left: 2rem;
+        padding-left: 3rem;
         padding-right: 2rem;
         padding-bottom: 3rem;
       }
@@ -169,7 +169,7 @@
         padding-bottom: 2rem;
       }
       .email-content {
-        padding: 3rem 11rem;
+        padding: 3rem 7.5rem;
         background-color: white;
       }
       .goa-logo {


### PR DESCRIPTION
https://goa-dio.atlassian.net/browse/CS-1252

before: 
![image](https://user-images.githubusercontent.com/31360331/158506305-906eb3ca-f2a7-4296-8f21-d4a8d70d7029.png)

after: 
<img width="932" alt="Screen Shot 2022-03-16 at 11 36 58 AM" src="https://user-images.githubusercontent.com/31360331/158652717-79872be2-0be9-497c-870b-fed1103c5328.png">

