### PR TITLE
chore(task-service): change task event correlationId

### DIFF
--- a/apps/task-service/src/postgres/task.ts
+++ b/apps/task-service/src/postgres/task.ts
@@ -208,7 +208,7 @@ export class PostgresTaskRepository implements TaskRepository {
           definitionNamespace: entity.definition?.namespace,
           definitionName: entity.definition?.name,
           context: entity.context,
-          recordId: entity.recordId,
+          recordId: entity.recordId?.toString(),
           data: entity.data,
           name: entity.name,
           description: entity.description,

--- a/apps/task-service/src/postgres/types.ts
+++ b/apps/task-service/src/postgres/types.ts
@@ -1,6 +1,6 @@
 import { Task, TaskPriority, TaskStatus } from '../task';
 
-export interface TaskRecord extends Omit<Task, 'tenantId' | 'definition' | 'queue' | 'assignment'> {
+export interface TaskRecord extends Omit<Task, 'tenantId' | 'definition' | 'queue' | 'assignment' | 'recordId'> {
   tenant: string;
   queueNamespace: string;
   queueName: string;
@@ -12,6 +12,7 @@ export interface TaskRecord extends Omit<Task, 'tenantId' | 'definition' | 'queu
   assignedToName: string;
   assignedToEmail: string;
   assignedOn: Date;
+  recordId?: string;
 }
 
 export interface TaskAggregationResult {

--- a/apps/task-service/src/task/mapper.ts
+++ b/apps/task-service/src/task/mapper.ts
@@ -1,0 +1,24 @@
+import { AdspId } from '@abgov/adsp-service-sdk';
+import { TaskEntity } from './model';
+import { Task, TaskPriority } from './types';
+
+export type TaskResponse = Omit<Task, 'tenantId' | 'priority'> & { urn: string; priority: string };
+export function mapTask(apiId: AdspId, entity: TaskEntity): TaskResponse {
+  return {
+    urn: `${apiId}:/tasks/${entity.id}`,
+    id: entity.id,
+    name: entity.name,
+    description: entity.description,
+    context: entity.context,
+    definition: entity.definition ? { namespace: entity.definition.namespace, name: entity.definition.name } : null,
+    queue: entity.queue ? { namespace: entity.queue.namespace, name: entity.queue.name } : null,
+    recordId: entity.recordId?.toString(),
+    data: entity.data,
+    status: entity.status,
+    priority: TaskPriority[entity.priority],
+    createdOn: entity.createdOn,
+    startedOn: entity.startedOn,
+    endedOn: entity.endedOn,
+    assignment: entity.assignment,
+  };
+}

--- a/apps/task-service/src/task/model/task.ts
+++ b/apps/task-service/src/task/model/task.ts
@@ -26,7 +26,7 @@ export class TaskEntity implements Task {
   name: string;
   description: string;
   priority: TaskPriority;
-  recordId: string;
+  recordId: string | AdspId;
   data: Record<string, unknown>;
   status: TaskStatus;
   createdOn: Date;
@@ -51,7 +51,7 @@ export class TaskEntity implements Task {
     this.definition = task.definition;
     this.name = task.name;
     this.description = task.description;
-    this.recordId = task.recordId;
+    this.recordId = AdspId.isAdspId(task.recordId as string) ? AdspId.parse(task.recordId as string) : task.recordId;
     this.data = task.data || {};
 
     const record = task as Task;

--- a/apps/task-service/src/task/router/queue.ts
+++ b/apps/task-service/src/task/router/queue.ts
@@ -19,9 +19,10 @@ import { QueueEntity } from '../model/queue';
 import { TaskEntity } from '../model/task';
 import { TaskRepository } from '../repository';
 import { Queue, TaskPriority, TaskServiceConfiguration, TaskStatus } from '../types';
-import { getTask, mapTask, taskOperation, TASK_KEY } from './task';
+import { getTask, taskOperation, TASK_KEY } from './task';
 import { UserInformation } from './types';
 import { CommentService } from '../comment';
+import { mapTask } from '../mapper';
 
 interface QueueRouterProps {
   apiId: AdspId;

--- a/apps/task-service/src/task/router/task.spec.ts
+++ b/apps/task-service/src/task/router/task.spec.ts
@@ -2,11 +2,12 @@ import { adspId, UnauthorizedUserError } from '@abgov/adsp-service-sdk';
 import { NotFoundError, InvalidOperationError } from '@core-services/core-common';
 import { Request, Response } from 'express';
 import { Logger } from 'winston';
-import { getTasks, taskOperation, updateTask } from '.';
-import { TaskServiceRoles } from '..';
+import { mapTask } from '../mapper';
 import { QueueEntity, TaskEntity } from '../model';
+import { TaskServiceRoles } from '../roles';
+import { getTasks, taskOperation, updateTask } from '../router';
 import { TaskPriority, TaskStatus } from '../types';
-import { createTaskRouter, getTask, mapTask } from './task';
+import { createTaskRouter, getTask } from './task';
 
 describe('task', () => {
   const apiId = adspId`urn:ads:platform:task-service:v1`;

--- a/apps/task-service/src/task/router/task.ts
+++ b/apps/task-service/src/task/router/task.ts
@@ -22,6 +22,7 @@ import {
   OPERATION_SET_PRIORITY,
   OPERATION_ASSIGN,
 } from './types';
+import { mapTask } from '../mapper';
 
 interface TaskRouterProps {
   apiId: AdspId;
@@ -31,24 +32,6 @@ interface TaskRouterProps {
 }
 
 export const TASK_KEY = 'task';
-
-export const mapTask = (apiId: AdspId, entity: TaskEntity) => ({
-  urn: `${apiId}:/tasks/${entity.id}`,
-  id: entity.id,
-  name: entity.name,
-  description: entity.description,
-  context: entity.context,
-  definition: entity.definition ? { namespace: entity.definition.namespace, name: entity.definition.name } : null,
-  queue: entity.queue ? { namespace: entity.queue.namespace, name: entity.queue.name } : null,
-  recordId: entity.recordId,
-  data: entity.data,
-  status: entity.status,
-  priority: TaskPriority[entity.priority],
-  createdOn: entity.createdOn,
-  startedOn: entity.startedOn,
-  endedOn: entity.endedOn,
-  assignment: entity.assignment,
-});
 
 export const getTasks =
   (apiId: AdspId, repository: TaskRepository): RequestHandler =>

--- a/apps/task-service/src/task/types/task.ts
+++ b/apps/task-service/src/task/types/task.ts
@@ -43,7 +43,7 @@ export interface Task {
   description: string;
   priority: TaskPriority;
   status: TaskStatus;
-  recordId?: string;
+  recordId?: string | AdspId;
   data?: Record<string, unknown>;
   createdOn: Date;
   startedOn: Date;


### PR DESCRIPTION
Use task associated record ID and fallback to task URN instead of using task ID as the even correlation ID. This will allow task related events to be associated with the other events against the associated entity.