### PR TITLE
feat(notification-service): add a direct notification type that gener…

### DIFF
--- a/apps/notification-service/src/notification/configuration/configuration.spec.ts
+++ b/apps/notification-service/src/notification/configuration/configuration.spec.ts
@@ -66,6 +66,27 @@ describe('NotificationConfiguration', () => {
     ],
   };
 
+  const direct = {
+    id: 'direct',
+    name: 'Direct Type',
+    description: '',
+    publicSubscribe: true,
+    subscriberRoles: [],
+    addressPath: 'address',
+    channels: [Channel.email],
+    events: [
+      {
+        namespace: 'test',
+        name: 'test-run',
+        templates: {
+          [Channel.email]: { subject: '', body: '' },
+          [Channel.sms]: null,
+          [Channel.mail]: null,
+        },
+      },
+    ],
+  };
+
   it('can be created', () => {
     const configuration = new NotificationConfiguration({}, {}, tenantId);
     expect(configuration).toBeTruthy();
@@ -74,7 +95,7 @@ describe('NotificationConfiguration', () => {
   describe('getNotificationType', () => {
     const configuration = new NotificationConfiguration(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { contact: {} as any, base: baseOverride, test: type },
+      { contact: {} as any, base: baseOverride, test: type, direct },
       { base: baseType },
       tenantId
     );
@@ -118,7 +139,7 @@ describe('NotificationConfiguration', () => {
 
   describe('getNotificationTypes', () => {
     const configuration = new NotificationConfiguration(
-      { base: baseOverride, test: type },
+      { base: baseOverride, test: type, direct },
       { base: baseType },
       tenantId
     );
@@ -148,7 +169,7 @@ describe('NotificationConfiguration', () => {
 
   describe('getEventNotificationTypes', () => {
     const configuration = new NotificationConfiguration(
-      { base: baseOverride, test: type },
+      { base: baseOverride, test: type, direct },
       { base: baseType },
       tenantId
     );
@@ -156,7 +177,7 @@ describe('NotificationConfiguration', () => {
     it('can return type for event', () => {
       const types = configuration.getEventNotificationTypes({ namespace: 'test', name: 'test-run' } as DomainEvent);
       expect(types).toBeTruthy();
-      expect(types.length).toBe(1);
+      expect(types.length).toBe(2);
       expect(types[0].name).toBe('Test Type');
     });
 

--- a/apps/notification-service/src/notification/configuration/configuration.ts
+++ b/apps/notification-service/src/notification/configuration/configuration.ts
@@ -1,8 +1,14 @@
 import type { AdspId } from '@abgov/adsp-service-sdk';
 import type { DomainEvent } from '@core-services/core-common';
-import { NotificationTypeEntity } from '../model';
+import { DirectNotificationTypeEntity, NotificationTypeEntity } from '../model';
 import { NotificationType } from '../types';
 import { Configuration, SupportContact } from './schema';
+
+function createTypeEntity(type: NotificationType, tenantId: AdspId): NotificationTypeEntity {
+  return type.addressPath
+    ? new DirectNotificationTypeEntity(type, tenantId)
+    : new NotificationTypeEntity(type, tenantId);
+}
 
 export class NotificationConfiguration {
   private types: Record<string, NotificationTypeEntity>;
@@ -11,7 +17,7 @@ export class NotificationConfiguration {
   constructor(tenantTypes: Configuration, coreTypes: Configuration, tenantId?: AdspId) {
     const coreTypesEntities: Record<string, NotificationTypeEntity> = Object.entries(coreTypes).reduce(
       (entities, [typeId, type]: [string, NotificationType]) => {
-        entities[typeId] = new NotificationTypeEntity(type, tenantId);
+        entities[typeId] = createTypeEntity(type, tenantId);
         return entities;
       },
       {}
@@ -24,7 +30,7 @@ export class NotificationConfiguration {
       delete tenantTypes.contact;
 
       this.types = Object.entries(tenantTypes).reduce((entities, [typeId, type]: [string, NotificationType]) => {
-        const typeEntity = new NotificationTypeEntity(type, tenantId);
+        const typeEntity = createTypeEntity(type, tenantId);
         entities[typeId] = entities[typeId] ? entities[typeId].overrideWith(typeEntity) : typeEntity;
         return entities;
       }, coreTypesEntities);

--- a/apps/notification-service/src/notification/configuration/schema.ts
+++ b/apps/notification-service/src/notification/configuration/schema.ts
@@ -30,6 +30,7 @@ export const configurationSchema = {
         description: { type: ['string', 'null'] },
         publicSubscribe: { type: 'boolean' },
         manageSubscribe: { type: 'boolean' },
+        addressPath: { type: ['string', 'null'] },
         channels: {
           type: 'array',
           items: {

--- a/apps/notification-service/src/notification/events.ts
+++ b/apps/notification-service/src/notification/events.ts
@@ -109,7 +109,7 @@ export const NotificationSendFailedDefinition: DomainEventDefinition = {
         },
       },
       subscriber: {
-        type: 'object',
+        type: ['object', 'null'],
         properties: {
           id: { type: 'string' },
           userId: { type: ['string', 'null'] },

--- a/apps/notification-service/src/notification/job/processEvent.ts
+++ b/apps/notification-service/src/notification/job/processEvent.ts
@@ -75,32 +75,15 @@ export const createProcessEventJob =
         const subscriberAppUrl = await directory.getServiceUrl(adspId`urn:ads:platform:subscriber-app`);
 
         for (const type of types) {
-          // Page through all subscriptions and generate notifications.
-          const notifications: Notification[] = [];
-          let after: string = null;
-          do {
-            const { results, page } = await subscriptionRepository.getSubscriptions(
-              configuration,
-              tenantId,
-              1000,
-              after,
-              {
-                typeIdEquals: type.id,
-              }
-            );
-            const pageNotifications = type.generateNotifications(
-              logger,
-              templateService,
-              subscriberAppUrl,
-              event,
-              results,
-              {
-                tenant,
-              }
-            );
-            notifications.push(...pageNotifications);
-            after = page.next;
-          } while (after);
+          const notifications: Notification[] = await type.generateNotifications(
+            logger,
+            templateService,
+            subscriberAppUrl,
+            subscriptionRepository,
+            configuration,
+            event,
+            { tenant }
+          );
 
           for (const notification of notifications) {
             queueService.enqueue({ generationId, ...notification });

--- a/apps/notification-service/src/notification/model/type.spec.ts
+++ b/apps/notification-service/src/notification/model/type.spec.ts
@@ -1,11 +1,12 @@
 import { adspId, User } from '@abgov/adsp-service-sdk';
-import { DomainEvent } from '@core-services/core-common';
+import { DomainEvent, InvalidOperationError } from '@core-services/core-common';
 import { Logger } from 'winston';
 import { SubscriptionRepository } from '../repository';
 import { Channel, ServiceUserRoles, Subscriber } from '../types';
 import { SubscriptionEntity } from './subscription';
 import { SubscriberEntity } from './subscriber';
-import { NotificationTypeEntity } from './type';
+import { DirectNotificationTypeEntity, NotificationTypeEntity } from './type';
+import { NotificationConfiguration } from '../configuration';
 
 describe('NotificationTypeEntity', () => {
   const logger = {
@@ -20,15 +21,19 @@ describe('NotificationTypeEntity', () => {
       return Promise.resolve(entity);
     }),
     deleteSubscriptions: jest.fn(() => Promise.resolve(true)),
+    getSubscriptions: jest.fn(),
   };
 
   const templateServiceMock = {
     generateMessage: jest.fn(),
   };
 
+  const configurationMock = {};
+
   beforeEach(() => {
     repositoryMock.saveSubscription.mockClear();
     repositoryMock.deleteSubscriptions.mockClear();
+    repositoryMock.getSubscriptions.mockClear();
     templateServiceMock.generateMessage.mockClear();
     templateServiceMock.generateMessage.mockClear();
   });
@@ -353,7 +358,7 @@ describe('NotificationTypeEntity', () => {
 
   describe('generateNotifications', () => {
     const subscriberAppUrl = new URL('https://subscriptions');
-    it('can generate notifications', () => {
+    it('can generate notifications', async () => {
       const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
       const tenant = { id: tenantId, name: 'test', realm: 'test' };
       const entity = new NotificationTypeEntity(
@@ -398,6 +403,7 @@ describe('NotificationTypeEntity', () => {
         entity,
         subscriber
       );
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({ results: [subscription], page: {} });
 
       const message = {
         subject: 'test',
@@ -413,12 +419,13 @@ describe('NotificationTypeEntity', () => {
         payload: {},
         traceparent: '123',
       };
-      const [notification] = entity.generateNotifications(
+      const [notification] = await entity.generateNotifications(
         logger,
         templateServiceMock,
         subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
         event,
-        [subscription],
         {
           tenant,
         }
@@ -429,7 +436,7 @@ describe('NotificationTypeEntity', () => {
       expect(notification.message).toBe(message);
     });
 
-    it('can return no notification for no channel match', () => {
+    it('can return no notification for no channel match', async () => {
       const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
       const tenant = { id: tenantId, name: 'test', realm: 'test' };
       const entity = new NotificationTypeEntity(
@@ -474,6 +481,7 @@ describe('NotificationTypeEntity', () => {
         entity,
         subscriber
       );
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({ results: [subscription], page: {} });
 
       const event: DomainEvent = {
         tenantId,
@@ -484,12 +492,13 @@ describe('NotificationTypeEntity', () => {
         traceparent: '123',
       };
 
-      const notifications = entity.generateNotifications(
+      const notifications = await entity.generateNotifications(
         logger,
         templateServiceMock,
         subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
         event,
-        [subscription],
         {
           tenant,
         }
@@ -497,7 +506,7 @@ describe('NotificationTypeEntity', () => {
       expect(notifications.length).toBe(0);
     });
 
-    it('can return notification for criteria match', () => {
+    it('can return notification for criteria match', async () => {
       const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
       const tenant = { id: tenantId, name: 'test', realm: 'test' };
 
@@ -543,6 +552,7 @@ describe('NotificationTypeEntity', () => {
         entity,
         subscriber
       );
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({ results: [subscription], page: {} });
 
       const message = {
         subject: 'test',
@@ -560,12 +570,13 @@ describe('NotificationTypeEntity', () => {
         traceparent: '123',
       };
 
-      const [notification] = entity.generateNotifications(
+      const [notification] = await entity.generateNotifications(
         logger,
         templateServiceMock,
         subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
         event,
-        [subscription],
         {
           tenant,
         }
@@ -575,7 +586,7 @@ describe('NotificationTypeEntity', () => {
       expect(notification.message).toBe(message);
     });
 
-    it('can return notification for criteria match without notification type tenant Id', () => {
+    it('can return notification for criteria match without notification type tenant Id', async () => {
       const tenantId = null;
 
       const entity = new NotificationTypeEntity(
@@ -620,6 +631,7 @@ describe('NotificationTypeEntity', () => {
         entity,
         subscriber
       );
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({ results: [subscription], page: {} });
 
       const message = {
         subject: 'test',
@@ -637,12 +649,13 @@ describe('NotificationTypeEntity', () => {
         traceparent: '123',
       };
 
-      const [notification] = entity.generateNotifications(
+      const [notification] = await entity.generateNotifications(
         logger,
         templateServiceMock,
         subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
         event,
-        [subscription],
         {
           tenant: null,
         }
@@ -652,7 +665,7 @@ describe('NotificationTypeEntity', () => {
       expect(notification.message).toBe(message);
     });
 
-    it('can return no notification for criteria mismatch', () => {
+    it('can return no notification for criteria mismatch', async () => {
       const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
       const tenant = { id: tenantId, name: 'test', realm: 'test' };
       const entity = new NotificationTypeEntity(
@@ -697,6 +710,7 @@ describe('NotificationTypeEntity', () => {
         entity,
         subscriber
       );
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({ results: [subscription], page: {} });
 
       const event: DomainEvent = {
         tenantId,
@@ -708,12 +722,13 @@ describe('NotificationTypeEntity', () => {
         traceparent: '123',
       };
 
-      const notifications = entity.generateNotifications(
+      const notifications = await entity.generateNotifications(
         logger,
         templateServiceMock,
         subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
         event,
-        [subscription],
         {
           tenant,
         }
@@ -868,6 +883,335 @@ describe('NotificationTypeEntity', () => {
           ]),
         })
       );
+    });
+  });
+});
+
+describe('DirectNotificationTypeEntity', () => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger;
+
+  const repositoryMock = {
+    saveSubscription: jest.fn((entity: SubscriptionEntity) => {
+      return Promise.resolve(entity);
+    }),
+    deleteSubscriptions: jest.fn(() => Promise.resolve(true)),
+    getSubscriptions: jest.fn(),
+  };
+
+  const templateServiceMock = {
+    generateMessage: jest.fn(),
+  };
+
+  const configurationMock = {};
+
+  beforeEach(() => {
+    repositoryMock.saveSubscription.mockClear();
+    repositoryMock.deleteSubscriptions.mockClear();
+    repositoryMock.getSubscriptions.mockClear();
+    templateServiceMock.generateMessage.mockClear();
+    templateServiceMock.generateMessage.mockClear();
+  });
+
+  it('can be created', () => {
+    const entity = new DirectNotificationTypeEntity(
+      {
+        id: 'test-type',
+        name: 'test type',
+        description: null,
+        publicSubscribe: false,
+        addressPath: 'details.email',
+        subscriberRoles: [],
+        channels: [],
+        events: [],
+      },
+      adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+    );
+
+    expect(entity).toBeTruthy();
+  });
+
+  it('can throw for missing addressPath', () => {
+    expect(() => {
+      new DirectNotificationTypeEntity(
+        {
+          id: 'test-type',
+          name: 'test type',
+          description: null,
+          publicSubscribe: false,
+          subscriberRoles: [],
+          channels: [],
+          events: [],
+        },
+        adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+      );
+    }).toThrowError(InvalidOperationError);
+  });
+
+  describe('subscribe', () => {
+    it('can throw invalid operation', async () => {
+      const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+      const entity = new DirectNotificationTypeEntity(
+        {
+          id: 'test-type',
+          name: 'test type',
+          description: null,
+          publicSubscribe: false,
+          addressPath: 'details.email',
+          subscriberRoles: [],
+          channels: [],
+          events: [],
+        },
+        adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+      );
+      const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
+        tenantId,
+        addressAs: 'Tester',
+        channels: [
+          {
+            channel: Channel.email,
+            address: 'test@testco.org',
+            verified: false,
+          },
+        ],
+      });
+
+      await expect(
+        entity.subscribe(
+          repositoryMock as unknown as SubscriptionRepository,
+          { id: 'test', tenantId, roles: [] } as User,
+          subscriber
+        )
+      ).rejects.toThrowError(InvalidOperationError);
+    });
+  });
+
+  describe('unsubscribe', () => {
+    it('can throw invalid operation', async () => {
+      const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+      const entity = new DirectNotificationTypeEntity(
+        {
+          id: 'test-type',
+          name: 'test type',
+          description: null,
+          publicSubscribe: false,
+          addressPath: 'details.email',
+          subscriberRoles: [],
+          channels: [],
+          events: [],
+        },
+        adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+      );
+      const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
+        tenantId,
+        addressAs: 'Tester',
+        channels: [
+          {
+            channel: Channel.email,
+            address: 'test@testco.org',
+            verified: false,
+          },
+        ],
+      });
+
+      await expect(
+        entity.unsubscribe(
+          repositoryMock as unknown as SubscriptionRepository,
+          { id: 'test', tenantId, roles: [] } as User,
+          subscriber
+        )
+      ).rejects.toThrowError(InvalidOperationError);
+    });
+  });
+
+  describe('generateNotifications', () => {
+    const subscriberAppUrl = new URL('https://subscriptions');
+
+    const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+    const tenant = { id: tenantId, name: 'test', realm: 'test' };
+
+    const entity = new DirectNotificationTypeEntity(
+      {
+        id: 'test-type',
+        name: 'test type',
+        description: null,
+        publicSubscribe: false,
+        addressPath: 'details.email',
+        subscriberRoles: [],
+        channels: [Channel.email],
+        events: [
+          {
+            namespace: 'test-service',
+            name: 'test-started',
+            templates: {
+              [Channel.email]: { subject: '', body: '' },
+            },
+          },
+        ],
+      },
+      adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+    );
+
+    it('can generate direction notification', async () => {
+      const event = {
+        tenantId,
+        namespace: 'test-service',
+        name: 'test-started',
+        timestamp: new Date(),
+        payload: { details: { email: 'tester@test.co' } },
+        traceparent: '123',
+      };
+
+      const message = {
+        subject: 'test',
+        body: 'test content',
+      };
+      templateServiceMock.generateMessage.mockReturnValueOnce(message);
+
+      const [result] = await entity.generateNotifications(
+        logger as Logger,
+        templateServiceMock,
+        subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
+        event,
+        { tenant }
+      );
+
+      expect(result).toMatchObject({ tenantId: tenantId.toString(), message, to: event.payload.details.email });
+    });
+
+    it('can handle missing address value', async () => {
+      const event = {
+        tenantId,
+        namespace: 'test-service',
+        name: 'test-started',
+        timestamp: new Date(),
+        payload: {},
+        traceparent: '123',
+      };
+
+      const message = {
+        subject: 'test',
+        body: 'test content',
+      };
+      templateServiceMock.generateMessage.mockReturnValueOnce(message);
+
+      const results = await entity.generateNotifications(
+        logger as Logger,
+        templateServiceMock,
+        subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
+        event,
+        { tenant }
+      );
+
+      expect(results).toMatchObject(expect.arrayContaining([]));
+    });
+
+    it('can handle missing channel', async () => {
+      const entity = new DirectNotificationTypeEntity(
+        {
+          id: 'test-type',
+          name: 'test type',
+          description: null,
+          publicSubscribe: false,
+          addressPath: 'details.email',
+          subscriberRoles: [],
+          channels: [],
+          events: [
+            {
+              namespace: 'test-service',
+              name: 'test-started',
+              templates: {
+                [Channel.email]: { subject: '', body: '' },
+              },
+            },
+          ],
+        },
+        adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+      );
+
+      const event = {
+        tenantId,
+        namespace: 'test-service',
+        name: 'test-started',
+        timestamp: new Date(),
+        payload: {},
+        traceparent: '123',
+      };
+
+      const message = {
+        subject: 'test',
+        body: 'test content',
+      };
+      templateServiceMock.generateMessage.mockReturnValueOnce(message);
+
+      const results = await entity.generateNotifications(
+        logger as Logger,
+        templateServiceMock,
+        subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
+        event,
+        { tenant }
+      );
+
+      expect(results).toMatchObject(expect.arrayContaining([]));
+    });
+
+    it('can handle missing channel template', async () => {
+      const entity = new DirectNotificationTypeEntity(
+        {
+          id: 'test-type',
+          name: 'test type',
+          description: null,
+          publicSubscribe: false,
+          addressPath: 'details.email',
+          subscriberRoles: [],
+          channels: [Channel.email],
+          events: [
+            {
+              namespace: 'test-service',
+              name: 'test-started',
+              templates: {},
+            },
+          ],
+        },
+        adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+      );
+
+      const event = {
+        tenantId,
+        namespace: 'test-service',
+        name: 'test-started',
+        timestamp: new Date(),
+        payload: {},
+        traceparent: '123',
+      };
+
+      const message = {
+        subject: 'test',
+        body: 'test content',
+      };
+      templateServiceMock.generateMessage.mockReturnValueOnce(message);
+
+      const results = await entity.generateNotifications(
+        logger as Logger,
+        templateServiceMock,
+        subscriberAppUrl,
+        repositoryMock as unknown as SubscriptionRepository,
+        configurationMock as NotificationConfiguration,
+        event,
+        { tenant }
+      );
+
+      expect(results).toMatchObject(expect.arrayContaining([]));
     });
   });
 });

--- a/apps/notification-service/src/notification/model/type.ts
+++ b/apps/notification-service/src/notification/model/type.ts
@@ -1,7 +1,8 @@
 import { AdspId, Channel, isAllowedUser, User } from '@abgov/adsp-service-sdk';
 import type { DomainEvent } from '@core-services/core-common';
-import { UnauthorizedError } from '@core-services/core-common';
+import { InvalidOperationError, UnauthorizedError } from '@core-services/core-common';
 import { getTemplateBody } from '@core-services/notification-shared';
+import { get as getAtPath } from 'lodash';
 import { Logger } from 'winston';
 import { SubscriptionRepository } from '../repository';
 import { TemplateService } from '../template';
@@ -16,6 +17,7 @@ import {
 } from '../types';
 import { SubscriberEntity } from './subscriber';
 import { SubscriptionEntity } from './subscription';
+import { NotificationConfiguration } from '../configuration';
 
 export class NotificationTypeEntity implements NotificationType {
   tenantId?: AdspId;
@@ -77,30 +79,57 @@ export class NotificationTypeEntity implements NotificationType {
     return repository.deleteSubscriptions(subscriber.tenantId, this.id, subscriber.id);
   }
 
-  generateNotifications(
+  async generateNotifications(
     logger: Logger,
     templateService: TemplateService,
     subscriberAppUrl: URL,
+    subscriptionRepository: SubscriptionRepository,
+    configuration: NotificationConfiguration,
     event: DomainEvent,
-    subscriptions: SubscriptionEntity[],
     messageContext: Record<string, unknown>
-  ): Notification[] {
+  ): Promise<Notification[]> {
     const notifications: Notification[] = [];
-    for (const subscription of subscriptions) {
-      if (subscription.shouldSend(event)) {
-        const notification = this.generateNotification(
-          logger,
-          templateService,
-          subscriberAppUrl,
-          event,
-          subscription,
-          messageContext
-        );
-        if (notification) {
-          notifications.push(notification);
+
+    // Page through all subscriptions and generate notifications.
+    let after: string = null;
+    let pageNumber = 1;
+    do {
+      logger.debug(
+        `Processing page ${pageNumber} of subscriptions of type ${this.id} for event ${event.namespace}:${event.name}...`,
+        {
+          context: 'NotificationType',
+          tenant: event.tenantId?.toString(),
+        }
+      );
+
+      const { results: subscriptions, page } = await subscriptionRepository.getSubscriptions(
+        configuration,
+        event.tenantId,
+        1000,
+        after,
+        {
+          typeIdEquals: this.id,
+        }
+      );
+
+      for (const subscription of subscriptions) {
+        if (subscription.shouldSend(event)) {
+          const notification = this.generateNotification(
+            logger,
+            templateService,
+            subscriberAppUrl,
+            event,
+            subscription,
+            messageContext
+          );
+          if (notification) {
+            notifications.push(notification);
+          }
         }
       }
-    }
+      after = page.next;
+      pageNumber++;
+    } while (after);
 
     return notifications;
   }
@@ -178,11 +207,116 @@ export class NotificationTypeEntity implements NotificationType {
     }
   }
 
-  private getTemplate(channel: Channel, template: Template, context: Record<string, unknown>): Template {
+  protected getTemplate(channel: Channel, template: Template, context: Record<string, unknown>): Template {
     const effectiveTemplate = { ...template };
     if (channel === Channel.email) {
       effectiveTemplate.body = getTemplateBody(template.body.toString(), channel, context);
     }
     return effectiveTemplate;
+  }
+}
+/**
+ * Represents a notification type that generates notification based on trigger event without requiring a subscription.
+ *
+ * Note: This is a subclass because subscription-based notifications were implemented first.
+ *
+ * @export
+ * @class DirectNotificationTypeEntity
+ * @extends {NotificationTypeEntity}
+ * @implements {NotificationType}
+ */
+export class DirectNotificationTypeEntity extends NotificationTypeEntity implements NotificationType {
+  addressPath?: string;
+
+  constructor(type: NotificationType, tenantId?: AdspId) {
+    super(type, tenantId);
+
+    if (!this.addressPath) {
+      throw new InvalidOperationError('Direct notification type must include an addressPath.');
+    }
+  }
+
+  override async subscribe(
+    _repository: SubscriptionRepository,
+    _user: User,
+    _subscriber: SubscriberEntity,
+    _criteria?: SubscriptionCriteria
+  ): Promise<SubscriptionEntity> {
+    throw new InvalidOperationError('Direct notification types cannot be subscribed to.');
+  }
+
+  override async unsubscribe(
+    _repository: SubscriptionRepository,
+    _user: User,
+    _subscriber: SubscriberEntity
+  ): Promise<boolean> {
+    throw new InvalidOperationError('Direct notification types cannot be subscribed to.');
+  }
+
+  override async generateNotifications(
+    logger: Logger,
+    templateService: TemplateService,
+    _subscriberAppUrl: URL,
+    _subscriptionRepository: SubscriptionRepository,
+    _configuration: NotificationConfiguration,
+    event: DomainEvent,
+    messageContext: Record<string, unknown>
+  ): Promise<Notification[]> {
+    logger.debug(`Processing direct notification type ${this.id} for event ${event.namespace}:${event.name}...`, {
+      context: 'NotificationType',
+      tenant: event.tenantId?.toString(),
+    });
+
+    const eventNotification = this.events.find((e) => e.namespace === event.namespace && e.name === event.name);
+
+    // For direct notification, channel is the first (only) channel and address is from event.
+    const [channel] = this.channels;
+    const address = getAtPath(event.payload, this.addressPath);
+
+    const notifications = [];
+    if (eventNotification && channel && address && eventNotification.templates[channel]) {
+      const context = {
+        ...messageContext,
+        event,
+      };
+
+      notifications.push({
+        tenantId: event.tenantId.toString(),
+        type: {
+          id: this.id,
+          name: this.name,
+        },
+        event: {
+          namespace: event.namespace,
+          name: event.name,
+          timestamp: event.timestamp,
+        },
+        correlationId: event.correlationId,
+        context: event.context,
+        to: address,
+        channel,
+        message: templateService.generateMessage(
+          this.getTemplate(channel, eventNotification.templates[channel], context),
+          context
+        ),
+      });
+
+      logger.debug(`Generated direct notification for type ${this.id} on event ${event.namespace}:${event.name}.`, {
+        context: 'NotificationType',
+        tenant: event.tenantId?.toString(),
+      });
+    } else if (eventNotification) {
+      // Not resolving a notification type can be due to event criteria and isn't unexpected.
+      // However, unresolved channel or address suggests broken configuration.
+      logger.warn(
+        `Direct notification type ${this.id} failed to resolve channel (${channel}), address (${address}), and/or channel template.`,
+        {
+          context: 'NotificationType',
+          tenant: event.tenantId?.toString(),
+        }
+      );
+    }
+
+    return notifications;
   }
 }

--- a/apps/notification-service/src/notification/types/notification.ts
+++ b/apps/notification-service/src/notification/types/notification.ts
@@ -20,7 +20,7 @@ export interface Notification extends NotificationContent {
   correlationId?: string;
   context?: Record<string, boolean | number | string>;
   channel: Channel;
-  subscriber: {
+  subscriber?: {
     id: string;
     userId: string;
     addressAs: string;

--- a/apps/notification-service/src/notification/types/type.ts
+++ b/apps/notification-service/src/notification/types/type.ts
@@ -6,6 +6,7 @@ export { Channel } from '@abgov/adsp-service-sdk';
 export interface NotificationType extends Exclude<BaseNotificationType, 'displayName'> {
   id: string;
   events: NotificationTypeEvent[];
+  addressPath?: string;
 }
 
 export interface NotificationTypeCriteria {


### PR DESCRIPTION
…ates without subscription

Direct notification type to support use cases where notification is sent based purely on information in the trigger event.