### PR TITLE
feat(file-service): allow user to specify the mime type when uploading

### DIFF
--- a/apps/file-service/src/file/router/file.swagger.yml
+++ b/apps/file-service/src/file/router/file.swagger.yml
@@ -156,6 +156,10 @@ components:
                 description: The application-supplied name of the file.
                 example: TestFile23
                 type: string
+              mimeType:
+                description: Default MIME type of the file unless detected to be different.
+                example: application/octet-stream
+                type: string
               file:
                 description: File contents.
                 type: string

--- a/apps/file-service/src/file/router/upload.ts
+++ b/apps/file-service/src/file/router/upload.ts
@@ -42,7 +42,7 @@ export class FileStorageEngine implements multer.StorageEngine {
       benchmark(req, 'operation-handler-time');
 
       const user = req.user;
-      const { type = null, recordId = null, filename = null } = { ...req.query, ...req.body };
+      const { type = null, recordId = null, filename = null, mimeType = null } = { ...req.query, ...req.body };
 
       if (!type) {
         throw new InvalidOperationError('Type of file not specified.');
@@ -78,7 +78,7 @@ export class FileStorageEngine implements multer.StorageEngine {
         {
           filename: filename || file.originalname,
           recordId,
-          securityClassification: fileType.securityClassification,
+          mimeType,
         },
         file.stream
       );

--- a/apps/file-service/src/file/types/file.ts
+++ b/apps/file-service/src/file/types/file.ts
@@ -36,12 +36,4 @@ export interface FileCriteria {
   lastAccessedAfter?: string;
 }
 
-export type NewFile = {
-  recordId: string;
-  filename: string;
-};
-
-export type SecurityClassificationMimeTypeInfo = {
-  securityClassification: string;
-  mimeType?: string;
-};
+export type NewFile = Pick<File, 'recordId' | 'filename' | 'mimeType'>;

--- a/apps/task-app/src/app/state/config.slice.ts
+++ b/apps/task-app/src/app/state/config.slice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
 import { environment as envStatic } from '../../environments/environment';
 import { AppState } from './store';
 import { getAccessToken } from './user.slice';
@@ -71,6 +72,7 @@ export const loadExtensions = createAsyncThunk(
 
       if (!config.environment.extensions?.[tenantId] && data.configuration?.extensions?.length) {
         return rejectWithValue({
+          id: uuidv4(),
           level: 'error',
           message: 'There are task extensions, but extensions are not enabled for the tenant.',
         } as FeedbackMessage);


### PR DESCRIPTION
User provided mime type is overwritten if the magic bytes detection determines a value. Cleaning up some extraneous code in file router.

Also, fixing missing id for task app feedback payload.