### PR TITLE
fix(push-service): fix event matching logic in stream entity

### DIFF
--- a/apps/push-service/src/push/model/stream.spec.ts
+++ b/apps/push-service/src/push/model/stream.spec.ts
@@ -194,7 +194,7 @@ describe('StreamEntity', () => {
               name: 'test-started',
               timestamp: new Date(),
               correlationId: '123',
-              context: { value: 123 },
+              context: { value: 123, other: '234' },
               payload: {},
             }
           )

--- a/apps/push-service/src/push/model/stream.ts
+++ b/apps/push-service/src/push/model/stream.ts
@@ -3,8 +3,8 @@ import { Observable } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { AdspId, hasRequiredRole, isAllowedUser, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
 import { DomainEvent, InvalidOperationError } from '@core-services/core-common';
+import { PushServiceRoles } from '../roles';
 import { EventCriteria, Stream, StreamEvent } from '../types';
-import { PushServiceRoles } from '..';
 
 export type StreamItem = unknown & Pick<DomainEvent, 'namespace' | 'name' | 'correlationId' | 'context' | 'tenantId'>;
 export class StreamEntity implements Stream {
@@ -47,10 +47,14 @@ export class StreamEntity implements Stream {
   }
 
   private isMatch(event: StreamItem, criteria?: EventCriteria) {
+    // Is a match if there is:
+    // 1. No criteria; or
+    // 2. Not (has correlationId criteria and does not match event correlationId) and
+    // 3. Not (has context criteria with any context value that does not match event context).
     return (
       !criteria ||
       (!(criteria.correlationId && criteria.correlationId !== event.correlationId) &&
-        !(criteria.context && !_.isEqual(criteria.context, event.context)))
+        !(criteria.context && !Object.entries(criteria.context).find(([key, value]) => value !== event.context?.[key])))
     );
   }
 


### PR DESCRIPTION
Context criteria is failed if any criteria value does not match event context, and criteria can specify a subset of values.