### PR TITLE
feat(value-service): adding flag to value definition for controlling …

### DIFF
--- a/apps/value-service/src/main.ts
+++ b/apps/value-service/src/main.ts
@@ -51,7 +51,10 @@ const initializeApp = async () => {
             description: 'Writer role for writing new values.',
           },
         ],
-        configurationSchema,
+        configuration: {
+          description: 'Definitions for values including write schema and option to enable write events.',
+          schema: configurationSchema,
+        },
         events: [ValueWrittenDefinition],
         clientSecret: environment.CLIENT_SECRET,
         directoryUrl: new URL(environment.DIRECTORY_URL),

--- a/apps/value-service/src/values/configuration.ts
+++ b/apps/value-service/src/values/configuration.ts
@@ -13,6 +13,7 @@ export const configurationSchema = {
             displayName: { type: 'string' },
             description: { type: 'string' },
             jsonSchema: { type: 'object' },
+            sendWriteEvent: { type: 'boolean' },
           },
           required: ['name', 'description', 'jsonSchema'],
           additionalProperties: false,

--- a/apps/value-service/src/values/events.ts
+++ b/apps/value-service/src/values/events.ts
@@ -3,7 +3,8 @@ import { Value } from './types';
 
 export const ValueWrittenDefinition: DomainEventDefinition = {
   name: 'value-written',
-  description: 'Signalled when a value is written to',
+  description:
+    'Signalled when a value is written to. This event is only sent for values of value definitions configured to send write events.',
   payloadSchema: {
     type: 'object',
     properties: {
@@ -19,8 +20,8 @@ export const ValueWrittenDefinition: DomainEventDefinition = {
     },
   },
   log: {
-    skip: true
-  }
+    skip: true,
+  },
 };
 
 export function valueWritten(

--- a/apps/value-service/src/values/model/definition.ts
+++ b/apps/value-service/src/values/model/definition.ts
@@ -13,6 +13,7 @@ export class ValueDefinitionEntity implements ValueDefinition {
   public description: string;
   public type: string;
   public jsonSchema: Record<string, unknown>;
+  public sendWriteEvent: boolean;
 
   constructor(public namespace: NamespaceEntity, definition: ValueDefinition) {
     this.namespace = namespace;
@@ -20,6 +21,7 @@ export class ValueDefinitionEntity implements ValueDefinition {
     this.description = definition.description;
     this.type = definition.type;
     this.jsonSchema = definition.jsonSchema;
+    this.sendWriteEvent = definition.sendWriteEvent || false;
     namespace.validationService.setSchema(this.getSchemaKey(), definition.jsonSchema || {});
   }
 

--- a/apps/value-service/src/values/router/value.ts
+++ b/apps/value-service/src/values/router/value.ts
@@ -226,7 +226,12 @@ export function writeValue(logger: Logger, eventService: EventService, repositor
           }
 
           results.push(result);
-          eventService.send(valueWritten(req.user, namespace, name, result));
+
+          // Only send write events for value definitions configured to emit write events.
+          // TODO: This is better encapsulated in ValueDefinitionEntity.writeValue ?
+          if (definition?.sendWriteEvent) {
+            eventService.send(valueWritten(req.user, namespace, name, result));
+          }
 
           logger.info(`Value ${namespace}:${name} written by user ${user.name} (ID: ${user.id}).`, {
             context: 'value-router',

--- a/apps/value-service/src/values/types/valueDefinition.ts
+++ b/apps/value-service/src/values/types/valueDefinition.ts
@@ -3,4 +3,5 @@ export interface ValueDefinition {
   description: string;
   type: string;
   jsonSchema: Record<string, unknown>;
+  sendWriteEvent?: boolean;
 }


### PR DESCRIPTION
…if writes send events. Value write events are not used for any current values (event log, metrics) and introduce a lot of extraneous events into the event system.