### PR TITLE
feat(file-service): adjusting permissions on files

### DIFF
--- a/apps/file-service/src/file/model/file.ts
+++ b/apps/file-service/src/file/model/file.ts
@@ -81,19 +81,27 @@ export class FileEntity implements File {
   }
 
   canAccess(user: User): boolean {
-    return this.type
-      ? this.type.canAccessFile(user)
-      : isAllowedUser(user, this.tenantId, [ServiceUserRoles.Admin], true);
+    // User who created a file can always access it again, or
+    // Admin user, or
+    // User allowed to access based on role configuration on file type.
+    return (
+      user?.id === this.createdBy.id ||
+      isAllowedUser(user, this.tenantId, [ServiceUserRoles.Admin], true) ||
+      this.type?.canAccessFile(user)
+    );
   }
 
-  canUpdate(user: User): boolean {
-    return this.type
-      ? this.type.canUpdateFile(user)
-      : isAllowedUser(user, this.tenantId, [ServiceUserRoles.Admin], true);
+  canDelete(user: User): boolean {
+    // Admin user can delete, or
+    // User allowed to update based on role configuration on file type and is original creator.
+    return (
+      isAllowedUser(user, this.tenantId, [ServiceUserRoles.Admin], true) ||
+      (this.type?.canUpdateFile(user) && user.id === this.createdBy.id)
+    );
   }
 
   markForDeletion(user: User): Promise<FileEntity> {
-    if (!this.canUpdate(user)) {
+    if (!this.canDelete(user)) {
       throw new UnauthorizedError('User not authorized to delete file.');
     }
 

--- a/apps/file-service/src/file/model/type.ts
+++ b/apps/file-service/src/file/model/type.ts
@@ -53,10 +53,7 @@ export class FileTypeEntity implements FileType {
   }
 
   canAccessFile(user: User): boolean {
-    return (
-      this.anonymousRead ||
-      isAllowedUser(user, this.tenantId, [ServiceUserRoles.Admin, ...this.readRoles, ...this.updateRoles], true)
-    );
+    return this.anonymousRead || isAllowedUser(user, this.tenantId, [ServiceUserRoles.Admin, ...this.readRoles], true);
   }
 
   canUpdateFile(user: User): boolean {
@@ -64,6 +61,8 @@ export class FileTypeEntity implements FileType {
   }
 
   canAccess(user: User): boolean {
+    // This is for whether the user can access the File Type,
+    // but logic happens to be identical to accessing for file of type for now.
     return this.canAccessFile(user);
   }
 }

--- a/apps/file-service/src/file/router/file.spec.ts
+++ b/apps/file-service/src/file/router/file.spec.ts
@@ -450,7 +450,7 @@ describe('file router', () => {
       const req = {
         user: {
           tenantId,
-          id: 'test',
+          id: 'tester',
           roles: ['test-updater'],
         },
         getConfiguration: jest.fn(),


### PR DESCRIPTION
Adjusting permissions so creator is always allowed to download their own file, but users with update permission are no longer allowed to access all files of the type (i.e. files uploaded by others). General deletion is restricted to file service admin, but creators of files are allowed to delete if they still have an update role.