### PR TITLE
feat(token-handler): add configuration to disable verify host

### DIFF
--- a/apps/token-handler/src/token/configuration/schema.ts
+++ b/apps/token-handler/src/token/configuration/schema.ts
@@ -18,6 +18,7 @@ export const configurationSchema = {
               items: { type: 'string' },
             },
             idpHint: { type: ['string', 'null'] },
+            disableVerifyHost: { type: ['boolean', 'null'] },
             successRedirectUrl: { type: ['string', 'null'] },
             failureRedirectUrl: { type: ['string', 'null'] },
           },

--- a/apps/token-handler/src/token/model/client.ts
+++ b/apps/token-handler/src/token/model/client.ts
@@ -34,6 +34,7 @@ export class AuthenticationClient implements Client {
   scope: string | string[];
   idpHint: string;
   authCallbackUrl: string;
+  disableVerifyHost: boolean;
   successRedirectUrl?: string;
   failureRedirectUrl?: string;
   credentials?: ClientCredentials;
@@ -52,6 +53,7 @@ export class AuthenticationClient implements Client {
     this.scope = client.scope;
     this.idpHint = client.idpHint;
     this.authCallbackUrl = client.authCallbackUrl;
+    this.disableVerifyHost = !!client.disableVerifyHost;
     this.successRedirectUrl = client.successRedirectUrl;
     this.failureRedirectUrl = client.failureRedirectUrl;
     this.callbackUrl = new URL(this.authCallbackUrl);
@@ -215,7 +217,7 @@ export class AuthenticationClient implements Client {
     });
 
     return (req, res, next) => {
-      if (req.hostname !== this.callbackUrl.hostname) {
+      if (!this.disableVerifyHost && req.hostname !== this.callbackUrl.hostname) {
         throw new InvalidOperationError('Request not to allowed host.');
       }
 

--- a/apps/token-handler/src/token/router/client.swagger.yml
+++ b/apps/token-handler/src/token/router/client.swagger.yml
@@ -19,7 +19,7 @@ components:
     - name: clientId
       description: ID of the client.
       in: path
-      required: false
+      required: true
       schema:
         type: string
   get:
@@ -62,3 +62,71 @@ components:
         description: Not authorized.
       403:
         description: User not permitted for requested operation.
+
+/token-handler/v1/clients/{clientId}/auth:
+  parameters:
+    - name: clientId
+      description: ID of the client.
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: X-ADSP-TENANT
+      description: ID of the tenant.
+      in: header
+      required: true
+      schema:
+        type: string
+  get:
+    tags:
+      - Client
+    description: Initiates authentication via the client.
+    security: []
+    responses:
+      302:
+        description: Redirect to authenticate.
+      400:
+        description: Bad request.
+      401:
+        description: Not authorized.
+
+/token-handler/v1/clients/{clientId}/callback:
+  parameters:
+    - name: clientId
+      description: ID of the client.
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: X-ADSP-TENANT
+      description: ID of the tenant.
+      in: header
+      required: true
+      schema:
+        type: string
+  get:
+    tags:
+      - Client
+    description: Completes authentication via the client.
+    security: []
+    responses:
+      200:
+        description: Request completed successfully.
+
+/token-handler/v1/clients/{clientId}/logout:
+  parameters:
+    - name: clientId
+      description: ID of the client.
+      in: path
+      required: true
+      schema:
+        type: string
+  get:
+    tags:
+      - Client
+    description: Completes authentication via the client.
+    security:
+      - sessionCookie: []
+    responses:
+      200:
+        description: Request completed successfully.

--- a/apps/token-handler/src/token/router/client.ts
+++ b/apps/token-handler/src/token/router/client.ts
@@ -110,13 +110,21 @@ export function completeAuthenticate(passport: PassportStatic) {
 
 export function logout(): RequestHandler {
   return function (req, res, next) {
-    const { id } = req.params;
-    const user = req.user as UserSessionData;
-    if (id != user.authenticatedBy) {
-      throw new InvalidOperationError('User not authenticate by specified client.');
-    }
+    try {
+      const { id } = req.params;
+      const user = req.user as UserSessionData;
+      if (!user) {
+        throw new InvalidOperationError('No user to logout.');
+      }
 
-    req.logOut((err) => (err ? next(err) : res.redirect('/')));
+      if (id != user.authenticatedBy) {
+        throw new InvalidOperationError('User not authenticate by specified client.');
+      }
+
+      req.logOut((err) => (err ? next(err) : res.redirect('/')));
+    } catch (err) {
+      next(err);
+    }
   };
 }
 

--- a/apps/token-handler/src/token/router/session.swagger.yml
+++ b/apps/token-handler/src/token/router/session.swagger.yml
@@ -1,0 +1,34 @@
+components:
+  schemas:
+    UserSessionData:
+      type: object
+      properties:
+        tenantId:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        roles:
+          type: array
+          items: string
+        expiry:
+          type: string
+          format: date-time
+
+/token-handler/v1/sessions:
+  get:
+    tags:
+      - Session
+    description: Retrieves sessions. Returns session of current user for user authenticated by handler.
+    responses:
+      200:
+        description: Request completed successfully.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/UserSessionData"

--- a/apps/token-handler/src/token/router/target.swagger.yml
+++ b/apps/token-handler/src/token/router/target.swagger.yml
@@ -1,0 +1,77 @@
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: adsp_tk_session
+
+  schemas:
+    UserSessionData:
+      type: object
+      properties:
+        tenantId:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        expiry:
+          type: string
+          format: date-time
+
+/token-handler/v1/targets/{targetId}/{targetPath}:
+  parameters:
+    - name: targetId
+      description: ID of the target.
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: targetPath
+      description: Request path on the target.
+      in: path
+      required: true
+      schema:
+        type: string
+  get:
+    tags:
+      - Target
+    description: Perform GET request to target. Note that sub-paths are supported by the API, but not in OpenAPI.
+    security:
+      - sessionCookie: []
+    responses:
+      200:
+        description: Request completed successfully.
+  post:
+    tags:
+      - Target
+    description: Perform POST request to target. Note that sub-paths are supported by the API, but not in OpenAPI.
+    security:
+      - sessionCookie: []
+    responses:
+      200:
+        description: Request completed successfully.
+  put:
+    tags:
+      - Target
+    description: Perform PUT request to target. Note that sub-paths are supported by the API, but not in OpenAPI.
+    security:
+      - sessionCookie: []
+    responses:
+      200:
+        description: Request completed successfully.
+  delete:
+    tags:
+      - Target
+    description: Perform DELETE request to target. Note that sub-paths are supported by the API, but not in OpenAPI.
+    security:
+      - sessionCookie: []
+    responses:
+      200:
+        description: Request completed successfully.

--- a/apps/token-handler/src/token/types.ts
+++ b/apps/token-handler/src/token/types.ts
@@ -15,6 +15,7 @@ export interface Client {
   idpHint?: string;
   prompt?: Prompt;
   scope?: string | string[];
+  disableVerifyHost?: boolean;
   authCallbackUrl: string;
   successRedirectUrl?: string;
   failureRedirectUrl?: string;

--- a/apps/token-handler/swagger.config.js
+++ b/apps/token-handler/swagger.config.js
@@ -3,7 +3,10 @@ module.exports = {
   info: {
     title: 'Token handler',
     version: '0.0.0',
-    description: 'Token handler pattern as a service.',
+    description:
+      'Token handler pattern as a service. ' +
+      'This service provides authentication and a proxy to other services. ' +
+      'Most endpoints are not RESTful, and OpenAPI docs are for reference only.',
   },
   tags: [],
   components: {


### PR DESCRIPTION
Disabling verify host is used for local development, as server will not accept x-forwarded- header from outside local.