### PR TITLE
CS-2461 - prevent stringed null from being returned

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/keycloak.ts
+++ b/apps/tenant-management-webapp/src/app/lib/keycloak.ts
@@ -27,10 +27,10 @@ export const getOrCreateKeycloakAuth = async (config: KeycloakConfig, realm: str
 
 export const getIdpHint = () => {
   const location: string = window.location.href;
-  const skipSSO = location.indexOf('kc_idp_hint') > -1;
   const urlParams = new URLSearchParams(window.location.search);
-  const idpFromUrl = encodeURIComponent(urlParams.get('kc_idp_hint'));
+  const skipSSO = location.indexOf('kc_idp_hint') > -1 && urlParams.get('kc_idp_hint') !== 'null';
   if (skipSSO) {
+    const idpFromUrl = encodeURIComponent(urlParams.get('kc_idp_hint'));
     return idpFromUrl;
   }
 


### PR DESCRIPTION
This should fix all the login flows

To test this properly, you will need to have your own tenant you can log into. I tried this locally using my own tenant I just created  and it works if you make this change, and doesn't work without it