### PR TITLE
feat(pii-service): restrict to en for now

### DIFF
--- a/apps/pii-service/pii_service/app.py
+++ b/apps/pii-service/pii_service/app.py
@@ -113,6 +113,9 @@ def supported_entities():
 def analyze():
     analyzer_request = AnalyzerRequest(request.get_json())
 
+    if analyzer_request.language != "en":
+        raise BadRequest("Only en is supported at this time")
+
     if not analyzer_request.text:
         raise BadRequest("No text provided")
 
@@ -144,6 +147,9 @@ def analyze():
 @require_user(service_roles.ANALYZER, allow_core=True)
 def anonymize():
     analyzer_request = AnalyzerRequest(request.get_json())
+
+    if analyzer_request.language != "en":
+        raise BadRequest("Only en is supported at this time")
 
     if not analyzer_request.text:
         raise BadRequest("No text provided")

--- a/apps/pii-service/pii_service/resources/swagger.yml
+++ b/apps/pii-service/pii_service/resources/swagger.yml
@@ -18,7 +18,9 @@ components:
           type: string
           enum: [en]
         entities:
-          type: string
+          type: array
+          items:
+            type: string
         correlation_id:
           type: string
         score_threshold:
@@ -28,7 +30,9 @@ components:
         return_decision_process:
           type: boolean
         context:
-          type: string
+          type: array
+          items:
+            type: string
       required: [text, language]
     RecognizerResult:
       type: object


### PR DESCRIPTION
Additional language models may be expensive in memory to load, so keep to to en as the required one to support for now.