### PR TITLE
chore(tenant-management-webapp): feedback script cache busting

### DIFF
--- a/apps/tenant-management-webapp/src/app/store/config/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/config/sagas.ts
@@ -78,8 +78,13 @@ export function* fetchConfig(): SagaIterator {
           new URL('/feedback/v1/script/integrity', feedbackServiceUrl).href
         )).data;
 
+        // Set the feedback script information.
+        // Include a portion of the integrity value for cache busting; the integrity endpoint doesn't apply cache-control header.
         tenantWebConfig.feedback = {
-          script: { src: new URL('/feedback/v1/script/adspFeedback.js', feedbackServiceUrl), integrity },
+          script: {
+            src: new URL(`/feedback/v1/script/adspFeedback.js?${integrity.substring(40)}`, feedbackServiceUrl),
+            integrity,
+          },
           tenant: data.feedback?.tenant || 'autotest',
         };
       }


### PR DESCRIPTION
Use a portion of the integrity value to cache bust the feedback script source.