### PR TITLE
CS-2634 - failed to fetch tenant

### DIFF
--- a/apps/tenant-management-webapp/src/app/components/AppHeader.tsx
+++ b/apps/tenant-management-webapp/src/app/components/AppHeader.tsx
@@ -45,7 +45,6 @@ const ActionsMenu = (props: HeaderMenuProps): JSX.Element => {
             <div className="close">
               <img src={CloseIcon} width="24" alt="Close" />
             </div>
-            <Sidebar type="mobile" />
           </SidebarWrapper>
         </SidebarController>
       </div>


### PR DESCRIPTION
* We dispatch an attempted tenant fetch on the mobile app header which causes the following error during tenant creation
  * failed to fetch tenant: Cannet read properties of undefined (reading 'id')
* We no longer need this mobile app header in it's entirety - it's never visible because we've disabled mobile view, but it's still being run in the background even when it's not visible. Mostly this doesn't cause any errors, but in this case we're getting an error because we're not logged in

fixes

![image](https://github.com/GovAlta/adsp-monorepo/assets/11400938/de1a1057-62da-4bcf-b2c4-2848aeb1d2dd)
