### PR TITLE
CS-1659 - prep cors so I can use deployed script service to test

### DIFF
--- a/apps/script-service/Program.cs
+++ b/apps/script-service/Program.cs
@@ -11,7 +11,20 @@ internal class Program
 {
   private static void Main(string[] args)
   {
+    var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
     var builder = WebApplication.CreateBuilder(args);
+
+    builder.Services.AddCors(options =>
+      {
+        options.AddPolicy(name: MyAllowSpecificOrigins,
+          policy =>
+          {
+            policy.AllowAnyOrigin()
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+          });
+      }
+    );
     builder.Logging.ClearProviders();
     builder.Logging.AddConsole();
 
@@ -87,7 +100,7 @@ internal class Program
 
     var app = builder.Build();
     app.UseAdspMetrics();
-
+    app.UseCors(MyAllowSpecificOrigins);
     app.UseSwagger(new SwaggerOptions { RouteTemplate = "docs/{documentName}/swagger.json" });
 
     app.UseAuthorization();
@@ -97,7 +110,7 @@ internal class Program
       SwaggerJsonPath = "docs/v1/swagger.json",
       ApiPath = "script/v1"
     });
-
+    
     app.MapControllers();
 
     app.Run();


### PR DESCRIPTION
Having trouble using this locally - it used to work, now it doesn't and I have no idea why

changing this will allow me to call the remote version locally (we do this with other services already)