### PR TITLE
CS-2889 - Fix regular login

### DIFF
--- a/apps/subscriber-app/src/app/lib/keycloak.ts
+++ b/apps/subscriber-app/src/app/lib/keycloak.ts
@@ -133,7 +133,7 @@ class KeycloakAuth {
     const skipSSO = location.indexOf('kc_idp_hint') > -1;
 
     const urlParams = new URLSearchParams(window.location.search);
-    const idpFromUrl = encodeURIComponent(urlParams.get('kc_idp_hint'));
+    const idpFromUrl = urlParams.has('kc_idp_hint') ? encodeURIComponent(urlParams.get('kc_idp_hint')) : null;
     const code = encodeURIComponent(urlParams.get('code'));
     const smscode = encodeURIComponent(urlParams.get('smscode'));
 


### PR DESCRIPTION
If the parameter 'kc_idp_hint' does not exist in the urlParams object, calling urlParams.get('kc_idp_hint') will return null. If you then pass null to encodeURIComponent, it will not cause an error, but the result will be the string "null" being encoded.

This results in the logic after than to incorrectly determine than a parameter is there when none was passed, preventing the regular login

This code checks to ensure there is a parameter. If there is none, it will set it idpFromUrl to null, and the core will execute as intended