### PR TITLE
fix(tenant-management-webapp): default to empty object in fetchWebhoo…

### DIFF
--- a/apps/tenant-management-webapp/src/app/store/status/actions/fetchWebhooks.ts
+++ b/apps/tenant-management-webapp/src/app/store/status/actions/fetchWebhooks.ts
@@ -26,6 +26,6 @@ export const fetchWebhooksSuccess = (
   hookIntervals: Record<string, WebhookStatus>
 ): FetchWebhooksSuccessAction => ({
   type: FETCH_WEBHOOK_SUCCESS_ACTION,
-  payload,
-  hookIntervals,
+  payload: payload || {},
+  hookIntervals: hookIntervals || {},
 });


### PR DESCRIPTION
…kSuccess action

In case of new tenants, there is no configuration for webhook, so default to object for easier handling downstream.