### PR TITLE
fix(form-service): remove form data and files from form response

### DIFF
--- a/apps/form-service/src/form/model/form.spec.ts
+++ b/apps/form-service/src/form/model/form.spec.ts
@@ -137,38 +137,6 @@ describe('FormEntity', () => {
     });
   });
 
-  describe('canAssess', () => {
-    const formInfo = {
-      id: 'test-form',
-      formDraftUrl: 'https://my-form/test-form',
-      anonymousApplicant: false,
-      created: new Date(),
-      createdBy: { id: 'tester', name: 'tester' },
-      status: FormStatus.Draft,
-      locked: null,
-      submitted: null,
-      lastAccessed: new Date(),
-      data: {},
-      files: {},
-    };
-    const entity = new FormEntity(repositoryMock, definition, subscriber, formInfo);
-
-    it('can return true for user with assessor role', () => {
-      const result = entity.canAssess({ tenantId, id: 'tester', roles: ['test-assessor'] } as User);
-      expect(result).toBe(true);
-    });
-
-    it('can return true for user with admin role', () => {
-      const result = entity.canAssess({ tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User);
-      expect(result).toBe(true);
-    });
-
-    it('can return false for user without assessor role', () => {
-      const result = entity.canAssess({ tenantId, id: 'tester', roles: [] } as User);
-      expect(result).toBe(false);
-    });
-  });
-
   describe('sendCode', () => {
     const formInfo = {
       id: 'test-form',
@@ -196,6 +164,58 @@ describe('FormEntity', () => {
       await expect(entity.sendCode({ tenantId, id: 'tester', roles: [] } as User, notificationMock)).rejects.toThrow(
         UnauthorizedUserError
       );
+    });
+  });
+
+  describe('canRead', () => {
+    const formInfo = {
+      id: 'test-form',
+      formDraftUrl: 'https://my-form/test-form',
+      anonymousApplicant: false,
+      created: new Date(),
+      createdBy: { id: 'tester', name: 'tester' },
+      status: FormStatus.Draft,
+      locked: null,
+      submitted: null,
+      lastAccessed: new Date(),
+      data: {},
+      files: {},
+    };
+    const entity = new FormEntity(repositoryMock, definition, subscriber, formInfo);
+
+    it('can return true for applicant', () => {
+      const result = entity.canRead({ tenantId, id: 'tester', roles: ['test-applicant'] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return false for wrong applicant', () => {
+      const result = entity.canRead({ tenantId, id: 'tester2', roles: ['test-applicant'] } as User);
+      expect(result).toBe(false);
+    });
+
+    it('can return true for admin', () => {
+      const result = entity.canRead({ tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return true for intake app', () => {
+      const result = entity.canRead({ tenantId, id: 'tester', roles: [FormServiceRoles.IntakeApp] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return true for clerk', () => {
+      const result = entity.canRead({ tenantId, id: 'tester', roles: ['test-clerk'] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return true for assessor', () => {
+      const result = entity.canRead({ tenantId, id: 'tester', roles: ['test-assessor'] } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return false for user without role', () => {
+      const result = entity.canRead({ tenantId, id: 'tester', roles: [] } as User);
+      expect(result).toBe(false);
     });
   });
 
@@ -332,6 +352,15 @@ describe('FormEntity', () => {
     it('can throw for user without role on submitted form', async () => {
       const submitted = new FormEntity(repositoryMock, definition, subscriber, formInfo);
       submitted.status = FormStatus.Submitted;
+
+      await expect(submitted.accessByUser({ tenantId, id: 'tester', roles: [] } as User)).rejects.toThrow(
+        UnauthorizedUserError
+      );
+    });
+
+    it('can throw for user without role on archived form', async () => {
+      const submitted = new FormEntity(repositoryMock, definition, subscriber, formInfo);
+      submitted.status = FormStatus.Archived;
 
       await expect(submitted.accessByUser({ tenantId, id: 'tester', roles: [] } as User)).rejects.toThrow(
         UnauthorizedUserError

--- a/apps/form-service/src/form/model/form.ts
+++ b/apps/form-service/src/form/model/form.ts
@@ -13,7 +13,7 @@ import { FormSubmissionEntity } from './formSubmission';
 
 // Any form created by user with the intake app role is treated as anonymous.
 function isAnonymousApplicant(user: User, applicant?: Subscriber): boolean {
-  return user?.roles.find((role) => role === FormServiceRoles.IntakeApp) && applicant && applicant.userId !== user.id;
+  return user?.roles.includes(FormServiceRoles.IntakeApp) && applicant && applicant.userId !== user.id;
 }
 
 export class FormEntity implements Form {
@@ -86,8 +86,27 @@ export class FormEntity implements Form {
     this.files = form.files || {};
   }
 
-  canAssess(user: User): boolean {
-    return isAllowedUser(user, this.tenantId, [...this.definition.assessorRoles, FormServiceRoles.Admin], true);
+  /**
+   * Checks if user is allowed to read the form 'metadata' (not including data and files).
+   *
+   * Note that this is more permissive than accessing the form data. For example, assessors are allowed to read forms
+   * even while in draft, but not access the form data.
+   *
+   * @param {User} user
+   * @returns {boolean}
+   * @memberof FormEntity
+   */
+  canRead(user: User): boolean {
+    // Admins, intake apps, clerks and assessors are allowed read of the form.
+    // Applicants are allowed to read forms they created.
+    return (
+      isAllowedUser(user, this.tenantId, [FormServiceRoles.Admin, FormServiceRoles.IntakeApp], true) ||
+      isAllowedUser(user, this.tenantId, [
+        ...(this.definition?.clerkRoles || []),
+        ...(this.definition?.assessorRoles || []),
+      ]) ||
+      (isAllowedUser(user, this.tenantId, this.definition?.applicantRoles || []) && user.id === this.createdBy.id)
+    );
   }
 
   private async access(_user: User): Promise<FormEntity> {
@@ -100,7 +119,7 @@ export class FormEntity implements Form {
   }
 
   async sendCode(user: User, notificationService: NotificationService): Promise<FormEntity> {
-    if (!isAllowedUser(user, this.tenantId, FormServiceRoles.IntakeApp)) {
+    if (!isAllowedUser(user, this.tenantId, FormServiceRoles.IntakeApp, true)) {
       throw new UnauthorizedUserError('send code', user);
     }
 
@@ -117,7 +136,7 @@ export class FormEntity implements Form {
     }
 
     // When access by code, the user needs to be an intake application.
-    if (!isAllowedUser(user, this.tenantId, FormServiceRoles.IntakeApp)) {
+    if (!isAllowedUser(user, this.tenantId, FormServiceRoles.IntakeApp, true)) {
       throw new UnauthorizedUserError('access form', user);
     }
 
@@ -131,25 +150,21 @@ export class FormEntity implements Form {
   }
 
   async accessByUser(user: User): Promise<FormEntity> {
+    // Allowed if:
+    // 1. User is Form Admin
+    // 2. User is Applicant who created the form
+    // 3. Form is Draft and user is Clerk
+    // 4. Form is Submitted and user is Assessor
     if (
-      this.status === FormStatus.Draft &&
-      !(
-        isAllowedUser(user, this.tenantId, this.definition.clerkRoles) ||
-        (isAllowedUser(user, this.tenantId, this.definition.applicantRoles) && user.id === this.createdBy.id)
-      )
+      isAllowedUser(user, this.tenantId, FormServiceRoles.Admin) ||
+      (isAllowedUser(user, this.tenantId, this.definition?.applicantRoles || []) && user.id === this.createdBy.id) ||
+      (this.status === FormStatus.Draft && isAllowedUser(user, this.tenantId, this.definition?.clerkRoles || [])) ||
+      (this.status === FormStatus.Submitted && isAllowedUser(user, this.tenantId, this.definition?.assessorRoles || []))
     ) {
-      throw new UnauthorizedUserError('access draft form', user);
-    }
-
-    if (
-      this.status === FormStatus.Submitted &&
-      !this.canAssess(user) &&
-      !(isAllowedUser(user, this.tenantId, this.definition.applicantRoles) && user.id === this.createdBy.id)
-    ) {
+      return await this.access(user);
+    } else {
       throw new UnauthorizedUserError('access submitted form', user);
     }
-
-    return await this.access(user);
   }
 
   async update(user: User, data?: Record<string, unknown>, files?: Record<string, AdspId>): Promise<FormEntity> {
@@ -198,7 +213,7 @@ export class FormEntity implements Form {
   }
 
   async unlock(user: User): Promise<FormEntity> {
-    if (!isAllowedUser(user, this.tenantId, FormServiceRoles.Admin)) {
+    if (!isAllowedUser(user, this.tenantId, FormServiceRoles.Admin, true)) {
       throw new UnauthorizedUserError('unlock form', user);
     }
 

--- a/apps/form-service/src/form/model/formSubmission.ts
+++ b/apps/form-service/src/form/model/formSubmission.ts
@@ -70,6 +70,13 @@ export class FormSubmissionEntity implements FormSubmission {
     this.hash = formSubmission.hash;
   }
 
+  canRead(user: User): boolean {
+    return (
+      isAllowedUser(user, this.tenantId, FormServiceRoles.Admin, true) ||
+      isAllowedUser(user, this.tenantId, this.form?.definition?.assessorRoles || [])
+    );
+  }
+
   async delete(user: User): Promise<boolean> {
     if (!isAllowedUser(user, this.tenantId, FormServiceRoles.Admin, true)) {
       throw new UnauthorizedUserError('delete form', user);

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -421,6 +421,26 @@ describe('form router', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(next).toBeCalledWith(expect.any(NotFoundError));
     });
+
+    it('can call next with unauthorized', async () => {
+      const user = {
+        tenantId,
+        id: 'tester',
+        roles: [],
+      };
+      const req = {
+        user,
+        tenant: { id: tenantId },
+        params: { formId: 'test-form' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      repositoryMock.get.mockResolvedValueOnce(entity);
+      const handler = getForm(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(next).toBeCalledWith(expect.any(UnauthorizedUserError));
+    });
   });
 
   describe('accessForm', () => {

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -43,12 +43,6 @@ components:
           properties:
             addressAs:
               type: string
-        data:
-          type: object
-          description: Will contain the form data when a form submission/resubmission is created. Otherwise it will be empty.
-        files:
-          type: object
-          description: Will contain the form files when a form submission/resubmission is created. Otherwise it will be empty.
         status:
           type: string
           enum: [draft, locked, submitted, archived]


### PR DESCRIPTION
Form data and files is accessed via dedicated 'access' operation to enforce permissions based on roles and form lifecycle. Also adding check on form read, since even 'metadata' access should be restricted to users with form related roles.