### PR TITLE
fix(adsp-service-spring-sdk): return null instead of throwing excepti…

### DIFF
--- a/libs/adsp-service-spring-sdk/src/main/java/ca/ab/gov/alberta/adsp/sdk/access/TenantAuthManagerResolver.java
+++ b/libs/adsp-service-spring-sdk/src/main/java/ca/ab/gov/alberta/adsp/sdk/access/TenantAuthManagerResolver.java
@@ -25,7 +25,8 @@ class TenantAuthManagerResolver implements AuthenticationManagerResolver<String>
   public AuthenticationManager resolve(String issuer) {
     var cached = this.issuerCache.getCached(issuer);
     if (cached == null) {
-      throw new IllegalArgumentException("Issuer not recognized");
+      // Returning null causes the framework to respond with 401.
+      return null;
     }
 
     var provider = providers.computeIfAbsent(issuer, iss -> {


### PR DESCRIPTION
…on so framework returns 401

Spring security appears to handle null return as a 401. This happens if the issuer is not a recognized tenant.