### PR TITLE
CS-2700 - Validation was done at an earlier level, fix to give specif…

### DIFF
--- a/apps/subscriber-app/src/app/store/notifications/reducers.ts
+++ b/apps/subscriber-app/src/app/store/notifications/reducers.ts
@@ -5,18 +5,19 @@ export default function (state: NotificationState = NOTIFICATION_INIT, action: A
   switch (action.type) {
     case 'notifications/error': {
       let errorMessage = action.payload.message;
-
-      const error = action.payload?.error;
+      const error = action.payload.error;
+      let additionalMessage = `${error?.message}`;
 
       if (!error?.response) {
-        if (error) {
-          errorMessage = `${errorMessage ? errorMessage + ': ' : ''}${error?.message || error}`;
-        }
+        additionalMessage = `${error?.message || error || ''}`;
       } else if (error.response.status >= 400 && error.response.status < 500) {
-        errorMessage = `${errorMessage ? errorMessage + ': ' : ''}${
-          error?.response?.data?.errorMessage || error?.response?.data?.error || error?.response?.data
+        additionalMessage = `${
+          error?.response?.data?.errorMessage || error?.response?.data?.error || error?.response?.data || ''
         }`;
       }
+      const spacer = additionalMessage.length > 0 ? ': ' : '';
+      errorMessage = `${errorMessage}${spacer}${additionalMessage}`;
+
       return {
         notification: {
           message: errorMessage,

--- a/apps/tenant-management-webapp/src/app/store/notifications/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/notifications/reducers.ts
@@ -26,17 +26,18 @@ export default function (state: NotificationState = NOTIFICATION_INIT, action: A
     case BASIC_NOTIFICATION:
     case ERROR_NOTIFICATION: {
       let errorMessage = action.payload.message;
-
       const error = action.payload.error;
+      let additionalMessage = `${error?.message}`;
+
       if (!error?.response) {
-        errorMessage = `${errorMessage ? errorMessage + ': ' : ''}${error?.message || error}`;
+        additionalMessage = `${error?.message || error || ''}`;
       } else if (error.response.status >= 400 && error.response.status < 500) {
-        errorMessage = `${errorMessage ? errorMessage + ': ' : ''}${
-          error?.response?.data?.errorMessage || error?.response?.data?.error || error?.response?.data
+        additionalMessage = `${
+          error?.response?.data?.errorMessage || error?.response?.data?.error || error?.response?.data || ''
         }`;
-      } else {
-        errorMessage = `${errorMessage ? errorMessage + ': ' : ''}${error?.message}`;
       }
+      const spacer = additionalMessage.length > 0 ? ': ' : '';
+      errorMessage = `${errorMessage}${spacer}${additionalMessage}`;
       return {
         notifications: [
           ...state.notifications,

--- a/apps/tenant-management-webapp/src/app/store/tenant/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/tenant/sagas.ts
@@ -87,7 +87,15 @@ export function* createTenant(action: CreateTenantAction): SagaIterator {
     const result = yield call([api, api.createTenant], name);
     yield put(CreateTenantSuccess(result.realm));
   } catch (err) {
-    yield put(ErrorNotification({ error: err }));
+    if (err.message.includes('Invalid value')) {
+      yield put(
+        ErrorNotification({
+          message: 'Value not valid for Tenant name: Names cannot contain special characters (e.g. ! & %).',
+        })
+      );
+    } else {
+      yield put(ErrorNotification({ error: err }));
+    }
   }
 }
 


### PR DESCRIPTION
…ic error again


Ting added - matches: line
![image](https://github.com/GovAlta/adsp-monorepo/assets/11400938/19aa2267-416f-4c67-8646-d2909667cf1e)
validation is now different and less human friendly because it's validation before the specific error message in the back end is constructed - it is more correct, but produces less nice error messages