### PR TITLE
fix: remove the whitespace for the link in email template

### DIFF
--- a/libs/notification-shared/src/templates/email-wrapper.hbs
+++ b/libs/notification-shared/src/templates/email-wrapper.hbs
@@ -220,10 +220,7 @@
             Please do not reply to this email.
             {{#if managementUrl}}
               Manage your subscription
-              <a href="{{managementUrl}}" target='_blank' rel='noopener noreferrer'>
-                here
-              </a>
-              .
+              <a href="{{managementUrl}}" target='_blank' rel='noopener noreferrer'>here</a>.
             {{/if}}
           </span>
           <br />


### PR DESCRIPTION
<img width="482" alt="Screen Shot 2022-05-24 at 10 47 34 AM" src="https://user-images.githubusercontent.com/8821979/171231097-981195ac-8292-418d-a2cb-a5eeabf9468f.png">
