### PR TITLE
fix(adsp-service-sdk): removing cache bypass from configuration service

### DIFF
--- a/apps/pdf-service/src/pdf/job/generate.ts
+++ b/apps/pdf-service/src/pdf/job/generate.ts
@@ -39,23 +39,18 @@ export function createGenerateJob({
 
     const tenantId = AdspId.parse(tenantIdValue);
 
-    const disableCaching = true;
-
     try {
       const token = await tokenProvider.getAccessToken();
       const [configuration] = await configurationService.getConfiguration<Record<string, PdfTemplateEntity>>(
         serviceId,
         token,
-        tenantId,
-        disableCaching
+        tenantId
       );
 
       const pdfTemplate = configuration[templateId];
       if (!pdfTemplate) {
         throw new NotFoundError('PDF Template', templateId);
       }
-
-      await pdfTemplate.evaluateTemplates();
 
       const pdf = await pdfTemplate.generate({ data });
 

--- a/apps/pdf-service/src/pdf/model/template.spec.ts
+++ b/apps/pdf-service/src/pdf/model/template.spec.ts
@@ -39,7 +39,6 @@ describe('PdfTemplateEntity', () => {
     const context = {};
     const stream = {};
     pdfServiceMock.generatePdf.mockResolvedValueOnce(stream);
-    entity.evaluateTemplates();
     const result = await entity.generate(context);
     expect(template).toHaveBeenCalledWith(context);
     expect(pdfServiceMock.generatePdf).toHaveBeenCalledWith({

--- a/apps/pdf-service/src/pdf/model/template.ts
+++ b/apps/pdf-service/src/pdf/model/template.ts
@@ -36,22 +36,27 @@ export class PdfTemplateEntity implements PdfTemplate {
     this.additionalStylesWrapped = '<style>' + additionalStyles + '</style>';
   }
 
-  evaluateTemplates() {
-    this.evaluateTemplate = this.templateService.getTemplateFunction(
-      this.additionalStylesWrapped.concat(this.template),
-      null
-    );
-    this.evaluateFooterTemplate = this.templateService.getTemplateFunction(
-      this.additionalStylesWrapped.concat(this.footer),
-      'pdf-footer'
-    );
-    this.evaluateHeaderTemplate = this.templateService.getTemplateFunction(
-      this.additionalStylesWrapped.concat(this.header),
-      'pdf-header'
-    );
+  private initializeTemplates() {
+    // Lazy initialize; no need to re-initialize unless templates change (i.e. configuration update).
+    if (!this.evaluateTemplate) {
+      this.evaluateTemplate = this.templateService.getTemplateFunction(
+        this.additionalStylesWrapped.concat(this.template),
+        null
+      );
+      this.evaluateFooterTemplate = this.templateService.getTemplateFunction(
+        this.additionalStylesWrapped.concat(this.footer),
+        'pdf-footer'
+      );
+      this.evaluateHeaderTemplate = this.templateService.getTemplateFunction(
+        this.additionalStylesWrapped.concat(this.header),
+        'pdf-header'
+      );
+    }
   }
 
   generate(context: unknown): Promise<Buffer> {
+    this.initializeTemplates();
+
     const content = this.evaluateTemplate(context);
     const footer = this.evaluateFooterTemplate(context);
     const header = this.evaluateHeaderTemplate(context);


### PR DESCRIPTION
ADSP onfiguration capabilities are intended to limit sync coupling using caching, and including bypass breaks that pattern. Direct API use can still circumvent the consumer side caching.

BREAKING CHANGE: cache bypass is no longer available on the configuration service interface.