### PR TITLE
fix(configuration-service): handle falsy schema

### DIFF
--- a/apps/configuration-service/project.json
+++ b/apps/configuration-service/project.json
@@ -9,6 +9,7 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "webpackConfig": "apps/configuration-service/webpack.config.js",
+        "sourceMap": true,
         "outputPath": "dist/apps/configuration-service",
         "main": "apps/configuration-service/src/main.ts",
         "tsConfig": "apps/configuration-service/tsconfig.app.json",

--- a/apps/configuration-service/src/configuration/index.ts
+++ b/apps/configuration-service/src/configuration/index.ts
@@ -26,7 +26,6 @@ export const applyConfigurationMiddleware = async (
             type: ['string', 'null'],
           },
           configurationSchema: {
-            type: 'object',
             $ref: 'http://json-schema.org/draft-07/schema#',
           },
         },

--- a/apps/configuration-service/src/configuration/model/configuration.ts
+++ b/apps/configuration-service/src/configuration/model/configuration.ts
@@ -23,7 +23,7 @@ export class ConfigurationEntity<C = Record<string, unknown>> implements Configu
     public validationService: ValidationService,
     public latest?: ConfigurationRevision<C>,
     public tenantId?: AdspId,
-    private schema?: Record<string, unknown>,
+    schema?: Record<string, unknown>,
     public active?: number
   ) {
     if (!namespace || !name) {
@@ -35,7 +35,7 @@ export class ConfigurationEntity<C = Record<string, unknown>> implements Configu
     }
 
     try {
-      validationService.setSchema(this.getSchemaKey(), schema);
+      validationService.setSchema(this.getSchemaKey(), schema || {});
       return;
     } catch {
       this.logger.warn(`JSON schema of ${namespace}:${name} is invalid. An empty JSON schema {} will be used.`);


### PR DESCRIPTION
The loading of configuration definition generally doesn't include the schema, and that shouldn't result in an error.