### PR TITLE
feat: cs-1227 short cut for directory entries

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/directory/directoryModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/directory/directoryModal.tsx
@@ -4,21 +4,22 @@ import { GoAButton } from '@abgov/react-components';
 import { GoAForm, GoAFormItem } from '@abgov/react-components/experimental';
 import { Service } from '@store/directory/models';
 import { useDispatch, useSelector } from 'react-redux';
-import { createEntry, updateEntry } from '@store/directory/actions';
+import { createEntry, updateEntry, fetchEntryDetail } from '@store/directory/actions';
 import { RootState } from '@store/index';
 
 interface DirectoryModalProps {
   entry?: Service;
-  type: 'new' | 'edit';
+  type: string;
   onCancel?: () => void;
   open: boolean;
 }
 
 export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
   const isNew = props.type === 'new';
+  const isQuickAdd = props.type === 'quickAdd';
   const [entry, setEntry] = useState(props.entry);
 
-  const title = isNew ? 'Add entry' : 'Edit entry';
+  const title = isNew || isQuickAdd ? 'Add entry' : 'Edit entry';
   const [errors, setErrors] = useState<Record<string, string>>({});
   const { directory } = useSelector((state: RootState) => state.directory);
   const tenantName = useSelector((state: RootState) => state.tenant?.name);
@@ -55,7 +56,7 @@ export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
               onChange={(e) => setEntry({ ...entry, service: e.target.value })}
               aria-label="service"
               maxLength={50}
-              disabled={!isNew}
+              disabled={!isNew || isQuickAdd}
             />
           </GoAFormItem>
           <GoAFormItem error={errors?.['api']}>
@@ -68,7 +69,7 @@ export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
               onChange={(e) => setEntry({ ...entry, api: e.target.value })}
               aria-label="api"
               maxLength={50}
-              disabled={!isNew}
+              disabled={!isNew || isQuickAdd}
             />
           </GoAFormItem>
           <GoAFormItem error={errors?.['url']}>
@@ -81,6 +82,7 @@ export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
               onChange={(e) => setEntry({ ...entry, url: e.target.value })}
               aria-label="name"
               maxLength={1024}
+              disabled={isQuickAdd}
             />
           </GoAFormItem>
         </GoAForm>
@@ -127,10 +129,13 @@ export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
               setErrors({ ...errors, service: 'Service duplicate, please use another one' });
               return;
             }
-            if (props.type === 'new') {
+            if (isNew) {
+              dispatch(createEntry(entry));
+              dispatch(fetchEntryDetail(entry));
+            }
+            if (isQuickAdd) {
               dispatch(createEntry(entry));
             }
-
             if (props.type === 'edit') {
               dispatch(updateEntry(entry));
             }

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/directory/services.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/directory/services.tsx
@@ -15,7 +15,7 @@ import styled from 'styled-components';
 
 export const DirectoryService: FunctionComponent = () => {
   const dispatch = useDispatch();
-  const [isEdit, setIsEdit] = useState(false);
+  const [modalType, setModalType] = useState('');
   const [editEntry, setEditEntry] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [selectedEntry, setSelectedEntry] = useState<Service>(defaultService);
@@ -44,7 +44,7 @@ export const DirectoryService: FunctionComponent = () => {
 
   const onEdit = (service) => {
     setSelectedEntry(service);
-    setIsEdit(true);
+    setModalType('edit');
     setEditEntry(true);
   };
   const onDelete = (service) => {
@@ -52,6 +52,11 @@ export const DirectoryService: FunctionComponent = () => {
     setSelectedEntry(service);
   };
 
+  const onQuickAdd = (service) => {
+    setSelectedEntry(service);
+    setModalType('quickAdd');
+    setEditEntry(true);
+  };
   return (
     <>
       {indicator.show && <PageIndicator />}
@@ -68,7 +73,7 @@ export const DirectoryService: FunctionComponent = () => {
                 onClick={() => {
                   defaultService.namespace = toKebabName(tenantName);
                   setSelectedEntry(defaultService);
-                  setIsEdit(false);
+                  setModalType('new');
                   setEditEntry(true);
                 }}
               >
@@ -81,6 +86,7 @@ export const DirectoryService: FunctionComponent = () => {
                 isCore={false}
                 onEdit={onEdit}
                 onDelete={onDelete}
+                onQuickAdd={onQuickAdd}
               />
             </>
           )}
@@ -91,6 +97,7 @@ export const DirectoryService: FunctionComponent = () => {
             isCore={true}
             onEdit={onEdit}
             onDelete={onDelete}
+            onQuickAdd={onQuickAdd}
           />
         </div>
       )}
@@ -113,7 +120,7 @@ export const DirectoryService: FunctionComponent = () => {
         <DirectoryModal
           open={true}
           entry={selectedEntry}
-          type={isEdit ? 'edit' : 'new'}
+          type={modalType}
           onCancel={() => {
             reset();
           }}


### PR DESCRIPTION
As a tenant admin, when I add directory entries, I can select from APIs resolved via service metadata, so I have a quick way to add API entries.

![image](https://user-images.githubusercontent.com/58053108/165818107-31c44831-61e6-46ce-9497-71fd4c0d687d.png)
