### PR TITLE
fix(script-service): use DTO for domain event in function

### DIFF
--- a/apps/script-service/Services/IScriptFunctions.cs
+++ b/apps/script-service/Services/IScriptFunctions.cs
@@ -12,7 +12,7 @@ interface IScriptFunctions
     string queueNamespace, string queueName, string name,
     string? description = null, string? recordId = null, string? priority = null, LuaTable? context = null
   );
-  string? SendDomainEvent(string namespaceValue, string name, string? correlationId, IDictionary<string, object>? context = null, IDictionary<string, object>? payload = null);
+  bool SendDomainEvent(string namespaceValue, string name, string? correlationId, IDictionary<string, object>? context = null, IDictionary<string, object>? payload = null);
   object? HttpGet(string url);
 
   DispositionResponse? DispositionFormSubmission(string formId, string submissionId, object dispositionState, string reason);

--- a/apps/script-service/Services/Platform/DispositionResponse.cs
+++ b/apps/script-service/Services/Platform/DispositionResponse.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Serialization;
 using Adsp.Sdk.Util;
 
 namespace Adsp.Platform.ScriptService.Services.Platform;
-[SuppressMessage("Usage", "CA2227: Collection properties should be read only", Justification = "Data transfer object")]
 [SuppressMessage("Usage", "CA1812: Avoid uninstantiated internal classes", Justification = "For deserialization")]
 internal sealed class DispositionResponse
 {
@@ -56,6 +55,7 @@ internal sealed class DispositionResponse
   public string? Hash { get; set; }
 }
 
+[SuppressMessage("Usage", "CA1812: Avoid uninstantiated internal classes", Justification = "For deserialization")]
 internal sealed class CreatedBy
 {
   [JsonPropertyName("id")]
@@ -64,6 +64,8 @@ internal sealed class CreatedBy
   [JsonPropertyName("name")]
   public string? Name { get; set; }
 }
+
+[SuppressMessage("Usage", "CA1812: Avoid uninstantiated internal classes", Justification = "For deserialization")]
 internal sealed class UpdatedBy
 {
   [JsonPropertyName("id")]
@@ -73,6 +75,7 @@ internal sealed class UpdatedBy
   public string? Name { get; set; }
 }
 
+[SuppressMessage("Usage", "CA1812: Avoid uninstantiated internal classes", Justification = "For deserialization")]
 internal sealed class Disposition
 {
   [JsonPropertyName("date")]

--- a/apps/script-service/Services/StubScriptFunctions.cs
+++ b/apps/script-service/Services/StubScriptFunctions.cs
@@ -18,9 +18,9 @@ internal sealed class StubScriptFunctions : ScriptFunctions, IScriptFunctions
     return null;
   }
 
-  public override string? SendDomainEvent(string namespaceValue, string name, string? correlationId, IDictionary<string, object>? context = null, IDictionary<string, object>? payload = null)
+  public override bool SendDomainEvent(string namespaceValue, string name, string? correlationId, IDictionary<string, object>? context = null, IDictionary<string, object>? payload = null)
   {
-    return "Simulated success";
+    return true;
   }
 
   public override DispositionResponse? DispositionFormSubmission(string formId, string submissionId, object dispositionState, string reason)


### PR DESCRIPTION
Tenant ID is required to send under the core context service account. Also updating event service to permit tenant ID in the body for non-core if consistent with user tenant.