### PR TITLE
feat(push-service): supporting a cross-tenant context for streams wit…

### DIFF
--- a/apps/push-service/src/main.ts
+++ b/apps/push-service/src/main.ts
@@ -31,30 +31,31 @@ const initializeApp = async (): Promise<Server> => {
 
   const serviceId = AdspId.parse(environment.CLIENT_ID);
   const accessServiceUrl = new URL(environment.KEYCLOAK_ROOT_URL);
-  const { tenantService, tenantStrategy, configurationHandler, clearCached, healthCheck } = await initializePlatform(
-    {
-      serviceId,
-      displayName: 'Push service',
-      description: 'Service for push mode connections.',
-      roles: [
-        {
-          role: PushServiceRoles.StreamListener,
-          description: 'Role used to allow an account to listen to all streams.',
-          inTenantAdmin: true,
-        },
-      ],
-      configurationSchema,
-      combineConfiguration: (tenant: Record<string, Stream>, core: Record<string, Stream>, tenantId) =>
-        Object.entries({ ...tenant, ...core }).reduce(
-          (c, [k, s]) => ({ ...c, [k]: new StreamEntity(tenantId, s) }),
-          {}
-        ),
-      clientSecret: environment.CLIENT_SECRET,
-      accessServiceUrl,
-      directoryUrl: new URL(environment.DIRECTORY_URL),
-    },
-    { logger }
-  );
+  const { tenantService, tenantStrategy, coreStrategy, configurationHandler, clearCached, healthCheck } =
+    await initializePlatform(
+      {
+        serviceId,
+        displayName: 'Push service',
+        description: 'Service for push mode connections.',
+        roles: [
+          {
+            role: PushServiceRoles.StreamListener,
+            description: 'Role used to allow an account to listen to all streams.',
+            inTenantAdmin: true,
+          },
+        ],
+        configurationSchema,
+        combineConfiguration: (tenant: Record<string, Stream>, core: Record<string, Stream>, tenantId) =>
+          Object.entries({ ...tenant, ...core }).reduce(
+            (c, [k, s]) => ({ ...c, [k]: new StreamEntity(tenantId, s) }),
+            {}
+          ),
+        clientSecret: environment.CLIENT_SECRET,
+        accessServiceUrl,
+        directoryUrl: new URL(environment.DIRECTORY_URL),
+      },
+      { logger }
+    );
 
   const configurationSync = await createAmqpConfigUpdateService({
     ...environment,
@@ -67,6 +68,7 @@ const initializeApp = async (): Promise<Server> => {
   });
 
   passport.use('jwt', tenantStrategy);
+  passport.use('core', coreStrategy);
   passport.use(new AnonymousStrategy());
   passport.serializeUser(function (user, done) {
     done(null, user);
@@ -91,17 +93,14 @@ const initializeApp = async (): Promise<Server> => {
   });
   ioServer.adapter(createIoAdapter(redisClient, redisClient.duplicate()));
 
-  // No connection on default namespace.
-  ioServer.of('/').on('connection', async (socket) => socket.disconnect(true));
-
   // Connections on namespace correspond to tenants.
-  const io = ioServer.of(/^\/[a-zA-Z0-9- ]+$/);
+  const io = ioServer.of(/^\/[a-zA-Z0-9- ]*$/);
 
   const wrapForIo = (handler: express.RequestHandler) => (socket: Socket, next) =>
     handler(socket.request as express.Request, {} as express.Response, next);
 
   io.use(wrapForIo(passport.initialize()));
-  io.use(wrapForIo(passport.authenticate(['jwt', 'anonymous'], { session: false })));
+  io.use(wrapForIo(passport.authenticate(['jwt', 'anonymous', 'core'], { session: false })));
   io.use(wrapForIo(configurationHandler));
 
   const eventService = await createAmqpEventService({ ...environment, logger });

--- a/apps/push-service/src/push/model/stream.spec.ts
+++ b/apps/push-service/src/push/model/stream.spec.ts
@@ -84,6 +84,62 @@ describe('StreamEntity', () => {
       const result = publicEntity.canSubscribe(null);
       expect(result).toBe(true);
     });
+
+    it('can return false for cross-tenant non-core user', () => {
+      const stream = new StreamEntity(null, {
+        id: 'test',
+        name: 'Test Stream',
+        description: null,
+        subscriberRoles: ['test-subscriber'],
+        publicSubscribe: false,
+        events: [
+          {
+            namespace: 'test-service',
+            name: 'test-started',
+          },
+        ],
+      });
+
+      const result = stream.canSubscribe({ tenantId, id: 'tester', roles: ['test-subscriber'] } as User);
+      expect(result).toBe(false);
+    });
+
+    it('can return true for cross-tenant core user with role', () => {
+      const stream = new StreamEntity(null, {
+        id: 'test',
+        name: 'Test Stream',
+        description: null,
+        subscriberRoles: ['test-subscriber'],
+        publicSubscribe: false,
+        events: [
+          {
+            namespace: 'test-service',
+            name: 'test-started',
+          },
+        ],
+      });
+
+      const result = stream.canSubscribe({ isCore: true, id: 'tester', roles: ['test-subscriber'] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return false for cross-tenant public stream', () => {
+      const publicEntity = new StreamEntity(null, {
+        id: 'test',
+        name: 'Test Stream',
+        description: null,
+        subscriberRoles: ['test-subscriber'],
+        publicSubscribe: true,
+        events: [
+          {
+            namespace: 'test-service',
+            name: 'test-started',
+          },
+        ],
+      });
+      const result = publicEntity.canSubscribe(null);
+      expect(result).toBe(false);
+    });
   });
 
   describe('connect', () => {

--- a/apps/push-service/src/push/router/stream.spec.ts
+++ b/apps/push-service/src/push/router/stream.spec.ts
@@ -123,10 +123,10 @@ describe('stream router', () => {
       );
     });
 
-    it('can call next with error for no tenant context', async () => {
+    it('can call next with error for non-core user with no tenant context', async () => {
       const req = {
         tenantId,
-        user: { isCore: true, id: 'tester', roles: [] } as User,
+        user: { isCore: false, id: 'tester', roles: [] } as User,
         params: { stream: 'test' },
         query: {},
         getConfiguration: jest.fn(),
@@ -145,6 +145,28 @@ describe('stream router', () => {
       );
       expect(res.send).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledWith(expect.any(InvalidOperationError));
+    });
+
+    it('can get stream with no tenant context for core user', async () => {
+      const req = {
+        tenantId,
+        user: { isCore: true, id: 'tester', roles: [] } as User,
+        params: { stream: 'test' },
+        query: {},
+        getConfiguration: jest.fn(),
+      };
+
+      const next = jest.fn();
+
+      req.getConfiguration.mockResolvedValueOnce({ test: stream });
+      await getStream(
+        tenantServiceMock as unknown as TenantService,
+        req as unknown as Request,
+        null,
+        req.params.stream,
+        next
+      );
+      expect(req['stream']).toBe(stream);
     });
 
     it('can call next for not found', async () => {


### PR DESCRIPTION
…h items that include tenant information for connections under a core context.