### PR TITLE
CS-1950 - Turns out its much easier to ignore

### DIFF
--- a/apps/tenant-management-webapp/src/app/store/pdf/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/reducers.ts
@@ -76,7 +76,9 @@ export default function (state: PdfState = defaultState, action: PdfActionTypes)
         jobs[index].stream.push(action.payload);
         jobs[index].status = action.payload.name;
       } else {
-        jobs = [action.payload].concat(jobs);
+        if (action.payload?.filename) {
+          jobs = [action.payload].concat(jobs);
+        }
       }
       return {
         ...state,


### PR DESCRIPTION
... the extra data coming in at the reducer than during the saga. Occasionally the stream pumped out data for a specific file before we know about the file, and this just ignores that data. This prevents a bunch of empty fields from being displayed, thus fixing the bug