### PR TITLE
feat(comment-service): support core context configuration for comment…

### DIFF
--- a/apps/comment-service/src/comment/model/topic.ts
+++ b/apps/comment-service/src/comment/model/topic.ts
@@ -38,6 +38,7 @@ export class TopicEntity implements Topic {
     const record = topic as Topic;
     if (record.id) {
       this.id = record.id;
+      this.securityClassification = record.securityClassification;
     }
   }
 

--- a/apps/comment-service/src/comment/router/topic.ts
+++ b/apps/comment-service/src/comment/router/topic.ts
@@ -7,7 +7,7 @@ import { commentCreated, commentDeleted, commentUpdated, topicCreated, topicDele
 import { TopicEntity, TopicTypeEntity } from '../model';
 import { TopicRepository } from '../repository';
 import { ServiceRoles } from '../roles';
-import { Topic } from '../types';
+import { Topic, TopicType } from '../types';
 
 interface TopicRouterProps {
   apiId: AdspId;
@@ -16,15 +16,21 @@ interface TopicRouterProps {
   repository: TopicRepository;
 }
 
+function mapTopicType(type: TopicType) {
+  return type ? {
+    id: type.id,
+    name: type.name,
+    adminRoles: type.adminRoles,
+    readerRoles: type.readerRoles,
+    commenterRoles: type.commenterRoles,
+    securityClassification: type.securityClassification,
+  } : null;
+}
+
 function mapTopic(apiId: AdspId, topic: Topic) {
   return topic
     ? {
-        type: topic.type
-          ? {
-              id: topic.type?.id,
-              name: topic.type?.name,
-            }
-          : null,
+        type: mapTopicType(topic.type),
         id: topic.id,
         urn: adspId`${apiId}:/topics/${topic.id}`.toString(),
         name: topic.name,

--- a/apps/comment-service/src/main.ts
+++ b/apps/comment-service/src/main.ts
@@ -16,6 +16,7 @@ import {
   ServiceRoles,
   TopicCreatedEventDefinition,
   TopicDeletedEventDefinition,
+  TopicType,
   TopicUpdatedEventDefinition,
   applyCommentMiddleware,
 } from './comment';
@@ -84,12 +85,11 @@ const initializeApp = async (): Promise<express.Application> => {
         description: 'Topic types with configuration of topic administrator, commenter, and reader roles.',
         schema: CommentConfigurationSchema,
       },
-      configurationConverter: (config, tenantId) =>
-        Object.entries(config || {}).reduce(
+      combineConfiguration: (tenant: Record<string, TopicType>, core: Record<string, TopicType>, tenantId) =>
+        Object.entries({ ...core, ...tenant }).reduce(
           (entities, [id, type]) => ({ ...entities, [id]: new TopicTypeEntity(tenantId, type) }),
           {} as Record<string, TopicTypeEntity>
         ),
-      combineConfiguration: (tenant) => tenant,
       enableConfigurationInvalidation: true,
       values: [ServiceMetricsValueDefinition],
     },


### PR DESCRIPTION
… service

Also, set classification from record instead of type when creating entity from existing record.