### PR TITLE
CS-2544 - take into account the no phone case

### DIFF
--- a/apps/subscriber-app/src/app/pages/private/Subscriptions/ContactInfoCard.tsx
+++ b/apps/subscriber-app/src/app/pages/private/Subscriptions/ContactInfoCard.tsx
@@ -201,10 +201,12 @@ export const ContactInfoCard = ({ subscriber }: ContactInfoCardProps): JSX.Eleme
     subscriber?.channels[smsChannelIndex]?.pendingVerification &&
     subscriber?.channels[smsChannelIndex]?.timeCodeSent + 1000 * 60 * expireMinutes > Date.now();
 
+  const noSms = !subscriber?.channels[smsChannelIndex];
+
   const emailValidated = subscriber?.channels[emailChannelIndex]?.verified;
   const smsValidated = subscriber?.channels[smsChannelIndex]?.verified;
 
-  const neitherChannelUnverified = (codeEmailExists || emailValidated) && (codeSMSExists || smsValidated);
+  const neitherChannelUnverified = (codeEmailExists || emailValidated) && (codeSMSExists || smsValidated || noSms);
 
   return (
     <InfoCard title="Contact information">

--- a/apps/subscriber-app/src/app/pages/validateModal.tsx
+++ b/apps/subscriber-app/src/app/pages/validateModal.tsx
@@ -47,6 +47,8 @@ export const ValidateModal: FC<Props> = ({ isOpen, title, onClose, testId, onVal
   const emailValidated = subscriber?.channels[emailChannelIndex]?.verified;
   const smsValidated = subscriber?.channels[smsChannelIndex]?.verified;
 
+  const noSms = !subscriber?.channels[smsChannelIndex];
+
   let buttons = [
     { value: 'email', label: 'Email' },
     { value: 'SMS', label: 'SMS' },
@@ -57,7 +59,7 @@ export const ValidateModal: FC<Props> = ({ isOpen, title, onClose, testId, onVal
     buttons = buttons.filter((item) => item?.value !== 'email');
   }
 
-  if (codeSMSExists || smsValidated) {
+  if (codeSMSExists || smsValidated || noSms) {
     console.log('sms');
     buttons = buttons.filter((item) => item?.value !== 'SMS');
   }


### PR DESCRIPTION
Don't allow verification of phone number when there is no phone number 

Previously this would only display an error afterwards, now we hide it entirely

![image](https://github.com/GovAlta/adsp-monorepo/assets/11400938/d1001f3c-9672-44ab-bf66-b8d0f5786148)
