### PR TITLE
chore(comment-service): change topic and comment correlationId

### DIFF
--- a/apps/comment-service/src/comment/events.ts
+++ b/apps/comment-service/src/comment/events.ts
@@ -1,5 +1,6 @@
-import { DomainEvent, DomainEventDefinition, User } from '@abgov/adsp-service-sdk';
+import { AdspId, DomainEvent, DomainEventDefinition, User } from '@abgov/adsp-service-sdk';
 import { Comment, Topic } from './types';
+import { TopicResponse, mapTopic } from './mapper';
 
 const userSchema = {
   type: 'object',
@@ -123,18 +124,6 @@ export const CommentDeletedEventDefinition: DomainEventDefinition = {
   },
 };
 
-function mapTopic(topic: Topic) {
-  return {
-    typeId: topic.type.id,
-    id: topic.id,
-    name: topic.name,
-    description: topic.description,
-    resourceId: topic.resourceId?.toString(),
-    commenters: topic.commenters,
-    securityClassification: topic.securityClassification,
-  };
-}
-
 function mapComment(comment: Comment) {
   return {
     id: comment.id,
@@ -145,17 +134,22 @@ function mapComment(comment: Comment) {
   };
 }
 
-export function topicCreated(topic: Topic, createdBy: User): DomainEvent {
+function getCorrelationId(topic: TopicResponse) {
+  return topic.resourceId?.toString() || topic.urn;
+}
+
+export function topicCreated(apiId: AdspId, topic: Topic, createdBy: User): DomainEvent {
+  const topicResponse = mapTopic(apiId, topic);
   return {
     tenantId: topic.tenantId,
     name: TopicCreatedEventDefinition.name,
     timestamp: new Date(),
-    correlationId: `topic-${topic.id}`,
+    correlationId: getCorrelationId(topicResponse),
     context: {
       topicId: topic.id,
     },
     payload: {
-      topic: mapTopic(topic),
+      topic: topicResponse,
       createdBy: {
         id: createdBy.id,
         name: createdBy.name,
@@ -164,17 +158,18 @@ export function topicCreated(topic: Topic, createdBy: User): DomainEvent {
   };
 }
 
-export function topicUpdated(topic: Topic, updatedBy: User): DomainEvent {
+export function topicUpdated(apiId: AdspId, topic: Topic, updatedBy: User): DomainEvent {
+  const topicResponse = mapTopic(apiId, topic);
   return {
     tenantId: topic.tenantId,
     name: TopicUpdatedEventDefinition.name,
     timestamp: new Date(),
-    correlationId: `topic-${topic.id}`,
+    correlationId: getCorrelationId(topicResponse),
     context: {
       topicId: topic.id,
     },
     payload: {
-      topic: mapTopic(topic),
+      topic: topicResponse,
       updatedBy: {
         id: updatedBy.id,
         name: updatedBy.name,
@@ -183,17 +178,18 @@ export function topicUpdated(topic: Topic, updatedBy: User): DomainEvent {
   };
 }
 
-export function topicDeleted(topic: Topic, deletedBy: User): DomainEvent {
+export function topicDeleted(apiId: AdspId, topic: Topic, deletedBy: User): DomainEvent {
+  const topicResponse = mapTopic(apiId, topic);
   return {
     tenantId: topic.tenantId,
     name: TopicDeletedEventDefinition.name,
     timestamp: new Date(),
-    correlationId: `topic-${topic.id}`,
+    correlationId: getCorrelationId(topicResponse),
     context: {
       topicId: topic.id,
     },
     payload: {
-      topic: mapTopic(topic),
+      topic: topicResponse,
       deletedBy: {
         id: deletedBy.id,
         name: deletedBy.name,
@@ -202,18 +198,19 @@ export function topicDeleted(topic: Topic, deletedBy: User): DomainEvent {
   };
 }
 
-export function commentCreated(topic: Topic, comment: Comment): DomainEvent {
+export function commentCreated(apiId: AdspId, topic: Topic, comment: Comment): DomainEvent {
+  const topicResponse = mapTopic(apiId, topic);
   return {
     tenantId: topic.tenantId,
     name: CommentCreatedEventDefinition.name,
     timestamp: comment.createdOn,
-    correlationId: `topic-${topic.id}:${comment.id}`,
+    correlationId: getCorrelationId(topicResponse),
     context: {
       topicId: topic.id,
       commentId: comment.id,
     },
     payload: {
-      topic: mapTopic(topic),
+      topic: topicResponse,
       comment: mapComment(comment),
       createdBy: {
         id: comment.createdBy.id,
@@ -223,18 +220,19 @@ export function commentCreated(topic: Topic, comment: Comment): DomainEvent {
   };
 }
 
-export function commentUpdated(topic: Topic, comment: Comment): DomainEvent {
+export function commentUpdated(apiId: AdspId, topic: Topic, comment: Comment): DomainEvent {
+  const topicResponse = mapTopic(apiId, topic);
   return {
     tenantId: topic.tenantId,
     name: CommentUpdatedEventDefinition.name,
     timestamp: comment.lastUpdatedOn,
-    correlationId: `topic-${topic.id}:${comment.id}`,
+    correlationId: getCorrelationId(topicResponse),
     context: {
       topicId: topic.id,
       commentId: comment.id,
     },
     payload: {
-      topic: mapTopic(topic),
+      topic: topicResponse,
       comment: mapComment(comment),
       updatedBy: {
         id: comment.lastUpdatedBy.id,
@@ -244,18 +242,19 @@ export function commentUpdated(topic: Topic, comment: Comment): DomainEvent {
   };
 }
 
-export function commentDeleted(topic: Topic, comment: Comment, deletedBy: User): DomainEvent {
+export function commentDeleted(apiId: AdspId, topic: Topic, comment: Comment, deletedBy: User): DomainEvent {
+  const topicResponse = mapTopic(apiId, topic);
   return {
     tenantId: topic.tenantId,
     name: CommentUpdatedEventDefinition.name,
     timestamp: new Date(),
-    correlationId: `topic-${topic.id}:${comment.id}`,
+    correlationId: getCorrelationId(topicResponse),
     context: {
       topicId: topic.id,
       commentId: comment.id,
     },
     payload: {
-      topic: mapTopic(topic),
+      topic: topicResponse,
       comment: mapComment(comment),
       updatedBy: {
         id: deletedBy.id,

--- a/apps/comment-service/src/comment/mapper.ts
+++ b/apps/comment-service/src/comment/mapper.ts
@@ -1,0 +1,30 @@
+import { AdspId } from '@abgov/adsp-service-sdk';
+import { TopicType, Topic } from './types';
+
+type TopicTypeResponse = Omit<TopicType, 'tenantId'>;
+export function mapTopicType(type: TopicType): TopicTypeResponse | null {
+  return type
+    ? {
+        id: type.id,
+        name: type.name,
+        adminRoles: type.adminRoles,
+        readerRoles: type.readerRoles,
+        commenterRoles: type.commenterRoles,
+        securityClassification: type.securityClassification,
+      }
+    : null;
+}
+
+export type TopicResponse = Omit<Topic, 'tenantId' | 'type'> & { type: TopicTypeResponse; urn: string };
+export function mapTopic(apiId: AdspId, topic: Topic): TopicResponse {
+  return {
+    type: mapTopicType(topic.type),
+    id: topic.id,
+    urn: `${apiId}:/topics/${topic.id}`,
+    name: topic.name,
+    description: topic.description,
+    resourceId: topic.resourceId?.toString(),
+    commenters: topic.commenters,
+    securityClassification: topic.securityClassification,
+  };
+}

--- a/apps/comment-service/src/comment/router/topic.spec.ts
+++ b/apps/comment-service/src/comment/router/topic.spec.ts
@@ -444,7 +444,7 @@ describe('topic', () => {
     });
 
     it('can create handler', () => {
-      const handler = deleteTopic(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopic(apiId, loggerMock as unknown as Logger, eventServiceMock);
       expect(handler).toBeTruthy();
     });
 
@@ -465,7 +465,7 @@ describe('topic', () => {
 
       repositoryMock.delete.mockResolvedValueOnce(true);
 
-      const handler = deleteTopic(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopic(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
@@ -489,7 +489,7 @@ describe('topic', () => {
 
       repositoryMock.delete.mockResolvedValueOnce(false);
 
-      const handler = deleteTopic(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopic(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: false }));
@@ -513,7 +513,7 @@ describe('topic', () => {
 
       repositoryMock.delete.mockResolvedValueOnce(true);
 
-      const handler = deleteTopic(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopic(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).not.toHaveBeenCalled();
@@ -589,7 +589,7 @@ describe('topic', () => {
     });
 
     it('can create handler', () => {
-      const handler = createTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = createTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       expect(handler).toBeTruthy();
     });
 
@@ -613,7 +613,7 @@ describe('topic', () => {
 
       repositoryMock.saveComment.mockResolvedValueOnce(comment);
 
-      const handler = createTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = createTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).toHaveBeenCalledWith(comment);
@@ -638,7 +638,7 @@ describe('topic', () => {
       };
       const next = jest.fn();
 
-      const handler = createTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = createTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).not.toHaveBeenCalled();
@@ -741,7 +741,7 @@ describe('topic', () => {
     });
 
     it('can create handler', () => {
-      const handler = updateTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = updateTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       expect(handler).toBeTruthy();
     });
 
@@ -766,7 +766,7 @@ describe('topic', () => {
       repositoryMock.getComment.mockResolvedValueOnce(comment);
       repositoryMock.saveComment.mockResolvedValueOnce(comment);
 
-      const handler = updateTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = updateTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).toHaveBeenCalledWith(comment);
@@ -793,7 +793,7 @@ describe('topic', () => {
 
       repositoryMock.getComment.mockResolvedValueOnce(comment);
 
-      const handler = updateTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = updateTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).not.toHaveBeenCalled();
@@ -820,7 +820,7 @@ describe('topic', () => {
 
       repositoryMock.getComment.mockResolvedValueOnce(null);
 
-      const handler = updateTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = updateTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).not.toHaveBeenCalled();
@@ -835,7 +835,7 @@ describe('topic', () => {
     });
 
     it('can create handler', () => {
-      const handler = deleteTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       expect(handler).toBeTruthy();
     });
 
@@ -860,7 +860,7 @@ describe('topic', () => {
       repositoryMock.getComment.mockResolvedValueOnce(comment);
       repositoryMock.deleteComment.mockResolvedValueOnce(true);
 
-      const handler = deleteTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
@@ -888,7 +888,7 @@ describe('topic', () => {
       repositoryMock.getComment.mockResolvedValueOnce(comment);
       repositoryMock.deleteComment.mockResolvedValueOnce(true);
 
-      const handler = deleteTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).not.toHaveBeenCalled();
@@ -915,7 +915,7 @@ describe('topic', () => {
 
       repositoryMock.getComment.mockResolvedValueOnce(null);
 
-      const handler = deleteTopicComment(loggerMock as unknown as Logger, eventServiceMock);
+      const handler = deleteTopicComment(apiId, loggerMock as unknown as Logger, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(res.send).not.toHaveBeenCalled();

--- a/apps/comment-service/src/comment/types/topic.ts
+++ b/apps/comment-service/src/comment/types/topic.ts
@@ -24,7 +24,7 @@ export interface Topic {
 export interface TopicCriteria {
   tenantIdEquals?: AdspId;
   typeIdEquals?: string;
-  resourceIdEquals?: AdspId;
+  resourceIdEquals?: AdspId | string;
   // nameLike?: string;
   // descriptionLike?: string;
 }


### PR DESCRIPTION
Use resourceId and fallback to topic URN so that comment events can be correlated with other events against the associated entity.