### PR TITLE
fix: add html doctype to email template

### DIFF
--- a/libs/notification-shared/src/templates/email-wrapper.hbs
+++ b/libs/notification-shared/src/templates/email-wrapper.hbs
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <html>
   <head>
     <style>


### PR DESCRIPTION
For: https://goa-dio.atlassian.net/browse/CS-1501