### PR TITLE
fix(form-disposition-script): allow core roles - needed to use servic…

### DIFF
--- a/apps/form-service/src/form/model/formSubmission.ts
+++ b/apps/form-service/src/form/model/formSubmission.ts
@@ -88,7 +88,12 @@ export class FormSubmissionEntity implements FormSubmission {
 
   async dispositionSubmission(user: User, status: string, reason?: string): Promise<FormSubmissionEntity> {
     if (
-      !isAllowedUser(user, this.tenantId, [FormServiceRoles.Admin, ...(this.form?.definition?.assessorRoles || [])])
+      !isAllowedUser(
+        user,
+        this.tenantId,
+        [FormServiceRoles.Admin, ...(this.form?.definition?.assessorRoles || [])],
+        true
+      )
     ) {
       throw new UnauthorizedUserError('updated form disposition', user);
     }


### PR DESCRIPTION
…e accounts

export function isAllowedUser(user: User, tenantId: AdspId, roles: string | string[], **allowCore = false**): boolean {
