### PR TITLE
Add input string length validation

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/checkInput.ts
+++ b/apps/tenant-management-webapp/src/app/lib/checkInput.ts
@@ -100,6 +100,16 @@ export const isValidJSONCheck = (label?: string): Validator => {
   };
 };
 
+export const wordMaxLengthCheck = (maxLen: number): Validator => {
+  return (input: string) => {
+    if (input && input.length > maxLen) {
+      return `The input exceeds the maximum allowed length ${maxLen}`;
+    } else {
+      return '';
+    }
+  };
+};
+
 export interface ValidationAction {
   // Action to take when a problem is detected
   onFailure(message: string): void;

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/configuration/definitions/addEditDefinition.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/configuration/definitions/addEditDefinition.tsx
@@ -44,6 +44,9 @@ export const AddEditConfigDefinition: FunctionComponent<AddEditConfigDefinitionP
     };
   };
 
+  const MAX_NAME_LENGTH = 32;
+  const MAX_NAMESPACE_LENGTH = 32;
+
   const namespaceCheck = (): Validator => {
     return (namespace: string) => {
       return namespace === 'platform' ? 'Cannot use the word platform as namespace' : '';
@@ -113,10 +116,11 @@ export const AddEditConfigDefinition: FunctionComponent<AddEditConfigDefinitionP
                   disabled={isEdit}
                   data-testid="form-namespace"
                   aria-label="nameSpace"
-                  onChange={(name, value) => {
+                  onChange={(key, value) => {
+                    const namespace = value.substring(0, MAX_NAMESPACE_LENGTH);
                     validators.remove('namespace');
-                    validators['namespace'].check(value);
-                    setDefinition({ ...definition, namespace: value });
+                    validators['namespace'].check(namespace);
+                    setDefinition({ ...definition, namespace });
                   }}
                 />
               </GoAFormItem>
@@ -129,25 +133,27 @@ export const AddEditConfigDefinition: FunctionComponent<AddEditConfigDefinitionP
                   disabled={isEdit}
                   data-testid="form-name"
                   aria-label="name"
-                  onChange={(name, value) => {
+                  onChange={(key, value) => {
+                    const name = value.substring(0, MAX_NAME_LENGTH);
                     validators.remove('name');
-                    validators['name'].check(value);
-                    setDefinition({ ...definition, name: value });
+                    validators['name'].check(name);
+                    setDefinition({ ...definition, name });
                   }}
                 />
               </GoAFormItem>
               <GoAFormItem error={errors?.['description']}>
                 <label>Description</label>
-                <GoAInput
-                  type="text"
+                <textarea
                   name="description"
                   value={definition.description}
                   data-testid="form-description"
                   aria-label="description"
-                  onChange={(description, value) => {
+                  maxLength={512}
+                  onChange={(e) => {
+                    const description = e.target.value;
                     validators.remove('description');
-                    validators['description'].check(value);
-                    setDefinition({ ...definition, description: value });
+                    validators['description'].check(description);
+                    setDefinition({ ...definition, description });
                   }}
                 />
               </GoAFormItem>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/directory/directoryModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/directory/directoryModal.tsx
@@ -6,7 +6,7 @@ import { Service } from '@store/directory/models';
 import { useDispatch, useSelector } from 'react-redux';
 import { createEntry, updateEntry, fetchEntryDetail } from '@store/directory/actions';
 import { RootState } from '@store/index';
-import { characterCheck, validationPattern, Validator, isNotEmptyCheck } from '@lib/checkInput';
+import { characterCheck, validationPattern, Validator, isNotEmptyCheck, wordMaxLengthCheck } from '@lib/checkInput';
 import { useValidators } from '@lib/useValidators';
 
 interface DirectoryModalProps {
@@ -47,6 +47,7 @@ const lowerCaseCheck = characterCheck(validationPattern.lowerKebabCase);
 const checkForBadUrl = characterCheck(validationPattern.validURL);
 const checkServiceExists = isNotEmptyCheck('service');
 const checkUrlExists = isNotEmptyCheck('URL');
+const wordLengthCheck = wordMaxLengthCheck(32);
 
 export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
   const isNew = props.type === 'new';
@@ -58,7 +59,13 @@ export const DirectoryModal = (props: DirectoryModalProps): JSX.Element => {
   const { directory } = useSelector((state: RootState) => state.directory);
   const tenantName = useSelector((state: RootState) => state.tenant?.name);
   const dispatch = useDispatch();
-  const { errors, validators } = useValidators('service', 'service', lowerCaseCheck, checkServiceExists)
+  const { errors, validators } = useValidators(
+    'service',
+    'service',
+    lowerCaseCheck,
+    checkServiceExists,
+    wordLengthCheck
+  )
     .add('api', 'api', lowerCaseCheck)
     .add('url', 'url', checkForBadUrl, checkUrlExists)
     .add('apiDuplicate', 'api', duplicateApiCheck(directory, tenantName, isNew))

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/edit.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/edit.tsx
@@ -17,6 +17,7 @@ import {
   isNotEmptyCheck,
   Validator,
   isValidJSONCheck,
+  wordMaxLengthCheck,
 } from '@lib/checkInput';
 import { useValidators } from '@lib/useValidators';
 import { updateEventDefinition } from '@store/event/actions';
@@ -48,6 +49,7 @@ export const EventDefinitionModalForm: FunctionComponent<EventDefinitionFormProp
   const forbiddenWords = coreNamespaces.concat('platform');
   const checkForConflicts = wordCheck(forbiddenWords);
   const checkForBadChars = characterCheck(validationPattern.mixedKebabCase);
+  const wordLengthCheck = wordMaxLengthCheck(32);
 
   const duplicateEventCheck = (definitions: EventDefinition[]): Validator => {
     return (identifier: string) => {
@@ -68,9 +70,10 @@ export const EventDefinitionModalForm: FunctionComponent<EventDefinitionFormProp
     'namespace',
     checkForConflicts,
     checkForBadChars,
+    wordLengthCheck,
     isNotEmptyCheck('namespace')
   )
-    .add('name', 'name', checkForBadChars, isNotEmptyCheck('name'))
+    .add('name', 'name', checkForBadChars, wordLengthCheck, isNotEmptyCheck('name'))
     .add('duplicated', 'name', duplicateEventCheck(definitions))
     .add('payloadSchema', 'payloadSchema', isValidJSONCheck('payloadSchema'))
     .build();
@@ -122,6 +125,7 @@ export const EventDefinitionModalForm: FunctionComponent<EventDefinitionFormProp
                 value={definition.description}
                 aria-label="description"
                 className="goa-textarea"
+                maxLength={512}
                 onChange={(e) => setDefinition({ ...definition, description: e.target.value })}
               />
             </GoAFormItem>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypeModal.tsx
@@ -17,7 +17,7 @@ import { ConfigServiceRole } from '@store/access/models';
 import { useValidators } from '@lib/useValidators';
 import { FETCH_KEYCLOAK_SERVICE_ROLES } from '@store/access/actions';
 import { ActionState } from '@store/session/models';
-import { characterCheck, validationPattern, isNotEmptyCheck, Validator } from '@lib/checkInput';
+import { characterCheck, validationPattern, isNotEmptyCheck, Validator, wordMaxLengthCheck } from '@lib/checkInput';
 interface FileTypeModalProps {
   fileType?: FileTypeItem;
   onCancel: () => void;
@@ -131,6 +131,7 @@ export const FileTypeModal = (props: FileTypeModalProps): JSX.Element => {
   const [fileType, setFileType] = useState(props.fileType);
   const title = isNew ? 'Add file type' : 'Edit file type';
   const checkForBadChars = characterCheck(validationPattern.mixedArrowCaseWithSpace);
+  const wordLengthCheck = wordMaxLengthCheck(32);
 
   const duplicateFileTypeCheck = (names: string[]): Validator => {
     return (name: string) => {
@@ -140,7 +141,7 @@ export const FileTypeModal = (props: FileTypeModalProps): JSX.Element => {
     };
   };
 
-  const { errors, validators } = useValidators('name', 'name', checkForBadChars, isNotEmptyCheck('name'))
+  const { errors, validators } = useValidators('name', 'name', checkForBadChars, wordLengthCheck, isNotEmptyCheck('name'))
     .add('duplicated', 'name', duplicateFileTypeCheck(props.fileTypeNames))
     .build();
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/AddEditPdfTemplates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/AddEditPdfTemplates.tsx
@@ -6,7 +6,7 @@ import { PdfTemplate } from '@store/pdf/model';
 import { IdField } from '../styled-components';
 import { toKebabName } from '@lib/kebabName';
 import { useValidators } from '@lib/useValidators';
-import { characterCheck, validationPattern, isNotEmptyCheck, Validator } from '@lib/checkInput';
+import { characterCheck, validationPattern, isNotEmptyCheck, Validator, wordMaxLengthCheck } from '@lib/checkInput';
 import styled from 'styled-components';
 import { RootState } from '@store/index';
 import { useSelector } from 'react-redux';
@@ -61,8 +61,15 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
         : '';
     };
   };
+  const wordLengthCheck = wordMaxLengthCheck(32);
 
-  const { errors, validators } = useValidators('name', 'name', checkForBadChars, isNotEmptyCheck('name'))
+  const { errors, validators } = useValidators(
+    'name',
+    'name',
+    checkForBadChars,
+    wordLengthCheck,
+    isNotEmptyCheck('name')
+  )
     .add('duplicate', 'name', isDuplicateTemplateId())
     .build();
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/PDFConfigForm.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/PDFConfigForm.tsx
@@ -3,7 +3,7 @@ import { PdfTemplate } from '@store/pdf/model';
 import { GoAForm, GoAFormItem, GoAInput } from '@abgov/react-components/experimental';
 import { Grid, GridItem } from '@components/Grid';
 import { useValidators } from '@lib/useValidators';
-import { characterCheck, validationPattern, isNotEmptyCheck } from '@lib/checkInput';
+import { characterCheck, validationPattern, isNotEmptyCheck, wordMaxLengthCheck } from '@lib/checkInput';
 import { PdfConfigFormWrapper } from './styled-components';
 
 interface PDFConfigFormProps {
@@ -13,8 +13,16 @@ interface PDFConfigFormProps {
 }
 export const PDFConfigForm = ({ template, onChange, setError }: PDFConfigFormProps) => {
   const { id, name, description } = template;
+  const wordLengthCheck = wordMaxLengthCheck(32);
+
   const checkForBadChars = characterCheck(validationPattern.mixedArrowCaseWithSpace);
-  const { errors, validators } = useValidators('name', 'name', checkForBadChars, isNotEmptyCheck('name')).build();
+  const { errors, validators } = useValidators(
+    'name',
+    'name',
+    checkForBadChars,
+    wordLengthCheck,
+    isNotEmptyCheck('name')
+  ).build();
 
   return (
     <PdfConfigFormWrapper>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/templates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/templates.tsx
@@ -292,7 +292,7 @@ export const PdfTemplates: FunctionComponent<PdfTemplatesProps> = ({ openAddTemp
           <DeleteModal
             isOpen={showDeleteConfirmation}
             title="Delete PDF template"
-            content={`Delete ${currentTemplate?.id}?`}
+            content={`Delete ${currentTemplate?.name} (ID: ${currentTemplate?.id})?`}
             onCancel={() => setShowDeleteConfirmation(false)}
             onDelete={() => {
               setShowDeleteConfirmation(false);

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.tsx
@@ -95,21 +95,22 @@ export const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
               value={name}
               data-testid={`script-modal-name-input`}
               aria-label="script-name"
-              onChange={(name, value) => {
-                onNameChange(value);
+              onChange={(key, value) => {
+                const name = value.substring(0, 32);
+                onNameChange(name);
               }}
             />
           </GoAFormItem>
           <GoAFormItem error={errors?.['description']}>
             <label>Description</label>
-            <GoAInput
-              type="text"
+            <textarea
               name="description"
               value={description}
               data-testid={`script-modal-description-input`}
               aria-label="script-description"
-              onChange={(name, value) => {
-                onDescriptionChange(value);
+              maxLength={512}
+              onChange={(e) => {
+                onDescriptionChange(e.target.value);
               }}
             />
           </GoAFormItem>


### PR DESCRIPTION
<img width="582" alt="Screen Shot 2022-10-20 at 3 11 30 PM" src="https://user-images.githubusercontent.com/8821979/197059180-65a7a4d0-4cfd-49d7-b642-a4ac9a94d563.png">

Summary of update:

Calendar service - Add calendar modal:
* Name: added word length check - 32
* Description: changed to textarea - 512
* Save button: added disabled check

Configuration service - Add definition modal:
* Namespace: truncate string - 32
* Name: truncate string - 32
* Description: changed to textarea -512

Directory service - Add entry modal:
* Service: added word length check - 32

Event service - Add definition modal:
* Name: added word length check - 32
* Namespace: added word length check - 32

File service - Add file type modal:
* Name: added word length check - 32

PDF service - Add template modal:
* Name: added word length check - 32
* Description: added word length check - 512
Template edit:
* Name: added word length check - 32
* Description: added word length check - 512

Script service - Add script modal:
* Name: added word length check - 32
* Description: changed to textarea -512
Edit script modal:
* Name: truncate string - 32
* Description: changed to textarea -512