### PR TITLE
feat(task-service, task-app): create task topic when creating a task

### DIFF
--- a/apps/comment-service/src/main.ts
+++ b/apps/comment-service/src/main.ts
@@ -112,7 +112,7 @@ const initializeApp = async (): Promise<express.Application> => {
   app.use(
     '/comment',
     metricsHandler,
-    passport.authenticate(['tenant'], { session: false }),
+    passport.authenticate(['core', 'tenant'], { session: false }),
     tenantHandler,
     configurationHandler
   );

--- a/apps/task-app/src/app/containers/CommentsViewer.tsx
+++ b/apps/task-app/src/app/containers/CommentsViewer.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {
   AppDispatch,
   addComment,
+  canCommentSelector,
   commentActions,
   commentExecutingSelector,
   commentLoadingSelector,
@@ -35,6 +36,7 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({ class
   const loading = useSelector(commentLoadingSelector);
   const executing = useSelector(commentExecutingSelector);
   const { title, content } = useSelector(draftSelector);
+  const canComment = useSelector(canCommentSelector);
 
   const dispatch = useDispatch<AppDispatch>();
 
@@ -43,26 +45,29 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({ class
       <h3>Comments</h3>
       <div className="comments">
         {results.map((result) => (
-          <div key={result.id} className="comment">
+          <div key={result.id} className="comment" data-user-comment={result.byCurrentUser}>
             <div>
               <span>{result.createdBy.name}</span>
               <span>{formatTimestamp(result.createdOn)}</span>
             </div>
-            <p>{result.content}</p>
+            <div>
+              <p>{result.content}</p>
+            </div>
           </div>
         ))}
+        <GoACircularProgress variant="inline" size="small" visible={loading} />
         {!loading && next && (
           <GoAButton type="tertiary" onClick={() => dispatch(loadComments({ next, topic }))}>
             Load more
           </GoAButton>
         )}
-        <GoACircularProgress variant="inline" size="small" visible={loading} />
       </div>
       <form>
         <GoAFormItem label="New comment">
           <GoATextArea
             name="comment"
             value={content}
+            disabled={!canComment}
             onChange={(_, value) => dispatch(commentActions.setDraftComment({ title, content: value }))}
             placeholder="Write your comment..."
             width="100%"
@@ -111,7 +116,7 @@ export const CommentsViewer = styled(CommentsViewerComponent)`
     flex: 1 1 0;
     overflow-y: auto;
     display: flex;
-    flex-direction: column;
+    flex-direction: column-reverse;
     padding-left: var(--goa-spacing-l);
     padding-right: var(--goa-spacing-l);
     > .comment {
@@ -132,15 +137,32 @@ export const CommentsViewer = styled(CommentsViewerComponent)`
         margin-left: var(--goa-space-m);
       }
 
+      div {
+        display: flex;
+        p {
+          margin-top: var(--goa-space-2xs);
+          margin-right: auto;
+          padding-right: var(--goa-space-2xl);
+          font-size: 16px;
+          font-weight: 400;
+          line-height: 24px;
+          color: rgb(51, 51, 51);
+          letter-spacing: 0em;
+          text-align: left;
+          text-wrap: wrap;
+        }
+      }
+    }
+    > .comment[data-user-comment='true'] {
+      div {
+        > :first-child {
+          margin-left: auto;
+          margin-right: 0;
+        }
+      }
       p {
-        margin-top: var(--goa-space-2xs);
-        font-size: 16px;
-        font-weight: 400;
-        line-height: 24px;
-        color: rgb(51, 51, 51);
-        letter-spacing: 0em;
-        text-align: left;
-        text-wrap: wrap;
+        padding-left: var(--goa-space-2xl);
+        padding-right: 0;
       }
     }
     & > * {

--- a/apps/task-app/src/app/state/util.ts
+++ b/apps/task-app/src/app/state/util.ts
@@ -4,3 +4,8 @@ export function isAxiosErrorPayload(payload: unknown): payload is SerializedAxio
   const error = payload as SerializedAxiosError;
   return typeof error?.status === 'number' && typeof error?.message === 'string';
 }
+
+export function hasRole(role: string | string[], user: { roles?: string[] }): boolean {
+  const roles = Array.isArray(role) ? role : [role];
+  return !!roles.find((r) => user?.roles?.includes(r));
+}

--- a/apps/task-service/src/comment.ts
+++ b/apps/task-service/src/comment.ts
@@ -1,0 +1,57 @@
+import { ServiceDirectory, TokenProvider, adspId } from '@abgov/adsp-service-sdk';
+import axios from 'axios';
+import { Logger } from 'winston';
+import { CommentService, Task } from './task';
+
+class CommentServiceImpl implements CommentService {
+  private commentTopicUrl: URL;
+  constructor(
+    private logger: Logger,
+    private tokenProvider: TokenProvider,
+    commentServiceUrl: URL,
+    private topicTypeId: string
+  ) {
+    this.commentTopicUrl = new URL('/comment/v1/topics', commentServiceUrl);
+  }
+  async createTopic(task: Task, urn: string): Promise<void> {
+    try {
+      this.logger.debug(`Creating comment topic for task (${urn})...`);
+
+      const token = await this.tokenProvider.getAccessToken();
+      const { data } = await axios.post<{ urn: string }>(
+        this.commentTopicUrl.href,
+        {
+          typeId: this.topicTypeId,
+          resourceId: urn,
+          name: `Task ${task.name} (ID: ${task.id}) comments`,
+          description: `Topic created by task service for comments related to task ${task.name} (ID: ${task.id}) in queue ${task.queue.namespace}:${task.queue.name}.`,
+        },
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          params: { tenantId: task.tenantId.toString() },
+        }
+      );
+      this.logger.info(`Created comment topic for task (${urn}) at ${data.urn}.`);
+    } catch (err) {
+      this.logger.error(`Failed to create comment topic for task (${urn}): ${err}`);
+    }
+  }
+}
+
+interface CommentServiceProps {
+  logger: Logger;
+  directory: ServiceDirectory;
+  tokenProvider: TokenProvider;
+  topicTypeId: string;
+}
+
+const commentServiceId = adspId`urn:ads:platform:comment-service`;
+export async function createCommentService({
+  logger,
+  directory,
+  tokenProvider,
+  topicTypeId,
+}: CommentServiceProps): Promise<CommentService> {
+  const commentServiceUrl = await directory.getServiceUrl(commentServiceId);
+  return new CommentServiceImpl(logger, tokenProvider, commentServiceUrl, topicTypeId);
+}

--- a/apps/task-service/src/main.ts
+++ b/apps/task-service/src/main.ts
@@ -5,7 +5,7 @@ import * as passport from 'passport';
 import * as compression from 'compression';
 import * as cors from 'cors';
 import * as helmet from 'helmet';
-import { AdspId, initializePlatform, ServiceMetricsValueDefinition } from '@abgov/adsp-service-sdk';
+import { adspId, AdspId, initializePlatform, ServiceMetricsValueDefinition } from '@abgov/adsp-service-sdk';
 import type { User } from '@abgov/adsp-service-sdk';
 import { createLogger, createErrorHandler } from '@core-services/core-common';
 import { environment } from './environments/environment';
@@ -24,6 +24,7 @@ import {
   TaskUpdatedDefinition,
 } from './task';
 import { createRepositories } from './postgres';
+import { createCommentService } from './comment';
 
 const logger = createLogger('task-service', environment.LOG_LEVEL);
 
@@ -38,6 +39,8 @@ const initializeApp = async (): Promise<express.Application> => {
   if (environment.TRUSTED_PROXY) {
     app.set('trust proxy', environment.TRUSTED_PROXY);
   }
+
+  const COMMENT_TOPIC_TYPE_ID = 'task-comments';
 
   const serviceId = AdspId.parse(environment.CLIENT_ID);
   const accessServiceUrl = new URL(environment.KEYCLOAK_ROOT_URL);
@@ -120,6 +123,20 @@ const initializeApp = async (): Promise<express.Application> => {
           ],
         },
       ],
+      serviceConfigurations: [
+        {
+          serviceId: adspId`urn:ads:platform:comment-service`,
+          configuration: {
+            COMMENT_TOPIC_TYPE_ID: {
+              id: COMMENT_TOPIC_TYPE_ID,
+              name: 'Task comments',
+              adminRoles: [`${serviceId}:${TaskServiceRoles.Admin}`],
+              readerRoles: [],
+              commenterRoles: [`${serviceId}:${TaskServiceRoles.TaskReader}`],
+            },
+          },
+        },
+      ],
       configuration: {
         schema: configurationSchema,
         description: 'Task queues where tasks are created for processing by workers.',
@@ -159,6 +176,12 @@ const initializeApp = async (): Promise<express.Application> => {
   );
 
   const repositories = await createRepositories({ logger, ...environment });
+  const commentService = await createCommentService({
+    logger,
+    directory,
+    tokenProvider,
+    topicTypeId: COMMENT_TOPIC_TYPE_ID,
+  });
   applyTaskMiddleware(app, {
     KEYCLOAK_ROOT_URL: environment.KEYCLOAK_ROOT_URL,
     serviceId,
@@ -167,6 +190,7 @@ const initializeApp = async (): Promise<express.Application> => {
     tokenProvider,
     taskRepository: repositories.taskRepository,
     eventService,
+    commentService,
   });
 
   const swagger = JSON.parse(await promisify(readFile)(`${__dirname}/swagger.json`, 'utf8'));

--- a/apps/task-service/src/task/comment.ts
+++ b/apps/task-service/src/task/comment.ts
@@ -1,0 +1,5 @@
+import { Task } from './types';
+
+export interface CommentService {
+  createTopic(task: Task, urn: string): Promise<void>;
+}

--- a/apps/task-service/src/task/configuration.ts
+++ b/apps/task-service/src/task/configuration.ts
@@ -18,6 +18,9 @@ export const configurationSchema = {
               type: 'string',
               pattern: '^[a-zA-Z0-9-_ ]{1,50}$',
             },
+            displayName: {
+              type: ['string', 'null'],
+            },
             context: {
               type: 'object',
               additionalProperties: {

--- a/apps/task-service/src/task/index.ts
+++ b/apps/task-service/src/task/index.ts
@@ -3,6 +3,7 @@ import { Application } from 'express';
 import { Logger } from 'winston';
 import { TaskRepository } from './repository';
 import { createQueueRouter, createTaskRouter } from './router';
+import { CommentService } from './comment';
 
 export * from './configuration';
 export * from './events';
@@ -10,6 +11,7 @@ export * from './roles';
 export * from './types';
 export * from './model';
 export * from './repository';
+export * from './comment';
 
 interface TaskMiddlewareProps {
   KEYCLOAK_ROOT_URL: string;
@@ -19,6 +21,7 @@ interface TaskMiddlewareProps {
   tokenProvider: TokenProvider;
   taskRepository: TaskRepository;
   eventService: EventService;
+  commentService: CommentService;
 }
 export function applyTaskMiddleware(app: Application, { serviceId, ...props }: TaskMiddlewareProps): Application {
   const apiId = adspId`${serviceId}:v1`;

--- a/apps/task-service/src/task/model/queue.ts
+++ b/apps/task-service/src/task/model/queue.ts
@@ -9,6 +9,7 @@ export class QueueEntity implements Queue {
   tenantId: AdspId;
   namespace: string;
   name: string;
+  displayName?: string;
   assignerRoles: string[] = [];
   workerRoles: string[] = [];
   context: Record<string, string | number | boolean>;
@@ -17,6 +18,7 @@ export class QueueEntity implements Queue {
     this.tenantId = queue.tenantId;
     this.namespace = queue.namespace;
     this.name = queue.name;
+    this.displayName = queue.displayName;
     this.assignerRoles = queue.assignerRoles || [];
     this.workerRoles = queue.workerRoles || [];
     this.context = queue.context || {};

--- a/apps/task-service/src/task/router/queue.spec.ts
+++ b/apps/task-service/src/task/router/queue.spec.ts
@@ -52,6 +52,10 @@ describe('queue', () => {
 
   const getConfigurationMock = jest.fn();
 
+  const commentServiceMock = {
+    createTopic: jest.fn(),
+  };
+
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
   const queue = new QueueEntity({
     tenantId,
@@ -96,6 +100,7 @@ describe('queue', () => {
         logger: loggerMock,
         taskRepository: repositoryMock,
         eventService: eventServiceMock,
+        commentService: commentServiceMock,
       });
 
       expect(router).toBeTruthy();
@@ -435,10 +440,10 @@ describe('queue', () => {
   });
 
   describe('createTask', () => {
-    const handler = createTask(apiId, repositoryMock, eventServiceMock);
+    const handler = createTask(apiId, repositoryMock, eventServiceMock, commentServiceMock);
 
     it('can create handler', () => {
-      const result = createTask(apiId, repositoryMock, eventServiceMock);
+      const result = createTask(apiId, repositoryMock, eventServiceMock, commentServiceMock);
       expect(result).toBeTruthy();
     });
 
@@ -457,6 +462,7 @@ describe('queue', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining(req.body));
       expect(eventServiceMock.send).toHaveBeenCalledWith(expect.objectContaining({ name: 'task-created' }));
+      expect(commentServiceMock.createTopic).toHaveBeenCalled();
     });
 
     it('can handle create task request with priority', async () => {

--- a/apps/task-service/src/task/router/task.ts
+++ b/apps/task-service/src/task/router/task.ts
@@ -32,7 +32,7 @@ interface TaskRouterProps {
 
 export const TASK_KEY = 'task';
 
-export const mapTask = (apiId: AdspId, entity: TaskEntity): unknown => ({
+export const mapTask = (apiId: AdspId, entity: TaskEntity) => ({
   urn: `${apiId}:/tasks/${entity.id}`,
   id: entity.id,
   name: entity.name,

--- a/apps/task-service/src/task/types/queue.ts
+++ b/apps/task-service/src/task/types/queue.ts
@@ -4,6 +4,7 @@ export interface Queue {
   tenantId: AdspId;
   namespace: string;
   name: string;
+  displayName?: string;
   context: Record<string, string | number | boolean>;
   assignerRoles: string[];
   workerRoles: string[];


### PR DESCRIPTION
Add support for retrieving topic of task and topic of entity associated with task (via recordId) in task app.