### PR TITLE
fix(adsp-service-sdk): adjusting sdk to use query to retrieve tenants…

### DIFF
--- a/libs/adsp-service-sdk/src/access/createRealmStrategy.spec.ts
+++ b/libs/adsp-service-sdk/src/access/createRealmStrategy.spec.ts
@@ -1,0 +1,45 @@
+import { Logger } from 'winston';
+import { TenantService } from '../tenant';
+import { adspId } from '../utils';
+import { createRealmStrategy } from './createRealmStrategy';
+
+describe('createRealmStrategy', () => {
+  const tenantServiceMock = {
+    getTenantByRealm: jest.fn(),
+  };
+  const loggerMock = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  it('can create strategy', async () => {
+    const strategy = await createRealmStrategy({
+      realm: 'core',
+      serviceId: adspId`urn:ads:platform:test`,
+      tenantService: tenantServiceMock as unknown as TenantService,
+      accessServiceUrl: new URL('https://access-service'),
+      logger: loggerMock,
+      ignoreServiceAud: false,
+    });
+    expect(strategy).toBeTruthy();
+  });
+
+  it('can create tenant realm strategy', async () => {
+    tenantServiceMock.getTenantByRealm.mockResolvedValueOnce({
+      id: adspId`urn:ads:platform:tenant-service:v2:/tenants/test`,
+      name: 'test',
+      realm: 'test',
+    });
+    const strategy = await createRealmStrategy({
+      realm: 'test',
+      serviceId: adspId`urn:ads:platform:test`,
+      tenantService: tenantServiceMock as unknown as TenantService,
+      accessServiceUrl: new URL('https://access-service'),
+      logger: loggerMock,
+      ignoreServiceAud: false,
+    });
+    expect(strategy).toBeTruthy();
+    expect(tenantServiceMock.getTenantByRealm).toHaveBeenCalled();
+  });
+});

--- a/libs/adsp-service-sdk/src/access/createTenantStrategy.spec.ts
+++ b/libs/adsp-service-sdk/src/access/createTenantStrategy.spec.ts
@@ -1,0 +1,24 @@
+import { Logger } from 'winston';
+import { TenantService } from '../tenant';
+import { adspId } from '../utils';
+import { createTenantStrategy } from './createTenantStrategy';
+
+describe('createTenantStrategy', () => {
+  const tenantServiceMock = {};
+  const loggerMock = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  it('can create strategy', () => {
+    const strategy = createTenantStrategy({
+      serviceId: adspId`urn:ads:platform:test`,
+      tenantService: tenantServiceMock as unknown as TenantService,
+      accessServiceUrl: new URL('https://access-service'),
+      logger: loggerMock,
+      ignoreServiceAud: false,
+    });
+    expect(strategy).toBeTruthy();
+  });
+});

--- a/libs/adsp-service-sdk/src/access/issuerCache.spec.ts
+++ b/libs/adsp-service-sdk/src/access/issuerCache.spec.ts
@@ -58,13 +58,32 @@ describe('IssuerCache', () => {
     };
 
     cacheMock.mockReturnValueOnce(null);
-    serviceMock.getTenants.mockResolvedValueOnce([tenant]);
+    serviceMock.getTenants.mockResolvedValueOnce([
+      tenant,
+      // Incomplete tenant value.
+      {
+        id: adspId`urn:ads:platform:tenant-service:v2:/tenants/test2`,
+        name: 'test2',
+      },
+      null,
+    ]);
     cacheMock.mockReturnValueOnce(tenant);
 
     const cache = new IssuerCache(logger, new URL('http://totally-access'), serviceMock);
     const result = await cache.getTenantByIssuer('issuer');
 
     expect(result).toBe(tenant);
+    expect(serviceMock.getTenants).toHaveBeenCalledTimes(1);
+  });
+
+  it('can null from get tenants from service', async () => {
+    cacheMock.mockReturnValueOnce(null);
+    serviceMock.getTenants.mockResolvedValueOnce(null);
+
+    const cache = new IssuerCache(logger, new URL('http://totally-access'), serviceMock);
+    const result = await cache.getTenantByIssuer('issuer');
+
+    expect(result).toBeFalsy();
     expect(serviceMock.getTenants).toHaveBeenCalledTimes(1);
   });
 

--- a/libs/adsp-service-sdk/src/access/issuerCache.ts
+++ b/libs/adsp-service-sdk/src/access/issuerCache.ts
@@ -17,7 +17,7 @@ export class IssuerCache {
   ) {}
 
   #getIssuer = (tenant: Tenant): string => {
