### PR TITLE
feat(tenant-management-api): adding helper clients to new tenant crea…

### DIFF
--- a/.openshift/configuration/tenant-management-api.yml
+++ b/.openshift/configuration/tenant-management-api.yml
@@ -16,6 +16,7 @@ items:
       TENANT_WEB_APP_CLIENT_ID: tenant-management-webapp
       TENANT_WEB_APP_HOST: "https://tenant-management-webapp-core-services-dev.os99.gov.ab.ca"
       SUBSCRIBER_APP_HOST: "https://subscriber-app-core-services-dev.os99.gov.ab.ca"
+      API_APP_HOST: "https://api-core-services-dev.os99.gov.ab.ca"
       LOG_LEVEL: info
   - apiVersion: v1
     kind: Secret

--- a/apps/tenant-management-api/src/environments/environment.ts
+++ b/apps/tenant-management-api/src/environments/environment.ts
@@ -22,6 +22,7 @@ export const environment = envalid.cleanEnv(
     SUBSCRIBER_APP_CLIENT_ID: envalid.str({ default: 'urn:ads:platform:subscriber-app' }),
     TENANT_WEB_APP_HOST: envalid.str({ default: 'http://localhost:4200' }),
     SUBSCRIBER_APP_HOST: envalid.str({ default: 'http://localhost:4200' }),
+    API_APP_HOST: envalid.str({ default: 'http://localhost:4200' }),
     CLIENT_ID: envalid.str({ default: 'urn:ads:platform:tenant-service' }),
     CLIENT_SECRET: envalid.str({ default: '' }),
     APP_ENVIRONMENT: envalid.str({ default: 'dev' }),

--- a/apps/tenant-management-api/src/keycloak/configuration.ts
+++ b/apps/tenant-management-api/src/keycloak/configuration.ts
@@ -69,3 +69,35 @@ export const createSubscriberAppPublicClientConfig = (id: string): ClientReprese
 
   return config;
 };
+
+export const createApiAppPublicClientConfig = (id: string): ClientRepresentation => {
+  const config: ClientRepresentation = {
+    id,
+    clientId: 'api-app-client',
+    enabled: false,
+    publicClient: true,
+    directAccessGrantsEnabled: false,
+    redirectUris: [`${environment.API_APP_HOST}/*`],
+    webOrigins: [environment.API_APP_HOST],
+    description:
+      'Platform configured client for ADSP API site. Enable for easy authorization via openId (OAuth2, authorization_code) from the ADSP API site',
+  };
+
+  return config;
+};
+
+export const createNxAdspPublicClientConfig = (id: string): ClientRepresentation => {
+  const config: ClientRepresentation = {
+    id,
+    clientId: 'nx-adsp-cli',
+    enabled: false,
+    publicClient: true,
+    directAccessGrantsEnabled: false,
+    redirectUris: ['http://localhost:3000/callback'],
+    webOrigins: ['http://localhost:3000'],
+    description:
+      'Platform configured client for NX ADSP generators. Enable to use @abgov/nx-adsp generators that retrieve tenant configuration.',
+  };
+
+  return config;
+};

--- a/apps/tenant-management-api/src/keycloak/keycloak.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.ts
@@ -10,6 +10,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { Logger } from 'winston';
 import { RealmService, ServiceClient, Tenant, TenantServiceRoles } from '../tenant';
 import {
+  createApiAppPublicClientConfig,
+  createNxAdspPublicClientConfig,
   createPlatformServiceConfig,
   createSubscriberAppPublicClientConfig,
   createWebappClientConfig,
@@ -308,6 +310,8 @@ export class KeycloakRealmServiceImpl implements RealmService {
     const brokerClientSecret = uuidv4();
     const tenantPublicClientId = uuidv4();
     const subscriberAppPublicClientId = uuidv4();
+    const apiAppPublicClientId = uuidv4();
+    const nxAdspPublicClientId = uuidv4();
     const brokerClient = this.brokerClientName(realm);
 
     let client = await this.createAdminClient();
@@ -316,6 +320,8 @@ export class KeycloakRealmServiceImpl implements RealmService {
     this.logger.debug(`Creating realm '${realm}' with base configuration...`, LOG_CONTEXT);
     const publicClientConfig = createWebappClientConfig(tenantPublicClientId);
     const subscriberAppPublicClientConfig = createSubscriberAppPublicClientConfig(subscriberAppPublicClientId);
+    const apiAppPublicClientConfig = createApiAppPublicClientConfig(apiAppPublicClientId);
+    const nxAdspPublicClientConfig = createNxAdspPublicClientConfig(nxAdspPublicClientId);
 
     const clients = serviceClients.map((registeredClient) =>
       createPlatformServiceConfig(registeredClient.serviceId, ...registeredClient.roles)
@@ -328,7 +334,13 @@ export class KeycloakRealmServiceImpl implements RealmService {
       displayNameHtml: name,
       loginTheme: 'ads-theme',
       accountTheme: 'ads-theme',
-      clients: [subscriberAppPublicClientConfig, publicClientConfig, ...clients.map((c) => c.client)],
+      clients: [
+        subscriberAppPublicClientConfig,
+        publicClientConfig,
+        apiAppPublicClientConfig,
+        nxAdspPublicClientConfig,
+        ...clients.map((c) => c.client),
+      ],
       roles: {
         client: clients.reduce((cs, c) => ({ ...cs, [c.client.clientId]: c.clientRoles }), {}),
       },


### PR DESCRIPTION
…tion

Adding clients for the API docs swagger app and NX ADSP generators so that new tenants can enable and use pre-configured clients.