### PR TITLE
tenant-web: notification service events fix

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/editEvent.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/editEvent.tsx
@@ -15,7 +15,7 @@ import { EventItem, baseTemplate } from '@store/notification/models';
 
 interface NotificationDefinitionFormProps {
   initialValue?: NotificationItem;
-  onCancel?: () => void;
+  onCancel?: (closeEventModal: boolean) => void;
   onClickedOutside?: () => void;
   onNext?: (notify: NotificationItem, event: EventItem) => void;
   open: boolean;
@@ -43,7 +43,8 @@ export const EventModalForm: FunctionComponent<NotificationDefinitionFormProps> 
   }, []);
 
   useEffect(() => {
-    if (selectedEvent) {
+    // only show next if there is an event selected and its name isnt empty
+    if (selectedEvent && selectedEvent.name !== '') {
       setValues([`${selectedEvent.namespace}:${selectedEvent.name}`]);
     } else {
       setValues(['']);
@@ -100,7 +101,7 @@ export const EventModalForm: FunctionComponent<NotificationDefinitionFormProps> 
             type="secondary"
             onClick={() => {
               setValues(['']);
-              onCancel();
+              onCancel(true);
             }}
           >
             Cancel
@@ -114,15 +115,14 @@ export const EventModalForm: FunctionComponent<NotificationDefinitionFormProps> 
               const eventObject: EventItem = {
                 namespace: dropdownObject.nameSpace,
                 name: dropdownObject.name,
-                templates: baseTemplate,
+                templates: JSON.parse(JSON.stringify(baseTemplate)),
               };
               // deep cloning props to avoid unwanted side effects
               // note: do not mutate props directly, it will cause unnecessary side effects
               const deepClonedDefinition = JSON.parse(JSON.stringify(definition));
               deepClonedDefinition.events.push(eventObject);
-              onCancel();
+              onCancel(true);
               onNext(deepClonedDefinition, eventObject);
-
               setValues(['']);
             }}
           >

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationTypes.tsx
@@ -83,6 +83,7 @@ interface ParentCompProps {
 export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEdit, activateEdit }) => {
   const [editType, setEditType] = useState(false);
   const [selectedType, setSelectedType] = useState(emptyNotificationType);
+  const [editEventOpen, setEditEventOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [editEvent, setEditEvent] = useState(null);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
@@ -204,6 +205,8 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
     setEditType(false);
     if (closeEventModal) {
       setEditEvent(null);
+      setEditEventOpen(false);
+      setSelectedEvent(null);
     }
     setTemplateEditErrors(templateDefaultError);
     setSelectedType(emptyNotificationType);
@@ -526,6 +529,7 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
                           onClick={() => {
                             setSelectedEvent(emptyEvent);
                             manageEvents(notificationType);
+                            setEditEventOpen(true);
                           }}
                         >
                           + Select an event
@@ -726,7 +730,7 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
       />
       {/* add an event */}
       <EventModalForm
-        open={editEvent}
+        open={editEventOpen}
         initialValue={editEvent}
         selectedEvent={selectedEvent}
         errors={errors}
@@ -735,8 +739,9 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
           setSelectedType(notifications);
           setShowTemplateForm(true);
         }}
-        onCancel={() => {
-          reset(true);
+        onCancel={(closeEventModal: boolean) => {
+          reset(closeEventModal);
+          // reset(true);
         }}
         onClickedOutside={() => {
           reset(true);
@@ -797,7 +802,7 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
               saveCurrentTemplate={() => saveOrAddEventTemplate()}
               resetToSavedAction={() => {
                 setTemplates(JSON.parse(JSON.stringify(savedTemplates)));
-                reset();
+                reset(true);
               }}
               saveAndReset={saveAndReset}
               validateEventTemplateFields={() => validateEventTemplateFields()}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -240,7 +240,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
         }}
         onSave={() => {
           saveChangesAction();
-          saveAndReset();
+          saveAndReset(true);
           setSaveModal(false);
         }}
         onCancel={() => {


### PR DESCRIPTION
- disables next in event creation when none is selected
- clears the event selection when users back out the creation flow