### PR TITLE
fix(status-service): use SDK configuration service instead of API req…

### DIFF
--- a/apps/status-service/src/app/jobs/JobScheduler.spec.ts
+++ b/apps/status-service/src/app/jobs/JobScheduler.spec.ts
@@ -135,6 +135,7 @@ describe('JobScheduler', () => {
     applicationManager: appManagerFactory('urn:ads:mock-tenant:mock-service'),
     tokenProvider: mockTokenProvider,
     directory: serviceDirectoryMock,
+    configurationService: configurationServiceMock,
     serviceId: adspId`urn:ads:platform:test-service`,
   };
   const jobScheduler = new HealthCheckJobScheduler(props);

--- a/apps/status-service/src/app/jobs/JobScheduler.ts
+++ b/apps/status-service/src/app/jobs/JobScheduler.ts
@@ -2,7 +2,7 @@ import { Job } from 'node-schedule';
 import { Logger } from 'winston';
 import { EndpointStatusEntryRepository } from '../repository/endpointStatusEntry';
 import { ServiceStatusRepository } from '../repository/serviceStatus';
-import { EventService, ServiceDirectory, TokenProvider, AdspId } from '@abgov/adsp-service-sdk';
+import { EventService, ServiceDirectory, TokenProvider, AdspId, ConfigurationService } from '@abgov/adsp-service-sdk';
 import { HealthCheckJobCache } from './HealthCheckJobCache';
 import { HealthCheckJob } from './HealthCheckJob';
 import { getScheduler } from './SchedulerFactory';
@@ -16,6 +16,7 @@ export interface HealthCheckSchedulingProps {
   eventService: EventService;
   endpointStatusEntryRepository: EndpointStatusEntryRepository;
   applicationManager: ApplicationManager;
+  configurationService: ConfigurationService;
   directory: ServiceDirectory;
   tokenProvider: TokenProvider;
   serviceId: AdspId;

--- a/apps/status-service/src/app/jobs/checkEndpoint.spec.ts
+++ b/apps/status-service/src/app/jobs/checkEndpoint.spec.ts
@@ -41,6 +41,10 @@ describe('checkEndpoint', () => {
     send: jest.fn(),
   };
 
+  const configurationServiceMock = {
+    getConfiguration: jest.fn(),
+  };
+
   const mockTokenProvider = {
     getAccessToken: jest.fn(),
   };
@@ -61,6 +65,7 @@ describe('checkEndpoint', () => {
         eventService: eventServiceMock,
         tokenProvider: mockTokenProvider,
         directory: serviceDirectoryMock,
+        configurationService: configurationServiceMock,
         serviceId: adspId`urn:ads:platform:test-service`,
       });
 
@@ -83,6 +88,7 @@ describe('checkEndpoint', () => {
         eventService: eventServiceMock,
         tokenProvider: mockTokenProvider,
         directory: serviceDirectoryMock,
+        configurationService: configurationServiceMock,
         serviceId: adspId`urn:ads:platform:test-service`,
       });
 
@@ -92,6 +98,7 @@ describe('checkEndpoint', () => {
         endpointRepositoryMock.findRecentByUrlAndApplicationId.mockReset();
         statusRepositoryMock.get.mockReset();
         statusRepositoryMock.save.mockReset();
+        configurationServiceMock.getConfiguration.mockReset();
       });
 
       it('can updated application healthy', async () => {
@@ -122,10 +129,9 @@ describe('checkEndpoint', () => {
         ]);
 
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
-
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } }).mockResolvedValueOnce({
-          data: { latest: { configuration: { applicationWebhookIntervals: {} } } },
-        });
+        configurationServiceMock.getConfiguration
+          .mockReturnValueOnce({})
+          .mockResolvedValueOnce({ applicationWebhookIntervals: {} });
 
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
@@ -168,10 +174,10 @@ describe('checkEndpoint', () => {
           },
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
+        configurationServiceMock.getConfiguration
+          .mockReturnValueOnce({})
+          .mockResolvedValueOnce({ applicationWebhookIntervals: {} });
 
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } }).mockResolvedValueOnce({
-          data: { latest: { configuration: { applicationWebhookIntervals: {} } } },
-        });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -234,12 +240,10 @@ describe('checkEndpoint', () => {
           },
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
+        configurationServiceMock.getConfiguration.mockResolvedValueOnce({ webhooks: webHooks }).mockResolvedValueOnce({
+          applicationWebhookIntervals: applicationWebhookIntervals,
+        });
 
-        axiosMock.get
-          .mockResolvedValueOnce({ data: { latest: { configuration: { webhooks: webHooks } } } })
-          .mockResolvedValueOnce({
-            data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
-          });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -299,10 +303,10 @@ describe('checkEndpoint', () => {
           },
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
-
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: webHooks } } }).mockResolvedValueOnce({
-          data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
+        configurationServiceMock.getConfiguration.mockResolvedValueOnce({ webhooks: webHooks }).mockResolvedValueOnce({
+          applicationWebhookIntervals: applicationWebhookIntervals,
         });
+
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -362,12 +366,10 @@ describe('checkEndpoint', () => {
           },
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
+        configurationServiceMock.getConfiguration.mockResolvedValueOnce({ webhooks: webHooks }).mockResolvedValueOnce({
+          applicationWebhookIntervals: applicationWebhookIntervals,
+        });
 
-        axiosMock.get
-          .mockResolvedValueOnce({ data: { latest: { configuration: { webhooks: webHooks } } } })
-          .mockResolvedValueOnce({
-            data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
-          });
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',
@@ -411,10 +413,10 @@ describe('checkEndpoint', () => {
           },
         ]);
         mockTokenProvider.getAccessToken.mockResolvedValueOnce('test');
-
-        axiosMock.get.mockResolvedValueOnce({ data: { latest: { configuration: {} } } }).mockResolvedValueOnce({
-          data: { latest: { configuration: { applicationWebhookIntervals: applicationWebhookIntervals } } },
+        configurationServiceMock.getConfiguration.mockResolvedValueOnce({}).mockResolvedValueOnce({
+          applicationWebhookIntervals: applicationWebhookIntervals,
         });
+
         statusRepositoryMock.get.mockResolvedValueOnce(
           new ServiceStatusApplicationEntity(statusRepositoryMock, {
             _id: 'test-app',

--- a/apps/status-service/src/app/model/serviceStatus.ts
+++ b/apps/status-service/src/app/model/serviceStatus.ts
@@ -10,7 +10,9 @@ import {
 } from '../types';
 
 // Stored in the configuration service repository
-export type StatusServiceConfiguration = Record<string, ApplicationConfiguration>;
+export type StatusServiceConfiguration = Record<string, ApplicationConfiguration> & {
+  applicationWebhookIntervals?: Record<string, HookInterval>;
+};
 
 // The application bits that rarely change (so not quite static)
 // and are stored as part of the status-service
@@ -33,11 +35,8 @@ export interface StaticApplicationData extends ApplicationConfiguration {
   tenantId: AdspId;
 }
 
-export interface Configuration {
-  latest: { configuration: { webhooks: Record<string, Webhooks> } };
-}
-export interface StatusConfiguration {
-  latest: { configuration: { applicationWebhookIntervals: Record<string, HookInterval> } };
+export interface PushServiceConfiguration {
+  webhooks: Record<string, Webhooks>;
 }
 
 export interface HookInterval {

--- a/apps/status-service/src/app/model/statusApplications.ts
+++ b/apps/status-service/src/app/model/statusApplications.ts
@@ -1,5 +1,5 @@
 import { isApp } from '../../mongo/schema';
-import { StaticApplicationData, StatusServiceApplications, StatusServiceConfiguration } from './serviceStatus';
+import { StaticApplicationData, StatusServiceApplications } from './serviceStatus';
 
 export class StatusApplications {
   #apps: StatusServiceApplications;
@@ -67,11 +67,11 @@ export class StatusApplications {
 }
 
 class AppIterator {
-  #apps: StatusServiceConfiguration;
+  #apps: StatusServiceApplications;
   #keys: Array<string>;
   #current: number;
 
-  constructor(apps: StatusServiceConfiguration, keys: Array<string>) {
+  constructor(apps: StatusServiceApplications, keys: Array<string>) {
     this.#apps = apps;
     this.#keys = keys;
     this.#current = 0;

--- a/apps/status-service/src/main.ts
+++ b/apps/status-service/src/main.ts
@@ -131,6 +131,7 @@ app.use(express.json({ limit: '1mb' }));
 
   const healthCheckSchedulingProps = {
     logger,
+    configurationService,
     eventService,
     serviceStatusRepository: repositories.serviceStatusRepository,
     endpointStatusEntryRepository: repositories.endpointStatusEntryRepository,

--- a/apps/status-service/src/mongo/schema.ts
+++ b/apps/status-service/src/mongo/schema.ts
@@ -109,7 +109,7 @@ export const noticeApplicationSchema = new Schema(
 );
 
 // An application property is pretty wide open.
-export const appPropertyRegex = '^.+$';
+export const appPropertyRegex = '^.{1,100}$';
 
 // A poor mans test for a valid application
 export const isApp = (app): boolean => {
@@ -126,19 +126,22 @@ export const configurationSchema = {
       },
     },
     applicationWebhookIntervals: {
-      appPropertyRegex: {
-        type: 'object',
-        properties: {
-          appId: { type: 'string', description: 'The unique application identifier' },
-          waitTimeInterval: { type: 'string', description: 'Webhook wait time for application (in minutes)' },
+      type: 'object',
+      patternProperties: {
+        [appPropertyRegex]: {
+          type: 'object',
+          properties: {
+            appId: { type: 'string', description: 'The unique application identifier' },
+            waitTimeInterval: { type: 'string', description: 'Webhook wait time for application (in minutes)' },
+          },
+          required: ['appId', 'waitTimeInterval'],
+          additionalProperties: false,
         },
-        required: ['appId', 'waitTimeInterval'],
-        additionalProperties: false,
       },
     },
   },
   patternProperties: {
-    appPropertyRegex: {
+    [appPropertyRegex]: {
       type: 'object',
       properties: {
         appKey: { type: 'string', description: 'A unique identifier for the application' },


### PR DESCRIPTION
…uest

Replace API request with SDK configuration service so that caching is used; otherwise there is 2 request per health check interval per app. Also fixing configuration schema so pattern properties spec is correctly set.