-    if (!tenant || !tenant.realm) {
+    if (!tenant?.realm) {
       return null;
     }
 
@@ -46,12 +46,10 @@ export class IssuerCache {
   getTenantByIssuer = async (issuer: string): Promise<Tenant> => {
     let tenant = this.#issuers.get<Tenant>(issuer);
     if (!tenant) {
-      try
-      {
+      try {
         await this.#updateIssuers();
         tenant = this.#issuers.get<Tenant>(issuer);
-      }
-      catch (err) {
+      } catch (err) {
         this.logger.error(`Encountered error on updating issuers. ${err}`);
       }
     }

--- a/libs/adsp-service-sdk/src/event/eventService.spec.ts
+++ b/libs/adsp-service-sdk/src/event/eventService.spec.ts
@@ -59,8 +59,6 @@ describe('EventService', () => {
       ]
     );
 
-    axiosMock.get.mockResolvedValue({ data: { results: [{ id: 'test-123', configOptions: {} }] } });
-
     const event = {
       tenantId,
       name: 'test-event',
@@ -96,10 +94,7 @@ describe('EventService', () => {
       ]
     );
 
-    axiosMock.get.mockResolvedValue({ data: { results: [{ id: 'test-123', configOptions: {} }] } });
-
     const event = {
-      tenantId,
       name: 'test-event',
       timestamp: new Date(),
       payload: {},
@@ -134,5 +129,37 @@ describe('EventService', () => {
         payload: {},
       })
     ).rejects.toThrow(/Event test-service:test-event is not recognized; only registered events can be sent./);
+  });
+
+  it('can handle send error', async () => {
+    const service = new EventServiceImpl(
+      true,
+      logger,
+      directoryMock,
+      tokenProviderMock,
+      adspId`urn:ads:platform:test-service`,
+      [
+        {
+          name: 'test-event',
+          description: 'signalled when unit testing',
+          payloadSchema: {
+            type: 'object',
+          },
+        },
+      ]
+    );
+
+    axiosMock.post.mockRejectedValue(new Error('oh noes!'));
+
+    const event = {
+      tenantId,
+      name: 'test-event',
+      timestamp: new Date(),
+      payload: {},
+    };
+
+    await service.send(event);
+
+    expect(axiosMock.post).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/adsp-service-sdk/src/initialize/platform.ts
+++ b/libs/adsp-service-sdk/src/initialize/platform.ts
@@ -43,7 +43,7 @@ export async function initializePlatform(
   const tenantService = service?.tenantService || createTenantService({ logger, directory, tokenProvider });
   const tenantHandler = createTenantHandler(tenantService);
 
-  const coreStrategy = createRealmStrategy({
+  const coreStrategy = await createRealmStrategy({
     realm: 'core',
     logger,
     serviceId,
@@ -55,7 +55,7 @@ export async function initializePlatform(
   const tenantStrategy =
     realm === 'core'
       ? createTenantStrategy({ logger, serviceId, accessServiceUrl, tenantService, ignoreServiceAud })
-      : createRealmStrategy({ realm, logger, serviceId, accessServiceUrl, tenantService, ignoreServiceAud });
+      : await createRealmStrategy({ realm, logger, serviceId, accessServiceUrl, tenantService, ignoreServiceAud });
 
   let configurationService = service?.configurationService;
   let clearCached = function (_tenantId: AdspId, _serviceId: AdspId) {

--- a/libs/adsp-service-sdk/src/metrics/benchmark.spec.ts
+++ b/libs/adsp-service-sdk/src/metrics/benchmark.spec.ts
@@ -34,6 +34,6 @@ describe('benchmark', () => {
       benchmark(req as unknown as Request, 'test');
       expect(req[REQ_BENCHMARK].metrics['test']).toBeGreaterThan(200);
       done();
-    }, 200);
+    }, 205);
   });
 });

--- a/libs/adsp-service-sdk/src/registration/registration.spec.ts
+++ b/libs/adsp-service-sdk/src/registration/registration.spec.ts
@@ -78,6 +78,29 @@ describe('ServiceRegistrar', () => {
     expect(axiosMock.patch.mock.calls[1][1].update).toHaveProperty('test-service');
   });
 
+  it('can register roles', async () => {
+    const registrar = new ServiceRegistrarImpl(logger, directoryMock, tokenProviderMock);
+
+    axiosMock.patch.mockResolvedValue({ data: {} });
+
+    await registrar.register({
+      serviceId: adspId`urn:ads:platform:test-service`,
+      displayName: 'Test service',
+      description: 'This is a test service.',
+      roles: [
+        {
+          role: 'tester',
+          description: 'For testing.',
+        },
+        'tester2',
+      ],
+    });
+
+    expect(axiosMock.patch).toHaveBeenCalledTimes(1);
+    expect(axiosMock.patch.mock.calls[0][0]).toContain('tenant-service');
+    expect(axiosMock.patch.mock.calls[0][1].update).toHaveProperty('urn:ads:platform:test-service');
+  });
+
   it('can register notifications', async () => {
     const registrar = new ServiceRegistrarImpl(logger, directoryMock, tokenProviderMock);
 

--- a/libs/adsp-service-sdk/src/tenant/tenantService.ts
+++ b/libs/adsp-service-sdk/src/tenant/tenantService.ts
@@ -36,6 +36,11 @@ export interface TenantService {
   getTenantByRealm(realm: string): Promise<Tenant>;
 }
 
+interface TenantCriteria {
+  name?: string;
+  realm?: string;
+}
+
 export class TenantServiceImpl implements TenantService {
   private readonly LOG_CONTEXT = { context: 'TenantService' };
 
@@ -50,18 +55,27 @@ export class TenantServiceImpl implements TenantService {
   constructor(
     private readonly logger: Logger,
     private readonly directory: ServiceDirectory,
-    private readonly tokenProvider: TokenProvider
+    private readonly tokenProvider: TokenProvider,
+    preload = true
   ) {
-    // load into the cache.
-    this.#retrieveTenants().catch((err) => logger.error(`Encountered error during initialization of tenants. ${err}`));
+    if (preload) {
+      // load into the cache.
+      this.#retrieveTenants().catch((err) =>
+        logger.error(`Encountered error during initialization of tenants. ${err}`)
+      );
+    }
   }
 
-  #tryRetrieveTenants = async (requestUrl: URL, count: number): Promise<Tenant[]> => {
+  #tryRetrieveTenants = async (requestUrl: URL, count: number, criteria?: TenantCriteria): Promise<Tenant[]> => {
     this.logger.debug(`Try ${count}: retrieving tenants from ${requestUrl}...'`, this.LOG_CONTEXT);
 
     const token = await this.tokenProvider.getAccessToken();
     const { data } = await axios.get<TenantsResponse>(requestUrl.href, {
       headers: { Authorization: `Bearer ${token}` },
+      params: {
+        name: criteria?.name,
+        realm: criteria?.realm,
+      },
     });
 
     const tenants = data?.results?.map((r) => ({
@@ -73,14 +87,14 @@ export class TenantServiceImpl implements TenantService {
     return tenants;
   };
 
-  #retrieveTenants = async (): Promise<Tenant[]> => {
+  #retrieveTenants = async (criteria?: TenantCriteria): Promise<Tenant[]> => {
     const tenantServiceUrl = await this.directory.getServiceUrl(adspId`urn:ads:platform:tenant-service:v2`);
     const tenantsUrl = new URL('v2/tenants', tenantServiceUrl);
 
     try {
       const tenants: Tenant[] = await retry(async (next, count) => {
         try {
-          return await this.#tryRetrieveTenants(tenantsUrl, count);
+          return await this.#tryRetrieveTenants(tenantsUrl, count, criteria);
         } catch (err) {
           this.logger.debug(`Try ${count} failed with error. ${err}`, this.LOG_CONTEXT);
           next(err);
@@ -131,6 +145,7 @@ export class TenantServiceImpl implements TenantService {
       if (tenant) {
         this.#tenants.set(`${tenant.id}`, tenant);
         this.#tenantNames[tenant.name.toLowerCase()] = tenant.id;
+        this.#tenantRealms[tenant.realm.toLowerCase()] = tenant.id;
         this.logger.debug(`Cached tenant '${tenant.id}' -> ${tenant.name} (${tenant.realm})`, this.LOG_CONTEXT);
       }
 
@@ -158,14 +173,32 @@ export class TenantServiceImpl implements TenantService {
   };
 
   getTenantByName = async (name: string): Promise<Tenant> => {
-    const tenantId = name && this.#tenantNames[name.toLowerCase()];
+    if (!name) {
+      return;
+    } else {
+      let tenantId = this.#tenantNames[name.toLowerCase()];
+      if (!tenantId) {
+        // Query for the tenant if no existing record.
+        await this.#retrieveTenants({ name });
+        tenantId = this.#tenantNames[name.toLowerCase()];
+      }
 
-    return tenantId ? this.getTenant(tenantId) : null;
+      return tenantId ? this.getTenant(tenantId) : null;
+    }
   };
 
   getTenantByRealm = async (realm: string): Promise<Tenant> => {
-    const tenantId = realm && this.#tenantRealms[realm.toLowerCase()];
+    if (!realm) {
+      return;
+    } else {
+      let tenantId = this.#tenantRealms[realm.toLowerCase()];
+      if (!tenantId) {
+        // Query for the tenant if no existing record.
+        await this.#retrieveTenants({ realm });
+        tenantId = this.#tenantNames[realm.toLowerCase()];
+      }
 
-    return tenantId ? this.getTenant(tenantId) : null;
+      return tenantId ? this.getTenant(tenantId) : null;
+    }
   };
 }

--- a/libs/adsp-service-sdk/src/utils/adspId.ts
+++ b/libs/adsp-service-sdk/src/utils/adspId.ts
@@ -17,7 +17,7 @@ export type ResourceType = 'namespace' | 'service' | 'api' | 'resource';
 export class AdspId {
   static parse(urn: string): AdspId {
     // urn:ads:{namespace}:{service}:{apiVersion}:{resource}
-    if (!urn.startsWith(PREFIX)) {
+    if (!urn?.startsWith(PREFIX)) {
       throw new AdspIdFormatError(`ADSP ID must begin with: ${PREFIX}`);
     }
 


### PR DESCRIPTION
… by name or realm. Before this change, new tenants would not be accounted for.

Also increasing unit test coverage across the sdk.