### PR TITLE
CS-2566 - Get Request Script Function

### DIFF
--- a/apps/script-service/Services/IScriptFunctions.cs
+++ b/apps/script-service/Services/IScriptFunctions.cs
@@ -13,4 +13,5 @@ interface IScriptFunctions
     string? description = null, string? recordId = null, string? priority = null, LuaTable? context = null
   );
   string? SendDomainEvent(string namespaceValue, string name, string? correlationId, IDictionary<string, object>? context = null, IDictionary<string, object>? payload = null);
+  object HttpGet(string url);
 }

--- a/apps/script-service/Services/StubScriptFunctions.cs
+++ b/apps/script-service/Services/StubScriptFunctions.cs
@@ -23,6 +23,11 @@ internal sealed class StubScriptFunctions : ScriptFunctions, IScriptFunctions
     return "Simulated success";
   }
 
+  public override string? HttpGet(string url)
+  {
+    return "simulated success";
+  }
+
   public override string? CreateTask(
     string queueNamespace, string queueName, string name,
     string? description = null, string? recordId = null, string? priority = null, LuaTable? context = null

--- a/apps/tenant-management-webapp/src/app/lib/luaCodeCompletion.ts
+++ b/apps/tenant-management-webapp/src/app/lib/luaCodeCompletion.ts
@@ -19,6 +19,10 @@ export const functionSuggestion = [
     label: 'adsp.SendDomainEvent',
     insertText: 'adsp.SendDomainEvent',
   },
+  {
+    label: 'adsp.HttpGet',
+    insertText: 'adsp.HttpGet',
+  },
 ];
 
 export const functionSignature = [
@@ -120,6 +124,15 @@ export const functionSignature = [
       {
         label: 'payload',
         documentation: 'nested dictionary to allow arbitrary json structure',
+      },
+    ],
+  },
+  {
+    label: 'adsp.HttpGet(string url)',
+    parameters: [
+      {
+        label: 'url',
+        documentation: 'The url of the get request',
       },
     ],
   },


### PR DESCRIPTION
using the api (POST https://calendar-service.adsp-dev.gov.ab.ca/script/v1/scripts/scriptId ) should allow you to send events using the ui allows you to add HttpGet, but will only return a simulated response if you execute it in the ui itself

---- LUA SCRIPT ----

```
local x = adsp.HttpGet("http://postman-echo.com/get")

return x;

```
---------------------