### PR TITLE
feat(comment-service): adding comments endpoint for cross topic searches

### DIFF
--- a/apps/comment-service/src/comment/index.ts
+++ b/apps/comment-service/src/comment/index.ts
@@ -1,7 +1,7 @@
 import { AdspId, EventService, adspId } from '@abgov/adsp-service-sdk';
 import { Application } from 'express';
 import { Logger } from 'winston';
-import { createTopicRouter } from './router';
+import { createCommentRouter, createTopicRouter } from './router';
 import { assertAuthenticatedHandler } from '@core-services/core-common';
 import { TopicRepository } from './repository';
 
@@ -19,8 +19,11 @@ interface CommentMiddlewareProps {
 }
 
 export function applyCommentMiddleware(app: Application, { serviceId, ...props }: CommentMiddlewareProps): Application {
-  const router = createTopicRouter({ ...props, apiId: adspId`${serviceId}:v1` });
-  app.use('/comment/v1', assertAuthenticatedHandler, router);
+  const apiId = adspId`${serviceId}:v1`;
+  const commentRouter = createCommentRouter(props);
+  const topicRouter = createTopicRouter({ ...props, apiId });
+
+  app.use('/comment/v1', assertAuthenticatedHandler, [commentRouter, topicRouter]);
 
   return app;
 }

