### PR TITLE
fix(tenant-management-webapp-e2e): import axios from dist in test step

### DIFF
--- a/apps/tenant-management-webapp-e2e/src/integration/file-service/file-service.step.ts
+++ b/apps/tenant-management-webapp-e2e/src/integration/file-service/file-service.step.ts
@@ -1,6 +1,8 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import fd = require('form-data');
-import axios, { AxiosResponse } from 'axios';
+// NOTE: import from dist since browserify/tsify preprocessors don't seem to handle resolving axios module properly.
+import axios from 'axios/dist/browser/axios.cjs';
+import type { AxiosResponse } from 'axios';
 import commonlib from '../common/common-library';
 import fileServicePage from './file-service.page';
 


### PR DESCRIPTION
Current cypress browserify / tsify preprocessor configuration seems to resolve to the wrong axios bundle based.