### PR TITLE
fix: delete unnecessary state update

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -31,6 +31,7 @@ interface TemplateEditorProps {
   errors?: any;
   suggestion?: any;
   cancel: () => void;
+  updateTemplate: (template: PdfTemplate) => void;
   validateEventTemplateFields: () => boolean;
 }
 
@@ -51,6 +52,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   errors,
   suggestion,
   cancel,
+  updateTemplate,
   validateEventTemplateFields,
 }) => {
   const monaco = useMonaco();
@@ -95,12 +97,19 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   }, [modelOpen]);
 
   const channels = ['main', 'footer/header'];
+  const tmpTemplate = template;
 
   return (
     <TemplateEditorContainerPdf>
       <GoAForm>
         <GoAFormItem>
-          <Tabs activeIndex={activeIndex} changeTabCallback={(index: number) => switchTabPreview(channels[index])}>
+          <Tabs
+            activeIndex={activeIndex}
+            changeTabCallback={(index: number) => {
+              switchTabPreview(channels[index]);
+              updateTemplate(tmpTemplate);
+            }}
+          >
             <Tab
               label={
                 <div>
@@ -114,35 +123,21 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
               </h3>
 
               <>
-                {bodyEditorHintText && (
-                  <GoAFormItem error={errors?.body ?? ''} helpText={bodyEditorHintText}>
-                    <MonacoDivBody>
-                      <MonacoEditor
-                        language={'handlebars'}
-                        defaultValue={template?.template}
-                        onChange={(value) => {
-                          onBodyChange(value);
-                        }}
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
-                  </GoAFormItem>
-                )}
-
-                {!bodyEditorHintText && (
-                  <GoAFormItem error={errors?.body ?? ''}>
-                    <MonacoDivBody>
-                      <MonacoEditor
-                        language={'handlebars'}
-                        defaultValue={template?.template}
-                        onChange={(value) => {
-                          onBodyChange(value);
-                        }}
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
-                  </GoAFormItem>
-                )}
+                <GoAFormItem error={errors?.body ?? null} helpText={bodyEditorHintText}>
+                  <MonacoDivBody>
+                    <MonacoEditor
+                      language={'handlebars'}
+                      defaultValue={template?.template}
+                      onChange={(value) => {
+                        onBodyChange(value);
+                        if (tmpTemplate) {
+                          tmpTemplate.template = value;
+                        }
+                      }}
+                      {...bodyEditorConfig}
+                    />
+                  </MonacoDivBody>
+                </GoAFormItem>
               </>
             </Tab>
             <Tab
@@ -169,6 +164,9 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                       defaultValue={template?.header}
                       onChange={(value) => {
                         onHeaderChange(value);
+                        if (tmpTemplate) {
+                          tmpTemplate.header = value;
+                        }
                       }}
                       {...bodyEditorConfig}
                     />
@@ -184,6 +182,9 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                       value={template?.footer}
                       onChange={(value) => {
                         onFooterChange(value);
+                        if (tmpTemplate) {
+                          tmpTemplate.footer = value;
+                        }
                       }}
                       {...bodyEditorConfig}
                     />

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -179,7 +179,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                   <MonacoDivFooter>
                     <MonacoEditor
                       language={'handlebars'}
-                      value={template?.footer}
+                      defaultValue={template?.footer}
                       onChange={(value) => {
                         onFooterChange(value);
                         if (tmpTemplate) {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -119,7 +119,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                     <MonacoDivBody>
                       <MonacoEditor
                         language={'handlebars'}
-                        value={template?.template}
+                        defaultValue={template?.template}
                         onChange={(value) => {
                           onBodyChange(value);
                         }}
@@ -134,7 +134,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                     <MonacoDivBody>
                       <MonacoEditor
                         language={'handlebars'}
-                        value={template?.template}
+                        defaultValue={template?.template}
                         onChange={(value) => {
                           onBodyChange(value);
                         }}
@@ -166,7 +166,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                   <MonacoDivHeader>
                     <MonacoEditor
                       language={'handlebars'}
-                      value={template?.header}
+                      defaultValue={template?.header}
                       onChange={(value) => {
                         onHeaderChange(value);
                       }}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/templates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/templates.tsx
@@ -321,6 +321,9 @@ export const PdfTemplates: FunctionComponent<PdfTemplatesProps> = ({ openAddTemp
                 onFooterChange={(value) => {
                   setFooter(value);
                 }}
+                updateTemplate={(template) => {
+                  setCurrentTemplate(template);
+                }}
                 setPreview={(channel) => {
                   try {
                     setBodyPreview(

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/templates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/templates.tsx
@@ -122,10 +122,6 @@ export const PdfTemplates: FunctionComponent<PdfTemplatesProps> = ({ openAddTemp
       setFooterPreview(
         generateMessage(template, { data: currentTemplate, serviceUrl: webappUrl, today: new Date().toDateString() })
       );
-      if (currentTemplate) {
-        currentTemplate.footer = footer;
-      }
-      setCurrentTemplate(currentTemplate);
     } catch (e) {
       console.error('error: ' + e.message);
     }
@@ -141,10 +137,6 @@ export const PdfTemplates: FunctionComponent<PdfTemplatesProps> = ({ openAddTemp
       setHeaderPreview(
         generateMessage(template, { data: currentTemplate, serviceUrl: webappUrl, today: new Date().toDateString() })
       );
-      if (currentTemplate) {
-        currentTemplate.header = header;
-      }
-      setCurrentTemplate(currentTemplate);
     } catch (e) {
       console.error('error: ' + e.message);
     }
@@ -160,10 +152,6 @@ export const PdfTemplates: FunctionComponent<PdfTemplatesProps> = ({ openAddTemp
       setBodyPreview(
         generateMessage(template, { data: currentTemplate, serviceUrl: webappUrl, today: new Date().toDateString() })
       );
-      if (currentTemplate) {
-        currentTemplate.template = body;
-      }
-      setCurrentTemplate(currentTemplate);
     } catch (e) {
       console.error('error: ' + e.message);
     }


### PR DESCRIPTION
Updating the template state within the onChange function might be unnecessary. We only need to update the state and sync with the remote when we click the save button.