### PR TITLE
Cs 2058

### DIFF
--- a/apps/status-app/src/app/api/models.ts
+++ b/apps/status-app/src/app/api/models.ts
@@ -21,6 +21,7 @@ export interface ServiceStatusApplication {
   statusTimestamp?: number;
   status: ServiceStatusType;
   endpoints: ServiceStatusEndpoint[];
+  monitorOnly: boolean;
 }
 
 export interface ServiceStatusEndpoint {

--- a/apps/status-app/src/app/pages/status.tsx
+++ b/apps/status-app/src/app/pages/status.tsx
@@ -59,6 +59,8 @@ const ServiceStatusPage = (): JSX.Element => {
     allApplicationsNotices: state.notice?.allApplicationsNotices,
   }));
 
+  const noMonitorOnlyApplications = applications?.filter((application) => !application.monitorOnly);
+
   useEffect(() => {
     dispatch(fetchApplications(realm));
   }, [realm]);
@@ -93,7 +95,7 @@ const ServiceStatusPage = (): JSX.Element => {
           {applications?.length === 0 && <div>There are no services available by this provider</div>}
         </div>
 
-        {applications?.length > 0 && (
+        {noMonitorOnlyApplications?.length > 0 && (
           <div className="title-line">
             <Grid>
               <GridItem md={7}>
@@ -110,7 +112,7 @@ const ServiceStatusPage = (): JSX.Element => {
         )}
 
         <Grid>
-          {applications.map((app, index) => {
+          {noMonitorOnlyApplications.map((app, index) => {
             return (
               <GridItem key={index} md={12} vSpacing={1} hSpacing={0.5}>
                 <ServiceStatus
@@ -187,7 +189,7 @@ const ServiceStatusPage = (): JSX.Element => {
         </div>
         {allApplicationsNotices.map((notice) => {
           return (
-            <div data-testid="all-application-notice">
+            <div data-testid="all-application-notice" className="mb-1">
               <GoACallout title="Notice" type="important" key={`{notice-${notice.id}}`}>
                 <div data-testid="all-application-notice-message">{notice.message}</div>
                 <br />
@@ -368,6 +370,10 @@ const AllApplications = styled.div`
     color: #666666;
     line-height: 2rem;
     text-align: right;
+  }
+
+  .mb-1 {
+    margin-bottom: 1rem;
   }
 `;
 

--- a/apps/status-app/src/app/store/status/models.ts
+++ b/apps/status-app/src/app/store/status/models.ts
@@ -28,6 +28,7 @@ export interface ServiceStatusApplication {
   lastUpdated: string;
   status: ServiceStatusType;
   notices?: Notice[];
+  monitorOnly?: boolean;
 }
 
 export interface ServiceStatusEndpoint {

--- a/apps/status-service/src/app/events.ts
+++ b/apps/status-service/src/app/events.ts
@@ -9,6 +9,7 @@ const ApplicationDefinition = {
     name: { type: ['string', 'null'] },
     description: { type: ['string', 'null'] },
     url: { type: ['string', 'null'] },
+    monitorOnly: { type: ['boolean', 'null'] },
   },
 };
 
@@ -268,6 +269,7 @@ export const applicationStatusChange = (
       id: app.appKey,
       name: app.name,
       description: app.description,
+      monitorOnly: app.monitorOnly,
       originalStatus: originalStatus,
       newStatus: newStatus,
       updatedBy: {

--- a/apps/status-service/src/app/model/serviceStatus.ts
+++ b/apps/status-service/src/app/model/serviceStatus.ts
@@ -23,6 +23,7 @@ export interface ApplicationConfiguration {
   name: string;
   url: string;
   description?: string;
+  monitorOnly?: boolean;
 }
 
 // Add the tenant to the configuration.
@@ -41,6 +42,7 @@ export interface ApplicationData {
   description?: string;
   status: PublicServiceStatusType;
   metadata: unknown;
+  monitorOnly?: boolean;
   statusTimestamp: number;
   enabled: boolean;
 }

--- a/apps/status-service/src/app/router/ApplicationRepo.ts
+++ b/apps/status-service/src/app/router/ApplicationRepo.ts
@@ -109,6 +109,7 @@ export class ApplicationRepo {
       appKey: app.appKey,
       name: app.name,
       description: app.description,
+      monitorOnly: app.monitorOnly,
       tenantId: tenantId,
       metadata: status?.metadata ?? '',
       enabled: status?.enabled ?? false,
@@ -122,12 +123,20 @@ export class ApplicationRepo {
     };
   };
 
-  createApp = async (appKey: string, appName: string, description: string, url: string, tenant: Tenant) => {
+  createApp = async (
+    appKey: string,
+    appName: string,
+    description: string,
+    url: string,
+    monitorOnly: boolean,
+    tenant: Tenant
+  ) => {
     const newApp = {
       appKey: appKey,
       name: appName,
       url: url,
       description: description,
+      monitorOnly: monitorOnly,
     };
     await this.updateApp(newApp, tenant.id.toString());
     return this.mergeApplicationData(tenant.id.toString(), newApp);

--- a/apps/status-service/src/app/router/publicServiceStatus.ts
+++ b/apps/status-service/src/app/router/publicServiceStatus.ts
@@ -43,6 +43,7 @@ export const getApplicationsByName =
           name: app.name,
           description: app.description,
           status: status?.status || '',
+          monitorOnly: app.monitorOnly,
           lastUpdated: status?.statusTimestamp ? new Date(status.statusTimestamp) : null,
         };
       });

--- a/apps/status-service/src/app/router/serviceStatus.ts
+++ b/apps/status-service/src/app/router/serviceStatus.ts
@@ -96,7 +96,7 @@ export const createNewApplication =
   async (req, res, next) => {
     const user = req.user as User;
     const tenant = await tenantService.getTenant(user.tenantId);
-    const { name, description, endpoint, appKey } = req.body;
+    const { name, description, endpoint, appKey, monitorOnly } = req.body;
 
     try {
       const newAppKey = appKey ? appKey : ApplicationRepo.getApplicationKey(name);
@@ -107,7 +107,7 @@ export const createNewApplication =
         }
       });
 
-      const newApp = await applicationRepo.createApp(newAppKey, name, description, endpoint.url, tenant);
+      const newApp = await applicationRepo.createApp(newAppKey, name, description, endpoint.url, monitorOnly, tenant);
       res.status(201).json(newApp);
     } catch (err) {
       logger.error(`Failed to create new application: ${err.message}`);
@@ -122,7 +122,7 @@ export const updateApplication =
       logger.info(`${req.method} - ${req.url}`);
 
       const user = req.user as User;
-      const { name, description, endpoint } = req.body;
+      const { name, description, endpoint, monitorOnly } = req.body;
       const { appKey } = req.params;
       const tenantId = user.tenantId?.toString() ?? '';
 
@@ -139,6 +139,7 @@ export const updateApplication =
         name,
         url: endpoint.url,
         description,
+        monitorOnly,
       };
       await applicationRepo.updateApp(update, tenantId);
 

--- a/apps/status-service/src/main.ts
+++ b/apps/status-service/src/main.ts
@@ -134,8 +134,6 @@ app.use(express.json({ limit: '1mb' }));
 
   // start the endpoint checking jobs
   if (!environment.HA_MODEL || (environment.HA_MODEL && environment.POD_TYPE === POD_TYPES.job)) {
-    // TODO remove this (see comments in ApplicationManager).
-    await applicationManager.synchronizeData();
     // clear the health status database every midnight
     const scheduleDataReset = async () => {
       scheduleJob('0 0 * * *', async () => {

--- a/apps/status-service/src/mongo/schema.ts
+++ b/apps/status-service/src/mongo/schema.ts
@@ -134,6 +134,7 @@ export const configurationSchema = {
         name: { type: 'string', description: 'Name of the application' },
         url: { type: 'string', description: 'URL to be checked' },
         description: { type: 'string', description: 'Tell us about your application' },
+        monitorOnly: { type: 'boolean', description: 'If selected, do not show publicly' },
       },
       required: ['name', 'url'],
       additionalProperties: false,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/form.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/form.tsx
@@ -5,6 +5,7 @@ import { fetchDirectory, fetchDirectoryDetailByURNs } from '@store/directory/act
 import { ApplicationStatus } from '@store/status/models';
 import { GoAButton, GoADropdownOption } from '@abgov/react-components';
 import { useValidators } from '@lib/validation/useValidators';
+import { GoACheckbox } from '@abgov/react-components-new';
 import {
   characterCheck,
   validationPattern,
@@ -248,6 +249,22 @@ export const ApplicationFormModal: FC<Props> = ({
                 </DropdownList>
               </DropdownListContainer>
             )}
+          </GoAFormItem>
+          <GoAFormItem>
+            <GoACheckbox
+              checked={application.monitorOnly}
+              name="monitor-only-checkbox"
+              data-testid="monitor-only-checkbox"
+              onChange={() => {
+                setApplication({
+                  ...application,
+                  monitorOnly: !application.monitorOnly,
+                });
+              }}
+              ariaLabel={`monitor-only-checkbox`}
+            >
+              Monitor only (the application will not be publicly displayed in the status app)
+            </GoACheckbox>
           </GoAFormItem>
         </GoAForm>
       </GoAModalContent>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/noticeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/noticeModal.tsx
@@ -50,6 +50,8 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
     notices: state.notice.notices,
   }));
 
+  const noMonitorOnlyApplications = applications.filter((application) => !application.monitorOnly);
+
   useEffect(() => {
     if (props.noticeId) {
       const notice = notices.find((nt) => props.noticeId === nt.id);
@@ -182,7 +184,7 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
                 {isAllApplications === false && (
                   <MultiDropdownStyle>
                     <Multiselect
-                      options={applications}
+                      options={noMonitorOnlyApplications}
                       onSelect={onSelect}
                       onRemove={onSelect}
                       displayValue="name"

--- a/apps/tenant-management-webapp/src/app/store/status/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/models.ts
@@ -44,6 +44,7 @@ export interface ApplicationStatus {
   status?: ServiceStatusType;
   internalStatus?: InternalServiceStatusType;
   endpoint?: ServiceStatusEndpoint;
+  monitorOnly?: boolean;
 }
 
 export interface ServiceStatusEndpoint {


### PR DESCRIPTION
[CS-2058 - Monitoring only option for status application](https://github.com/GovAlta/adsp-monorepo/commit/903c443ca0a9bce3f27c0fa50896c07ba53fd7f5) 
![image](https://user-images.githubusercontent.com/11400938/230827628-ac26f79b-8ad6-416c-9dc0-375e25dbbe48.png)


* users can check a box to tell the system whether or not to display the status of an application on the public page
* status service configuration schema extended to support this value on the application and backwards compatible (default is not monitor only)
* monitor only applications do not show up on public page
* public applications do show up on the public page
* Notices cannot be posted for monitor only applications