### PR TITLE
Disable back button on update with the tombstone

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -14,7 +14,7 @@ import MonacoEditor, { useMonaco } from '@monaco-editor/react';
 import { PdfTemplate } from '@store/pdf/model';
 import { languages } from 'monaco-editor';
 import { buildSuggestions, triggerInScope, convertToEditorSuggestion } from '@lib/autoComplete';
-import { GoAButton, GoAFormItem, GoAButtonGroup } from '@abgov/react-components-new';
+import { GoAButton, GoAFormItem, GoAButtonGroup, GoASkeleton } from '@abgov/react-components-new';
 import { Tab, Tabs } from '@components/Tabs';
 import { SaveFormModal } from '@components/saveModal';
 import { PDFConfigForm } from './PDFConfigForm';
@@ -66,6 +66,10 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
   const suggestion =
     pdfTemplate && pdfTemplate.variables && convertToEditorSuggestion(JSON.parse(pdfTemplate.variables));
 
+  const elementIndicator = useSelector((state: RootState) => {
+    return state?.session?.elementIndicator;
+  });
+
   const notifications = useSelector((state: RootState) => state.notifications.notifications);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const debouncedTmpTemplate = useDebounce(tmpTemplate, TEMPLATE_RENDER_DEBOUNCE_TIMER);
@@ -82,11 +86,8 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
 
   //eslint-disable-next-line
   useEffect(() => {
-    if (saveModal.closeEditor) {
-      cancel();
-    }
     setTmpTemplate(JSON.parse(JSON.stringify(pdfTemplate || '')));
-  }, [pdfTemplate, saveModal.closeEditor]);
+  }, [pdfTemplate]);
 
   useEffect(() => {
     if (saveModal.closeEditor) {
@@ -161,12 +162,21 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
   const pdfList = useSelector((state: RootState) =>
     state.pdf?.jobs?.filter((job) => job.templateId === pdfTemplate.id)
   );
+
+  const backButtonDisabled = () => {
+    if (!elementIndicator) return false;
+
+    if (elementIndicator && elementIndicator.show) return true;
+  };
+
   return (
     <TemplateEditorContainerPdf>
       <LogoutModal />
       <PDFTitle>PDF / Template Editor</PDFTitle>
       <hr />
-      {pdfTemplate && <PDFConfigForm template={pdfTemplate} />}
+
+      {elementIndicator?.show && <GoASkeleton type="paragraph" />}
+      {pdfTemplate && !elementIndicator?.show && <PDFConfigForm template={pdfTemplate} />}
 
       <GoAFormItem label="">
         <Tabs activeIndex={0}>
@@ -309,6 +319,7 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
                 }}
                 testId="template-form-close"
                 type="secondary"
+                disabled={backButtonDisabled()}
               >
                 Back
               </GoAButton>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -14,7 +14,7 @@ import MonacoEditor, { useMonaco } from '@monaco-editor/react';
 import { PdfTemplate } from '@store/pdf/model';
 import { languages } from 'monaco-editor';
 import { buildSuggestions, triggerInScope, convertToEditorSuggestion } from '@lib/autoComplete';
-import { GoAButton, GoAFormItem, GoAButtonGroup, GoASkeleton } from '@abgov/react-components-new';
+import { GoAButton, GoAFormItem, GoAButtonGroup } from '@abgov/react-components-new';
 import { Tab, Tabs } from '@components/Tabs';
 import { SaveFormModal } from '@components/saveModal';
 import { PDFConfigForm } from './PDFConfigForm';
@@ -166,7 +166,9 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
   const backButtonDisabled = () => {
     if (!elementIndicator) return false;
 
-    if (elementIndicator && elementIndicator.show) return true;
+    if (elementIndicator?.show) return true;
+
+    return false;
   };
 
   return (
@@ -175,9 +177,7 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
       <PDFTitle>PDF / Template Editor</PDFTitle>
       <hr />
 
-      {elementIndicator?.show && <GoASkeleton type="paragraph" />}
-      {pdfTemplate && !elementIndicator?.show && <PDFConfigForm template={pdfTemplate} />}
-
+      {pdfTemplate && <PDFConfigForm template={pdfTemplate} />}
       <GoAFormItem label="">
         <Tabs activeIndex={0}>
           <Tab testId={`pdf-edit-header`} label={<PdfEditorLabelWrapper>Header</PdfEditorLabelWrapper>}>

--- a/apps/tenant-management-webapp/src/app/store/pdf/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/sagas.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { SagaIterator } from '@redux-saga/core';
-import { UpdateIndicator } from '@store/session/actions';
+import { UpdateElementIndicator, UpdateIndicator } from '@store/session/actions';
 import { RootState } from '../index';
 import { select, call, put, takeEvery, take, apply, fork } from 'redux-saga/effects';
 import { eventChannel } from 'redux-saga';
@@ -150,6 +150,9 @@ const connect = (pushServiceUrl, token, stream, tenantName) => {
 
 export function* updatePdfTemplate({ template, options }: UpdatePdfTemplatesAction): SagaIterator {
   const baseUrl: string = yield select((state: RootState) => state.config.serviceUrls?.configurationServiceApiUrl);
+
+  yield put(UpdateElementIndicator({ show: true }));
+
   const token: string = yield call(getAccessToken);
   if (baseUrl && token) {
     try {
@@ -179,7 +182,9 @@ export function* updatePdfTemplate({ template, options }: UpdatePdfTemplatesActi
           )
         );
       }
+      yield put(UpdateElementIndicator({ show: false }));
     } catch (err) {
+      yield put(UpdateElementIndicator({ show: false }));
       yield put(ErrorNotification({ message: err.message }));
     }
   }


### PR DESCRIPTION
This change is to prevent users from pressing the back button in turn it redirects it back to PDF Editor when updating the name and description in the Tombstone by disabling the back button.

