### PR TITLE
feat(script-service): return inner error for net error

### DIFF
--- a/apps/script-service/Events/ScriptExecutionFailed.cs
+++ b/apps/script-service/Events/ScriptExecutionFailed.cs
@@ -39,4 +39,7 @@ public class ScriptExecutionFailed
 
   [JsonPropertyName("error")]
   public string? Error { get; set; }
+
+  [JsonPropertyName("source")]
+  public string? Source { get; set; }
 }

--- a/apps/script-service/Services/ScriptFunctions.cs
+++ b/apps/script-service/Services/ScriptFunctions.cs
@@ -11,16 +11,14 @@ internal class ScriptFunctions : IScriptFunctions
   private readonly AdspId _tenantId;
   private readonly IServiceDirectory _directory;
   private readonly Func<Task<string>> _getToken;
-  private readonly IEventService _eventService;
   private readonly RestClient _client;
 
 
-  public ScriptFunctions(AdspId tenantId, IServiceDirectory directory, Func<Task<string>> getToken, IEventService eventService, RestClient? client = null)
+  public ScriptFunctions(AdspId tenantId, IServiceDirectory directory, Func<Task<string>> getToken, RestClient? client = null)
   {
     _tenantId = tenantId;
     _directory = directory;
     _getToken = getToken;
-    _eventService = eventService;
     _client = client ?? new RestClient(new RestClientOptions { ThrowOnAnyError = true });
   }
 

--- a/apps/script-service/Services/StubScriptFunctions.cs
+++ b/apps/script-service/Services/StubScriptFunctions.cs
@@ -8,8 +8,8 @@ namespace Adsp.Platform.ScriptService.Services;
 internal sealed class StubScriptFunctions : ScriptFunctions, IScriptFunctions
 {
 
-  public StubScriptFunctions(AdspId tenantId, IServiceDirectory directory, Func<Task<string>> getToken, IEventService eventService)
-  : base(tenantId, directory, getToken, eventService)
+  public StubScriptFunctions(AdspId tenantId, IServiceDirectory directory, Func<Task<string>> getToken)
+  : base(tenantId, directory, getToken)
   {
   }
 


### PR DESCRIPTION
Return inner error message in script failure since the outer exception is always a wrapping LuaScriptException.