### PR TITLE
feat(notification-service): support collection of criteria objects fo…

### DIFF
--- a/apps/notification-service/src/mongo/schema.ts
+++ b/apps/notification-service/src/mongo/schema.ts
@@ -53,14 +53,7 @@ export const subscriptionSchema = new Schema(
       ref: 'subscriber',
       required: true,
     },
-    criteria: {
-      _id: false,
-      correlationId: String,
-      context: {
-        type: Map,
-        of: Schema.Types.Mixed,
-      },
-    },
+    criteria: Schema.Types.Mixed,
   },
   { _id: false }
 );

--- a/apps/notification-service/src/mongo/subscription.ts
+++ b/apps/notification-service/src/mongo/subscription.ts
@@ -300,7 +300,11 @@ export class MongoSubscriptionRepository implements SubscriptionRepository {
       tenantId: entity.tenantId.toString(),
       typeId: entity.typeId,
       subscriberId: entity.subscriberId,
-      criteria: entity.criteria,
+      criteria: entity.criteria?.map((criteria) => ({
+        description: criteria?.description,
+        correlationId: criteria?.correlationId,
+        context: criteria?.context,
+      })),
     };
   }
 }

--- a/apps/notification-service/src/notification/model/subscription.ts
+++ b/apps/notification-service/src/notification/model/subscription.ts
@@ -1,4 +1,5 @@
 import { AdspId, DomainEvent, NotificationType, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
+import { InvalidOperationError } from '@core-services/core-common';
 import { SubscriptionRepository } from '../repository';
 import { NotificationTypeEvent, SubscriberChannel, Subscription, SubscriptionCriteria } from '../types';
 import { SubscriberEntity } from './subscriber';
@@ -7,7 +8,7 @@ import { NotificationTypeEntity } from './type';
 export class SubscriptionEntity implements Subscription {
   tenantId: AdspId;
   typeId: string;
-  criteria: SubscriptionCriteria;
+  criteria: SubscriptionCriteria[];
   subscriberId: string;
 
   static async create(
@@ -29,19 +30,26 @@ export class SubscriptionEntity implements Subscription {
     this.tenantId = subscription.tenantId;
     this.typeId = subscription.typeId;
     this.subscriberId = subscription.subscriberId;
-    this.criteria = subscription.criteria || {};
+    this.criteria = subscription.criteria
+      ? Array.isArray(subscription.criteria)
+        ? subscription.criteria
+        : [subscription.criteria]
+      : [{}];
   }
 
+  private evaluateCriteria(event: DomainEvent, criteria: SubscriptionCriteria): boolean {
+    return (
+      (!criteria.correlationId || criteria.correlationId === event.correlationId) &&
+      !Object.entries(criteria.context || {}).find(([key, value]) => value !== event.context[key])
+    );
+  }
+
+  // NOTE: Due to legacy schema design multiple subscriptions to the same notification type is represented as a single subscription
+  // with all collection of criteria where each represents a criteria to a specific context (e.g. form ID).
+  //
   shouldSend(event: DomainEvent): boolean {
     // truthy event AND correlationId match AND context match
-    return (
-      !!event &&
-      (!this.criteria.correlationId ||
-        !!(
-          Array.isArray(this.criteria.correlationId) ? this.criteria.correlationId : [this.criteria.correlationId]
-        ).find((correlationId) => correlationId === event.correlationId)) &&
-      !Object.entries(this.criteria.context || {}).find(([key, value]) => value !== event.context[key])
-    );
+    return !!(event && this.criteria.find((criteria) => this.evaluateCriteria(event, criteria)));
   }
 
   getSubscriberChannel(type: NotificationType, event: NotificationTypeEvent): SubscriberChannel {
@@ -63,12 +71,51 @@ export class SubscriptionEntity implements Subscription {
     }
   }
 
-  updateCriteria(user: User, criteria: SubscriptionCriteria): Promise<SubscriptionEntity> {
+  private isEmptyCriteria(criteria: SubscriptionCriteria): boolean {
+    return !criteria?.context && !criteria?.correlationId;
+  }
+
+  async updateCriteria(
+    user: User,
+    criteria: SubscriptionCriteria | SubscriptionCriteria[]
+  ): Promise<SubscriptionEntity> {
     if (!this.type.canSubscribe(user, this.subscriber)) {
       throw new UnauthorizedUserError('update subscription', user);
     }
 
-    this.criteria = criteria;
+    if (Array.isArray(criteria)) {
+      if (!criteria.length) {
+        // Unfortunately the intent of the requester is ambiguous if they specify an empty array.
+        // It could either mean unsubscribe fully, or make the criteria unrestricted.
+        throw new InvalidOperationError(
+          'Cannot set criteria to an empty array. ' +
+            'Delete the subscription to unsubscribe from all notifications on the type; ' +
+            'otherwise, include an empty criteria to subscribe include all notifications on type.'
+        );
+      }
+
+      this.criteria = criteria;
+    } else {
+      // Add the criteria. This means the subscription will send for events that meet the new criteria as well as other
+      // pre-existing criteria. e.g. this is used in forms where a subscriber can be subscribed to notifications on multiple
+      // specific forms.
+      this.criteria.push({
+        description: criteria.description,
+        correlationId: criteria.correlationId,
+        context: criteria.context,
+      });
+    }
+
+    // If after the update we have more than one criteria object and at least one is an empty criteria then throw.
+    // This configuration 'works' but is likely indicating a bad configuration, since effectively the more specific criteria
+    // are overridden by the empty criteria.
+    if (this.criteria.find((criteria) => this.isEmptyCriteria(criteria)) && this.criteria.length !== 1) {
+      throw new InvalidOperationError(
+        'This subscription includes multiple criteria objects including an empty criteria which will always send when trigger. ' +
+          'Update the array of criteria to remove extraneous criteria.'
+      );
+    }
+
     return this.repository.saveSubscription(this);
   }
 }

--- a/apps/notification-service/src/notification/router/__snapshots__/subscription.spec.ts.snap
+++ b/apps/notification-service/src/notification/router/__snapshots__/subscription.spec.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`subscription router addOrUpdateTypeSubscription can add subscription 1`] = `
 Object {
-  "criteria": Object {},
+  "criteria": Array [
+    Object {},
+  ],
   "subscriber": Object {
     "addressAs": "tester",
     "channels": Array [],
@@ -19,10 +21,12 @@ Object {
 
 exports[`subscription router addOrUpdateTypeSubscription can update subscription criteria 1`] = `
 Object {
-  "criteria": Object {
-    "context": Object {},
-    "correlationId": "123",
-  },
+  "criteria": Array [
+    Object {
+      "context": Object {},
+      "correlationId": "123",
+    },
+  ],
   "subscriber": Object {
     "addressAs": "tester",
     "channels": Array [],
@@ -50,7 +54,9 @@ Object {
 
 exports[`subscription router createTypeSubscription can create subscription 1`] = `
 Object {
-  "criteria": Object {},
+  "criteria": Array [
+    Object {},
+  ],
   "subscriber": Object {
     "addressAs": "tester",
     "channels": Array [],
@@ -101,7 +107,9 @@ Object {
   "id": "subscriber",
   "subscriptions": Array [
     Object {
-      "criteria": Object {},
+      "criteria": Array [
+        Object {},
+      ],
       "subscriberId": "subscriber",
       "type": Object {
         "channels": Array [],
@@ -146,7 +154,9 @@ Array [
 
 exports[`subscription router getTypeSubscription can get subscription 1`] = `
 Object {
-  "criteria": Object {},
+  "criteria": Array [
+    Object {},
+  ],
   "subscriber": Object {
     "addressAs": "tester",
     "channels": Array [],

--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -73,6 +73,7 @@ describe('subscription router', () => {
   beforeEach(() => {
     repositoryMock.findSubscribers.mockReset();
     repositoryMock.getSubscriber.mockReset();
+    repositoryMock.getSubscription.mockReset();
     repositoryMock.getSubscriptions.mockReset();
     repositoryMock.saveSubscriber.mockClear();
     repositoryMock.saveSubscription.mockReset();
@@ -315,6 +316,7 @@ describe('subscription router', () => {
         req.notificationType,
         subscriber
       );
+      repositoryMock.getSubscription.mockResolvedValueOnce(null);
       repositoryMock.saveSubscriber.mockResolvedValueOnce(subscriber);
       repositoryMock.saveSubscription.mockResolvedValueOnce(subscription);
 
@@ -356,6 +358,7 @@ describe('subscription router', () => {
         req.notificationType,
         subscriber
       );
+      repositoryMock.getSubscription.mockResolvedValueOnce(null);
       repositoryMock.saveSubscriber.mockResolvedValueOnce(subscriber);
       repositoryMock.saveSubscription.mockResolvedValueOnce(subscription);
 
@@ -403,6 +406,7 @@ describe('subscription router', () => {
         subscriber
       );
       repositoryMock.getSubscriber.mockResolvedValueOnce(subscriber);
+      repositoryMock.getSubscription.mockResolvedValueOnce(null);
       repositoryMock.saveSubscription.mockResolvedValueOnce(subscription);
 
       const handler = createTypeSubscription(apiId, repositoryMock);
@@ -444,6 +448,7 @@ describe('subscription router', () => {
         subscriber
       );
       repositoryMock.getSubscriber.mockResolvedValueOnce(subscriber);
+      repositoryMock.getSubscription.mockResolvedValueOnce(null);
       repositoryMock.saveSubscription.mockResolvedValueOnce(subscription);
 
       const handler = createTypeSubscription(apiId, repositoryMock);
@@ -472,7 +477,7 @@ describe('subscription router', () => {
           email: 'tester@test.co',
           roles: [ServiceUserRoles.SubscriptionAdmin],
         },
-        body: {},
+        body: { criteria: { correlationId: 'test' } },
         query: {},
         params: { subscriber: 'subscriber' },
         notificationType: new NotificationTypeEntity(notificationType, tenantId),
@@ -544,10 +549,12 @@ describe('subscription router', () => {
       expect(repositoryMock.getSubscriber).toHaveBeenCalledWith(tenantId, 'subscriber', false);
       expect(repositoryMock.saveSubscription).toHaveBeenCalledWith(
         expect.objectContaining({
-          criteria: expect.objectContaining({
-            correlationId: req.body.criteria.correlationId,
-            context: req.body.criteria.context,
-          }),
+          criteria: expect.arrayContaining([
+            expect.objectContaining({
+              correlationId: req.body.criteria.correlationId,
+              context: req.body.criteria.context,
+            }),
+          ]),
         })
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ typeId: 'test' }));
@@ -565,7 +572,7 @@ describe('subscription router', () => {
           email: 'tester@test.co',
           roles: [ServiceUserRoles.SubscriptionAdmin],
         },
-        body: { criteria: { correlationId: '123', context: {} } },
+        body: { criteria: [{ correlationId: '123', context: {} }] },
         query: {},
         params: { subscriber: 'subscriber' },
         notificationType: new NotificationTypeEntity(notificationType, tenantId),
@@ -594,10 +601,11 @@ describe('subscription router', () => {
       expect(repositoryMock.getSubscriber).toHaveBeenCalledWith(tenantId, 'subscriber', false);
       expect(repositoryMock.saveSubscription).toHaveBeenCalledWith(
         expect.objectContaining({
-          criteria: expect.objectContaining({
-            correlationId: req.body.criteria.correlationId,
-            context: req.body.criteria.context,
-          }),
+          criteria: expect.arrayContaining([
+            expect.objectContaining({
+              correlationId: req.body.criteria[0].correlationId,
+            }),
+          ]),
         })
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ typeId: 'test' }));
@@ -616,7 +624,7 @@ describe('subscription router', () => {
           email: 'tester@test.co',
           roles: [ServiceUserRoles.SubscriptionAdmin],
         },
-        body: {},
+        body: { criteria: { correlationId: 'test' } },
         query: {},
         params: { subscriber: 'subscriber' },
         notificationType: new NotificationTypeEntity(notificationType, tenantId),

--- a/apps/notification-service/src/notification/router/subscription.swagger.yml
+++ b/apps/notification-service/src/notification/router/subscription.swagger.yml
@@ -42,11 +42,11 @@ components:
                 type: object
                 properties:
                   email:
-                    $ref: '#/components/schemas/Template'
+                    $ref: "#/components/schemas/Template"
                   bot:
-                    $ref: '#/components/schemas/Template'
+                    $ref: "#/components/schemas/Template"
                   sms:
-                    $ref: '#/components/schemas/Template'
+                    $ref: "#/components/schemas/Template"
     Subscriber:
       type: object
       properties:
@@ -71,16 +71,12 @@ components:
         subscriptions:
           type: array
           items:
-            $ref: '#/components/schemas/Subscription'
+            $ref: "#/components/schemas/Subscription"
     SubscriptionCriteria:
       type: object
       properties:
         correlationId:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+          type: string
         context:
           type: object
           additionalProperties: true
@@ -90,9 +86,13 @@ components:
         typeId:
           type: string
         subscriber:
-          $ref: '#/components/schemas/Subscriber'
+          $ref: "#/components/schemas/Subscriber"
         criteria:
-          $ref: '#/components/schemas/SubscriptionCriteria'
+          anyOf:
+            - $ref: "#/components/schemas/SubscriptionCriteria"
+            - type: array
+              items:
+                $ref: "#/components/schemas/SubscriptionCriteria"
     SendVerifyCodeOperation:
       type: object
       properties:
@@ -113,9 +113,13 @@ components:
         typeId:
           type: string
         subscriber:
-          $ref: '#/components/schemas/Subscriber'
+          $ref: "#/components/schemas/Subscriber"
         criteria:
-          $ref: '#/components/schemas/SubscriptionCriteria'
+          anyOf:
+            - $ref: "#/components/schemas/SubscriptionCriteria"
+            - type: array
+              items:
+                $ref: "#/components/schemas/SubscriptionCriteria"
     MySubscriberDetails:
       type: object
       properties:
@@ -140,7 +144,7 @@ components:
         subscriptions:
           type: array
           items:
-            $ref: '#/components/schemas/MySubscriberSubscriptions'
+            $ref: "#/components/schemas/MySubscriberSubscriptions"
     CheckCodeOperation:
       type: object
       properties:
@@ -183,7 +187,7 @@ components:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/NotificationType'
+                $ref: "#/components/schemas/NotificationType"
 /subscription/v1/types/{type}:
   get:
     tags:
@@ -202,7 +206,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationType'
+              $ref: "#/components/schemas/NotificationType"
 /subscription/v1/types/{type}/subscriptions:
   parameters:
     - name: type
@@ -250,7 +254,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscription'
+                    $ref: "#/components/schemas/Subscription"
                 page:
                   type: object
                   properties:
@@ -279,7 +283,7 @@ components:
             type: object
             properties:
               criteria:
-                $ref: '#/components/schemas/SubscriptionCriteria'
+                $ref: "#/components/schemas/SubscriptionCriteria"
               id:
                 type: string
               userId:
@@ -303,7 +307,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscription'
+              $ref: "#/components/schemas/Subscription"
 
 /subscription/v1/types/{type}/subscriptions/{subscriber}:
   parameters:
@@ -329,7 +333,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscription'
+              $ref: "#/components/schemas/Subscription"
   post:
     tags:
       - Subscription
@@ -342,7 +346,11 @@ components:
             type: object
             properties:
               criteria:
-                $ref: '#/components/schemas/SubscriptionCriteria'
+                anyOf:
+                  - $ref: "#/components/schemas/SubscriptionCriteria"
+                  - type: array
+                    items:
+                      $ref: "#/components/schemas/SubscriptionCriteria"
 
     responses:
       200:
@@ -350,7 +358,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscription'
+              $ref: "#/components/schemas/Subscription"
 
   delete:
     tags:
@@ -383,7 +391,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscriber'
+                    $ref: "#/components/schemas/Subscriber"
                 page:
                   type: object
                   properties:
@@ -436,7 +444,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscriber'
+                    $ref: "#/components/schemas/Subscriber"
                 page:
                   type: object
                   properties:
@@ -471,7 +479,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscriber'
+              $ref: "#/components/schemas/Subscriber"
   patch:
     tags:
       - Subscription
@@ -501,7 +509,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscriber'
+              $ref: "#/components/schemas/Subscriber"
   post:
     tags:
       - Subscription
@@ -512,15 +520,15 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: '#/components/schemas/SendVerifyCodeOperation'
-              - $ref: '#/components/schemas/VerifyChannelOperation'
-              - $ref: '#/components/schemas/CheckCodeOperation'
+              - $ref: "#/components/schemas/SendVerifyCodeOperation"
+              - $ref: "#/components/schemas/VerifyChannelOperation"
+              - $ref: "#/components/schemas/CheckCodeOperation"
             discriminator:
               propertyName: operation
               mapping:
-                send-code: '#/components/schemas/SendVerifyCodeOperation'
-                check-code: '#/components/schemas/CheckCodeOperation'
-                verify-channel: '#/components/schemas/VerifyChannelOperation'
+                send-code: "#/components/schemas/SendVerifyCodeOperation"
+                check-code: "#/components/schemas/CheckCodeOperation"
+                verify-channel: "#/components/schemas/VerifyChannelOperation"
     responses:
       200:
         description: Subscriber successfully updated.
@@ -586,7 +594,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscription'
+                    $ref: "#/components/schemas/Subscription"
                 page:
                   type: object
                   properties:
@@ -615,4 +623,4 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MySubscriberDetails'
+              $ref: "#/components/schemas/MySubscriberDetails"

--- a/apps/notification-service/src/notification/router/subscription.ts
+++ b/apps/notification-service/src/notification/router/subscription.ts
@@ -3,10 +3,10 @@ import { Logger } from 'winston';
 import { adspId, AdspId, isAllowedUser, TenantService, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
 import { createValidationHandler, InvalidOperationError, NotFoundError, decodeAfter } from '@core-services/core-common';
 import { SubscriptionRepository } from '../repository';
-import { NotificationTypeEntity, SubscriberEntity } from '../model';
+import { NotificationTypeEntity, SubscriberEntity, SubscriptionEntity } from '../model';
 import { mapSubscriber, mapSubscription, mapType } from './mappers';
 import { NotificationConfiguration } from '../configuration';
-import { Channel, ServiceUserRoles, Subscriber } from '../types';
+import { Channel, ServiceUserRoles, Subscriber, SubscriptionCriteria } from '../types';
 import {
   SubscriberOperationRequests,
   SUBSCRIBER_CHECK_CODE,
@@ -93,6 +93,31 @@ export function getTypeSubscriptions(apiId: AdspId, repository: SubscriptionRepo
   };
 }
 
+async function addOrUpdateSubscription(
+  repository: SubscriptionRepository,
+  user: User,
+  type: NotificationTypeEntity,
+  subscriber: SubscriberEntity,
+  criteria: SubscriptionCriteria | SubscriptionCriteria[]
+): Promise<SubscriptionEntity> {
+  let subscription = await repository.getSubscription(type, subscriber?.id);
+  if (subscription) {
+    // If there is a pre-existing subscription, update the criteria.
+    subscription = await subscription.updateCriteria(user, criteria);
+  } else {
+    if (Array.isArray(criteria)) {
+      throw new InvalidOperationError('New subscription cannot be created with an array of criteria.');
+    }
+
+    subscription = await type.subscribe(repository, user, subscriber, {
+      description: criteria?.description,
+      correlationId: criteria?.correlationId,
+      context: criteria?.context,
+    });
+  }
+  return subscription;
+}
+
 export function createTypeSubscription(apiId: AdspId, repository: SubscriptionRepository): RequestHandler {
   return async (req, res, next) => {
     try {
@@ -139,10 +164,7 @@ export function createTypeSubscription(apiId: AdspId, repository: SubscriptionRe
         subscriberEntity = await SubscriberEntity.create(user, repository, newSubscriber);
       }
 
-      const subscription = await type.subscribe(repository, user, subscriberEntity, {
-        correlationId: criteria?.correlationId,
-        context: criteria?.context,
-      });
+      const subscription = await addOrUpdateSubscription(repository, user, type, subscriberEntity, criteria);
       res.send(mapSubscription(apiId, subscription));
     } catch (err) {
       next(err);
@@ -160,24 +182,16 @@ export function addOrUpdateTypeSubscription(apiId: AdspId, repository: Subscript
       const { subscriber } = req.params;
       const { criteria } = req.body;
 
+      if (!criteria) {
+        throw new InvalidOperationError('criteria value must be specified.');
+      }
+
       const subscriberEntity = await repository.getSubscriber(tenantId, subscriber, false);
       if (!subscriberEntity) {
         throw new NotFoundError('Subscriber', subscriber);
       }
 
-      let subscription = await repository.getSubscription(type, subscriber);
-      if (subscription) {
-        // If there is a pre-existing subscription, update the criteria.
-        subscription = await subscription.updateCriteria(user, {
-          correlationId: criteria?.correlationId,
-          context: criteria?.context,
-        });
-      } else {
-        subscription = await type.subscribe(repository, user, subscriberEntity, {
-          correlationId: criteria?.correlationId,
-          context: criteria?.context,
-        });
-      }
+      const subscription = await addOrUpdateSubscription(repository, user, type, subscriberEntity, criteria);
       res.send(mapSubscription(apiId, subscription));
     } catch (err) {
       next(err);
@@ -583,12 +597,20 @@ export const createSubscriptionRouter = ({
     '/types/:type/subscriptions/:subscriber',
     validateTypeAndSubscriberHandler,
     createValidationHandler(
-      body('criteria').optional().isObject(),
       oneOf([
-        body('criteria.correlationId').optional().isString(),
-        body('criteria.correlationId').optional().isArray({ min: 1, max: 100 }),
-      ]),
-      body('criteria.context').optional().isObject()
+        [
+          body('criteria').isArray({ min: 1, max: 200 }),
+          body('criteria.*.description').optional().isString(),
+          body('criteria.*.correlationId').optional().isString(),
+          body('criteria.*.context').optional().isObject(),
+        ],
+        [
+          body('criteria').isObject(),
+          body('criteria.description').optional().isString(),
+          body('criteria.correlationId').optional().isString(),
+          body('criteria.context').optional().isObject(),
+        ],
+      ])
     ),
     getNotificationType,
     addOrUpdateTypeSubscription(apiId, subscriptionRepository)

--- a/apps/notification-service/src/notification/types/subscription.ts
+++ b/apps/notification-service/src/notification/types/subscription.ts
@@ -2,7 +2,8 @@ import { AdspId } from '@abgov/adsp-service-sdk';
 import { SubscriberCriteria } from './subscriber';
 
 export interface SubscriptionCriteria {
-  correlationId?: string | string[];
+  description?: string;
+  correlationId?: string;
   context?: {
     [key: string]: unknown;
   };
@@ -11,7 +12,7 @@ export interface SubscriptionCriteria {
 export interface Subscription {
   tenantId: AdspId;
   typeId: string;
-  criteria: SubscriptionCriteria;
+  criteria: SubscriptionCriteria | SubscriptionCriteria[];
   subscriberId: string;
 }
 


### PR DESCRIPTION
…r multiple specific subscriptions

Currently the database schema includes a unique constraint on notification type and subscriber for subscriptions, so that each subscriber can only have a single subscription per type. This is not easily changed in a migration, and so to support a subscriber with subscription to multiple but specific forms use a collection of criteria instead. The subscription sends if any criteria object in the collection matches.