### PR TITLE
Fixes for CS-2095 / CS-2191 / CS-2146

### DIFF
--- a/apps/status-service/src/app/jobs/checkEndpoint.spec.ts
+++ b/apps/status-service/src/app/jobs/checkEndpoint.spec.ts
@@ -121,7 +121,9 @@ describe('checkEndpoint', () => {
 
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } });
+        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } }).mockResolvedValueOnce({
+          data: { latest: { configuration: { applicationWebhookIntervals: {} } } },
+        });
 
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
@@ -165,13 +167,16 @@ describe('checkEndpoint', () => {
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } });
+        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } }).mockResolvedValueOnce({
+          data: { latest: { configuration: { applicationWebhookIntervals: {} } } },
+        });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
             endpoint: { status: 'online' },
           } as ServiceStatusApplication)
         );
+
         statusRepositoryMock.save.mockImplementationOnce((entity) => entity);
         await job();
         expect(eventServiceMock.send).toHaveBeenCalledWith(expect.objectContaining({ name: 'application-unhealthy' }));
@@ -181,6 +186,12 @@ describe('checkEndpoint', () => {
       });
 
       it('sends a managed application down event', async () => {
+        const applicationWebhookIntervals = {
+          asdf: {
+            appId: 'the-other-key',
+            waitTimeInterval: 3,
+          },
+        };
         const webHooks = {
           asdf: {
             id: 'asdf',
@@ -222,7 +233,11 @@ describe('checkEndpoint', () => {
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: webHooks } } });
+        axiosMock.get
+          .mockResolvedValueOnce({ data: { latest: { configuration: { webhooks: webHooks } } } })
+          .mockResolvedValueOnce({
+            data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
+          });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -235,6 +250,12 @@ describe('checkEndpoint', () => {
       });
 
       it('does not send a managed application down event because app is already down', async () => {
+        const applicationWebhookIntervals = {
+          asdf: {
+            appId: 'the-other-key',
+            waitTimeInterval: 3,
+          },
+        };
         const webHooks = {
           asdf: {
             id: 'asdf',
@@ -277,7 +298,9 @@ describe('checkEndpoint', () => {
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: webHooks } } });
+        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: webHooks } } }).mockResolvedValueOnce({
+          data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
+        });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -292,13 +315,18 @@ describe('checkEndpoint', () => {
       });
 
       it('sends a managed application up event', async () => {
+        const applicationWebhookIntervals = {
+          asdf: {
+            appId: 'the-other-key',
+            waitTimeInterval: 3,
+          },
+        };
         const webHooks = {
           asdf: {
             id: 'asdf',
             name: 'Fubar',
             url: 'http://www.localhost:3000/uptime',
             targetId: 'the-other-key',
-            intervalMinutes: 3,
             description: 'asdfasdf',
             eventTypes: [
               { id: 'status-service:monitored-service-down' },
@@ -333,7 +361,11 @@ describe('checkEndpoint', () => {
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: webHooks } } });
+        axiosMock.get
+          .mockResolvedValueOnce({ data: { latest: { configuration: { webhooks: webHooks } } } })
+          .mockResolvedValueOnce({
+            data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
+          });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -347,6 +379,13 @@ describe('checkEndpoint', () => {
       });
 
       it('can not update when status unchanged', async () => {
+        const applicationWebhookIntervals = {
+          asdf: {
+            appId: 'the-other-key',
+            waitTimeInterval: 3,
+          },
+        };
+
         getEndpointResponse.mockResolvedValueOnce({ status: 200 });
         endpointRepositoryMock.save.mockImplementationOnce((entity) => entity);
         endpointRepositoryMock.findRecentByUrlAndApplicationId.mockReturnValueOnce([
@@ -371,7 +410,9 @@ describe('checkEndpoint', () => {
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } });
+        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } }).mockResolvedValueOnce({
+          data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
+        });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',

--- a/apps/status-service/src/app/model/serviceStatus.ts
+++ b/apps/status-service/src/app/model/serviceStatus.ts
@@ -33,7 +33,15 @@ export interface StaticApplicationData extends ApplicationConfiguration {
 }
 
 export interface Configuration {
-  latest: { configuration: Record<string, Webhooks> };
+  latest: { configuration: { webhooks: Record<string, Webhooks> }};
+}
+export interface StatusConfiguration {
+  latest: { configuration: { applicationWebhookIntervals: Record<string, HookInterval> }};
+}
+
+export interface HookInterval {
+  appId: string,
+  waitTimeInterval: number,
 }
 
 export interface Webhooks {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/testWebhook.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/testWebhook.tsx
@@ -6,7 +6,6 @@ import DataTable from '@components/DataTable';
 import { EventSearchCriteria } from '@store/event/models';
 import { getEventLogEntries } from '@store/event/actions';
 import { GoAButton, GoARadio } from '@abgov/react-components';
-import { getEventDefinitions } from '@store/event/actions';
 
 import { GoAPageLoader } from '@abgov/react-components';
 
@@ -37,7 +36,9 @@ export const TestWebhookModal: FC<Props> = ({ isOpen, title, onClose, testId, de
   const dispatch = useDispatch();
 
   const [showEntries, setShowEntries] = useState<boolean>(false);
-  const [selectedStatusName, setSelectedStatusName] = useState<string>('monitored-service-down');
+  const [selectedStatusName, setSelectedStatusName] = useState<string>(
+    defaultWebhooks && defaultWebhooks.eventTypes[0].id.split(':')[1]
+  );
 
   const indicator = useSelector((state: RootState) => {
     return state?.session?.indicator;
@@ -60,12 +61,10 @@ export const TestWebhookModal: FC<Props> = ({ isOpen, title, onClose, testId, de
   const testSuccess = useSelector((state: RootState) => state.serviceStatus.testSuccess);
 
   useEffect(() => {
-    dispatch(getEventDefinitions());
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(getEventLogEntries('', initCriteria));
-    setShowEntries(true);
+    if (testSuccess) {
+      dispatch(getEventLogEntries('', initCriteria));
+      setShowEntries(true);
+    }
   }, [testSuccess]);
 
   useEffect(() => {
@@ -130,7 +129,7 @@ export const TestWebhookModal: FC<Props> = ({ isOpen, title, onClose, testId, de
                 </DataTable>
               </GoAFormItem>
 
-              {(showEntries || indicator.show) && (
+              {(showEntries || (indicator.show && indicator.message !== 'Loading...')) && (
                 <EntryDetail>
                   {indicator.show ? (
                     <div className="loading-border">

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhookForm.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhookForm.tsx
@@ -74,7 +74,7 @@ export const WebhookFormModal: FC<Props> = ({
 
   const isDuplicateWebhookName = (): Validator => {
     return (name: string) => {
-      const existingWebhooks = webhooks && Object.keys(webhooks).filter((hook) => webhooks[hook].name === name);
+      const existingWebhooks = webhooks && Object.keys(webhooks).filter((hook) => webhooks[hook]?.name === name);
       return existingWebhooks?.length === 1 ? 'webhook name is duplicate, please use a different name' : '';
     };
   };

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhookHistoryForm.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhookHistoryForm.tsx
@@ -8,6 +8,7 @@ import { getEventDefinitions } from '@store/event/actions';
 
 import { GoABadge } from '@abgov/react-components/experimental';
 import styled from 'styled-components';
+import { GoAPageLoader } from '@abgov/react-components';
 import { GoAButton } from '@abgov/react-components-new';
 
 import {
@@ -122,6 +123,10 @@ const EventLogEntryComponent: FunctionComponent<EventLogEntryComponentProps> = (
 
 export const WebhookHistoryModal: FunctionComponent<Props> = ({ onCancel, webhook }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const indicator = useSelector((state: RootState) => {
+    return state?.session?.indicator;
+  });
+
   const [viewWebhooks, setViewWebhooks] = useState(false);
   const [searched, setSearched] = useState(false);
   const initCriteria: EventSearchCriteria = {
@@ -141,6 +146,7 @@ export const WebhookHistoryModal: FunctionComponent<Props> = ({ onCancel, webhoo
 
   useEffect(() => {
     dispatch(getEventDefinitions());
+    onSearch(searchCriteria);
   }, [dispatch]);
 
   const onSearch = (criteria: EventSearchCriteria) => {
@@ -213,34 +219,40 @@ export const WebhookHistoryModal: FunctionComponent<Props> = ({ onCancel, webhoo
               {viewWebhooks && (
                 <div className="mt-1 mb-2px">
                   <>
-                    {entries?.length > 0 ? (
-                      <DataTable>
-                        <colgroup>
-                          <col className="data-col" />
-                          <col className="data-col" />
-                          <col className="data-col" />
-                          <col className="data-col" />
-                        </colgroup>
-                        <thead>
-                          <tr>
-                            <th id="name">Name</th>
-                            <th id="url">URL</th>
-                            <th id="status">Status</th>
-                            <th id="timestamp">Occurred</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {entries !== null &&
-                            entries.map((entry) => (
-                              <EventLogEntryComponent
-                                key={`${entry.timestamp}${entry.namespace}${entry.name}`}
-                                entry={entry}
-                              />
-                            ))}
-                        </tbody>
-                      </DataTable>
+                    {entries ? (
+                      entries?.length > 0 ? (
+                        <DataTable>
+                          <colgroup>
+                            <col className="data-col" />
+                            <col className="data-col" />
+                            <col className="data-col" />
+                            <col className="data-col" />
+                          </colgroup>
+                          <thead>
+                            <tr>
+                              <th id="name">Name</th>
+                              <th id="url">URL</th>
+                              <th id="status">Status</th>
+                              <th id="timestamp">Occurred</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {entries !== null &&
+                              entries.map((entry) => (
+                                <EventLogEntryComponent
+                                  key={`${entry.timestamp}${entry.namespace}${entry.name}`}
+                                  entry={entry}
+                                />
+                              ))}
+                          </tbody>
+                        </DataTable>
+                      ) : (
+                        'No webhook history found'
+                      )
                     ) : (
-                      'No webhook history found'
+                      <LoadingWrapper>
+                        <GoAPageLoader visible={true} type="infinite" message={indicator.message} pagelock={true} />
+                      </LoadingWrapper>
                     )}
                     {next && (
                       <div className="mt-1">
@@ -261,21 +273,21 @@ export const WebhookHistoryModal: FunctionComponent<Props> = ({ onCancel, webhoo
               <GoAButton
                 type="primary"
                 onClick={() => {
-                  onSearch(searchCriteria);
+                  setViewWebhooks(false);
+                  onCancel();
                 }}
               >
-                Show
+                Close
               </GoAButton>
             </ButtonWrapper>
             <ButtonWrapper>
               <GoAButton
                 type="secondary"
                 onClick={() => {
-                  setViewWebhooks(false);
-                  onCancel();
+                  onSearch(searchCriteria);
                 }}
               >
-                Close
+                Search
               </GoAButton>
             </ButtonWrapper>
           </ButtonPadding>
@@ -373,4 +385,8 @@ const AlignedTr = styled.tr`
   .padding-left-8 {
     padding-left: 8px;
   }
+`;
+
+const LoadingWrapper = styled.div`
+  margin: 30px 0 30px 0;
 `;

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookDeleteModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookDeleteModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { GoAModal, GoAModalActions, GoAModalContent, GoAModalTitle } from '@abgov/react-components/experimental';
+//import { GoAModal, GoAModalActions, GoAModalContent, GoAModalTitle } from '@abgov/react-components/experimental';
+import { GoAModal } from '@abgov/react-components-new';
 import { GoAButton, GoAButtonGroup } from '@abgov/react-components-new';
 import { useDispatch } from 'react-redux';
 import { DeleteWebhookService } from '@store/status/actions';
@@ -14,38 +15,33 @@ export const WebhookDeleteModal = ({ onCancel, webhook }: WebhookDeleteModalProp
   const dispatch = useDispatch();
 
   return (
-    <GoAModal testId="webhook-delete-modal" isOpen={true}>
-      <GoAModalTitle testId="webhook-delete-modal-title">Delete webhook</GoAModalTitle>
-      <GoAModalContent testId="webhook-delete-modal-content">
-        <p>
-          Are you sure you wish to delete #<b>{`${webhook?.name}?`}</b>
-        </p>
-
-        <GoAModalActions>
-          <GoAButtonGroup alignment="end">
-            <GoAButton
-              type="secondary"
-              testId="webhook-delete-modal-delete-cancel"
-              onClick={() => {
-                onCancel();
-              }}
-            >
-              Cancel
-            </GoAButton>
-            <GoAButton
-              type="primary"
-              variant="destructive"
-              testId="webhook-delete-modal-delete-btn"
-              onClick={() => {
-                dispatch(DeleteWebhookService(webhook));
-                onCancel();
-              }}
-            >
-              Delete
-            </GoAButton>
-          </GoAButtonGroup>
-        </GoAModalActions>
-      </GoAModalContent>
+    <GoAModal
+      testId="webhook-delete-modal"
+      open={true}
+      heading="Delete webhook"
+      width="640px"
+      actions={
+        <GoAButtonGroup alignment="end">
+          <GoAButton type="secondary" testId="webhook-delete-modal-delete-cancel" onClick={onCancel}>
+            Cancel
+          </GoAButton>
+          <GoAButton
+            type="primary"
+            variant="destructive"
+            testId="webhook-delete-modal-delete-btn"
+            onClick={() => {
+              dispatch(DeleteWebhookService(webhook));
+              onCancel();
+            }}
+          >
+            Delete
+          </GoAButton>
+        </GoAButtonGroup>
+      }
+    >
+      <p>
+        Are you sure you wish to delete #<b>{`${webhook?.name}?`}</b>
+      </p>
     </GoAModal>
   );
 };

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhooks.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhooks.tsx
@@ -185,6 +185,7 @@ export const WebhooksDisplay = ({ webhooks }: WebhookDisplayProps): JSX.Element 
           <tbody>
             {webhooks &&
               Object.keys(webhooks).map((key) => {
+                if (!webhooks[key]) return null;
                 return (
                   <FileTypeTableRow
                     key={`webhook-${webhooks[key].id}`}

--- a/apps/tenant-management-webapp/src/app/store/event/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/event/sagas.ts
@@ -223,7 +223,7 @@ export function* fetchEventLogEntries(action: FetchEventLogEntriesAction): SagaI
       yield put(
         UpdateIndicator({
           show: true,
-          message: 'Loading',
+          message: 'Loading...',
         })
       );
       const { data } = yield call(axios.get, eventUrl, {

--- a/apps/tenant-management-webapp/src/app/store/status/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/reducers.ts
@@ -78,9 +78,11 @@ export default function statusReducer(state: ServiceStatus = initialState, actio
       });
 
       Object.keys(webhooks).forEach((key) => {
-        webhooks[key].intervalMinutes = hookIntervalList.find(
-          (i) => i.appId === webhooks[key].targetId
-        )?.waitTimeInterval;
+        if (webhooks[key]) {
+          webhooks[key].intervalMinutes = hookIntervalList.find(
+            (i) => i.appId === webhooks[key]?.targetId
+          )?.waitTimeInterval;
+        }
       });
       return { ...state, webhooks: webhooks };
     }
@@ -104,9 +106,11 @@ export default function statusReducer(state: ServiceStatus = initialState, actio
 
       webhooks &&
         Object.keys(webhooks).forEach((key) => {
-          webhooks[key].intervalMinutes = hookIntervalList.find(
-            (i) => i.appId === webhooks[key].targetId
-          )?.waitTimeInterval;
+          if (webhooks[key]) {
+            webhooks[key].intervalMinutes = hookIntervalList.find(
+              (i) => i.appId === webhooks[key].targetId
+            )?.waitTimeInterval;
+          }
         });
 
       return {

--- a/apps/tenant-management-webapp/src/app/store/status/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/sagas.ts
@@ -204,9 +204,15 @@ export function* deleteWebhook(action: DeleteWebhookAction): SagaIterator {
   );
   const token = yield call(getAccessToken);
 
+  const id = action.payload.id;
+
+  const pushService: Record<string, Webhooks> = {
+    [id]: null,
+  };
+
   try {
     const api = new WebhookApi(configBaseUrl, token);
-    yield call([api, api.deleteWebhook], action.payload.id);
+    yield call([api, api.saveWebhookPush], pushService);
 
     yield put(deleteWebhookSuccess(action.payload.id));
   } catch (e) {


### PR DESCRIPTION
* Delete view had extra space on right / delete was not updating in backend (regression)
* webhook was only working in test and not when apps were up or down (regression)
* cleaned up test screen to not show loading when nothing is loading
* Now auto-searching when the webhook history page is openend
* re-arranged history buttons accordingly
* don't show 'no history' if we're in the middle of a reload
* Ensure the test window always has something selected