### PR TITLE
chore(notification-service): enable long ttl for configuration in ser…

### DIFF
--- a/apps/notification-service/src/main.ts
+++ b/apps/notification-service/src/main.ts
@@ -93,6 +93,7 @@ async function initializeApp() {
         },
       ],
       values: [ServiceMetricsValueDefinition],
+      useLongConfigurationCacheTTL: true,
     },
     { logger }
   );

--- a/apps/notification-service/src/notification/router/__snapshots__/subscription.spec.ts.snap
+++ b/apps/notification-service/src/notification/router/__snapshots__/subscription.spec.ts.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`subscription router addOrUpdateTypeSubscription can add subscription 1`] = `
+Object {
+  "criteria": Object {},
+  "subscriber": Object {
+    "addressAs": "tester",
+    "channels": Array [],
+    "id": "subscriber",
+    "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+    "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+    "userId": undefined,
+  },
+  "subscriberId": "subscriber",
+  "type": undefined,
+  "typeId": "test",
+}
+`;
+
+exports[`subscription router addOrUpdateTypeSubscription can update subscription criteria 1`] = `
+Object {
+  "criteria": Object {
+    "context": Object {},
+    "correlationId": "123",
+  },
+  "subscriber": Object {
+    "addressAs": "tester",
+    "channels": Array [],
+    "id": "subscriber",
+    "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+    "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+    "userId": undefined,
+  },
+  "subscriberId": "subscriber",
+  "type": undefined,
+  "typeId": "test",
+}
+`;
+
+exports[`subscription router createSubscriber can create subscriber 1`] = `
+Object {
+  "addressAs": "tester@test.com",
+  "channels": Array [],
+  "id": "subscriber",
+  "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+  "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+  "userId": undefined,
+}
+`;
+
+exports[`subscription router createTypeSubscription can create subscription 1`] = `
+Object {
+  "criteria": Object {},
+  "subscriber": Object {
+    "addressAs": "tester",
+    "channels": Array [],
+    "id": "subscriber",
+    "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+    "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+    "userId": undefined,
+  },
+  "subscriberId": "subscriber",
+  "type": undefined,
+  "typeId": "test",
+}
+`;
+
+exports[`subscription router deleteSubscriber can delete subscriber 1`] = `
+Object {
+  "deleted": true,
+}
+`;
+
+exports[`subscription router deleteTypeSubscription can delete subscription 1`] = `
+Object {
+  "deleted": true,
+}
+`;
+
+exports[`subscription router getNotificationTypes can get types 1`] = `
+Array [
+  Object {
+    "channels": Array [],
+    "description": "testing 1 2 3",
+    "events": Array [],
+    "id": "test",
+    "manageSubscribe": false,
+    "name": "Test",
+    "publicSubscribe": false,
+    "subscriberRoles": Array [
+      "test-subscriber",
+    ],
+  },
+]
+`;
+
+exports[`subscription router getSubscriberDetails can get subscriber subscriptions 1`] = `
+Object {
+  "addressAs": "tester",
+  "channels": Array [],
+  "id": "subscriber",
+  "subscriptions": Array [
+    Object {
+      "criteria": Object {},
+      "subscriberId": "subscriber",
+      "type": Object {
+        "channels": Array [],
+        "description": "testing 1 2 3",
+        "id": "test",
+        "manageSubscribe": false,
+        "name": "Test",
+        "publicSubscribe": false,
+      },
+      "typeId": "test",
+    },
+  ],
+  "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+  "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+  "userId": undefined,
+}
+`;
+
+exports[`subscription router getSubscriberSubscriptions can get subscriptions 1`] = `
+Object {
+  "page": Object {},
+  "results": Array [],
+}
+`;
+
+exports[`subscription router getSubscribers can get subscribers 1`] = `
+Object {
+  "page": Object {},
+  "results": Array [],
+}
+`;
+
+exports[`subscription router getSubscriptionChannels can get channels 1`] = `
+Array [
+  Object {
+    "address": "tester@test.co",
+    "channel": "email",
+    "verified": false,
+  },
+]
+`;
+
+exports[`subscription router getTypeSubscription can get subscription 1`] = `
+Object {
+  "criteria": Object {},
+  "subscriber": Object {
+    "addressAs": "tester",
+    "channels": Array [],
+    "id": "subscriber",
+    "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+    "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+    "userId": undefined,
+  },
+  "subscriberId": "subscriber",
+  "type": undefined,
+  "typeId": "test",
+}
+`;
+
+exports[`subscription router getTypeSubscriptions can get subscriptions 1`] = `
+Object {
+  "page": Object {},
+  "results": Array [],
+}
+`;
+
+exports[`subscription router subscriberOperations can check code 1`] = `
+Object {
+  "verified": true,
+}
+`;
+
+exports[`subscription router subscriberOperations can send code 1`] = `
+Object {
+  "sent": true,
+}
+`;
+
+exports[`subscription router subscriberOperations can verify channel 1`] = `
+Object {
+  "verified": true,
+}
+`;
+
+exports[`subscription router updateSubscriber can delete subscriber 1`] = `
+Object {
+  "addressAs": "tester",
+  "channels": Array [],
+  "id": "subscriber",
+  "tenantId": "urn:ads:platform:tenant-service:v2:/tenants/test",
+  "urn": "urn:ads:platform:notification-service:v1:/subscribers/subscriber",
+  "userId": undefined,
+}
+`;

