### PR TITLE
chore(tenant-management-api): changing to add all except the realm-ma…

### DIFF
--- a/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
@@ -174,7 +174,10 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce(testerRole);
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });
-      keycloakClientMock.clients.listRoles.mockResolvedValueOnce([{ id: 'realm-admin-role-123', name: 'realm-admin' }]);
+      keycloakClientMock.clients.listRoles.mockResolvedValueOnce([
+        { id: 'realm-admin-role-123', name: 'realm-admin' },
+        { id: 'realm-admin-role-321', name: 'manage-realm' },
+      ]);
 
       axiosMock.get.mockResolvedValueOnce({ data: [{ id: 'execution-123' }] });
 
@@ -219,7 +222,7 @@ describe('KeycloakRealmService', () => {
         expect.objectContaining({
           id: 'admin-user-123',
           realm,
-          roles: expect.arrayContaining([expect.objectContaining({ id: 'realm-admin-role-123' })]),
+          roles: expect.arrayContaining([expect.objectContaining({ id: 'realm-admin-role-321' })]),
         })
       );
       expect(keycloakClientMock.users.addClientRoleMappings).toHaveBeenCalledWith(

--- a/apps/tenant-management-api/src/keycloak/keycloak.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.ts
@@ -123,7 +123,7 @@ export class KeycloakRealmServiceImpl implements RealmService {
       });
     }
 
-    this.logger.debug(`Add realm management roles to user: ${util.inspect(roleMapping)}`, LOG_CONTEXT);
+    this.logger.debug(`Adding realm management roles to user: ${util.inspect(roleMapping)}`, LOG_CONTEXT);
     await client.users.addClientRoleMappings(roleMapping);
 
     this.logger.debug(`Adding tenant admin role to user.`, LOG_CONTEXT);


### PR DESCRIPTION
…nagement realm-admin role to the tenant admin.

There appears to be some specific handling around realm-admin making realm-admin not available to the master realm context service account with realm permissions via the associated client in master realm (perhaps because realm-admin doesn't exist in that client).