### PR TITLE
feat(task-service): mapping full task into event payload

### DIFF
--- a/apps/task-service/src/task/events.ts
+++ b/apps/task-service/src/task/events.ts
@@ -1,6 +1,8 @@
-import { DomainEvent, DomainEventDefinition, User } from '@abgov/adsp-service-sdk';
+import { AdspId, DomainEvent, DomainEventDefinition, User } from '@abgov/adsp-service-sdk';
 import { Update } from '@core-services/core-common';
 import { Task, TaskAssignment, TaskPriority } from './types';
+import { TaskEntity } from './model';
+import { mapTask } from './router';
 
 const taskSchema = {
   type: 'object',
@@ -188,14 +190,6 @@ function mapContext(task: Task): Record<string, string | number | boolean> {
   };
 }
 
-function mapTask(task: Task): Record<string, unknown> {
-  return {
-    id: task.id,
-    name: task.name,
-    description: task.description,
-  };
-}
-
 function mapUser({ id, name }: User): Record<string, unknown> {
   return {
     id,
@@ -203,91 +197,91 @@ function mapUser({ id, name }: User): Record<string, unknown> {
   };
 }
 
-export const taskCreated = (user: User, task: Task): DomainEvent => ({
+export const taskCreated = (apiId: AdspId, user: User, task: TaskEntity): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_CREATED,
   timestamp: task.createdOn,
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     createdBy: mapUser(user),
   },
 });
 
-export const taskUpdated = (user: User, task: Task, update: Update<Task>): DomainEvent => ({
+export const taskUpdated = (apiId: AdspId, user: User, task: TaskEntity, update: Update<Task>): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_UPDATED,
   timestamp: new Date(),
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     update,
     updatedBy: mapUser(user),
   },
 });
 
-export const taskPrioritySet = (user: User, task: Task, from: TaskPriority): DomainEvent => ({
+export const taskPrioritySet = (apiId: AdspId, user: User, task: TaskEntity, from: TaskPriority): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_PRIORITY_SET,
   timestamp: new Date(),
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     from: TaskPriority[from],
     to: TaskPriority[task.priority],
     updatedBy: mapUser(user),
   },
 });
 
-export const taskAssigned = (user: User, task: Task, from: TaskAssignment): DomainEvent => ({
+export const taskAssigned = (apiId: AdspId, user: User, task: TaskEntity, from: TaskAssignment): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_ASSIGNED,
   timestamp: task.assignment?.assignedOn || new Date(),
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     from,
     to: task.assignment,
     assignedBy: mapUser(user),
   },
 });
 
-export const taskStarted = (user: User, task: Task): DomainEvent => ({
+export const taskStarted = (apiId: AdspId, user: User, task: TaskEntity): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_STARTED,
   timestamp: task.startedOn,
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     startedBy: mapUser(user),
   },
 });
 
-export const taskCompleted = (user: User, task: Task): DomainEvent => ({
+export const taskCompleted = (apiId: AdspId, user: User, task: TaskEntity): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_COMPLETED,
   timestamp: task.endedOn,
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     completedBy: mapUser(user),
   },
 });
 
-export const taskCancelled = (user: User, task: Task, reason?: string): DomainEvent => ({
+export const taskCancelled = (apiId: AdspId, user: User, task: TaskEntity, reason?: string): DomainEvent => ({
   tenantId: task.tenantId,
   name: TASK_CANCELLED,
   timestamp: task.endedOn,
   correlationId: task.id,
   context: mapContext(task),
   payload: {
-    task: mapTask(task),
+    task: mapTask(apiId, task),
     cancelledBy: mapUser(user),
     reason,
   },

--- a/apps/task-service/src/task/router/queue.ts
+++ b/apps/task-service/src/task/router/queue.ts
@@ -113,7 +113,7 @@ export const createTask =
       });
       res.send(mapTask(apiId, entity));
 
-      eventService.send(taskCreated(user, entity));
+      eventService.send(taskCreated(apiId, user, entity));
     } catch (err) {
       next(err);
     }

--- a/apps/task-service/src/task/router/task.ts
+++ b/apps/task-service/src/task/router/task.ts
@@ -116,7 +116,7 @@ export const updateTask =
       const updated = await task.update(user, update);
       res.send(mapTask(apiId, updated));
 
-      eventService.send(taskUpdated(user, updated, update));
+      eventService.send(taskUpdated(apiId, user, updated, update));
     } catch (err) {
       next(err);
     }
@@ -136,26 +136,26 @@ export const taskOperation =
       switch (request.operation) {
         case OPERATION_START:
           result = await task.start(user);
-          event = taskStarted(user, result);
+          event = taskStarted(apiId,user, result);
           break;
         case OPERATION_COMPLETE:
           result = await task.complete(user);
-          event = taskCompleted(user, result);
+          event = taskCompleted(apiId,user, result);
           break;
         case OPERATION_CANCEL:
           result = await task.cancel(user);
-          event = taskCancelled(user, result, request.reason);
+          event = taskCancelled(apiId,user, result, request.reason);
           break;
         case OPERATION_SET_PRIORITY: {
           const from = task.priority;
           result = await task.setPriority(user, TaskPriority[request.priority]);
-          event = taskPrioritySet(user, result, from);
+          event = taskPrioritySet(apiId,user, result, from);
           break;
         }
         case OPERATION_ASSIGN: {
           const from = task.assignment;
           result = await task.assign(user, request.assignTo);
-          event = taskAssigned(user, result, from);
+          event = taskAssigned(apiId,user, result, from);
           break;
         }
         default:


### PR DESCRIPTION
Using the same data mapper as the router when populating the event payload so event consumers can access all properties.