### PR TITLE
feat(form-service): limit access of form definitions to users with fo…

### DIFF
--- a/apps/form-service/src/form/model/definition.spec.ts
+++ b/apps/form-service/src/form/model/definition.spec.ts
@@ -27,6 +27,63 @@ describe('FormDefinitionEntity', () => {
     expect(validationService.setSchema).toHaveBeenCalledWith(entity.id, expect.any(Object));
   });
 
+  describe('canAccessDefinition', () => {
+    const entity = new FormDefinitionEntity(validationService, tenantId, {
+      id: 'test',
+      name: 'test-form-definition',
+      description: null,
+      formDraftUrlTemplate: 'https://my-form/{{ id }}',
+      anonymousApply: false,
+      applicantRoles: ['test-applicant'],
+      assessorRoles: ['test-assessor'],
+      clerkRoles: [],
+      dataSchema: null,
+      submissionRecords: false,
+    });
+
+    it('can return true for user with applicant role', () => {
+      const result = entity.canAccessDefinition({ tenantId, id: 'tester', roles: ['test-applicant'] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return false for user without applicant role', () => {
+      const result = entity.canAccessDefinition({ tenantId, id: 'tester', roles: [] } as User);
+      expect(result).toBe(false);
+    });
+
+    it('can return true for intake app', () => {
+      const result = entity.canAccessDefinition({
+        tenantId,
+        id: 'tester',
+        roles: [FormServiceRoles.IntakeApp],
+      } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return true for form admin', () => {
+      const result = entity.canAccessDefinition({
+        tenantId,
+        id: 'tester',
+        roles: [FormServiceRoles.Admin],
+      } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return false for core user', () => {
+      const result = entity.canAccessDefinition({ isCore: true, id: 'tester', roles: ['test-applicant'] } as User);
+      expect(result).toBe(false);
+    });
+
+    it('can return false for user of different tenant', () => {
+      const result = entity.canAccessDefinition({
+        tenantId: adspId`urn:ads:platform:tenant-service:v2:/tenants/test2`,
+        id: 'tester',
+        roles: ['test-applicant'],
+      } as User);
+      expect(result).toBe(false);
+    });
+  });
+
   describe('canApply', () => {
     const entity = new FormDefinitionEntity(validationService, tenantId, {
       id: 'test',

--- a/apps/form-service/src/form/model/definition.ts
+++ b/apps/form-service/src/form/model/definition.ts
@@ -40,6 +40,15 @@ export class FormDefinitionEntity implements FormDefinition {
     this.validationService.setSchema(this.id, this.dataSchema);
   }
 
+  public canAccessDefinition(user: User): boolean {
+    return isAllowedUser(user, this.tenantId, [
+      FormServiceRoles.Admin,
+      FormServiceRoles.IntakeApp,
+      ...this.applicantRoles,
+      ...this.clerkRoles,
+    ]);
+  }
+
   public canApply(user: User): boolean {
     return isAllowedUser(
       user,

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -104,7 +104,7 @@ describe('form router', () => {
       const user = {
         tenantId,
         id: 'tester',
-        roles: [],
+        roles: ['test-applicant'],
       };
       const req = {
         user,
@@ -122,10 +122,53 @@ describe('form router', () => {
         expect.arrayContaining([expect.objectContaining({ id: 'test', name: 'test-form-definition' })])
       );
     });
+
+    it('can filter out definitions not accessible to user', async () => {
+      const user = {
+        tenantId,
+        id: 'tester',
+        roles: [],
+      };
+      const req = {
+        user,
+        getConfiguration: jest.fn(),
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const configuration = { test: definition };
+      req.getConfiguration.mockResolvedValueOnce([configuration]);
+      await getFormDefinitions(req as unknown as Request, res as unknown as Response, next);
+
+      expect(req.getConfiguration).toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith(expect.arrayContaining([]));
+    });
   });
 
   describe('getFormDefinition', () => {
     it('can get definition', async () => {
+      const user = {
+        tenantId,
+        id: 'tester',
+        roles: ['test-applicant'],
+      };
+      const req = {
+        user,
+        params: { definitionId: 'test' },
+        getConfiguration: jest.fn(),
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const configuration = { test: definition };
+      req.getConfiguration.mockResolvedValueOnce([configuration]);
+      await getFormDefinition(req as unknown as Request, res as unknown as Response, next);
+
+      expect(req.getConfiguration).toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'test', name: 'test-form-definition' }));
+    });
+
+    it('can call next with unauthorized', async () => {
       const user = {
         tenantId,
         id: 'tester',
@@ -144,7 +187,8 @@ describe('form router', () => {
       await getFormDefinition(req as unknown as Request, res as unknown as Response, next);
 
       expect(req.getConfiguration).toHaveBeenCalled();
-      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'test', name: 'test-form-definition' }));
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
     });
 
     it('can call next with not found', async () => {


### PR DESCRIPTION
…rm roles

Configuration service API is still available for access to form service configuration.