### PR TITLE
fix(task-app, form-app): fix clearing of comment draft

### DIFF
--- a/libs/app-common/src/components/CommentsViewer.tsx
+++ b/libs/app-common/src/components/CommentsViewer.tsx
@@ -84,7 +84,7 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
         <GoAFormItem label={`New ${typeLabel}`}>
           <GoATextArea
             name="comment"
-            value={draft.content}
+            value={draft.content || ''}
             disabled={!canComment}
             // eslint-disable-next-line
             onChange={() => {}}


### PR DESCRIPTION
Fallback to empty string in GoATextArea so that the draft is cleared.