### PR TITLE
feat(adsp-service-sdk): add decorator to limit multiple executions of…

### DIFF
--- a/libs/adsp-service-sdk/src/configuration/configurationService.ts
+++ b/libs/adsp-service-sdk/src/configuration/configurationService.ts
@@ -21,10 +21,11 @@ export interface ConfigurationService {
    * @param {AdspId} serviceId
    * @param {string} token
    * @param {AdspId} tenantId
+   * @param {AdspId} skipCache
    * @returns {Promise<R>}
    * @memberof ConfigurationService
    */
-  getConfiguration<C, R = [C, C]>(serviceId: AdspId, token: string, tenantId?: AdspId, unCached?: boolean): Promise<R>;
+  getConfiguration<C, R = [C, C]>(serviceId: AdspId, token: string, tenantId?: AdspId, skipCache?: boolean): Promise<R>;
 }
 
 export class ConfigurationServiceImpl implements ConfigurationService {
@@ -128,13 +129,13 @@ export class ConfigurationServiceImpl implements ConfigurationService {
     serviceId: AdspId,
     token: string,
     tenantId?: AdspId,
-    unCached?: boolean
+    skipCache?: boolean
   ): Promise<R> => {
     let configuration = null;
     if (tenantId) {
       assertAdspId(tenantId, 'Provided ID is not for a tenant', 'resource');
 
-      if (unCached) {
+      if (skipCache) {
         configuration = (await this.retrieveConfiguration<C>(serviceId, token, tenantId)) || null;
       } else {
         configuration =
@@ -146,7 +147,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
 
     let options = null;
 
-    if (unCached) {
+    if (skipCache) {
       options = (await this.retrieveConfiguration<C>(serviceId, token)) || null;
     } else {
       options =

--- a/libs/adsp-service-sdk/src/configuration/configurationService.ts
+++ b/libs/adsp-service-sdk/src/configuration/configurationService.ts
@@ -3,7 +3,7 @@ import moize from 'moize';
 import * as NodeCache from 'node-cache';
 import type { Logger } from 'winston';
 import { ServiceDirectory } from '../directory';
-import { adspId, AdspId, assertAdspId } from '../utils';
+import { adspId, AdspId, assertAdspId, LimitToOne } from '../utils';
 import type { CombineConfiguration, ConfigurationConverter } from './configuration';
 
 /**
@@ -69,7 +69,11 @@ export class ConfigurationServiceImpl implements ConfigurationService {
     }
   }
 
-  #retrieveConfiguration = async <C>(serviceId: AdspId, token: string, tenantId?: AdspId): Promise<C> => {
+  @LimitToOne(
+    (propertyKey, serviceId: AdspId, _token, tenantId?: AdspId) =>
+      `${propertyKey}-${tenantId ? `${tenantId}-` : ''}${serviceId}`
+  )
+  private async retrieveConfiguration<C>(serviceId: AdspId, token: string, tenantId?: AdspId): Promise<C> {
     const service = serviceId.service;
 
     this.logger.debug(`Retrieving tenant '${tenantId?.toString() || 'core'}' configuration for ${service}...'`, {
@@ -118,7 +122,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
       });
       return null as C;
     }
-  };
+  }
 
   getConfiguration = async <C, R = [C, C]>(
     serviceId: AdspId,
@@ -131,11 +135,11 @@ export class ConfigurationServiceImpl implements ConfigurationService {
       assertAdspId(tenantId, 'Provided ID is not for a tenant', 'resource');
 
       if (unCached) {
-        configuration = (await this.#retrieveConfiguration<C>(serviceId, token, tenantId)) || null;
+        configuration = (await this.retrieveConfiguration<C>(serviceId, token, tenantId)) || null;
       } else {
         configuration =
           this.#configuration.get<C>(`${tenantId}-${serviceId}`) ||
-          (await this.#retrieveConfiguration<C>(serviceId, token, tenantId)) ||
+          (await this.retrieveConfiguration<C>(serviceId, token, tenantId)) ||
           null;
       }
     }
@@ -143,10 +147,10 @@ export class ConfigurationServiceImpl implements ConfigurationService {
     let options = null;
 
     if (unCached) {
-      options = (await this.#retrieveConfiguration<C>(serviceId, token)) || null;
+      options = (await this.retrieveConfiguration<C>(serviceId, token)) || null;
     } else {
       options =
-        this.#configuration.get<C>(`${serviceId}`) || (await this.#retrieveConfiguration<C>(serviceId, token)) || null;
+        this.#configuration.get<C>(`${serviceId}`) || (await this.retrieveConfiguration<C>(serviceId, token)) || null;
     }
 
     return this.#combine(configuration, options, tenantId) as R;

--- a/libs/adsp-service-sdk/src/index.ts
+++ b/libs/adsp-service-sdk/src/index.ts
@@ -1,4 +1,12 @@
-export { adspId, AdspId, AdspIdFormatError, assertAdspId, GoAError, toKebabName } from './utils';
+export {
+  adspId,
+  AdspId,
+  AdspIdFormatError,
+  assertAdspId,
+  GoAError,
+  LimitToOne,
+  toKebabName,
+} from './utils';
 export { AssertCoreRole, AssertRole, isAllowedUser, UnauthorizedUserError, hasRequiredRole } from './access';
 export type { TokenProvider, User } from './access';
 export type { GoAErrorExtra } from './utils';

--- a/libs/adsp-service-sdk/src/utils/index.ts
+++ b/libs/adsp-service-sdk/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './adspId';
 export * from './logger';
 export * from './errors';
 export * from './naming';
+export * from './limitToOne';

--- a/libs/adsp-service-sdk/src/utils/limitToOne.spec.ts
+++ b/libs/adsp-service-sdk/src/utils/limitToOne.spec.ts
@@ -14,7 +14,7 @@ class Test {
     });
   }
 
-  @LimitToOne((propertyKey, a) => `${propertyKey}:${a}`)
+  @LimitToOne((propertyKey, a) => (a === 'skip' ? '' : `${propertyKey}:${a}`))
   doStuffWithInputs(a: string): Promise<string> {
     return new Promise((resolve) => {
       setTimeout(() => {
@@ -65,6 +65,15 @@ describe('LimitToOne', () => {
       test.doStuffWithInputs('a'),
     ]);
     expect(a).toBe(c);
+    expect(a).not.toBe(b);
+
+    expect(test.fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('can cause new execution on falsy key', async () => {
+    const test = new Test();
+
+    const [a, b] = await Promise.all([test.doStuffWithInputs('skip'), test.doStuffWithInputs('skip')]);
     expect(a).not.toBe(b);
 
     expect(test.fn).toHaveBeenCalledTimes(2);

--- a/libs/adsp-service-sdk/src/utils/limitToOne.spec.ts
+++ b/libs/adsp-service-sdk/src/utils/limitToOne.spec.ts
@@ -1,0 +1,81 @@
+import { v4 as uuid } from 'uuid/dist/index';
+import { LimitToOne } from './limitToOne';
+
+class Test {
+  public fn = jest.fn();
+
+  @LimitToOne()
+  doStuff(): Promise<string> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.fn();
+        resolve(`${uuid()}`);
+      }, 100);
+    });
+  }
+
+  @LimitToOne((propertyKey, a) => `${propertyKey}:${a}`)
+  doStuffWithInputs(a: string): Promise<string> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.fn(a);
+        resolve(`${uuid()}`);
+      }, 100);
+    });
+  }
+
+  @LimitToOne()
+  doStuffWithError(): Promise<void> {
+    return new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        this.fn();
+        reject(new Error('oh noes!'));
+      }, 100);
+    });
+  }
+}
+
+describe('LimitToOne', () => {
+  it('can share execution', async () => {
+    const test = new Test();
+
+    const [a, b] = await Promise.all([test.doStuff(), test.doStuff()]);
+    expect(a).toBe(b);
+
+    const c = await test.doStuff();
+    expect(a).not.toBe(c);
+
+    expect(test.fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('can not share across instances', async () => {
+    const instanceA = new Test();
+    const instanceB = new Test();
+
+    const [a, b] = await Promise.all([instanceA.doStuff(), instanceB.doStuff()]);
+    expect(a).not.toBe(b);
+  });
+
+  it('can share execution based on key', async () => {
+    const test = new Test();
+
+    const [a, b, c] = await Promise.all([
+      test.doStuffWithInputs('a'),
+      test.doStuffWithInputs('b'),
+      test.doStuffWithInputs('a'),
+    ]);
+    expect(a).toBe(c);
+    expect(a).not.toBe(b);
+
+    expect(test.fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('can return error', async () => {
+    const test = new Test();
+
+    await expect(Promise.all([test.doStuffWithError(), test.doStuffWithError()])).rejects.toThrow();
+    await expect(test.doStuffWithError()).rejects.toThrow();
+
+    expect(test.fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/adsp-service-sdk/src/utils/limitToOne.ts
+++ b/libs/adsp-service-sdk/src/utils/limitToOne.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type LimitToOne = (
+  getKey?: (propertyKey: string, ...args: any[]) => string
+) => (
+  target: unknown,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<(...args: unknown[]) => Promise<unknown>>
+) => TypedPropertyDescriptor<(...args: any[]) => Promise<any>>;
+
+const results = new WeakMap<object, Record<string, Promise<unknown>>>();
+
+/**
+ * Method decorator that limits a method to a single active execution per key.
+ * The same promise is used to respond to callers until it is fulfilled.
+ *
+ * @param {*} [getKey=(propertyKey) => propertyKey]
+ * Function to get the key used to determine which executions share an execution.
+ * By default only the method name is used.
+ */
+export const LimitToOne: LimitToOne =
+  (getKey = (propertyKey) => propertyKey) =>
+  (_target, propertyKey, descriptor) => {
+    const original = descriptor.value;
+
+    // This is an async function, and callers will end up with a chained promise rather than the 'cached' one.
+    descriptor.value = async function (...args: unknown[]) {
+      let promises = results.get(this);
+      if (!promises) {
+        promises = {};
+        results.set(this, promises);
+      }
+
+      const key = getKey(propertyKey, ...args);
+      let promise = promises[key];
+
+      if (!promise) {
+        promise = original.apply(this, args);
+        promises[key] = promise;
+      }
+
+      try {
+        return await promise;
+      } finally {
+        promises[key] = null;
+      }
+    };
+
+    return descriptor;
+  };


### PR DESCRIPTION
… requests

Adding a utility decorator that respond to callers using a shared promise of the decorated method's execution. This is used on some SDK methods to prevent extraneous API requests on cache miss.