### PR TITLE
Add error boundary to the json forms previous

### DIFF
--- a/apps/tenant-management-webapp/src/app/components/ErrorBoundary.tsx
+++ b/apps/tenant-management-webapp/src/app/components/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+
+type ErrorBoundaryProps = {
+  fallback?: ReactNode;
+  children: ReactNode;
+};
+type ErrorBoundaryState = {
+  hasError: boolean; // like this
+};
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  // eslint-disable-next-line
+  componentDidCatch(error, info) {}
+
+  render() {
+    if (this.state?.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/tenant-management-webapp/src/app/lib/validation/checkInput.ts
+++ b/apps/tenant-management-webapp/src/app/lib/validation/checkInput.ts
@@ -30,6 +30,7 @@ export interface ValidInput {
   onFailureMessage: string;
 }
 
+const ajv = new Ajv();
 /**
  * Given a list of validators and name of the input field, report on its cleanliness
  */
@@ -122,6 +123,17 @@ export const wordMaxLengthCheck = (maxLen: number, field: string): Validator => 
       return `${field}'s max length of ${maxLen} characters is reached.`;
     } else {
       return '';
+    }
+  };
+};
+
+export const isValidJSONSchemaCheck = (label?: string): Validator => {
+  return (str: string) => {
+    try {
+      ajv.compile(JSON.parse(str));
+      return '';
+    } catch (err) {
+      return `${capitalize(label)} is invalid for JSON Schema.`;
     }
   };
 };


### PR DESCRIPTION
Now, we can see the errors for the jsonforms validation.

![image](https://github.com/GovAlta/adsp-monorepo/assets/8821979/ab4c84a4-c532-423b-9a98-feee9b66d4fc)
