### PR TITLE
fix(push-service): allow null for specific web-hook

### DIFF
--- a/apps/push-service/src/push/configuration.ts
+++ b/apps/push-service/src/push/configuration.ts
@@ -4,10 +4,10 @@ export const configurationSchema = {
   type: 'object',
   properties: {
     webhooks: {
-      type: ['object', 'null'], // Null is allowed for backwards compatibility
+      type: ['object', 'null'],     // Null is allowed for backwards compatibility
       patternProperties: {
         '^[a-zA-Z0-9-_ ]{1,50}$': {
-          type: 'object',
+          type: ['object', 'null'], // Null is allowed for backwards compatibility
           properties: {
             id: { type: 'string' },
             name: { type: 'string' },

--- a/apps/push-service/src/push/events.ts
+++ b/apps/push-service/src/push/events.ts
@@ -71,10 +71,10 @@ export const WebhookTriggeredDefinition: DomainEventDefinition = {
         type: 'object',
         properties: {
           status: {
-            type: 'string',
+            type: ['string', 'null'],
           },
           statusCode: {
-            type: 'number',
+            type: ['number', 'null'],
           },
           timestamp: {
             type: ['string', 'null'],


### PR DESCRIPTION
Delete of web-hook currently sets a null instead of removing property; make configuration forgiving to support for now.