--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -129,6 +129,7 @@ describe('subscription router', () => {
       );
       await getNotificationTypes(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining(notificationType)]));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
   });
 
@@ -206,6 +207,7 @@ describe('subscription router', () => {
       const handler = getTypeSubscriptions(apiId, repositoryMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page: result.page }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can handle query params', async () => {
@@ -310,6 +312,7 @@ describe('subscription router', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(repositoryMock.saveSubscriber).toHaveBeenCalledWith(expect.objectContaining({ addressAs: 'tester' }));
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ typeId: 'test' }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can create user subscription', async () => {
@@ -487,6 +490,7 @@ describe('subscription router', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(repositoryMock.getSubscriber).toHaveBeenCalledWith(tenantId, 'subscriber', false);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ typeId: 'test' }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can add subscription with criteria', async () => {
@@ -587,6 +591,7 @@ describe('subscription router', () => {
         })
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ typeId: 'test' }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next with error', async () => {
@@ -671,6 +676,7 @@ describe('subscription router', () => {
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({ typeId: 'test', subscriber: expect.objectContaining({ id: 'subscriber' }) })
       );
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next for unauthorized', async () => {
@@ -738,6 +744,7 @@ describe('subscription router', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(repositoryMock.deleteSubscriptions).toHaveBeenCalledWith(tenantId, notificationType.id, 'subscriber');
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
   });
 
@@ -772,6 +779,7 @@ describe('subscription router', () => {
       const handler = getSubscribers(apiId, repositoryMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page: result.page }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can get subscribers with query params', async () => {
@@ -872,6 +880,7 @@ describe('subscription router', () => {
           addressAs: 'tester@test.com',
         })
       );
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can create user subscriber', async () => {
@@ -1225,6 +1234,7 @@ describe('subscription router', () => {
           ]),
         })
       );
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can get subscriber without subscriptions', async () => {
@@ -1294,6 +1304,7 @@ describe('subscription router', () => {
 
       await deleteSubscriber(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next with unauthorized', async () => {
@@ -1394,6 +1405,7 @@ describe('subscription router', () => {
       expect(res.json).toHaveBeenCalledWith(
         expect.arrayContaining([{ channel: 'email', address: 'tester@test.co', verified: false }])
       );
+      expect(res.json.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('will can ge empty channels', async () => {
@@ -1490,6 +1502,7 @@ describe('subscription router', () => {
       const handler = updateSubscriber(apiId);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining(req.body));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next with unauthorized', async () => {
@@ -1584,6 +1597,7 @@ describe('subscription router', () => {
       );
       expect(subscriber.channels[0].verifyKey).toBe('key');
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ sent: true }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can check code', async () => {
@@ -1630,6 +1644,7 @@ describe('subscription router', () => {
       expect(verifyServiceMock.verifyCode).toHaveBeenCalledWith(subscriber.channels[0], '123');
       expect(subscriber.channels[0].verified).toBe(false);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ verified: true }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can verify channel', async () => {
@@ -1677,6 +1692,7 @@ describe('subscription router', () => {
       expect(verifyServiceMock.verifyCode).toHaveBeenCalledWith(subscriber.channels[0], '123');
       expect(subscriber.channels[0].verified).toBe(true);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ verified: true }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next with invalid operation for unrecognized operation', async () => {
@@ -1769,6 +1785,7 @@ describe('subscription router', () => {
       const handler = getSubscriberSubscriptions(apiId, repositoryMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page: result.page }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can handle query params', async () => {


### PR DESCRIPTION
…vice; notification service has queue based configuration cache invalidation in place.

Also adding snapshot verification to unit tests.