### PR TITLE
CS-1649 - mongodb can't unique a on an array so...

### DIFF
--- a/apps/directory-service/src/mongo/repository.ts
+++ b/apps/directory-service/src/mongo/repository.ts
@@ -79,11 +79,19 @@ export class MongoDirectoryRepository implements DirectoryRepository {
   }
 
   update(directory: Directory): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) =>
-      this.directoryModel.findOneAndUpdate({ name: directory.name }, directory, { upsert: true }, (err, doc) =>
+    return new Promise<boolean>((resolve, reject) => {
+      const uniqueServices = [];
+      directory.services.forEach((entry) => {
+        if (!uniqueServices.map((uniqueService) => uniqueService.service).includes(entry.service)) {
+          uniqueServices.push(entry);
+        }
+      });
+      directory.services = uniqueServices;
+
+      return this.directoryModel.findOneAndUpdate({ name: directory.name }, directory, { upsert: true }, (err, doc) =>
         err ? reject(err) : resolve(!!doc)
-      )
-    );
+      );
+    });
   }
 
   async exists(name: string): Promise<boolean> {


### PR DESCRIPTION
..Implemention has to be done manually - filtering out unique elements -
the api already has a unique check, but it doesn't get triggered when
you bootstrap things

https://www.mongodb.com/community/forums/t/unique-key-on-array-fields-in-a-single-document/3453/5