### PR TITLE
chore: update dotnet namespace access unit test

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/dashboard/dashboard.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/dashboard/dashboard.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { GoAButton, GoACallout } from '@abgov/react-components';
-import { GoACard, GoAIcon, GoAInput } from '@abgov/react-components/experimental';
+import { GoACard } from '@abgov/react-components/experimental';
 import { Link } from 'react-router-dom';
 import ReactTooltip from 'react-tooltip';
 import { Grid, GridItem } from '@components/Grid';
@@ -9,58 +9,6 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@store/index';
 import styled from 'styled-components';
 import CopyIcon from '@icons/copy-outline.svg';
-import { GoAButton as GoAButtonV2, GoAChip } from '@abgov/react-components-new';
-
-interface ExternalLink {
-  link: string;
-  name: string;
-}
-
-const ExternalLink = ({ link, name }: ExternalLink): JSX.Element => {
-  return (
-    <ExternalLinkWrapper>
-      <a href={link} rel="noopener noreferrer" target="_blank">
-        {name}
-      </a>
-    </ExternalLinkWrapper>
-  );
-};
-
-interface LinkCopyComponentProps {
-  link: string;
-}
-
-const LinkCopyComponentWrapper = styled.div`
-  input {
-    width: 80%;
-    height: 48px;
-    border-width: 2px 2px 2px 0px;
-  }
-`;
-
-const LinkCopyComponent = ({ link }: LinkCopyComponentProps): JSX.Element => {
-  const [isCopied, setIsCopied] = useState<boolean>(false);
-
-  return (
-    <LinkCopyComponentWrapper>
-      {isCopied && <GoAChip content="Link copied to clipboard" leadingIcon="checkmark-circle" />}
-      <GoAButtonV2
-        type="tertiary"
-        leadingIcon="open"
-        onClick={() => {
-          navigator.clipboard.writeText(link);
-          setIsCopied(true);
-        }}
-      >
-        Copy link
-      </GoAButtonV2>
-    </LinkCopyComponentWrapper>
-  );
-};
-
-interface StaticLinkInputProps {
-  link: string;
-}
 
 const Dashboard = (): JSX.Element => {
   const tenantAdminRole = 'tenant-admin';
@@ -207,25 +155,33 @@ const Dashboard = (): JSX.Element => {
             <p>To give another user limited access to your realm:</p>
 
             <p>
-              <ListWrapper>
-                <li>
-                  Share the login URL below and have your user <ExternalLink link={loginUrl} name="login" /> once to
-                  create their account.
-                </li>
-                <li>
-                  Add the 'tenant-admin' role to the user's assigned roles from{' '}
-                  <ExternalLink link={getKeycloakAdminPortalUsers()} name="here" />
-                  <br />
-                  (Role Mapping › Client Roles › urn:ads:platform:tenant-service › Add selected)
-                </li>
-                <li>
-                  Once granted the role, the user can access tenant admin using the URL below.
-                  <br />
-                  <LinkCopyComponent link={loginUrl} />
-                </li>
-              </ListWrapper>
+              1. Add the 'tenant-admin' role to the user's assigned roles from{' '}
+              <a href={getKeycloakAdminPortalUsers()} rel="noopener noreferrer" target="_blank">
+                here
+              </a>
             </p>
-            <br />
+            <div className="small-font mt-2">
+              (Role Mapping &#8250; Client Roles &#8250; urn:ads:platform:tenant-service &#8250; Add selected)
+            </div>
+
+            <p>2. Share the following URL to complete the process.</p>
+
+            <div className="copy-url">
+              <a target="_blank" href={loginUrl} rel="noreferrer">
+                {loginUrl}
+              </a>
+            </div>
+            <GoAButton data-tip="Copied!" data-for="registerTipUrl">
+              Click to copy
+            </GoAButton>
+            <ReactTooltip
+              id="registerTipUrl"
+              place="top"
+              event="click"
+              eventOff="blur"
+              effect="solid"
+              afterShow={() => _afterShow(loginUrl)}
+            />
           </DashboardAside>
         </Page>
         <footer>
@@ -272,7 +228,7 @@ const DashboardAside = styled(Aside)`
   padding-top: 1.6em;
 
   .copy-url {
-    font - size: var(--fs-sm);
+            font - size: var(--fs-sm);
     background-color: var(--color-gray-100);
     border: 1px solid var(--color-gray-300);
     border-radius: 1px;
@@ -288,7 +244,7 @@ const DashboardAside = styled(Aside)`
   }
 
   .mt-2 {
-    margin - top: 2em;
+            margin - top: 2em;
   }
 `;
 const DashboardDiv = styled.div`
@@ -298,19 +254,4 @@ const DashboardDiv = styled.div`
     }
   }
   margin-bottom: 2.5rem;
-`;
-
-const ExternalLinkWrapper = styled.div`
-  display: inline-block;
-  .goa-icon {
-    display: inline !important;
-  }
-`;
-
-const ListWrapper = styled.ul`
-  list-style-type: value;
-  margin-left: 1rem;
-  li {
-    margin-bottom: 0.5rem;
-  }
 `;

--- a/apps/tenant-management-webapp/src/app/pages/admin/dashboard/dashboard.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/dashboard/dashboard.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GoAButton, GoACallout } from '@abgov/react-components';
-import { GoACard } from '@abgov/react-components/experimental';
+import { GoACard, GoAIcon, GoAInput } from '@abgov/react-components/experimental';
 import { Link } from 'react-router-dom';
 import ReactTooltip from 'react-tooltip';
 import { Grid, GridItem } from '@components/Grid';
@@ -9,6 +9,58 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@store/index';
 import styled from 'styled-components';
 import CopyIcon from '@icons/copy-outline.svg';
+import { GoAButton as GoAButtonV2, GoAChip } from '@abgov/react-components-new';
+
+interface ExternalLink {
+  link: string;
+  name: string;
+}
+
+const ExternalLink = ({ link, name }: ExternalLink): JSX.Element => {
+  return (
+    <ExternalLinkWrapper>
+      <a href={link} rel="noopener noreferrer" target="_blank">
+        {name}
+      </a>
+    </ExternalLinkWrapper>
+  );
+};
+
+interface LinkCopyComponentProps {
+  link: string;
+}
+
+const LinkCopyComponentWrapper = styled.div`
+  input {
+    width: 80%;
+    height: 48px;
+    border-width: 2px 2px 2px 0px;
+  }
+`;
+
+const LinkCopyComponent = ({ link }: LinkCopyComponentProps): JSX.Element => {
+  const [isCopied, setIsCopied] = useState<boolean>(false);
+
+  return (
+    <LinkCopyComponentWrapper>
+      {isCopied && <GoAChip content="Link copied to clipboard" leadingIcon="checkmark-circle" />}
+      <GoAButtonV2
+        type="tertiary"
+        leadingIcon="open"
+        onClick={() => {
+          navigator.clipboard.writeText(link);
+          setIsCopied(true);
+        }}
+      >
+        Copy link
+      </GoAButtonV2>
+    </LinkCopyComponentWrapper>
+  );
+};
+
+interface StaticLinkInputProps {
+  link: string;
+}
 
 const Dashboard = (): JSX.Element => {
   const tenantAdminRole = 'tenant-admin';
@@ -155,33 +207,25 @@ const Dashboard = (): JSX.Element => {
             <p>To give another user limited access to your realm:</p>
 
             <p>
-              1. Add the 'tenant-admin' role to the user's assigned roles from{' '}
-              <a href={getKeycloakAdminPortalUsers()} rel="noopener noreferrer" target="_blank">
-                here
-              </a>
+              <ListWrapper>
+                <li>
+                  Share the login URL below and have your user <ExternalLink link={loginUrl} name="login" /> once to
+                  create their account.
+                </li>
+                <li>
+                  Add the 'tenant-admin' role to the user's assigned roles from{' '}
+                  <ExternalLink link={getKeycloakAdminPortalUsers()} name="here" />
+                  <br />
+                  (Role Mapping › Client Roles › urn:ads:platform:tenant-service › Add selected)
+                </li>
+                <li>
+                  Once granted the role, the user can access tenant admin using the URL below.
+                  <br />
+                  <LinkCopyComponent link={loginUrl} />
+                </li>
+              </ListWrapper>
             </p>
-            <div className="small-font mt-2">
-              (Role Mapping &#8250; Client Roles &#8250; urn:ads:platform:tenant-service &#8250; Add selected)
-            </div>
-
-            <p>2. Share the following URL to complete the process.</p>
-
-            <div className="copy-url">
-              <a target="_blank" href={loginUrl} rel="noreferrer">
-                {loginUrl}
-              </a>
-            </div>
-            <GoAButton data-tip="Copied!" data-for="registerTipUrl">
-              Click to copy
-            </GoAButton>
-            <ReactTooltip
-              id="registerTipUrl"
-              place="top"
-              event="click"
-              eventOff="blur"
-              effect="solid"
-              afterShow={() => _afterShow(loginUrl)}
-            />
+            <br />
           </DashboardAside>
         </Page>
         <footer>
@@ -228,7 +272,7 @@ const DashboardAside = styled(Aside)`
   padding-top: 1.6em;
 
   .copy-url {
-            font - size: var(--fs-sm);
+    font - size: var(--fs-sm);
     background-color: var(--color-gray-100);
     border: 1px solid var(--color-gray-300);
     border-radius: 1px;
@@ -244,7 +288,7 @@ const DashboardAside = styled(Aside)`
   }
 
   .mt-2 {
-            margin - top: 2em;
+    margin - top: 2em;
   }
 `;
 const DashboardDiv = styled.div`
@@ -254,4 +298,19 @@ const DashboardDiv = styled.div`
     }
   }
   margin-bottom: 2.5rem;
+`;
+
+const ExternalLinkWrapper = styled.div`
+  display: inline-block;
+  .goa-icon {
+    display: inline !important;
+  }
+`;
+
+const ListWrapper = styled.ul`
+  list-style-type: value;
+  margin-left: 1rem;
+  li {
+    margin-bottom: 0.5rem;
+  }
 `;

--- a/libs/adsp-service-net-sdk/Access/AccessExtensions.Spec.cs
+++ b/libs/adsp-service-net-sdk/Access/AccessExtensions.Spec.cs
@@ -1,0 +1,407 @@
+using Adsp.Sdk.Access;
+using FluentAssertions;
+using Xunit;
+using System.Web;
+using Microsoft.AspNetCore.Authentication;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Adsp.Sdk;
+using Microsoft.Extensions.DependencyInjection;
+using Adsp.Sdk.Tenancy;
+using Microsoft.Extensions.Caching.Memory;
+using RichardSzalay.MockHttp;
+using RestSharp;
+using Adsp.Sdk.Access.Tests;
+using Adsp.Sdk.Directory;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Cryptography;
+using System.Text;
+using System;
+using Microsoft.AspNetCore.Http;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Principal;
+using System.Security.Claims;
+
+namespace Adsp.Sdk.Access.Tests;
+
+public class AccessExtensionsTests
+{
+
+  private static IServiceDirectory CreateFakeServiceDirectory()
+  {
+    var serviceDirectory = new Mock<IServiceDirectory>();
+    serviceDirectory
+    .Setup((d) => d.GetServiceUrl(AdspId.Parse("urn:ads:platform:tenant-service:v2")))
+    .ReturnsAsync(new Uri("https://tenant-service/tenants/v2"));
+
+    return serviceDirectory.Object;
+  }
+
+  private static Tenant CreateFakeTenant()
+  {
+    var tenant = new Tenant();
+    tenant.Name = "test-tenant";
+    tenant.Id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tenant.AdminEmail = "tester@gov.ab.ca";
+
+    // realm name shall be consisted with http response content.
+    tenant.Realm = "fake-realm";
+    return tenant;
+  }
+
+  private static AdspOptions CreateFakeOptions()
+  {
+
+    AdspOptions adspOptions = new AdspOptions()
+    {
+      AccessServiceUrl = new Uri("http://www.mock-test.com/"),
+      ServiceId = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test"),
+      Realm = "fake-realm"
+    };
+
+    return adspOptions;
+  }
+
+  private static ITokenProvider CreateFakeTokenProvider()
+  {
+    var tokenProvider = new Mock<ITokenProvider>();
+    tokenProvider.Setup((t) => t.GetAccessToken());
+    return tokenProvider.Object;
+  }
+
+  private static ITenantService CreateFakeTenantService()
+  {
+    var tenantService = new Mock<ITenantService>();
+
+    tenantService.Setup((t) => t.GetTenantByRealm("fake-realm"))
+      .ReturnsAsync(CreateFakeTenant());
+
+    return tenantService.Object;
+
+  }
+
+  private static SecurityKey CreateFakeSecurityKey()
+  {
+    var fakeSecret = "asdv234234^&%&^%&^hjsdfb2%%%";
+    return new SymmetricSecurityKey(Encoding.ASCII.GetBytes(fakeSecret));
+  }
+
+  private static ITenantKeyProvider CreateFakeKeyProvider()
+  {
+    var keyProvider = new Mock<ITenantKeyProvider>();
+    var fakeKid = "tlbK5byYcGdR1eyujaHtxrY1czP_dWs63s8kEeSMdes";
+    var issuer = "fake-issuer";
+
+    keyProvider.Setup(
+        p => p.ResolveSigningKey(issuer, fakeKid)
+      ).Returns(
+        Task.FromResult(CreateFakeSecurityKey() ?? null)
+      );
+
+    return keyProvider.Object;
+
+  }
+
+  private static TokenValidatedContext CreateFakeTokenValidatedContext()
+  {
+    var httpContext = new DefaultHttpContext()
+    {
+      User = CreateFakeUser()
+    };
+
+    var fakeJwtBearerOption = new Mock<JwtBearerOptions>();
+    var tokenHandler = new JwtSecurityTokenHandler();
+
+    var AuthenticationScheme = new AuthenticationScheme(
+      "fake-scheme",
+      null,
+      typeof(JwtBearerHandler)
+    );
+
+    var context = new Mock<TokenValidatedContext>(
+      httpContext,
+      AuthenticationScheme,
+      fakeJwtBearerOption.Object)
+    {
+
+    };
+
+    return context.Object;
+  }
+
+  private static AuthenticationBuilder CreateFakeAuthenticationBuilder()
+  {
+    var mockServices = new Mock<IServiceCollection>();
+    return new AuthenticationBuilder(mockServices.Object);
+  }
+
+
+  private static IIssuerCache CreateFakeIssuerCache()
+  {
+
+    var issuerCache = new Mock<IIssuerCache>();
+
+    issuerCache.Setup(
+      p => p.GetTenantByIssuer("fake-issuer")
+    ).ReturnsAsync(() => null);
+
+    return issuerCache.Object;
+  }
+
+  private static ClaimsPrincipal CreateFakeUser()
+  {
+
+    var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+    {
+        new Claim(ClaimTypes.NameIdentifier, "1"),
+        new Claim(ClaimTypes.Name, "fake-user"),
+    }, "mock"));
+
+    return user;
+  }
+
+
+  [Fact]
+  public void CanAddRealmJwtAuthentication()
+  {
+
+    var tenantScheme = AdspAuthenticationSchemes.Tenant;
+    var fakeAuthBuilder = CreateFakeAuthenticationBuilder();
+    var adspOptions = CreateFakeOptions();
+    var tenantService = CreateFakeTenantService();
+
+    var builder = AccessExtensions.AddRealmJwtAuthentication(
+        fakeAuthBuilder,
+        tenantScheme,
+        tenantService,
+        adspOptions
+    );
+
+    builder.Should().NotBeNull();
+  }
+
+  [Fact]
+  public void CanAddTenantJwtAuthentication()
+  {
+    var fakeAuthBuilder = CreateFakeAuthenticationBuilder();
+    var tenantScheme = AdspAuthenticationSchemes.Tenant;
+    var tenantService = CreateFakeTenantService();
+    var tenantKeyProvider = CreateFakeKeyProvider();
+    var issuerCache = CreateFakeIssuerCache();
+    var adspOptions = CreateFakeOptions();
+
+    var builder = AccessExtensions.AddTenantJwtAuthentication(
+        fakeAuthBuilder,
+        tenantScheme,
+        issuerCache,
+        tenantKeyProvider,
+        adspOptions
+    );
+    builder.Should().NotBeNull();
+  }
+
+  [Fact]
+  [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1806:Do not ignore method results", Justification = "Will not create object")]
+  public void WillThrowExceptionForInvalidOptionsInAddTenantJwtAuthentication()
+  {
+
+    var fakeAuthBuilder = CreateFakeAuthenticationBuilder();
+    var tenantScheme = AdspAuthenticationSchemes.Tenant;
+    var tenantService = CreateFakeTenantService();
+    var tenantKeyProvider = CreateFakeKeyProvider();
+    var issuerCache = CreateFakeIssuerCache();
+
+    Action NoServiceIdInOptionAction = () =>
+    {
+
+      AdspOptions adspOptions = new AdspOptions()
+      {
+        AccessServiceUrl = new Uri("http://www.mock-test.com/"),
+        Realm = "fake-realm"
+      };
+
+      AccessExtensions.AddTenantJwtAuthentication(
+          fakeAuthBuilder,
+          tenantScheme,
+          issuerCache,
+          tenantKeyProvider,
+          adspOptions
+      );
+    };
+
+    NoServiceIdInOptionAction.Should()
+  .Throw<System.ArgumentException>()
+  .Where(e => e.Message.StartsWith("Provided options must include value for ServiceId."));
+  }
+
+
+
+  [Fact]
+  [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1806:Do not ignore method results", Justification = "Will not create object")]
+  public void WillThrowExceptionForInvalidOptionsInAddRealmJwtAuthentication()
+  {
+    var tenantScheme = AdspAuthenticationSchemes.Tenant;
+    var fakeAuthBuilder = CreateFakeAuthenticationBuilder();
+    var tenantService = CreateFakeTenantService();
+
+    Action NoAccessServiceUrlInOptionAction = () =>
+    {
+
+      AdspOptions adspOptions = new AdspOptions()
+      {
+        ServiceId = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test"),
+        Realm = "fake-realm"
+      };
+
+      AccessExtensions.AddRealmJwtAuthentication(
+        fakeAuthBuilder,
+        tenantScheme,
+        tenantService,
+        adspOptions
+      );
+    };
+
+    NoAccessServiceUrlInOptionAction.Should()
+      .Throw<System.ArgumentException>()
+      .Where(e => e.Message.StartsWith("Provided options must include value for AccessServiceUrl"));
+
+
+    Action NoServerIdInOptionAction = () =>
+    {
+
+      AdspOptions adspOptions = new AdspOptions()
+      {
+        AccessServiceUrl = new Uri("http://www.mock-test.com/"),
+        Realm = "fake-realm"
+      };
+
+      AccessExtensions.AddRealmJwtAuthentication(
+        fakeAuthBuilder,
+        tenantScheme,
+        tenantService,
+        adspOptions
+      );
+    };
+
+    NoServerIdInOptionAction.Should()
+      .Throw<System.ArgumentException>()
+      .Where(e => e.Message.StartsWith("Provided options must include value for ServiceId."));
+
+
+    Action NoRealmInOptionAction = () =>
+    {
+
+      AdspOptions adspOptions = new AdspOptions()
+      {
+        AccessServiceUrl = new Uri("http://www.mock-test.com/"),
+        ServiceId = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test"),
+
+      };
+
+      AccessExtensions.AddRealmJwtAuthentication(
+      fakeAuthBuilder,
+      tenantScheme,
+      tenantService,
+      adspOptions);
+    };
+
+    NoRealmInOptionAction.Should()
+      .Throw<System.ArgumentException>()
+      .Where(e => e.Message.StartsWith("Provided options must include tenant realm for tenant authentication scheme."));
+  }
+
+  [Fact]
+  public void CanValidateTokenContextWithNoPrinciple()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, true, tenant);
+    context?.Principal.Should().BeNull();
+  }
+
+  [Fact]
+  public void CanValidateTokenContextWithSubClaim()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tokenContext.Principal = CreateFakeUser();
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, true, tenant);
+    context.HttpContext.Items[AccessConstants.AdspContextKey].Should().NotBeNull();
+  }
+
+  [Fact]
+  public void CanValidateTokenContextWithNotCore()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tokenContext.Principal = CreateFakeUser();
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, false, tenant);
+    context.HttpContext.Items[AccessConstants.AdspContextKey].Should().NotBeNull();
+  }
+
+  [Fact]
+  public void CanValidateTokenContextWithoutTenant()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tokenContext.Principal = CreateFakeUser();
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, false, null);
+    context.HttpContext.Items[AccessConstants.AdspContextKey].Should().NotBeNull();
+  }
+
+  [Fact]
+  public void CanValidateTokenContextWithRealmAccess()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+    {
+        new Claim(ClaimTypes.NameIdentifier, "1"),
+        new Claim(ClaimTypes.Name, "fake-user"),
+        new Claim("realm_access", "{\"Roles\":[\"fake-roles\"]}")
+    }, "mock"));
+
+    tokenContext.Principal = user;
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, false, null);
+    context.HttpContext.Items[AccessConstants.AdspContextKey].Should().NotBeNull();
+  }
+
+  [Fact]
+  public void CanValidateTokenContextWithResourceAccess()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+    {
+        new Claim(ClaimTypes.NameIdentifier, "1"),
+        new Claim(ClaimTypes.Name, "fake-user"),
+        new Claim("realm_access", "{\"Roles\":[\"fake-roles\"]}"),
+        new Claim("resource_access", "{\"fake-resource\":{\"Roles\":[\"fake-resource-roles\"]}}")
+    }, "mock"));
+
+    tokenContext.Principal = user;
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, false, null);
+    context.HttpContext.Items[AccessConstants.AdspContextKey].Should().NotBeNull();
+  }
+
+
+  [Fact]
+  public void CanValidateTokenContextForCoreRealm()
+  {
+    var tokenContext = CreateFakeTokenValidatedContext();
+    var tenant = CreateFakeTenant();
+    tenant.Id = null;
+    var id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tokenContext.Principal = CreateFakeUser();
+    var context = AccessExtensions.AddAdspContext(tokenContext, id, true, null);
+    context.HttpContext.Items[AccessConstants.AdspContextKey].Should().NotBeNull();
+  }
+}

