### PR TITLE
fix:cs-1330 Notification type email template editor syntax error

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -179,6 +179,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                   <GoAFormItem error={errors['subject'] ?? ''} helpText={subjectEditorHintText}>
                     <MonacoDiv>
                       <MonacoEditor
+                        language={item.name === 'email' ? 'handlebars' : 'markdown'}
                         onChange={(value) => {
                           onSubjectChange(value, item.name);
                         }}
@@ -191,6 +192,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                   <GoAFormItem error={errors['body'] ?? ''} helpText={bodyEditorHintText}>
                     <MonacoDivBody>
                       <MonacoEditor
+                        language={item.name === 'email' ? 'handlebars' : 'markdown'}
                         value={templates[item.name]?.body}
                         onChange={(value) => {
                           onBodyChange(value, item.name);

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/config.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/config.ts
@@ -1,7 +1,6 @@
 export const subjectEditorConfig = {
   'data-testid': 'templateForm-subject',
   height: 50,
-  language: 'markdown',
   options: {
     wordWrap: 'off' as const,
     scrollbar: { horizontal: 'hidden' as const, vertical: 'hidden' as const },
@@ -21,7 +20,6 @@ export const subjectEditorConfig = {
 
 export const bodyEditorConfig = {
   'data-testid': 'templateForm-body',
-  language: 'markdown',
   options: {
     tabSize: 2,
     minimap: { enabled: false },


### PR DESCRIPTION
Notification type email template editor syntax recognition broken in dev/uat

Syntax handling of html/handlebars for email template is broken in dev and uat, but still working in prod.