### PR TITLE
Allows refresh while in editor

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
@@ -76,6 +76,7 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
   useEffect(() => {
     dispatch(fetchKeycloakServiceRoles());
     dispatch(getFormDefinitions());
+    dispatch(FetchRealmRoles());
   }, []);
 
   const types = [
@@ -92,10 +93,6 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
       return serviceRoles?.keycloak || {};
     }
   );
-
-  useEffect(() => {
-    dispatch(FetchRealmRoles());
-  }, []);
 
   useEffect(() => {
     if (id && formDefinitions[id]) {
@@ -275,7 +272,9 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
                   onChange={(name, value) => {
                     validators.remove('description');
                     validators['description'].check(value);
-                    setDefinition({ ...definition, description: value });
+                    if (value !== definition?.description && definition !== defaultFormDefinition) {
+                      setDefinition({ ...definition, description: value });
+                    }
                   }}
                 />
 


### PR DESCRIPTION
* There is a glitch in GoATextArea that causes onChange to be executed on page reload. This prevents a page reload from showing current data in the editor correct. By conditioning this refresh we can show data correctly in the editor if we happen to refresh the page inside the editor or use a link outside the app to go to a specific form editor.