### PR TITLE
feat(configuration-service): rename properties prefixed with $ and ba…

### DIFF
--- a/apps/configuration-service/src/mongo/prefix.spec.ts
+++ b/apps/configuration-service/src/mongo/prefix.spec.ts
@@ -1,0 +1,32 @@
+import { renamePrefixProperties } from './prefix';
+
+describe('renamePrefixProperties', () => {
+  it('can rename prefix property', () => {
+    const value = {
+      $prefixed: true,
+      notPrefixed: false,
+    };
+
+    const result = renamePrefixProperties(value, '$', 'META_');
+    expect(result).toHaveProperty('META_prefixed');
+    expect(result['META_prefixed']).toBe(true);
+    expect(result).toHaveProperty('notPrefixed');
+    expect(result['notPrefixed']).toBe(false);
+  });
+
+  it('can recurse', () => {
+    const value = {
+      nested: {
+        $prefixed: true,
+        notPrefixed: false,
+      },
+      $prefixed: true,
+    };
+
+    const result = renamePrefixProperties(value, '$', 'META_');
+    expect(result).toHaveProperty('META_prefixed');
+    expect(result['META_prefixed']).toBe(true);
+    expect(result).toHaveProperty('nested.META_prefixed');
+    expect(result['nested']['META_prefixed']).toBe(true);
+  });
+});

--- a/apps/configuration-service/src/mongo/prefix.ts
+++ b/apps/configuration-service/src/mongo/prefix.ts
@@ -1,0 +1,14 @@
+export function renamePrefixProperties(value: unknown, prefix: string, replace: string): unknown {
+  if (value && typeof value == 'object') {
+    value = Object.getOwnPropertyNames(value).reduce((copy, property) => {
+      let copyProperty = property;
+      if (property.startsWith(prefix)) {
+        copyProperty = `${replace}${property.substring(prefix.length)}`;
+      }
+      copy[copyProperty] = renamePrefixProperties(value[property], prefix, replace);
+      return copy;
+    }, {});
+  }
+
+  return value;
+}

--- a/apps/configuration-service/src/mongo/repository.ts
+++ b/apps/configuration-service/src/mongo/repository.ts
@@ -7,11 +7,14 @@ import {
   ConfigurationRevision,
   RevisionCriteria,
 } from '../configuration';
+import { renamePrefixProperties } from './prefix';
 import { revisionSchema } from './schema';
 import { ConfigurationRevisionDoc } from './types';
 
 export class MongoConfigurationRepository implements ConfigurationRepository {
   private revisionModel: Model<ConfigurationRevisionDoc>;
+
+  private readonly META_PREFIX = 'META_';
 
   constructor(private validationService: ValidationService) {
     this.revisionModel = model<ConfigurationRevisionDoc>('revision', revisionSchema);
@@ -32,15 +35,7 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
         .limit(1)
         .exec((err, results: ConfigurationRevisionDoc[]) => (err ? reject(err) : resolve(results[0])));
     });
-    const latest = latestDoc
-      ? {
-          revision: latestDoc.revision,
-          created: latestDoc.created,
-          lastUpdated: latestDoc.lastUpdated,
-          configuration: latestDoc.configuration as C,
-        }
-      : null;
-
+    const latest = this.fromDoc<C>(latestDoc);
     return new ConfigurationEntity<C>(namespace, name, this, this.validationService, latest, tenantId, schema);
   }
 
@@ -70,12 +65,7 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
         .exec((err, results: ConfigurationRevisionDoc[]) => (err ? reject(err) : resolve(results)));
     });
     return {
-      results: docs.map((doc) => ({
-        revision: doc.revision,
-        created: doc.created,
-        lastUpdated: doc.lastUpdated,
-        configuration: doc.configuration as C,
-      })),
+      results: docs.map((doc) => this.fromDoc<C>(doc)),
       page: {
         after,
         next: encodeNext(docs.length, top, skip),
@@ -112,7 +102,7 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
           query,
           {
             ...update,
-            configuration: revision.configuration,
+            configuration: renamePrefixProperties(revision.configuration, '$', this.META_PREFIX),
           },
           { upsert: true, new: true, lean: true }
         )
@@ -124,5 +114,16 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
       created: doc.created,
       configuration: doc.configuration,
     };
+  }
+
+  private fromDoc<C>(doc: ConfigurationRevisionDoc): ConfigurationRevision<C> {
+    return doc
+      ? {
+          revision: doc.revision,
+          created: doc.created,
+          lastUpdated: doc.lastUpdated,
+          configuration: renamePrefixProperties(doc.configuration, this.META_PREFIX, '$') as C,
+        }
+      : null;
   }
 }


### PR DESCRIPTION
…ck for storage in mongo.

This is to support json schema meta properties.