### PR TITLE
fix(tenant-management-webapp): change value of dropdown options to be…

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileList.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileList.tsx
@@ -151,7 +151,7 @@ const FileList = (): JSX.Element => {
             }}
           >
             {getFileTypesValues().map((item, key) => (
-              <GoADropdownOption label={item.name} value={item.name} key={key} data-testid={item.id} />
+              <GoADropdownOption label={item.name} value={item.id} key={key} data-testid={item.id} />
             ))}
           </GoADropdown>
         </FileTypeDropdown>


### PR DESCRIPTION
… the id of the file type so upload uses id rather than name for type.