### PR TITLE
CS2192 - prevent triple processing

### DIFF
--- a/apps/push-service/src/main.ts
+++ b/apps/push-service/src/main.ts
@@ -18,6 +18,7 @@ import { createClient as createRedisClient } from 'redis';
 import { Server as IoServer, Socket } from 'socket.io';
 import { promisify } from 'util';
 import { createAmqpEventService } from './amqp';
+import { createAmqpEventService as createAmqpEventServiceWebhooks } from '@core-services/core-common';
 import { environment } from './environments/environment';
 import { applyPushMiddleware, configurationSchema, PushServiceRoles, Stream, StreamEntity } from './push';
 import { WebhookTriggeredDefinition } from './push/events';
@@ -139,9 +140,16 @@ const initializeApp = async (): Promise<Server> => {
 
   const eventServiceAmp = await createAmqpEventService({ ...environment, logger });
 
+  const eventServiceAmpWebhooks = await createAmqpEventServiceWebhooks({
+    ...environment,
+    queue: 'webhooks',
+    logger,
+  });
+
   applyPushMiddleware(app, [defaultIo, io], {
     logger,
     eventServiceAmp,
+    eventServiceAmpWebhooks,
     tenantService,
     configurationService,
     directory,

--- a/apps/push-service/src/push/index.ts
+++ b/apps/push-service/src/push/index.ts
@@ -20,6 +20,7 @@ export * from './roles';
 interface PushMiddlewareProps {
   logger: Logger;
   eventServiceAmp: DomainEventSubscriberService;
+  eventServiceAmpWebhooks: DomainEventSubscriberService;
   tenantService: TenantService;
   configurationService: ConfigurationService;
   directory: ServiceDirectory;

--- a/apps/push-service/src/push/router/stream.spec.ts
+++ b/apps/push-service/src/push/router/stream.spec.ts
@@ -79,6 +79,7 @@ describe('stream router', () => {
     const router = createStreamRouter([ioMock as unknown as Namespace], {
       logger: loggerMock,
       eventServiceAmp: eventServiceAmpMock as DomainEventSubscriberService,
+      eventServiceAmpWebhooks: eventServiceAmpMock as DomainEventSubscriberService,
       eventService: eventServiceMock as EventService,
       tenantService: tenantServiceMock as unknown as TenantService,
       tokenProvider: tokenProviderMock as unknown as TokenProvider,

--- a/apps/push-service/src/push/router/stream.ts
+++ b/apps/push-service/src/push/router/stream.ts
@@ -29,6 +29,7 @@ import { webhookTriggered } from '../events';
 interface StreamRouterProps {
   logger: Logger;
   eventServiceAmp: DomainEventSubscriberService;
+  eventServiceAmpWebhooks: DomainEventSubscriberService;
   tenantService: TenantService;
   tokenProvider: TokenProvider;
   eventService: EventService;
@@ -249,6 +250,7 @@ export const createStreamRouter = (
   {
     logger,
     eventServiceAmp,
+    eventServiceAmpWebhooks,
     tenantService,
     tokenProvider,
     eventService,
@@ -264,9 +266,19 @@ export const createStreamRouter = (
     share()
   );
 
+  const webhookEvents = eventServiceAmpWebhooks.getItems().pipe(
+    map(({ item, done }) => {
+      done();
+      return item;
+    }),
+    share()
+  );
+
   events.subscribe(async (next) => {
     logger.debug(`Processing event ${next.namespace}:${next.name} ...`);
+  });
 
+  webhookEvents.subscribe(async (next) => {
     if (`${next.namespace}:${next.name}` !== 'push-service:webhook-triggered') {
       const tenant = await tenantService.getTenants();
       const tenantId = tenant[0]?.id;
@@ -310,6 +322,7 @@ export const createStreamRouter = (
             const endpointWebsocket = webhooks[key].url;
 
             if (eventMatches.length > 0) {
+              logger.debug(`Processing webhooks: ${next.namespace}:${next.name} ...`);
               let response: StatusResponse = {};
               let callResponseTime = 0;
               const beforeWebhook = new Date().getTime();


### PR DESCRIPTION
by using a named instead of a '' queue, we should be able to prevent webhooks from being processed once for every pod