### PR TITLE
fix(value-service): fix destructuring of undefined for failed write

### DIFF
--- a/apps/value-service/src/values/router/value.ts
+++ b/apps/value-service/src/values/router/value.ts
@@ -14,9 +14,15 @@ interface ValueRouterProps {
   eventService: EventService;
 }
 
-const mapValue = ({ tenantId: _tenantId, ...value }: Value) => ({
-  ...value,
-});
+const mapValue = (value: Value) => {
+  if (value) {
+    const { tenantId: _tenantId, ...result } = value;
+
+    return result;
+  } else {
+    return null;
+  }
+};
 
 export const readValues: RequestHandler = async (req, res, next) => {
   try {


### PR DESCRIPTION
Fixing issue where result mapping causes value API to return 500 when there is a write failure; expected is that null is returned for scalar and empty array is returned for batch writes.