### PR TITLE
feat(notification-service): support deletion of a subscription criteria

### DIFF
--- a/apps/notification-service/src/notification/model/subscription.spec.ts
+++ b/apps/notification-service/src/notification/model/subscription.spec.ts
@@ -7,8 +7,9 @@ import { NotificationTypeEntity } from './type';
 import { InvalidOperationError } from '@core-services/core-common';
 
 describe('SubscriptionEntity', () => {
-  const repositoryMock: unknown = {
+  const repositoryMock = {
     saveSubscription: jest.fn((entity: SubscriptionEntity) => Promise.resolve(entity)),
+    deleteSubscriptions: jest.fn(() => Promise.resolve(true)),
   };
 
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
@@ -25,9 +26,14 @@ describe('SubscriptionEntity', () => {
     tenantId
   );
 
+  beforeEach(() => {
+    repositoryMock.saveSubscription.mockClear();
+    repositoryMock.deleteSubscriptions.mockClear();
+  });
+
   it('can be created', () => {
     const entity = new SubscriptionEntity(
-      repositoryMock as SubscriptionRepository,
+      repositoryMock as unknown as SubscriptionRepository,
       {
         tenantId,
         typeId: 'test',
@@ -41,17 +47,22 @@ describe('SubscriptionEntity', () => {
 
   describe('create', () => {
     it('can create entity', async () => {
-      const subscriber = new SubscriberEntity(repositoryMock as SubscriptionRepository, {
+      const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
         tenantId,
         addressAs: 'test',
         channels: [],
       });
-      const entity = await SubscriptionEntity.create(repositoryMock as SubscriptionRepository, type, subscriber, {
-        tenantId,
-        typeId: 'test',
-        subscriberId: 'test-subscriber',
-        criteria: {},
-      });
+      const entity = await SubscriptionEntity.create(
+        repositoryMock as unknown as SubscriptionRepository,
+        type,
+        subscriber,
+        {
+          tenantId,
+          typeId: 'test',
+          subscriberId: 'test-subscriber',
+          criteria: {},
+        }
+      );
       expect(entity).toBeTruthy();
     });
   });
@@ -59,7 +70,7 @@ describe('SubscriptionEntity', () => {
   describe('shouldSend', () => {
     it('can return true for empty criteria', () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -82,7 +93,7 @@ describe('SubscriptionEntity', () => {
 
     it('can return false for correlation criteria not matched', () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -107,7 +118,7 @@ describe('SubscriptionEntity', () => {
 
     it('can return true for correlation criteria matched', () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -132,7 +143,7 @@ describe('SubscriptionEntity', () => {
 
     it('can return true for array correlation criteria matched', () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -162,7 +173,7 @@ describe('SubscriptionEntity', () => {
 
     it('can return true for context criteria matched', () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -194,7 +205,7 @@ describe('SubscriptionEntity', () => {
         address: 'test@test.co',
         verified: false,
       };
-      const subscriber = new SubscriberEntity(repositoryMock as SubscriptionRepository, {
+      const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
         tenantId,
         addressAs: 'test',
         channels: [
@@ -207,7 +218,7 @@ describe('SubscriptionEntity', () => {
         ],
       });
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -228,7 +239,7 @@ describe('SubscriptionEntity', () => {
     });
 
     it('can return falsy for no channel match', () => {
-      const subscriber = new SubscriberEntity(repositoryMock as SubscriptionRepository, {
+      const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
         tenantId,
         addressAs: 'test',
         channels: [
@@ -240,7 +251,7 @@ describe('SubscriptionEntity', () => {
         ],
       });
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -266,7 +277,7 @@ describe('SubscriptionEntity', () => {
         address: 'test@test.co',
         verified: false,
       };
-      const subscriber = new SubscriberEntity(repositoryMock as SubscriptionRepository, {
+      const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
         tenantId,
         addressAs: 'test',
         channels: [
@@ -279,7 +290,7 @@ describe('SubscriptionEntity', () => {
         ],
       });
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -308,7 +319,7 @@ describe('SubscriptionEntity', () => {
       roles: [ServiceUserRoles.SubscriptionAdmin],
     } as User;
 
-    const subscriber = new SubscriberEntity(repositoryMock as SubscriptionRepository, {
+    const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
       tenantId,
       addressAs: 'test',
       channels: [],
@@ -316,7 +327,7 @@ describe('SubscriptionEntity', () => {
 
     it('can updated criteria', async () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -339,7 +350,7 @@ describe('SubscriptionEntity', () => {
 
     it('can throw for additive update to empty criteria', async () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -361,7 +372,7 @@ describe('SubscriptionEntity', () => {
 
     it('can throw for update to empty criteria', async () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -377,7 +388,7 @@ describe('SubscriptionEntity', () => {
 
     it('can throw for user not allowed to subscribe', async () => {
       const entity = new SubscriptionEntity(
-        repositoryMock as SubscriptionRepository,
+        repositoryMock as unknown as SubscriptionRepository,
         {
           tenantId,
           typeId: 'test',
@@ -395,6 +406,133 @@ describe('SubscriptionEntity', () => {
         },
       };
       await expect(entity.updateCriteria({ ...user, roles: [] }, criteria)).rejects.toThrow(UnauthorizedUserError);
+    });
+  });
+
+  describe('deleteCriteria', () => {
+    const user = {
+      id: 'test',
+      tenantId,
+      roles: [ServiceUserRoles.SubscriptionAdmin],
+    } as User;
+
+    const subscriber = new SubscriberEntity(repositoryMock as unknown as SubscriptionRepository, {
+      tenantId,
+      addressAs: 'test',
+      channels: [],
+    });
+
+    it('can delete criteria', async () => {
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: [
+            { correlationId: 'test2' },
+            { correlationId: 'test2', context: { test: 'test' } },
+            { context: { test1: 1 } },
+          ],
+          subscriberId: 'test',
+        },
+        type,
+        subscriber
+      );
+
+      const criteria = {
+        correlationId: 'test2',
+      };
+      const result = await entity.deleteCriteria(user, criteria);
+      expect(result).toBe(true);
+      expect(repositoryMock.saveSubscription).toHaveBeenCalledWith(entity);
+      expect(entity.criteria).toMatchObject(
+        expect.arrayContaining([expect.objectContaining({ context: expect.objectContaining({ test1: 1 }) })])
+      );
+    });
+
+    it('can delete last criteria', async () => {
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: [{ correlationId: 'test2' }],
+          subscriberId: 'test',
+        },
+        type,
+        subscriber
+      );
+
+      const criteria = {
+        correlationId: 'test2',
+      };
+      const result = await entity.deleteCriteria(user, criteria);
+      expect(result).toBe(true);
+      expect(repositoryMock.saveSubscription).not.toHaveBeenCalled();
+      expect(repositoryMock.deleteSubscriptions).toHaveBeenCalledWith(tenantId, 'test', 'test');
+    });
+
+    it('can return false for no match', async () => {
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: [{ correlationId: 'test2' }],
+          subscriberId: 'test',
+        },
+        type,
+        subscriber
+      );
+
+      const criteria = {
+        correlationId: 'test',
+      };
+      const result = await entity.deleteCriteria(user, criteria);
+      expect(result).toBe(false);
+      expect(repositoryMock.saveSubscription).not.toHaveBeenCalled();
+      expect(repositoryMock.deleteSubscriptions).not.toHaveBeenCalled();
+    });
+
+    it('can throw for empty criteria', async () => {
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: [{ correlationId: 'test2' }],
+          subscriberId: 'test',
+        },
+        type,
+        subscriber
+      );
+
+      const criteria = {
+        context: {},
+      };
+      await expect(entity.deleteCriteria(user, criteria)).rejects.toThrow(InvalidOperationError);
+    });
+
+    it('can throw for user not allowed to subscribe', async () => {
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: {},
+          subscriberId: 'test',
+        },
+        type,
+        subscriber
+      );
+
+      const criteria = {
+        correlationId: 'test',
+        context: {
+          value: 'test',
+        },
+      };
+      await expect(entity.deleteCriteria({ ...user, roles: [] }, criteria)).rejects.toThrow(UnauthorizedUserError);
     });
   });
 });

--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -20,6 +20,7 @@ import {
   getSubscriberDetails,
   getSubscriberByUserId,
   getSubscriptionChannels,
+  deleteTypeSubscriptionCriteria,
 } from './subscription';
 import { NotificationType, ServiceUserRoles, Subscription } from '../types';
 import { assertHasTenant, createSubscriber, deleteSubscriber, updateSubscriber } from '.';
@@ -763,6 +764,106 @@ describe('subscription router', () => {
       expect(repositoryMock.deleteSubscriptions).toHaveBeenCalledWith(tenantId, notificationType.id, 'subscriber');
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
       expect(res.send.mock.calls[0][0]).toMatchSnapshot();
+    });
+  });
+
+  describe('deleteTypeSubscriptionCriteria', () => {
+    it('can create handler', () => {
+      const handler = deleteTypeSubscriptionCriteria(repositoryMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can delete subscription criteria', async () => {
+      const req = {
+        tenant: {
+          id: tenantId,
+        },
+        user: {
+          id: 'tester',
+          tenantId,
+          name: 'Tester',
+          email: 'tester@test.co',
+          roles: [ServiceUserRoles.SubscriptionAdmin],
+        },
+        query: {
+          criteria: JSON.stringify({ correlationId: 'test' }),
+        },
+        params: { subscriber: 'subscriber' },
+        notificationType: new NotificationTypeEntity(notificationType, tenantId),
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const subscriber = new SubscriberEntity(repositoryMock, {
+        id: 'subscriber',
+        tenantId,
+        addressAs: 'tester',
+        channels: [],
+      });
+      const subscription = new SubscriptionEntity(
+        repositoryMock,
+        {
+          tenantId,
+          typeId: 'test',
+          subscriberId: 'subscriber',
+          criteria: [{ correlationId: 'test' }, { correlationId: 'test2' }],
+        },
+        req.notificationType,
+        subscriber
+      );
+
+      repositoryMock.getSubscription.mockResolvedValueOnce(subscription);
+      repositoryMock.saveSubscription.mockResolvedValueOnce(subscription);
+
+      const handler = deleteTypeSubscriptionCriteria(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(repositoryMock.saveSubscription).toHaveBeenCalledWith(subscription);
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
+    });
+
+    it('can call next with error', async () => {
+      const req = {
+        tenant: {
+          id: tenantId,
+        },
+        user: {
+          id: 'tester',
+          tenantId,
+          name: 'Tester',
+          email: 'tester@test.co',
+          roles: [ServiceUserRoles.SubscriptionAdmin],
+        },
+        query: {},
+        params: { subscriber: 'subscriber' },
+        notificationType: new NotificationTypeEntity(notificationType, tenantId),
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const subscriber = new SubscriberEntity(repositoryMock, {
+        id: 'subscriber',
+        tenantId,
+        addressAs: 'tester',
+        channels: [],
+      });
+      const subscription = new SubscriptionEntity(
+        repositoryMock,
+        {
+          tenantId,
+          typeId: 'test',
+          subscriberId: 'subscriber',
+          criteria: [{ correlationId: 'test' }, { correlationId: 'test2' }],
+        },
+        req.notificationType,
+        subscriber
+      );
+
+      repositoryMock.getSubscription.mockResolvedValueOnce(subscription);
+
+      const handler = deleteTypeSubscriptionCriteria(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(InvalidOperationError));
     });
   });
 

--- a/apps/notification-service/src/notification/router/subscription.swagger.yml
+++ b/apps/notification-service/src/notification/router/subscription.swagger.yml
@@ -75,6 +75,8 @@ components:
     SubscriptionCriteria:
       type: object
       properties:
+        description:
+          type: string
         correlationId:
           type: string
         context:
@@ -367,6 +369,42 @@ components:
     responses:
       200:
         description: Subscriptions successfully removed.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deleted:
+                  type: boolean
+
+/subscription/v1/types/{type}/subscriptions/{subscriber}/criteria:
+  parameters:
+    - name: type
+      description: ID of the notification type.
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: subscriber
+      description: ID of the subscriber.
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: criteria
+      description: Criteria for deletion of subscription criteria. Deletion criteria can match multiple subscription criteria.
+      in: query
+      required: true
+      schema:
+        $ref: "#/components/schemas/SubscriptionCriteria"
+
+  delete:
+    tags:
+      - Subscription
+    description: Removes a subscription criteria.
+    responses:
+      200:
+        description: Subscription criteria successfully removed.
         content:
           application/json:
             schema:


### PR DESCRIPTION
This is so that clients don't need to read just to remove a criteria object via update.