### PR TITLE
chore(pdf-service): using long ttl for configuration since pdf servic…

### DIFF
--- a/apps/pdf-service/src/main.ts
+++ b/apps/pdf-service/src/main.ts
@@ -88,6 +88,7 @@ const initializeApp = async (): Promise<express.Application> => {
       accessServiceUrl,
       directoryUrl: new URL(environment.DIRECTORY_URL),
       values: [ServiceMetricsValueDefinition],
+      useLongConfigurationCacheTTL: true,
     },
     { logger }
   );

--- a/apps/pdf-service/src/pdf/router/__snapshots__/pdf.spec.ts.snap
+++ b/apps/pdf-service/src/pdf/router/__snapshots__/pdf.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pdf generatePdf can generate pdf 1`] = `
+Object {
+  "id": "job1",
+  "result": null,
+  "status": undefined,
+  "urn": "urn:ads:platform:pdf-service:v1:/jobs/job1",
+}
+`;
+
+exports[`pdf getGeneratedFile can get file 1`] = `
+Object {
+  "id": "job1",
+  "result": null,
+  "status": "completed",
+  "urn": "urn:ads:platform:pdf-service:v1:/jobs/job1",
+}
+`;
+
+exports[`pdf getTemplates can get templates 1`] = `
+Array [
+  Object {
+    "description": "This is a test.",
+    "id": "test",
+    "name": "Test template",
+    "template": "",
+  },
+]
+`;

--- a/apps/pdf-service/src/pdf/router/pdf.spec.ts
+++ b/apps/pdf-service/src/pdf/router/pdf.spec.ts
@@ -81,6 +81,7 @@ describe('pdf', () => {
       await getTemplates(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).toHaveBeenCalledWith(expect.arrayContaining([configuration.test]));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next for error', async () => {
@@ -208,6 +209,7 @@ describe('pdf', () => {
         expect.objectContaining({ tenantId, name: PDF_GENERATION_QUEUED })
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'job1' }));
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next with invalid operation', async () => {
@@ -304,6 +306,7 @@ describe('pdf', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: req.params.jobId, status: 'completed' }));
       expect(next).not.toHaveBeenCalled();
+      expect(res.send.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('can call next with not found', async () => {


### PR DESCRIPTION
…e has queue based invalidation.

Also adding snapshot verification in some unit tests.