### PR TITLE
fix(adsp-service-sdk): revert unintentional change to role resolution

### DIFF
--- a/libs/adsp-service-sdk/src/access/assert.ts
+++ b/libs/adsp-service-sdk/src/access/assert.ts
@@ -31,14 +31,7 @@ export function hasRequiredRole(user: User, roles: string | string[]): boolean {
     roles = [roles];
   }
 
-  const userRoles =
-    user?.roles?.map((role) => {
-      if (role.split(':').length > 1) {
-        return role.split(':')[role.split(':').length - 1];
-      } else {
-        return role;
-      }
-    }) || [];
+  const userRoles = user?.roles || [];
 
   // If user has at least one of the roles, then they are permitted.
   const matchedRole = roles.find((required) => userRoles.includes(required));

--- a/libs/adsp-service-sdk/src/configuration/configurationUpdateHandler.ts
+++ b/libs/adsp-service-sdk/src/configuration/configurationUpdateHandler.ts
@@ -41,6 +41,10 @@ export const handleConfigurationUpdates = async (
     logger.info('Connected for configuration updates...', LOG_CONTEXT);
   });
 
+  socket.on('connect_error', async (err) => {
+    logger.error(`Connect to configuration updates failed with error: ${err}`, LOG_CONTEXT);
+  });
+
   socket.on('disconnect', async (reason) => {
     logger.debug(`Disconnected from configuration updates due to reason: ${reason}`);
 

--- a/libs/adsp-service-sdk/src/configuration/index.ts
+++ b/libs/adsp-service-sdk/src/configuration/index.ts
@@ -45,6 +45,7 @@ export const createConfigurationService = ({
     combine,
     useLongConfigurationCacheTTL ? 36000 : 900
   );
+
   if (enableConfigurationInvalidation) {
     handleConfigurationUpdates(logger, directory, tokenProvider, service);
   }


### PR DESCRIPTION
Convention is that roles are qualified with the service ID when the client doesn't match the current service (i.e. roles in other clients). This can't be changed without substantial rework.