### PR TITLE
chore(file-service): fallback to file URN for correlationId

### DIFF
--- a/apps/file-service/src/file/events.ts
+++ b/apps/file-service/src/file/events.ts
@@ -1,5 +1,6 @@
 import type { AdspId, DomainEvent, DomainEventDefinition, User } from '@abgov/adsp-service-sdk';
-import type { File } from './types';
+import { FileEntity } from './model';
+import { FileResponse, mapFile } from './mapper';
 
 export const FILE_UPLOADED_EVENT = 'file-uploaded';
 export const FILE_DELETED_EVENT = 'file-deleted';
@@ -93,14 +94,19 @@ export const FileScannedDefinition: DomainEventDefinition = {
   },
 };
 
-export function fileUploaded(tenantId: AdspId, user: User, file: File): DomainEvent {
+function getCorrelationId(file: FileResponse) {
+  return file.recordId || file.urn;
+}
+
+export function fileUploaded(apiId: AdspId, user: User, file: FileEntity): DomainEvent {
+  const fileResponse = mapFile(apiId, file);
   return {
     name: FILE_UPLOADED_EVENT,
-    tenantId,
+    tenantId: file.tenantId,
     timestamp: new Date(),
-    correlationId: file.recordId || file.id,
+    correlationId: getCorrelationId(fileResponse),
     payload: {
-      file,
+      file: fileResponse,
       uploadedBy: {
         id: user.id,
         name: user.name,
@@ -109,14 +115,15 @@ export function fileUploaded(tenantId: AdspId, user: User, file: File): DomainEv
   };
 }
 
-export function fileDeleted(user: User, file: File): DomainEvent {
+export function fileDeleted(apiId: AdspId, user: User, file: FileEntity): DomainEvent {
+  const fileResponse = mapFile(apiId, file);
   return {
     name: FILE_DELETED_EVENT,
-    tenantId: user.tenantId,
+    tenantId: file.tenantId,
     timestamp: new Date(),
-    correlationId: file.recordId || file.id,
+    correlationId: getCorrelationId(fileResponse),
     payload: {
-      file,
+      file: fileResponse,
       deletedBy: {
         id: user.id,
         name: user.name,
@@ -126,14 +133,15 @@ export function fileDeleted(user: User, file: File): DomainEvent {
   };
 }
 
-export function fileScanned(tenantId: AdspId, file: File, infected: boolean): DomainEvent {
+export function fileScanned(apiId: AdspId, file: FileEntity, infected: boolean): DomainEvent {
+  const fileResponse = mapFile(apiId, file);
   return {
     name: FILE_SCANNED_EVENT,
-    tenantId,
+    tenantId: file.tenantId,
     timestamp: new Date(),
-    correlationId: file.recordId || file.id,
+    correlationId: getCorrelationId(fileResponse),
     payload: {
-      file,
+      file: fileResponse,
       infected,
     },
   };

--- a/apps/file-service/src/file/events.ts
+++ b/apps/file-service/src/file/events.ts
@@ -127,7 +127,6 @@ export function fileDeleted(apiId: AdspId, user: User, file: FileEntity): Domain
       deletedBy: {
         id: user.id,
         name: user.name,
-        retention: file.retentionDays,
       },
     },
   };

--- a/apps/file-service/src/file/index.ts
+++ b/apps/file-service/src/file/index.ts
@@ -1,6 +1,13 @@
 import { Application } from 'express';
 import { Logger } from 'winston';
-import { AdspId, ConfigurationService, EventService, TenantService, TokenProvider } from '@abgov/adsp-service-sdk';
+import {
+  AdspId,
+  ConfigurationService,
+  EventService,
+  TenantService,
+  TokenProvider,
+  adspId,
+} from '@abgov/adsp-service-sdk';
 import { Repositories } from './repository';
 import { createFileRouter } from './router';
 import { createFileJobs, FileServiceWorkItem } from './job';
@@ -29,12 +36,13 @@ interface FileMiddlewareProps extends Repositories {
   scanService: ScanService;
 }
 
-export const applyFileMiddleware = (app: Application, { ...props }: FileMiddlewareProps): Application => {
-  const fileRouter = createFileRouter(props);
+export const applyFileMiddleware = (app: Application, props: FileMiddlewareProps): Application => {
+  const apiId = adspId`${props.serviceId}:v1`;
 
-  createFileJobs(props);
-
+  const fileRouter = createFileRouter({ ...props, apiId });
   app.use('/file/v1', fileRouter);
+
+  createFileJobs({ ...props, apiId });
 
   return app;
 };

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -82,10 +82,8 @@ export function createDeleteOldFilesJob({
 
                     if (!file.deleted) {
                       try {
-                        jobUser.tenantId = file.tenantId;
                         const deleted = await file.markForDeletion(jobUser);
                         if (deleted) {
-                          deleted.retentionDays = retention;
                           numberDeleted++;
                           eventService.send(fileDeleted(apiId, jobUser, deleted));
                         }

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -82,10 +82,10 @@ export function createDeleteOldFilesJob({
 
                     if (!file.deleted) {
                       try {
-                        const deleted = await file.markForDeletion(jobUser);
-                        if (deleted) {
+                        const result = await file.markForDeletion(jobUser);
+                        if (result.deleted) {
                           numberDeleted++;
-                          eventService.send(fileDeleted(apiId, jobUser, deleted));
+                          eventService.send(fileDeleted(apiId, jobUser, result));
                         }
                       } catch (err) {
                         logger.error(`Error deleting file with ID: ${file.id}. ${err}`);

--- a/apps/file-service/src/file/job/deleteOldFiles.ts
+++ b/apps/file-service/src/file/job/deleteOldFiles.ts
@@ -9,6 +9,7 @@ import { jobUser } from './user';
 
 interface DeleteJobProps {
   tokenProvider: TokenProvider;
+  apiId: AdspId;
   serviceId: AdspId;
   logger: Logger;
   fileRepository: FileRepository;
@@ -26,6 +27,7 @@ export function getBeforeLastAccessed(retention: number) {
 }
 
 export function createDeleteOldFilesJob({
+  apiId,
   serviceId,
   logger,
   fileRepository,
@@ -85,18 +87,7 @@ export function createDeleteOldFilesJob({
                         if (deleted) {
                           deleted.retentionDays = retention;
                           numberDeleted++;
-                          eventService.send(
-                            fileDeleted(jobUser, {
-                              id: deleted.id,
-                              filename: deleted.filename,
-                              size: deleted.size,
-                              recordId: deleted.recordId,
-                              created: deleted.created,
-                              lastAccessed: deleted.lastAccessed,
-                              createdBy: deleted.createdBy,
-                              retentionDays: deleted.retentionDays,
-                            })
-                          );
+                          eventService.send(fileDeleted(apiId, jobUser, deleted));
                         }
                       } catch (err) {
                         logger.error(`Error deleting file with ID: ${file.id}. ${err}`);

--- a/apps/file-service/src/file/job/index.ts
+++ b/apps/file-service/src/file/job/index.ts
@@ -1,4 +1,10 @@
-import { AdspId, EventService, TenantService, TokenProvider, ConfigurationService } from '@abgov/adsp-service-sdk';
+import {
+  AdspId,
+  EventService,
+  TenantService,
+  TokenProvider,
+  ConfigurationService,
+} from '@abgov/adsp-service-sdk';
 import { WorkQueueService } from '@core-services/core-common';
 import * as schedule from 'node-schedule';
 import { Logger } from 'winston';
@@ -19,6 +25,7 @@ export interface FileServiceWorkItem {
 }
 
 interface FileJobProps {
+  apiId: AdspId;
   serviceId: AdspId;
   logger: Logger;
   fileRepository: FileRepository;

--- a/apps/file-service/src/file/job/scan.spec.ts
+++ b/apps/file-service/src/file/job/scan.spec.ts
@@ -7,6 +7,8 @@ import { ScanService } from '../scan';
 import { createScanJob } from './scan';
 
 describe('Scan Job', () => {
+  const serviceId = adspId`urn:ads:platform:file-service`;
+  const apiId = adspId`${serviceId}:v1`;
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
   const logger = {
     debug: jest.fn(),
@@ -25,6 +27,7 @@ describe('Scan Job', () => {
 
   it('can be created', () => {
     const scanJob = createScanJob({
+      apiId,
       logger,
       scanService: scanServiceMock.object(),
       fileRepository: repositoryMock.object(),
@@ -36,6 +39,7 @@ describe('Scan Job', () => {
 
   it('can be executed', async () => {
     const scanJob = createScanJob({
+      apiId,
       logger,
       scanService: scanServiceMock.object(),
       fileRepository: repositoryMock.object(),
@@ -64,6 +68,7 @@ describe('Scan Job', () => {
 
   it('can skip deleted', async () => {
     const scanJob = createScanJob({
+      apiId,
       logger,
       scanService: scanServiceMock.object(),
       fileRepository: repositoryMock.object(),
@@ -83,6 +88,7 @@ describe('Scan Job', () => {
 
   it('can skip not found', async () => {
     const scanJob = createScanJob({
+      apiId,
       logger,
       scanService: scanServiceMock.object(),
       fileRepository: repositoryMock.object(),
@@ -102,6 +108,7 @@ describe('Scan Job', () => {
 
   it('can skip record result for not scanned', async () => {
     const scanJob = createScanJob({
+      apiId,
       logger,
       scanService: scanServiceMock.object(),
       fileRepository: repositoryMock.object(),
@@ -124,6 +131,7 @@ describe('Scan Job', () => {
 
   it('can call done with error', async () => {
     const scanJob = createScanJob({
+      apiId,
       logger,
       scanService: scanServiceMock.object(),
       fileRepository: repositoryMock.object(),

--- a/apps/file-service/src/file/job/scan.ts
+++ b/apps/file-service/src/file/job/scan.ts
@@ -1,11 +1,12 @@
 import { AdspId, EventService } from '@abgov/adsp-service-sdk';
 import { Logger } from 'winston';
 import { fileScanned } from '../events';
-import { File } from '../types';
 import { FileRepository } from '../repository';
 import { ScanService } from '../scan';
+import { File } from '../types';
 
 interface ScanJobProps {
+  apiId: AdspId,
   logger: Logger;
   scanService: ScanService;
   fileRepository: FileRepository;
@@ -13,7 +14,7 @@ interface ScanJobProps {
 }
 
 export const createScanJob =
-  ({ logger, scanService, fileRepository, eventService }: ScanJobProps) =>
+  ({ apiId, logger, scanService, fileRepository, eventService }: ScanJobProps) =>
   async (tenantId: AdspId, file: File, done: (err?: Error) => void): Promise<void> => {
     const { id, filename } = file;
     try {
@@ -37,7 +38,7 @@ export const createScanJob =
               tenant: tenantId?.toString(),
             });
           }
-          eventService.send(fileScanned(tenantId, file, infected));
+          eventService.send(fileScanned(apiId, result, infected));
         }
       }
       done();

--- a/apps/file-service/src/file/mapper.ts
+++ b/apps/file-service/src/file/mapper.ts
@@ -1,0 +1,34 @@
+import { AdspId, FileType } from '@abgov/adsp-service-sdk';
+import { FileEntity, FileTypeEntity } from './model';
+import { FileRecord } from './types';
+
+export function mapFileType(entity: FileTypeEntity): FileType {
+  return {
+    id: entity.id,
+    name: entity.name,
+    anonymousRead: entity.anonymousRead,
+    updateRoles: entity.updateRoles,
+    readRoles: entity.readRoles,
+    rules: entity?.rules,
+  };
+}
+
+export type FileResponse = Omit<FileRecord, 'tenantId' | 'deleted'> & { urn: string; typeName: string };
+export function mapFile(apiId: AdspId, entity: FileEntity): FileResponse {
+  return {
+    urn: `${apiId}:/files/${entity.id}`,
+    id: entity.id,
+    filename: entity.filename,
+    size: entity.size,
+    typeName: entity.type?.name,
+    recordId: entity.recordId,
+    created: entity.created,
+    createdBy: entity.createdBy,
+    lastAccessed: entity.lastAccessed,
+    scanned: entity.scanned,
+    infected: entity.infected,
+    mimeType: entity.mimeType,
+    digest: entity.digest,
+    securityClassification: entity.securityClassification,
+  };
+}

--- a/apps/file-service/src/file/model/file.ts
+++ b/apps/file-service/src/file/model/file.ts
@@ -24,7 +24,6 @@ export class FileEntity implements File {
   deleted = false;
   infected = false;
   digest?: string;
-  retentionDays?: number;
   securityClassification?: string;
 
   static async create(

--- a/apps/file-service/src/file/router/file.spec.ts
+++ b/apps/file-service/src/file/router/file.spec.ts
@@ -70,7 +70,7 @@ describe('file router', () => {
 
   it('can create router', () => {
     const router = createFileRouter({
-      serviceId,
+      apiId,
       logger: loggerMock,
       storageProvider: storageProviderMock,
       fileRepository: fileRepositoryMock,
@@ -448,7 +448,7 @@ describe('file router', () => {
 
   describe('deleteFile', () => {
     it('can create handler', () => {
-      const handler = deleteFile(loggerMock, eventServiceMock);
+      const handler = deleteFile(apiId, loggerMock, eventServiceMock);
       expect(handler).toBeTruthy();
     });
 
@@ -470,7 +470,7 @@ describe('file router', () => {
 
       fileRepositoryMock.save.mockResolvedValueOnce(file);
 
-      const handler = deleteFile(loggerMock, eventServiceMock);
+      const handler = deleteFile(apiId, loggerMock, eventServiceMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
     });

--- a/apps/file-service/src/file/router/upload.ts
+++ b/apps/file-service/src/file/router/upload.ts
@@ -14,7 +14,6 @@ declare global {
   namespace Express {
     interface Request {
       fileEntity?: FileEntity;
-      fileTypeEntity?: FileTypeEntity;
     }
   }
 }

--- a/apps/file-service/src/file/router/upload.ts
+++ b/apps/file-service/src/file/router/upload.ts
@@ -5,7 +5,7 @@ import * as multer from 'multer';
 import * as validFilename from 'valid-filename';
 import { Logger } from 'winston';
 import { ServiceConfiguration } from '../configuration';
-import { FileEntity, FileTypeEntity } from '../model';
+import { FileEntity } from '../model';
 import { FileRepository } from '../repository';
 import { FileStorageProvider } from '../storage';
 

--- a/apps/file-service/src/file/types/file.ts
+++ b/apps/file-service/src/file/types/file.ts
@@ -14,7 +14,6 @@ export interface File {
   createdBy: UserInfo;
   created: Date;
   lastAccessed?: Date;
-  retentionDays?: number;
   securityClassification?: string;
 }
 


### PR DESCRIPTION
Also removing some extraneous code for retrieving file type; file type is already retrieved and set on the file entity.