--- a/libs/adsp-service-net-sdk/Access/AccessExtensions.cs
+++ b/libs/adsp-service-net-sdk/Access/AccessExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.IdentityModel.Tokens;
 namespace Adsp.Sdk.Access;
 internal static class AccessExtensions
 {
-  private static TokenValidatedContext AddAdspContext(this TokenValidatedContext context, AdspId serviceId, bool isCore, Tenant? tenant)
+  internal static TokenValidatedContext AddAdspContext(this TokenValidatedContext context, AdspId serviceId, bool isCore, Tenant? tenant)
   {
     var subClaim = context.Principal?.Claims.FirstOrDefault(claim => claim.Type == ClaimTypes.NameIdentifier);
     var usernameClaim = context.Principal?.Claims.FirstOrDefault(claim => claim.Type == "preferred_username");
@@ -96,6 +96,7 @@ internal static class AccessExtensions
     AdspOptions options
   )
   {
+
     if (options.AccessServiceUrl == null)
     {
       throw new ArgumentException("Provided options must include value for AccessServiceUrl.", nameof(options));
@@ -103,7 +104,7 @@ internal static class AccessExtensions
 
     if (options.ServiceId == null)
     {
-      throw new ArgumentException("Provided options must include value for AccessServiceUrl.", nameof(options));
+      throw new ArgumentException("Provided options must include value for ServiceId.", nameof(options));
     }
 
     if (
@@ -115,6 +116,7 @@ internal static class AccessExtensions
     }
     var isCore = String.Equals(AdspAuthenticationSchemes.Core, authenticationScheme, StringComparison.Ordinal);
     var realm = isCore ? AccessConstants.CoreRealm : options.Realm;
+
 
     builder.AddJwtBearer(
       authenticationScheme,
@@ -154,7 +156,7 @@ internal static class AccessExtensions
   {
     if (options.ServiceId == null)
     {
-      throw new ArgumentException("Provided options must include value for AccessServiceUrl.", nameof(options));
+      throw new ArgumentException("Provided options must include value for ServiceId.", nameof(options));
     }
 
     builder.AddJwtBearer(authenticationScheme, jwt =>

--- a/libs/adsp-service-net-sdk/Access/IssuerCache.Spec.cs
+++ b/libs/adsp-service-net-sdk/Access/IssuerCache.Spec.cs
@@ -1,0 +1,112 @@
+using Adsp.Sdk.Access;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Moq;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using RichardSzalay.MockHttp;
+using RestSharp;
+using Adsp.Sdk.Tenancy;
+using Adsp.Sdk.Directory;
+
+namespace Adsp.Sdk.Access.Tests;
+
+public class IssuerCacheTests
+{
+  private static IOptions<AdspOptions> CreateFakeOptions()
+  {
+
+    AdspOptions adspOptions = new AdspOptions()
+    {
+      AccessServiceUrl = new Uri("http://www.mock-test.com/")
+    };
+    IOptions<AdspOptions> options = Options.Create(adspOptions);
+
+    return options;
+  }
+
+  private static Tenant CreateFakeTenant()
+  {
+    var tenant = new Tenant();
+    tenant.Name = "test-tenant";
+    tenant.Id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tenant.AdminEmail = "tester@gov.ab.ca";
+
+    // realm name shall be consisted with http response content.
+    tenant.Realm = "fake-realm";
+    return tenant;
+  }
+
+  private static ITenantService CreateFakeTenantService()
+  {
+    var tenantService = new Mock<ITenantService>();
+    var tenants = new List<Tenant>();
+    tenants.Add(CreateFakeTenant());
+    tenantService.Setup(
+      p => p.GetTenants()
+    ).ReturnsAsync(tenants);
+
+    return tenantService.Object;
+  }
+
+  [Fact]
+  public void CanCreateIssuerCache()
+  {
+    var logger = Mock.Of<ILogger<IssuerCache>>();
+    var cache = Mock.Of<IMemoryCache>();
+    var tenantService = Mock.Of<ITenantService>();
+    var options = CreateFakeOptions();
+    var issuerCache = new IssuerCache(logger, cache, tenantService, options);
+    issuerCache.Should().NotBeNull();
+  }
+
+  [Fact]
+  public void CanThrowExceptionForWrongOptions()
+  {
+    var adspOptions = new AdspOptions();
+    var options = Options.Create(adspOptions);
+    var logger = Mock.Of<ILogger<IssuerCache>>();
+    var cache = Mock.Of<IMemoryCache>();
+    var tenantService = Mock.Of<ITenantService>();
+
+    Action newIssuerCacheAction = () =>
+    {
+      var issuerCache = new IssuerCache(logger, cache, tenantService, options);
+    };
+
+    newIssuerCacheAction.Should()
+      .Throw<System.ArgumentException>()
+      .Where(e => e.Message.StartsWith("Provided options must include value for AccessServiceUrl"));
+  }
+
+
+  [Fact]
+  public async Task CanGetTenantIssuerFromCache()
+  {
+    var logger = Mock.Of<ILogger<IssuerCache>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+    var tenant = new Tenant();
+    tenant.Name = "fake-tenant";
+    cache.Set("fake-issuer", tenant);
+    var tenantService = Mock.Of<ITenantService>();
+    var issuerCache = new IssuerCache(logger, cache, tenantService, options);
+    var tenantInCache = await issuerCache.GetTenantByIssuer("fake-issuer");
+    tenantInCache?.Name.Should().Be(tenant.Name);
+  }
+
+  [Fact]
+  public async Task CanGetTenantIssuerFromRemote()
+  {
+    var logger = Mock.Of<ILogger<IssuerCache>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+
+    var tenantService = CreateFakeTenantService();
+    var issuer = "http://www.mock-test.com/auth/realms/fake-realm";
+    var issuerCache = new IssuerCache(logger, cache, tenantService, options);
+    var tenant = await issuerCache.GetTenantByIssuer(issuer);
+    tenant?.Name.Should().Be("test-tenant");
+  }
+}

--- a/libs/adsp-service-net-sdk/Access/TenantKeyProvider.Spec.cs
+++ b/libs/adsp-service-net-sdk/Access/TenantKeyProvider.Spec.cs
@@ -1,0 +1,245 @@
+using Adsp.Sdk.Access;
+using FluentAssertions;
+using Xunit;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using RichardSzalay.MockHttp;
+using System.Security.Cryptography;
+using System.Text;
+using RestSharp;
+
+namespace Adsp.Sdk.Access.Tests;
+public class TenantKeyProviderTests
+{
+
+  private static IOptions<AdspOptions> CreateFakeOptions()
+  {
+
+    AdspOptions adspOptions = new AdspOptions()
+    {
+      AccessServiceUrl = new Uri("http://www.mock-test.com/")
+    };
+    IOptions<AdspOptions> options = Options.Create(adspOptions);
+
+    return options;
+  }
+
+  private static Tenant CreateFakeTenant()
+  {
+    var tenant = new Tenant();
+    tenant.Name = "test-tenant";
+    tenant.Id = AdspId.Parse("urn:ads:platform:tenant-service:v2:/tenants/test");
+    tenant.AdminEmail = "tester@gov.ab.ca";
+
+    // realm name shall be consisted with http response content.
+    tenant.Realm = "fake-realm";
+    return tenant;
+  }
+
+  private static SecurityKey CreateFakeSecurityKey()
+  {
+    var fakeSecret = "asdv234234^&%&^%&^hjsdfb2%%%";
+    return new SymmetricSecurityKey(Encoding.ASCII.GetBytes(fakeSecret));
+  }
+
+  private static IIssuerCache CreateFakeIssuerCache(bool isNull = false)
+  {
+
+    var issuerCache = new Mock<IIssuerCache>();
+    if (isNull)
+    {
+      issuerCache.Setup(
+        p => p.GetTenantByIssuer("fake-issuer")
+      ).ReturnsAsync(() => null);
+    }
+    else
+    {
+
+      issuerCache.Setup(
+        p => p.GetTenantByIssuer("fake-issuer")
+      ).ReturnsAsync(CreateFakeTenant());
+    }
+
+    return issuerCache.Object;
+  }
+
+  [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2000:Dispose objects before losing scope", Justification = "Http client here will be disposed in TenantProvider Dispose function.")]
+  private static RestClient CreateFakeHttpClient(string realm)
+  {
+    var host = "https://fake-host.com";
+    var metadataPath = $"auth/realms/{realm}/.well-known/openid-configuration";
+    var metadataUrl = new Uri($"{host}/{metadataPath}");
+    var jwksUri = new Uri($"{host}/fake-jwks-path");
+    var mockHttp = new MockHttpMessageHandler();
+
+    mockHttp
+      .When(HttpMethod.Get, metadataUrl.AbsoluteUri)
+      .Respond(
+        "application/json",
+        "{\"issuer\":\"fake-issuer\",\"jwks_uri\":\"https://fake-host.com/fake-jwks-path\"}"
+      );
+
+    mockHttp
+      .When(HttpMethod.Get, jwksUri.AbsoluteUri)
+      .Respond(
+        "application/json",
+"{\"keys\":[{\"kid\":\"tlbK5byYcGdR1eyujaHtxrY1czP_dWs63s8kEeSMdes\",\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"n\":\"hvn2Pjnj_7oT7-EbPX-7pB2wk7g8BJzEgczkTiDh9-5WOt3SH9nRI4uAwYIXkpEmh5XzjfHwP2ePd8Fx7Oo5cRGL-XASOj7ZsdKuCXuhLXe9SWRyLYV_4pW6NJPPZfbrr1S-fTOWm1oiW936wjJ0fq5KPo5s1uPB8B_URS4-MtOfcdipKaR4AEVRUfYkGEiQCDswBSjBV6RV_zJ60mRXDk8XCqdmo7oGOvUfXByppXci4DhAWlDrpKyztkjSCNIdNaJo9UVY3YvpPNVcvB5f3ps6TH-4sVNa_ZjSEWVgVueTytSHjHTVZ8vXPF122pr3b-wrZgZVmwjksvLJHMFq2Q\",\"e\":\"AQAB\",\"x5c\":[\"MIIC1zCCAb8CBgF+eM7KiTANBgkqhkiG9w0BAQsFADAvMS0wKwYDVQQDDCRiNmFmZjc2Mi0yMGY4LTRjNWQtODhkMy1jMzhhZTE2ZDE5MzcwHhcNMjIwMTIwMTg0MzQ1WhcNMzIwMTIwMTg0NTI1WjAvMS0wKwYDVQQDDCRiNmFmZjc2Mi0yMGY4LTRjNWQtODhkMy1jMzhhZTE2ZDE5MzcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCG+fY+OeP/uhPv4Rs9f7ukHbCTuDwEnMSBzOROIOH37lY63dIf2dEji4DBgheSkSaHlfON8fA/Z493wXHs6jlxEYv5cBI6Ptmx0q4Je6Etd71JZHIthX/ilbo0k89l9uuvVL59M5abWiJb3frCMnR+rko+jmzW48HwH9RFLj4y059x2KkppHgARVFR9iQYSJAIOzAFKMFXpFX/MnrSZFcOTxcKp2ajugY69R9cHKmldyLgOEBaUOukrLO2SNII0h01omj1RVjdi+k81Vy8Hl/emzpMf7ixU1r9mNIRZWBW55PK1IeMdNVny9c8XXbamvdv7CtmBlWbCOSy8skcwWrZAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFujH1wRJDYArvMdKhU2dUYHneCkG6Z8DXdlIVz+0gNCSIdFUwMmlyEMFK4kmPC4pmvEXD13aYeSijcCKR0cgSESbsJohfcn51bEXT9jUGW3mmFXkWftzroIa9ogztDjr/CLFEmAr0RLeWV5eLbQi/Y2KdgZhzDLUY/sD9h3Kl9GbVhOzBLUWzgH+zHwNXWLhH77xbbvcH94AeN6RWMpyaTBWEAISg+UY2xA0zu6e2hpbs7MAweJDiS8ZhXmU6qLOZ7yHk9Iq1JL1knVpi1nNuHSZGXgZQYslKgghkHoMqEaMpigQKOr59opQUh8mPQeAJxtBeQMji/MWsEbi4WWIw0=\"],\"x5t\":\"67fiifDzfchm-BToFn-sc4NHAo8\",\"x5t#S256\":\"6Fvs_OYeZNw2WRo9gYwEyZMJk79S3XdrId9Zx7gtoKQ\"},{\"kid\":\"5FdwaPC0aOaPyC_DmDAt1AXhpVw68yx8ns5x9Wc-cfg\",\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"enc\",\"n\":\"6uXzBkFjvrL38Uy383R2yJOk1r953CMvRRKwGrL1UNsALW5Xi1WxrW1YeD9Pd_uTDNoOKLDRC4Lf3h3QUs8soJ_fJ4oBPvIcTWJs-qMpR9NkZjbUNfNuqpanG59ropyk3FV82-Xhgssv5Slu6_OKOCaPcOCWrXWRvvyu9_E7mp8uJ6wMCIdQgB-GhbloaQizWaWfC2nPSycJy21vQI0zp9yueJupgvzyi5biTgDnELYcBw0sqZxBy6KHPsqahHz-AMu6UG1MCkbjpiwNUDlyU-UqpYOLKqrKAmyrUQwEyTTWNT01DlYPeKjlpngXU4xlHHnBEgea9yE4iPPvfznQnQ\",\"e\":\"AQAB\",\"x5c\":[\"MIIC1zCCAb8CBgF+eM7MkjANBgkqhkiG9w0BAQsFADAvMS0wKwYDVQQDDCRiNmFmZjc2Mi0yMGY4LTRjNWQtODhkMy1jMzhhZTE2ZDE5MzcwHhcNMjIwMTIwMTg0MzQ1WhcNMzIwMTIwMTg0NTI1WjAvMS0wKwYDVQQDDCRiNmFmZjc2Mi0yMGY4LTRjNWQtODhkMy1jMzhhZTE2ZDE5MzcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDq5fMGQWO+svfxTLfzdHbIk6TWv3ncIy9FErAasvVQ2wAtbleLVbGtbVh4P093+5MM2g4osNELgt/eHdBSzyygn98nigE+8hxNYmz6oylH02RmNtQ1826qlqcbn2uinKTcVXzb5eGCyy/lKW7r84o4Jo9w4JatdZG+/K738Tuany4nrAwIh1CAH4aFuWhpCLNZpZ8Lac9LJwnLbW9AjTOn3K54m6mC/PKLluJOAOcQthwHDSypnEHLooc+ypqEfP4Ay7pQbUwKRuOmLA1QOXJT5Sqlg4sqqsoCbKtRDATJNNY1PTUOVg94qOWmeBdTjGUcecESB5r3ITiI8+9/OdCdAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJo72owOmt7iF8DEJKWiuKvgpCxLMW1huo/iePvxv6Sk135Mwo6gJeFtcGAj6jI9G+eq+Olv7cUEY06RxyJwMBk/FecqN4fNwmfQnN7/tjvBaxfRTrQiCLst4ftnI0HTnQMQupDRzlLVy3HyOQ2GU04PUYPoLViagxwcfqTk23aDmXAe+ceCIXy/QQWfiMTLk7fDhoua+CWRuDxCvfVkJeDQ/5DI0GS6cpMcr+j7LvgaB0lgBUt+vVHn3Pi3mvmZhjDc2HYORJMtuX7Tz4bHJK8J3Ah933t2b4W3MUrlRu7Tx52+VG9W7n1CfjKUU37sGeeGU9XlCwDe1AtB7VUvaOI=\"],\"x5t\":\"LCyvcIAibQy2hBuaaSqe4zkfUGI\",\"x5t#S256\":\"BBtrdUWAwDF1a3nP8dhCyLyFEQb9cTY_0A1logM3-ZA\"}]}");
+
+    mockHttp.Fallback.Throw(new InvalidOperationException("No matching mock handler"));
+
+    var client = new RestClient(
+      new RestClientOptions
+      {
+        BaseUrl = new Uri($"{host}"),
+        ConfigureMessageHandler = _ => mockHttp
+      }
+    );
+
+    return client;
+  }
+
+
+
+  [Fact]
+  public void CanCreateTenantKeyProvider()
+  {
+
+    var issuerCache = Mock.Of<IIssuerCache>();
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = Mock.Of<IMemoryCache>();
+    var options = CreateFakeOptions();
+    var tenantTokenProvider = new TenantKeyProvider(logger, cache, issuerCache, options);
+    tenantTokenProvider.Should().NotBeNull();
+    tenantTokenProvider.Dispose();
+  }
+
+  [Fact]
+  [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1806:Do not ignore method results", Justification = "Will not create object")]
+  public void WillThrowExceptionForInvalidOptions()
+  {
+
+    var issuerCache = Mock.Of<IIssuerCache>();
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = Mock.Of<IMemoryCache>();
+    var options = Options.Create(new AdspOptions() { });
+    Action newTokenProviderAction = () =>
+    {
+
+      new TenantKeyProvider(logger, cache, issuerCache, options);
+    };
+
+    newTokenProviderAction.Should()
+      .Throw<System.ArgumentException>()
+      .Where(e => e.Message.StartsWith("Provided options must include value for AccessServiceUrl"));
+  }
+
+  [Fact]
+  public async Task CanResolveSigningKeyFromCache()
+  {
+
+    var issuerCache = Mock.Of<IIssuerCache>();
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+    var fakeIssuer = "fake-issuer";
+    var fakeKid = "fake-kid";
+    cache.Set((fakeIssuer, fakeKid), CreateFakeSecurityKey());
+    var tenantTokenProvider = new TenantKeyProvider(logger, cache, issuerCache, options);
+
+    var keyFromCache = await tenantTokenProvider.ResolveSigningKey("fake-issuer", "fake-kid");
+    keyFromCache?.KeySize.Should().Be(224);
+    tenantTokenProvider.Dispose();
+
+  }
+
+  [Fact]
+  public async Task CanResolveSigningKeyFromRemote()
+  {
+
+    var issuerCache = CreateFakeIssuerCache();
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+    var fakeKid = "tlbK5byYcGdR1eyujaHtxrY1czP_dWs63s8kEeSMdes";
+    var realm = "fake-realm";
+    var client = CreateFakeHttpClient(realm);
+
+    var tenantTokenProvider = new TenantKeyProvider(
+      logger, cache, issuerCache,
+      options, client
+    );
+
+    var keyFromCache = await tenantTokenProvider.ResolveSigningKey("fake-issuer", fakeKid);
+
+    keyFromCache?.KeySize.Should().Be(2048);
+    tenantTokenProvider.Dispose();
+  }
+
+  [Fact]
+  public async Task CanRetrieveSigningKey()
+  {
+    var issuerCache = CreateFakeIssuerCache();
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+    var fakeKid = "tlbK5byYcGdR1eyujaHtxrY1czP_dWs63s8kEeSMdes";
+    var realm = "fake-realm";
+    var client = CreateFakeHttpClient(realm);
+    var tenantTokenProvider = new TenantKeyProvider(
+      logger, cache, issuerCache,
+      options, client
+    );
+
+    var keyFromCache = await tenantTokenProvider.RetrieveSigningKey("fake-issuer", fakeKid);
+    keyFromCache?.KeySize.Should().Be(2048);
+    tenantTokenProvider.Dispose();
+
+  }
+
+  [Fact]
+  public async Task CanNotRetrieveSigningKey()
+  {
+    var issuerCache = CreateFakeIssuerCache();
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+    // Use wrong kid for testing
+    var fakeKid = "error-fake-kid";
+    var realm = "fake-realm";
+    var client = CreateFakeHttpClient(realm);
+    var tenantTokenProvider = new TenantKeyProvider(
+      logger, cache, issuerCache,
+      options, client
+    );
+
+    var keyFromCache = await tenantTokenProvider.RetrieveSigningKey("fake-issuer", fakeKid);
+
+    Console.WriteLine(keyFromCache);
+    keyFromCache.Should().BeNull();
+    tenantTokenProvider.Dispose();
+  }
+
+  [Fact]
+  public async Task WillReturnNullForNoExistedTenant()
+  {
+    var issuerCache = CreateFakeIssuerCache(true);
+    var logger = Mock.Of<ILogger<TenantKeyProvider>>();
+    var cache = new MemoryCache(new MemoryCacheOptions());
+    var options = CreateFakeOptions();
+    var fakeKid = "tlbK5byYcGdR1eyujaHtxrY1czP_dWs63s8kEeSMdes";
+    var realm = "fake-realm";
+    var client = CreateFakeHttpClient(realm);
+    var tenantTokenProvider = new TenantKeyProvider(
+      logger, cache, issuerCache,
+      options, client
+    );
+
+    var keyFromCache = await tenantTokenProvider.RetrieveSigningKey("fake-issuer", fakeKid);
+
+    keyFromCache.Should().BeNull();
+    tenantTokenProvider.Dispose();
+  }
+}

--- a/libs/adsp-service-net-sdk/Access/TenantKeyProvider.cs
+++ b/libs/adsp-service-net-sdk/Access/TenantKeyProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using Adsp.Sdk.Tenancy;
 using RestSharp;
 
 namespace Adsp.Sdk.Access;
@@ -14,7 +15,7 @@ internal class TenantKeyProvider : ITenantKeyProvider, IDisposable
   private readonly IIssuerCache _issuerCache;
   private readonly RestClient _client;
 
-  public TenantKeyProvider(ILogger<TenantKeyProvider> logger, IMemoryCache cache, IIssuerCache issuerCache, IOptions<AdspOptions> options)
+  public TenantKeyProvider(ILogger<TenantKeyProvider> logger, IMemoryCache cache, IIssuerCache issuerCache, IOptions<AdspOptions> options, RestClient? client = null)
   {
     if (options.Value.AccessServiceUrl == null)
     {
@@ -24,7 +25,7 @@ internal class TenantKeyProvider : ITenantKeyProvider, IDisposable
     _logger = logger;
     _cache = cache;
     _issuerCache = issuerCache;
-    _client = new RestClient(options.Value.AccessServiceUrl);
+    _client = client ?? new RestClient(options.Value.AccessServiceUrl);
   }
 
   public async Task<SecurityKey?> ResolveSigningKey(string issuer, string kid)
@@ -42,6 +43,7 @@ internal class TenantKeyProvider : ITenantKeyProvider, IDisposable
   {
     SecurityKey? result = null;
     var tenant = await _issuerCache.GetTenantByIssuer(issuer);
+
     if (tenant != null)
     {
       try


### PR DESCRIPTION
Added unit tests to .NET Core SDK within access namespace.
The Code Coverage and Branch Coverage are listed as follows, respectively:

AccessClaimRoles:  100% N/A

AccessExtensions:   22.9% 9% - Cannot access to jwt => {} block in the AddJwtBearer.

IssuerCache: 100% 100%

MetadataResponse: 100% N/A

TenantKeyProvider: 90.9% 44.6 %- I have tested both  tenant != null and tenant == null explicitly branches for RetrieveSigningKey function. But, the branch coverage report shows the two branches have not been covered.

TokenProvider: 93.7% 88.8%



