### PR TITLE
CS 2038 - 

### DIFF
--- a/apps/file-service/src/file/events.ts
+++ b/apps/file-service/src/file/events.ts
@@ -108,6 +108,7 @@ export function fileDeleted(user: User, file: File): DomainEvent {
       deletedBy: {
         id: user.id,
         name: user.name,
+        retention: file.retentionDays,
       },
     },
   };

--- a/apps/file-service/src/file/index.ts
+++ b/apps/file-service/src/file/index.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 import { Logger } from 'winston';
-import { AdspId, EventService } from '@abgov/adsp-service-sdk';
+import { AdspId, ConfigurationService, EventService, TenantService, TokenProvider } from '@abgov/adsp-service-sdk';
 import { Repositories } from './repository';
 import { createFileRouter } from './router';
 import { createFileJobs, FileServiceWorkItem } from './job';
@@ -22,14 +22,16 @@ interface FileMiddlewareProps extends Repositories {
   logger: Logger;
   eventService: EventService;
   storageProvider: FileStorageProvider;
-  scanService: ScanService;
   queueService: WorkQueueService<FileServiceWorkItem>;
+  tenantService: TenantService;
+  configurationService: ConfigurationService;
+  tokenProvider: TokenProvider;
 }
 
-export const applyFileMiddleware = (app: Application, { scanService, ...props }: FileMiddlewareProps): Application => {
+export const applyFileMiddleware = (app: Application, { ...props }: FileMiddlewareProps): Application => {
   const fileRouter = createFileRouter(props);
 
-  createFileJobs({ ...props, scanService });
+  createFileJobs(props);
 
   app.use('/file/v1', fileRouter);
 

--- a/apps/file-service/src/file/index.ts
+++ b/apps/file-service/src/file/index.ts
@@ -26,6 +26,7 @@ interface FileMiddlewareProps extends Repositories {
   tenantService: TenantService;
   configurationService: ConfigurationService;
   tokenProvider: TokenProvider;
+  scanService: ScanService;
 }
 
 export const applyFileMiddleware = (app: Application, { ...props }: FileMiddlewareProps): Application => {

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -66,7 +66,7 @@ export function createDeleteOldFilesJob({
   
            Object.keys(configuration).forEach(async (key) => {
               if (configuration[key].rules?.retention?.active) {
-                let now = new Date();
+                const now = new Date();
                 const retention = configuration[key].rules?.retention?.deleteInDays
                 const backdate = new Date(now.setDate(now.getDate() - retention));
             
@@ -78,9 +78,11 @@ export function createDeleteOldFilesJob({
                   if (!file.deleted) {
                     try {
                       jobUser.tenantId = file.tenantId;
+                   
                       
                       const deleted = await file.markForDeletion(jobUser);
                       if (deleted) {
+                        deleted.retentionDays = retention;
                         numberDeleted++;
                         eventService.send(
                           fileDeleted(jobUser, {

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -6,23 +6,24 @@ import { FileRepository } from '../repository';
 import { EventService, TenantService, ConfigurationService } from '@abgov/adsp-service-sdk';
 // import { DateTime, Duration } from 'luxon';
 // import { Logger } from 'winston';
-import { FileService } from '../types';
+import { FileService, FileCriteria } from '../types';
 import { ServiceConfiguration } from '../configuration';
+import { fileDeleted } from '../events';
+
 
 // import { NotificationService } from '../../notification';
 // import { formDeleted } from '../events';
 // import { FormRepository } from '../repository';
 // import { FormStatus } from '../types';
-// import { jobUser } from './user';
+import { jobUser } from './user';
 
 interface DeleteJobProps {
   tokenProvider: TokenProvider;
   serviceId: AdspId;
   logger: Logger;
   fileRepository: FileRepository;
-  // eventService: EventService;
+  eventService: EventService;
   tenantService: TenantService;
-  fileService: FileService;
   configurationService: ConfigurationService;
   // notificationService: NotificationService;
 }
@@ -44,10 +45,10 @@ export function createDeleteOldFilesJob({
   serviceId,
   logger,
   fileRepository,
-  fileService,
   configurationService,
   tenantService,
   tokenProvider,
+  eventService,
 }: DeleteJobProps) {
   return async (): Promise<void> => {
     try {
@@ -57,149 +58,59 @@ export function createDeleteOldFilesJob({
       const tenants = await tenantService.getTenants();
       const token = await tokenProvider.getAccessToken();
 
-      console.log(JSON.stringify(tenants) + '< tenants=----------');
-
-      // [
-      //   {
-      //     id: {
-      //       type: 'resource',
-      //       namespace: 'platform',
-      //       service: 'tenant-service',
-      //       api: 'v2',
-      //       resource: '/tenants/63f54755a1f047f190ab5882',
-      //     },
-      //     name: 'Platform',
-      //     realm: '1b0dbf9a-58be-4604-b995-18ff15dcdfd5',
-      //   },
-      // ];
+       let numberDeleted = 0;
 
       // For each tenant, load file configuration (and core file configuration)
       tenants.forEach(async (tenant) => {
           const configuration = await configurationService.getConfiguration<ServiceConfiguration,ServiceConfiguration>(serviceId, token, tenant.id );
-          console.log(JSON.stringify(configuration, getCircularReplacer()) + "<configuration----------------")
-
-          // {
-          //   "jpg":{
-          //       "anonymousRead":true,
-          //       "readRoles":[
-                  
-          //       ],
-          //       "updateRoles":[
-                  
-          //       ],
-          //       "tenantId":{
-          //         "type":"resource",
-          //         "namespace":"platform",
-          //         "service":"tenant-service",
-          //         "api":"v2",
-          //         "resource":"/tenants/63f54755a1f047f190ab5882"
-          //       },
-          //       "id":"jpg",
-          //       "name":"jpg"
-          //   },
-          //   "generated-pdf":{
-          //       "anonymousRead":false,
-          //       "readRoles":[
-          //         "urn:ads:platform:pdf-service:pdf-generator"
-          //       ],
-          //       "updateRoles":[
-          //         "urn:ads:platform:tenant-service:platform-service"
-          //       ],
-          //       "id":"generated-pdf",
-          //       "name":"Generated PDF",
-          //       "rules":{
-          //         "retention":{
-          //             "active":true,
-          //             "createdAt":"2023-04-20T17:19:22Z",
-          //             "deleteInDays":30
-          //         }
-          //       }
-          //   }
-          // }
-
-           // For each file type with retention policy enabled, find files that should be deleted
-
-           Object.keys(configuration).forEach((key) => {
+  
+           Object.keys(configuration).forEach(async (key) => {
               if (configuration[key].rules?.retention?.active) {
+                let now = new Date();
+                const retention = configuration[key].rules?.retention?.deleteInDays
+                const backdate = new Date(now.setDate(now.getDate() - retention));
+            
+                let after = null;
+                do {
+                const { results, page }  = await fileRepository.find(tenant.id, 20, after as string, {lastAccessedBefore: backdate.toDateString()});
 
+                for (const file of results) {
+                  if (!file.deleted) {
+                    try {
+                      jobUser.tenantId = file.tenantId;
+                      
+                      const deleted = await file.markForDeletion(jobUser);
+                      if (deleted) {
+                        numberDeleted++;
+                        eventService.send(
+                          fileDeleted(jobUser, {
+                            id: deleted.id,
+                            filename: deleted.filename,
+                            size: deleted.size,
+                            recordId: deleted.recordId,
+                            created: deleted.created,
+                            lastAccessed: deleted.lastAccessed,
+                            createdBy: deleted.createdBy,
+                          })
+                        );
+                      }
+                    } catch (err) {
+                      logger.error(`Error deleting file with ID: ${file.id}. ${err}`);
+                    }
+                  } 
+                }
+
+                 after = page.next;
+                } while (after);
               }
            })
 
       })  
-    
-  
 
-      // For each file type with retention policy enabled, find files that should be deleted
-
-      // Delete files
-
-      // let after = null;
-      // let numberDeleted = 0;
-      //do {
-      // const { results, page } = await repository.find(20, after, {
-      //   statusEquals: FormStatus.Locked,
-      //   lockedBefore: DateTime.now().minus(MAX_LOCKED_AGE).toJSDate(),
-      // });
-
-      // for (const result of results) {
-      //   try {
-      //     const deleted = await result.delete(jobUser, fileService, notificationService);
-      //     if (deleted) {
-      //       numberDeleted++;
-      //       eventService.send(formDeleted(jobUser, result));
-      //     }
-      //   } catch (err) {
-      //     // Log and continue with other forms if there's an error on form delete.
-      //     logger.error(`Error deleting form with ID: ${result.id}. ${err}`);
-      //   }
-      // }
-
-      //after = page.next;
-      //} while (after);
-
-      logger.info(`Completed file delete job and deleted ${42} files.`);
+      logger.info(`Completed file delete job and deleted ${numberDeleted} files.`);
     } catch (err) {
       logger.error(`Error encountered in file deleting job. ${err}`);
     }
   };
 }
 
-// interface DeleteJobProps {
-//   logger: Logger;
-//   fileRepository: FileRepository;
-// }
-
-// export const createDeleteOldFilesJobxxx =
-//   ({ logger, fileRepository }: DeleteJobProps) =>
-//   async (tenantId: AdspId, { id, filename }: File, done: (err?: Error) => void): Promise<void> => {
-//     try {
-//       logger.debug(`Deleting file ${filename} (ID: ${id})...`, {
-//         context: 'FileDeleteJob',
-//         tenant: tenantId?.toString(),
-//       });
-//       console.log('DELETING FILE');
-//       const result = await fileRepository.get(id);
-//       if (result) {
-//         const deleted = await result.delete();
-//         if (deleted) {
-//           logger.debug(`Deleted file ${filename} (ID: ${id}).`, {
-//             context: 'FileDeleteJob',
-//             tenant: tenantId?.toString(),
-//           });
-//         }
-//       } else {
-//         logger.warn(`Could not find file ${filename} (ID: ${id}) for delete.`, {
-//           context: 'FileDeleteJob',
-//           tenant: tenantId?.toString(),
-//         });
-//       }
-
-//       done();
-//     } catch (err) {
-//       logger.error(`Error encountered deleting file ${filename} (ID: ${id}): ${err}`, {
-//         context: 'FileDeleteJob',
-//         tenant: tenantId?.toString(),
-//       });
-//       done(err);
-//     }
-//   };

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -1,0 +1,205 @@
+import { AdspId, TokenProvider } from '@abgov/adsp-service-sdk';
+import { Logger } from 'winston';
+import { FileRepository } from '../repository';
+//import { File } from '../types';
+
+import { EventService, TenantService, ConfigurationService } from '@abgov/adsp-service-sdk';
+// import { DateTime, Duration } from 'luxon';
+// import { Logger } from 'winston';
+import { FileService } from '../types';
+import { ServiceConfiguration } from '../configuration';
+
+// import { NotificationService } from '../../notification';
+// import { formDeleted } from '../events';
+// import { FormRepository } from '../repository';
+// import { FormStatus } from '../types';
+// import { jobUser } from './user';
+
+interface DeleteJobProps {
+  tokenProvider: TokenProvider;
+  serviceId: AdspId;
+  logger: Logger;
+  fileRepository: FileRepository;
+  // eventService: EventService;
+  tenantService: TenantService;
+  fileService: FileService;
+  configurationService: ConfigurationService;
+  // notificationService: NotificationService;
+}
+
+const getCircularReplacer = () => {
+  const seen = new WeakSet();
+  return (key, value) => {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) {
+        return;
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+};
+
+export function createDeleteOldFilesJob({
+  serviceId,
+  logger,
+  fileRepository,
+  fileService,
+  configurationService,
+  tenantService,
+  tokenProvider,
+}: DeleteJobProps) {
+  return async (): Promise<void> => {
+    try {
+      logger.debug('Starting delete job...');
+
+      // Load all tenants
+      const tenants = await tenantService.getTenants();
+      const token = await tokenProvider.getAccessToken();
+
+      console.log(JSON.stringify(tenants) + '< tenants=----------');
+
+      // [
+      //   {
+      //     id: {
+      //       type: 'resource',
+      //       namespace: 'platform',
+      //       service: 'tenant-service',
+      //       api: 'v2',
+      //       resource: '/tenants/63f54755a1f047f190ab5882',
+      //     },
+      //     name: 'Platform',
+      //     realm: '1b0dbf9a-58be-4604-b995-18ff15dcdfd5',
+      //   },
+      // ];
+
+      // For each tenant, load file configuration (and core file configuration)
+      tenants.forEach(async (tenant) => {
+          const configuration = await configurationService.getConfiguration<ServiceConfiguration,ServiceConfiguration>(serviceId, token, tenant.id );
+          console.log(JSON.stringify(configuration, getCircularReplacer()) + "<configuration----------------")
+
+          // {
+          //   "jpg":{
+          //       "anonymousRead":true,
+          //       "readRoles":[
+                  
+          //       ],
+          //       "updateRoles":[
+                  
+          //       ],
+          //       "tenantId":{
+          //         "type":"resource",
+          //         "namespace":"platform",
+          //         "service":"tenant-service",
+          //         "api":"v2",
+          //         "resource":"/tenants/63f54755a1f047f190ab5882"
+          //       },
+          //       "id":"jpg",
+          //       "name":"jpg"
+          //   },
+          //   "generated-pdf":{
+          //       "anonymousRead":false,
+          //       "readRoles":[
+          //         "urn:ads:platform:pdf-service:pdf-generator"
+          //       ],
+          //       "updateRoles":[
+          //         "urn:ads:platform:tenant-service:platform-service"
+          //       ],
+          //       "id":"generated-pdf",
+          //       "name":"Generated PDF",
+          //       "rules":{
+          //         "retention":{
+          //             "active":true,
+          //             "createdAt":"2023-04-20T17:19:22Z",
+          //             "deleteInDays":30
+          //         }
+          //       }
+          //   }
+          // }
+
+           // For each file type with retention policy enabled, find files that should be deleted
+
+           Object.keys(configuration).forEach((key) => {
+              if (configuration[key].rules?.retention?.active) {
+
+              }
+           })
+
+      })  
+    
+  
+
+      // For each file type with retention policy enabled, find files that should be deleted
+
+      // Delete files
+
+      // let after = null;
+      // let numberDeleted = 0;
+      //do {
+      // const { results, page } = await repository.find(20, after, {
+      //   statusEquals: FormStatus.Locked,
+      //   lockedBefore: DateTime.now().minus(MAX_LOCKED_AGE).toJSDate(),
+      // });
+
+      // for (const result of results) {
+      //   try {
+      //     const deleted = await result.delete(jobUser, fileService, notificationService);
+      //     if (deleted) {
+      //       numberDeleted++;
+      //       eventService.send(formDeleted(jobUser, result));
+      //     }
+      //   } catch (err) {
+      //     // Log and continue with other forms if there's an error on form delete.
+      //     logger.error(`Error deleting form with ID: ${result.id}. ${err}`);
+      //   }
+      // }
+
+      //after = page.next;
+      //} while (after);
+
+      logger.info(`Completed file delete job and deleted ${42} files.`);
+    } catch (err) {
+      logger.error(`Error encountered in file deleting job. ${err}`);
+    }
+  };
+}
+
+// interface DeleteJobProps {
+//   logger: Logger;
+//   fileRepository: FileRepository;
+// }
+
+// export const createDeleteOldFilesJobxxx =
+//   ({ logger, fileRepository }: DeleteJobProps) =>
+//   async (tenantId: AdspId, { id, filename }: File, done: (err?: Error) => void): Promise<void> => {
+//     try {
+//       logger.debug(`Deleting file ${filename} (ID: ${id})...`, {
+//         context: 'FileDeleteJob',
+//         tenant: tenantId?.toString(),
+//       });
+//       console.log('DELETING FILE');
+//       const result = await fileRepository.get(id);
+//       if (result) {
+//         const deleted = await result.delete();
+//         if (deleted) {
+//           logger.debug(`Deleted file ${filename} (ID: ${id}).`, {
+//             context: 'FileDeleteJob',
+//             tenant: tenantId?.toString(),
+//           });
+//         }
+//       } else {
+//         logger.warn(`Could not find file ${filename} (ID: ${id}) for delete.`, {
+//           context: 'FileDeleteJob',
+//           tenant: tenantId?.toString(),
+//         });
+//       }
+
+//       done();
+//     } catch (err) {
+//       logger.error(`Error encountered deleting file ${filename} (ID: ${id}): ${err}`, {
+//         context: 'FileDeleteJob',
+//         tenant: tenantId?.toString(),
+//       });
+//       done(err);
+//     }
+//   };

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -1,20 +1,10 @@
 import { AdspId, TokenProvider } from '@abgov/adsp-service-sdk';
 import { Logger } from 'winston';
 import { FileRepository } from '../repository';
-//import { File } from '../types';
-
 import { EventService, TenantService, ConfigurationService } from '@abgov/adsp-service-sdk';
-// import { DateTime, Duration } from 'luxon';
-// import { Logger } from 'winston';
-import { FileService, FileCriteria } from '../types';
 import { ServiceConfiguration } from '../configuration';
 import { fileDeleted } from '../events';
 
-
-// import { NotificationService } from '../../notification';
-// import { formDeleted } from '../events';
-// import { FormRepository } from '../repository';
-// import { FormStatus } from '../types';
 import { jobUser } from './user';
 
 interface DeleteJobProps {
@@ -25,21 +15,7 @@ interface DeleteJobProps {
   eventService: EventService;
   tenantService: TenantService;
   configurationService: ConfigurationService;
-  // notificationService: NotificationService;
 }
-
-const getCircularReplacer = () => {
-  const seen = new WeakSet();
-  return (key, value) => {
-    if (typeof value === "object" && value !== null) {
-      if (seen.has(value)) {
-        return;
-      }
-      seen.add(value);
-    }
-    return value;
-  };
-};
 
 export function createDeleteOldFilesJob({
   serviceId,
@@ -54,13 +30,11 @@ export function createDeleteOldFilesJob({
     try {
       logger.debug('Starting delete job...');
 
-      // Load all tenants
       const tenants = await tenantService.getTenants();
       const token = await tokenProvider.getAccessToken();
 
        let numberDeleted = 0;
 
-      // For each tenant, load file configuration (and core file configuration)
       tenants.forEach(async (tenant) => {
           const configuration = await configurationService.getConfiguration<ServiceConfiguration,ServiceConfiguration>(serviceId, token, tenant.id );
   

--- a/apps/file-service/src/file/job/index.ts
+++ b/apps/file-service/src/file/job/index.ts
@@ -3,7 +3,6 @@ import { WorkQueueService } from '@core-services/core-common';
 import { Logger } from 'winston';
 import { FileRepository } from '../repository';
 import { ScanService } from '../scan';
-import { FileService } from '../types';
 import { File } from '../types';
 import { createDeleteJob } from './delete';
 import { createDeleteOldFilesJob } from './deleteOldFiles';
@@ -26,7 +25,7 @@ interface FileJobProps {
   eventService: EventService;
   tenantService: TenantService;
   tokenProvider: TokenProvider;
-  configurationService: ConfigurationService
+  configurationService: ConfigurationService;
 }
 
 export const createFileJobs = (props: FileJobProps): void => {

--- a/apps/file-service/src/file/job/index.ts
+++ b/apps/file-service/src/file/job/index.ts
@@ -1,11 +1,13 @@
-import { AdspId, EventService } from '@abgov/adsp-service-sdk';
+import { AdspId, EventService, TenantService, NotificationService, File, TokenProvider } from '@abgov/adsp-service-sdk';
 import { WorkQueueService } from '@core-services/core-common';
 import { Logger } from 'winston';
 import { FileRepository } from '../repository';
 import { ScanService } from '../scan';
-import { File } from '../types';
+import { FileService } from '../types';
 import { createDeleteJob } from './delete';
+import { createDeleteOldFilesJob } from './deleteOldFiles';
 import { createScanJob } from './scan';
+import * as schedule from 'node-schedule';
 
 export interface FileServiceWorkItem {
   work: 'scan' | 'delete' | 'unknown';
@@ -15,21 +17,32 @@ export interface FileServiceWorkItem {
 }
 
 interface FileJobProps {
+  serviceId: AdspId;
   logger: Logger;
   fileRepository: FileRepository;
-  scanService: ScanService;
+  // scanService: ScanService;
   queueService: WorkQueueService<FileServiceWorkItem>;
-  eventService: EventService;
+  // eventService: EventService;
+  tenantService: TenantService;
+  // notificationService: NotificationService;
+  fileService: FileService;
+  tokenProvider: TokenProvider;
 }
 
 export const createFileJobs = (props: FileJobProps): void => {
-  const scanJob = createScanJob(props);
+  //const scanJob = createScanJob(props);
   const deleteJob = createDeleteJob(props);
+  const deleteOldFilesJob = createDeleteOldFilesJob(props);
+
+  schedule.scheduleJob('* * * * *', deleteOldFilesJob);
+  props.logger.info(`Scheduled daily delete job.`);
 
   props.queueService.getItems().subscribe(({ item, done }) => {
+    console.log(JSON.stringify(item.work) + '<item.work');
+    console.log('queue service');
     switch (item.work) {
       case 'scan':
-        scanJob(item.tenantId, item.file, done);
+        //scanJob(item.tenantId, item.file, done);
         break;
       case 'delete':
         deleteJob(item.tenantId, item.file, done);

--- a/apps/file-service/src/file/job/user.ts
+++ b/apps/file-service/src/file/job/user.ts
@@ -1,0 +1,16 @@
+import { User } from '@abgov/adsp-service-sdk';
+
+
+export enum ServiceRoles {
+  Admin = 'file-service-admin',
+  IntakeApp = 'intake-application',
+}
+
+export const jobUser = {
+  id: 'form-service-job',
+  name: 'form-service-job',
+  isCore: true,
+  roles: [ServiceRoles.Admin],
+} as User;
+
+

--- a/apps/file-service/src/file/model/file.ts
+++ b/apps/file-service/src/file/model/file.ts
@@ -19,6 +19,7 @@ export class FileEntity implements File {
   scanned = false;
   deleted = false;
   infected = false;
+  retentionDays?: number;
 
   static async create(
     storageProvider: FileStorageProvider,

--- a/apps/file-service/src/file/types/file.ts
+++ b/apps/file-service/src/file/types/file.ts
@@ -13,6 +13,7 @@ export interface File {
   createdBy: UserInfo;
   created: Date;
   lastAccessed?: Date;
+  retentionDays?: number
 }
 
 export interface FileRecord extends File {

--- a/apps/file-service/src/file/types/type.ts
+++ b/apps/file-service/src/file/types/type.ts
@@ -12,3 +12,7 @@ export interface FileTypeCriteria {
   spaceEquals?: string;
   typeEquals?: string;
 }
+
+export interface FileService {
+  delete(tenantId: AdspId, urn: AdspId): Promise<boolean>;
+}

--- a/apps/file-service/src/main.ts
+++ b/apps/file-service/src/main.ts
@@ -121,10 +121,10 @@ async function initializeApp(): Promise<express.Application> {
     storageProvider,
   });
 
-  // const scanService = createScanService(environment.AV_PROVIDER, {
-  //   host: environment.AV_HOST,
-  //   port: environment.AV_PORT,
-  // });
+  const scanService = createScanService(environment.AV_PROVIDER, {
+    host: environment.AV_HOST,
+    port: environment.AV_PORT,
+  });
 
   const queueService = await createFileQueueService({ ...environment, logger });
 
@@ -144,6 +144,7 @@ async function initializeApp(): Promise<express.Application> {
     logger,
     storageProvider,
     eventService,
+    scanService,
     queueService,
     tenantService,
     configurationService,

--- a/apps/file-service/src/main.ts
+++ b/apps/file-service/src/main.ts
@@ -53,6 +53,7 @@ async function initializeApp(): Promise<express.Application> {
     healthCheck,
     eventService,
     metricsHandler,
+    tenantService,
   } = await initializePlatform(
     {
       serviceId,
@@ -120,10 +121,10 @@ async function initializeApp(): Promise<express.Application> {
     storageProvider,
   });
 
-  const scanService = createScanService(environment.AV_PROVIDER, {
-    host: environment.AV_HOST,
-    port: environment.AV_PORT,
-  });
+  // const scanService = createScanService(environment.AV_PROVIDER, {
+  //   host: environment.AV_HOST,
+  //   port: environment.AV_PORT,
+  // });
 
   const queueService = await createFileQueueService({ ...environment, logger });
 
@@ -138,12 +139,14 @@ async function initializeApp(): Promise<express.Application> {
   });
 
   applyFileMiddleware(app, {
+    tokenProvider,
     serviceId,
     logger,
     storageProvider,
-    scanService,
     eventService,
     queueService,
+    tenantService,
+    configurationService,
     ...repositories,
   });
 

--- a/apps/file-service/src/mongo/file.ts
+++ b/apps/file-service/src/mongo/file.ts
@@ -38,8 +38,6 @@ export class MongoFileRepository implements FileRepository {
     const query: QueryProps = this.getQuery(tenantId, criteria);
     const types = await this.typeRepository.getTypes(tenantId);
 
-    console.log(query);
-
     const docs = await this.model.find(query, null, { lean: true }).skip(skip).limit(top).sort({ created: -1 }).exec();
     const results = docs.map((doc) => this.fromDoc(types[doc.typeId], doc as FileDoc));
 


### PR DESCRIPTION
File service in the job mode runs scheduled jobs

The retention policy file deletion is a scheduled job

- runs on daily
- operation performed by the job
- - Load all tenants
- - For each tenant, load file configuration (and core file configuration)
- - For each file type with retention policy enabled, find files that should be deleted
- - Delete files

* Job handles paging files when querying

Deletion functions as regular deletion and associated domain events are emitted where ‘user’ information indicates the retention process

mark for deletion (doesn’t need to be immediately deleted from underlying storage)