### PR TITLE
feat(configuration-service): require configuration schema to be json …

### DIFF
--- a/apps/configuration-service/src/configuration/index.ts
+++ b/apps/configuration-service/src/configuration/index.ts
@@ -27,6 +27,7 @@ export const applyConfigurationMiddleware = async (
           },
           configurationSchema: {
             type: 'object',
+            $ref: 'http://json-schema.org/draft-07/schema#',
           },
         },
         required: ['configurationSchema'],


### PR DESCRIPTION
…schema

This schema requires that the property is an object and satisfies json schema (json schema itself also allows boolean).