### PR TITLE
CS-1460 Ensure we preview initially

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -63,7 +63,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   useEffect(() => {
     setPreview(template?.useWrapper ? 'Snippet' : 'Html');
     setHtmlType(template?.useWrapper ? 'Snippet' : 'Html');
-  }, [template]);
+  }, [template, modelOpen]);
 
   let radioOptions = [];
 


### PR DESCRIPTION
The preview initally gets triggered before there are any templates
selected and the window is even open. We need to re-trigger it on window
open, to ensure we preview the template that is currently selected