--- a/apps/comment-service/src/comment/model/topic.spec.ts
+++ b/apps/comment-service/src/comment/model/topic.spec.ts
@@ -178,7 +178,11 @@ describe('TopicEntity', () => {
       const criteria = {};
       const result = await entity.getComments({ ...user, roles: ['test-reader'] } as User, 10, null, criteria);
       expect(result).toBe(comments);
-      expect(repositoryMock.getComments).toHaveBeenCalledWith(entity, 10, null, criteria);
+      expect(repositoryMock.getComments).toHaveBeenCalledWith(
+        10,
+        null,
+        expect.objectContaining({ topicIdEquals: entity.id, tenantIdEquals: entity.tenantId })
+      );
     });
 
     it('can fail for user without role', async () => {

--- a/apps/comment-service/src/comment/model/topic.ts
+++ b/apps/comment-service/src/comment/model/topic.ts
@@ -11,7 +11,7 @@ export class TopicEntity implements Topic {
   type?: TopicTypeEntity;
   name: string;
   description: string;
-  resourceId?: AdspId;
+  resourceId?: AdspId | string;
   commenters?: string[] = [];
 
   @AssertRole('create topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter])
@@ -86,7 +86,11 @@ export class TopicEntity implements Topic {
       throw new UnauthorizedUserError('read comments', user);
     }
 
-    return await this.repository.getComments(this, top, after, criteria);
+    return await this.repository.getComments(top, after, {
+      ...criteria,
+      tenantIdEquals: this.tenantId,
+      topicIdEquals: this.id,
+    });
   }
 
   public async getComment(user: User, commentId: number): Promise<Comment> {
@@ -105,6 +109,7 @@ export class TopicEntity implements Topic {
     const createdOn = new Date();
     return await this.repository.saveComment(this, {
       ...comment,
+      topicId: this.id,
       id: undefined,
       createdBy: user,
       createdOn,

--- a/apps/comment-service/src/comment/repository.ts
+++ b/apps/comment-service/src/comment/repository.ts
@@ -12,7 +12,7 @@ export interface TopicRepository {
     criteria?: TopicCriteria
   ): Promise<Results<TopicEntity>>;
   getComment(entity: TopicEntity, commentId: number): Promise<Comment>;
-  getComments(entity: TopicEntity, top: number, after?: string, criteria?: CommentCriteria): Promise<Results<Comment>>;
+  getComments(top: number, after?: string, criteria?: CommentCriteria): Promise<Results<Comment>>;
 
   save(entity: TopicEntity): Promise<TopicEntity>;
   delete(entity: TopicEntity): Promise<boolean>;

--- a/apps/comment-service/src/comment/router/comment.spec.ts
+++ b/apps/comment-service/src/comment/router/comment.spec.ts
@@ -1,0 +1,187 @@
+import { UnauthorizedUserError, adspId } from '@abgov/adsp-service-sdk';
+import { NotFoundError } from '@core-services/core-common';
+import { Request, Response } from 'express';
+import { ServiceRoles } from '../roles';
+import { TopicTypeEntity } from '../model';
+import { createCommentRouter, getComments } from './comment';
+
+describe('comment', () => {
+  const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+
+  const repositoryMock = {
+    getTopic: jest.fn(),
+    getTopics: jest.fn(),
+    getComment: jest.fn(),
+    getComments: jest.fn(),
+    save: jest.fn(),
+    saveComment: jest.fn(),
+    delete: jest.fn(),
+    deleteComment: jest.fn(),
+  };
+
+  const user = { tenantId, id: 'tester', name: 'Tester', roles: [] };
+
+  const type = new TopicTypeEntity(tenantId, {
+    id: 'test',
+    name: 'Test',
+    adminRoles: ['test-admin'],
+    commenterRoles: ['test-commenter'],
+    readerRoles: ['test-reader'],
+  });
+
+  beforeEach(() => {
+    repositoryMock.getComments.mockReset();
+  });
+
+  describe('createTopicRouter', () => {
+    it('can create router', () => {
+      const router = createCommentRouter({
+        repository: repositoryMock,
+      });
+      expect(router).toBeTruthy();
+    });
+  });
+
+  describe('getComments', () => {
+    it('can create handler', () => {
+      const handler = getComments(repositoryMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can get comments for admin', async () => {
+      const req = {
+        user: { ...user, roles: [ServiceRoles.Admin] },
+        tenant: {
+          id: tenantId,
+        },
+        query: {
+          top: '12',
+          after: 'abc-123',
+          criteria: JSON.stringify({}),
+        },
+        getConfiguration: jest.fn(),
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+
+      const result = {};
+      repositoryMock.getComments.mockResolvedValueOnce(result);
+
+      const handler = getComments(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.send).toHaveBeenCalledWith(result);
+    });
+  });
+
+  it('can call next with unauthorized for non-admin', async () => {
+    const req = {
+      user: { ...user, roles: [] },
+      tenant: {
+        id: tenantId,
+      },
+      query: {
+        top: '12',
+        after: 'abc-123',
+        criteria: JSON.stringify({}),
+      },
+      getConfiguration: jest.fn(),
+    };
+    const res = {
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+
+    const handler = getComments(repositoryMock);
+    await handler(req as unknown as Request, res as unknown as Response, next);
+    expect(res.send).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+  });
+
+  it('can get comments for type reader if type criteria specified', async () => {
+    const req = {
+      user: { ...user, roles: ['test-reader'] },
+      tenant: {
+        id: tenantId,
+      },
+      query: {
+        top: '12',
+        after: 'abc-123',
+        criteria: JSON.stringify({ typeIdEquals: type.id }),
+      },
+      getConfiguration: jest.fn(),
+    };
+    const res = {
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+
+    req.getConfiguration.mockResolvedValueOnce({ [type.id]: type });
+
+    const result = {};
+    repositoryMock.getComments.mockResolvedValueOnce(result);
+
+    const handler = getComments(repositoryMock);
+    await handler(req as unknown as Request, res as unknown as Response, next);
+    expect(res.send).toHaveBeenCalledWith(result);
+  });
+
+  it('can call next with unauthorized for non-type reader if type criteria specified', async () => {
+    const req = {
+      user: { ...user, roles: [] },
+      tenant: {
+        id: tenantId,
+      },
+      query: {
+        top: '12',
+        after: 'abc-123',
+        criteria: JSON.stringify({ typeIdEquals: type.id }),
+      },
+      getConfiguration: jest.fn(),
+    };
+    const res = {
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+
+    req.getConfiguration.mockResolvedValueOnce({ [type.id]: type });
+
+    const result = {};
+    repositoryMock.getComments.mockResolvedValueOnce(result);
+
+    const handler = getComments(repositoryMock);
+    await handler(req as unknown as Request, res as unknown as Response, next);
+    expect(res.send).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+  });
+
+  it('can call next with not found for if type criteria specifies missing type', async () => {
+    const req = {
+      user: { ...user, roles: [] },
+      tenant: {
+        id: tenantId,
+      },
+      query: {
+        top: '12',
+        after: 'abc-123',
+        criteria: JSON.stringify({ typeIdEquals: 'another' }),
+      },
+      getConfiguration: jest.fn(),
+    };
+    const res = {
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+
+    req.getConfiguration.mockResolvedValueOnce({ [type.id]: type });
+
+    const result = {};
+    repositoryMock.getComments.mockResolvedValueOnce(result);
+
+    const handler = getComments(repositoryMock);
+    await handler(req as unknown as Request, res as unknown as Response, next);
+    expect(res.send).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+  });
+});

--- a/apps/comment-service/src/comment/router/comment.swagger.yml
+++ b/apps/comment-service/src/comment/router/comment.swagger.yml
@@ -1,0 +1,68 @@
+/comment/v1/comments:
+  get:
+    tags:
+      - Comment
+    description: Retrieves comments.
+    parameters:
+      - name: top
+        description: Number of topics to return.
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: after
+        description: Cursor for the page to retrieve.  Use the _page.next_ value returned in the previous call to page sequentially through the data.
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: criteria
+        description: Criteria for comments to retrieve.
+        in: query
+        required: false
+        schema:
+          type: object
+          properties:
+            typeIdEquals:
+              type: string
+            topicIdEquals:
+              type: integer
+            titleLike:
+              type: string
+            contentLike:
+              type: string
+            titleOrContentLike:
+              type: string
+    responses:
+      200:
+        description: Request completed successfully.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                results:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Comment"
+                page:
+                  type: object
+                  properties:
+                    after:
+                      type: string
+                      description: cursor representing the set of data returned.
+                      example: Mw==
+                    next:
+                      type: string
+                      description: cursor representing the next set of data to be returned.
+                      example: Ng==
+                    size:
+                      description: The number of comments returned by the query.
+                      example: 10
+                      type: integer
+      401:
+        description: Not authorized.
+      403:
+        description: User not permitted for requested operation.
+      404:
+        description: Topic type not found.

--- a/apps/comment-service/src/comment/router/comment.ts
+++ b/apps/comment-service/src/comment/router/comment.ts
@@ -1,0 +1,55 @@
+import { UnauthorizedUserError, isAllowedUser } from '@abgov/adsp-service-sdk';
+import { RequestHandler, Router } from 'express';
+import { TopicTypeEntity } from '../model';
+import { TopicRepository } from '../repository';
+import { ServiceRoles } from '../roles';
+import { CommentCriteria } from '../types';
+import { NotFoundError } from '@core-services/core-common';
+
+interface CommentRouterProps {
+  repository: TopicRepository;
+}
+
+export function getComments(repository: TopicRepository): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const user = req.user;
+      const tenantId = req.tenant.id;
+      const { top: topValue, after, criteria: criteriaValue } = req.query;
+      const top = topValue ? parseInt(topValue as string) : 10;
+      const criteria: CommentCriteria = criteriaValue ? JSON.parse(criteriaValue as string) : null;
+
+      // If type ID is specified in the criteria, then access is determined by the type configuration.
+      // Otherwise user must be a comment service admin to search comments.
+      if (criteria?.typeIdEquals) {
+        const types = await req.getConfiguration<Record<string, TopicTypeEntity>, Record<string, TopicTypeEntity>>(
+          tenantId
+        );
+
+        const type = types[criteria.typeIdEquals];
+        if (!type) {
+          throw new NotFoundError('topic type', criteria.typeIdEquals);
+        }
+        if (!type.canRead(user)) {
+          throw new UnauthorizedUserError('get comments', user);
+        }
+      } else if (!isAllowedUser(user, tenantId, ServiceRoles.Admin)) {
+        throw new UnauthorizedUserError('get comments', user);
+      }
+
+      const result = await repository.getComments(top, after as string, { ...criteria, tenantIdEquals: tenantId });
+
+      res.send(result);
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export function createCommentRouter({ repository }: CommentRouterProps): Router {
+  const router = Router();
+
+  router.get('/comments', getComments(repository));
+
+  return router;
+}

--- a/apps/comment-service/src/comment/router/index.ts
+++ b/apps/comment-service/src/comment/router/index.ts
@@ -1,1 +1,2 @@
+export * from './comment';
 export * from './topic';

--- a/apps/comment-service/src/comment/types/comment.ts
+++ b/apps/comment-service/src/comment/types/comment.ts
@@ -1,4 +1,7 @@
+import { AdspId } from '@abgov/adsp-service-sdk';
+
 export interface Comment {
+  topicId: number;
   id: number;
   title: string;
   content: string;
@@ -15,6 +18,9 @@ export interface Comment {
 }
 
 export interface CommentCriteria {
+  tenantIdEquals?: AdspId;
+  typeIdEquals?: string;
+  topicIdEquals?: number;
   titleLike?: string;
   contentLike?: string;
   titleOrContentLike?: string;

--- a/apps/comment-service/src/comment/types/topic.ts
+++ b/apps/comment-service/src/comment/types/topic.ts
@@ -13,7 +13,7 @@ export interface Topic {
   type?: TopicType;
   tenantId: AdspId;
   id: number;
-  resourceId?: AdspId;
+  resourceId?: AdspId | string;
   name: string;
   description: string;
   commenters?: string[];

--- a/apps/comment-service/src/main.ts
+++ b/apps/comment-service/src/main.ts
@@ -130,7 +130,7 @@ const initializeApp = async (): Promise<express.Application> => {
     const rootUrl = new URL(`${req.protocol}://${req.get('host')}`);
     res.json({
       name: 'Comment service',
-      description: 'Put a description of the service here.',
+      description: 'Service that allows users to comment on topics.',
       _links: {
         self: { href: new URL(req.originalUrl, rootUrl).href },
         health: { href: new URL('/health', rootUrl).href },

--- a/apps/comment-service/src/postgres/types.ts
+++ b/apps/comment-service/src/postgres/types.ts
@@ -6,7 +6,7 @@ export interface TopicRecord extends Omit<Topic, 'tenantId' | 'type' | 'resource
   resource: string;
 }
 
-export interface CommentRecord extends Omit<Comment, 'topic' | 'createdBy' | 'lastUpdatedBy'> {
+export interface CommentRecord extends Omit<Comment, 'topicId' | 'createdBy' | 'lastUpdatedBy'> {
   tenant: string;
   topic_id: number;
   createdById: string;

--- a/apps/comment-service/src/utils/adspId.ts
+++ b/apps/comment-service/src/utils/adspId.ts
@@ -1,0 +1,7 @@
+// urn:ads:{namespace}:{service}:{apiVersion}:{resource}
+const AdspIdPattern =
+  /^urn:ads(?<namespace>:[a-zA-Z0-9-]{1,50})(?<service>:[a-zA-Z0-9-]{1,50})?(?<api>:[a-zA-Z0-9-]{1,50})?(?<resource>:[a-zA-Z0-9-_/ ]{1,1000})?$/;
+
+export function isAdspId(urn: string): boolean {
+  return typeof urn === 'string' && AdspIdPattern.test(urn);
+}

--- a/apps/comment-service/src/utils/index.ts
+++ b/apps/comment-service/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './adspId';


### PR DESCRIPTION
Also making resourceId forgiving so it doesn't have to be an ADSP ID.