### PR TITLE
chore(comment-service): permit core context topic setters

### DIFF
--- a/apps/comment-service/src/comment/model/topic.ts
+++ b/apps/comment-service/src/comment/model/topic.ts
@@ -15,7 +15,7 @@ export class TopicEntity implements Topic {
   resourceId?: AdspId | string;
   commenters?: string[] = [];
 
-  @AssertRole('create topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter])
+  @AssertRole('create topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter], null, true)
   public static async create(
     _user: User,
     repository: TopicRepository,
@@ -41,7 +41,7 @@ export class TopicEntity implements Topic {
     }
   }
 
-  @AssertRole('update topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter])
+  @AssertRole('update topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter], null, true)
   public async update(
     _user: User,
     { name, description, commenters }: Pick<Topic, 'name' | 'description' | 'commenters'>
@@ -61,7 +61,7 @@ export class TopicEntity implements Topic {
     return await this.repository.save(this);
   }
 
-  @AssertRole('delete topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter])
+  @AssertRole('delete topic', [ServiceRoles.Admin, ServiceRoles.TopicSetter], null, true)
   public async delete(_user: User): Promise<boolean> {
     return await this.repository.delete(this);
   }

--- a/apps/comment-service/src/comment/router/topic.spec.ts
+++ b/apps/comment-service/src/comment/router/topic.spec.ts
@@ -134,7 +134,7 @@ describe('topic', () => {
       );
     });
 
-    it('can call next with error for unauthorized user', async () => {
+    it('can call filter results for unauthorized user', async () => {
       const req = {
         user: { ...user, roles: [] },
         tenant: {
@@ -156,8 +156,7 @@ describe('topic', () => {
       const handler = getTopics(apiId, repositoryMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
-      expect(res.send).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ results: expect.arrayContaining([]) }));
     });
   });
 


### PR DESCRIPTION
This is to support platform services creating topics. Also, allowing query of topics, but with results filtered to those the user can read.