### PR TITLE
feat(task-service): changing how task service stores un-assignment

### DIFF
--- a/apps/task-service/src/postgres/task.ts
+++ b/apps/task-service/src/postgres/task.ts
@@ -38,11 +38,13 @@ export class PostgresTaskRepository implements TaskRepository {
                   id: record.assignedById,
                   name: record.assignedByName,
                 },
-                assignedTo: {
-                  id: record.assignedToId,
-                  name: record.assignedToName,
-                  email: record.assignedToEmail,
-                },
+                assignedTo: record.assignedToId
+                  ? {
+                      id: record.assignedToId,
+                      name: record.assignedToName,
+                      email: record.assignedToEmail,
+                    }
+                  : null,
                 assignedOn: record.assignedOn,
               }
             : null,

--- a/apps/task-service/src/task/events.ts
+++ b/apps/task-service/src/task/events.ts
@@ -31,6 +31,7 @@ const userSchema = {
 
 const assignedUserSchema = {
   ...userSchema,
+  type: ['object', 'null'],
   properties: {
     ...userSchema.properties,
     email: {

--- a/apps/task-service/src/task/router/queue.ts
+++ b/apps/task-service/src/task/router/queue.ts
@@ -280,7 +280,7 @@ export function createQueueRouter({
             isString: true,
           },
           assignTo: {
-            optional: true,
+            optional: { options: { nullable: true, checkFalsy: false } },
             isObject: true,
           },
         },


### PR DESCRIPTION
Store the assignment metadata even if the assignment is to no one.