### PR TITLE
chore(configuration-service): lazy load active revision in getter

### DIFF
--- a/apps/configuration-service/src/configuration/model/configuration.spec.ts
+++ b/apps/configuration-service/src/configuration/model/configuration.spec.ts
@@ -795,8 +795,8 @@ describe('ConfigurationEntity', () => {
     });
   });
 
-  describe('setActiveRevision', () => {
-    it('can be created', () => {
+  describe('getActiveRevision', () => {
+    it('get active revision', async () => {
       const entity = new ConfigurationEntity(
         namespace,
         name,
@@ -805,13 +805,19 @@ describe('ConfigurationEntity', () => {
         activeRevisionMock,
         validationMock,
         {
-          revision: 2,
+          revision: 1,
           configuration: {} as unknown,
         }
       );
-      expect(entity).toBeTruthy();
-    });
+      const active = 2;
 
+      activeRevisionMock.get.mockResolvedValueOnce({ active });
+      const result = await entity.getActiveRevision();
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('setActiveRevision', () => {
     it('sets active revision', async () => {
       const entity = new ConfigurationEntity(
         namespace,
@@ -831,14 +837,15 @@ describe('ConfigurationEntity', () => {
         return { active: rev };
       });
 
-      const activeRevisionResponse = await entity.setActiveRevision(
+      await entity.setActiveRevision(
         {
           isCore: true,
           roles: [ConfigurationServiceRoles.ConfigurationAdmin],
         } as User,
         active
       );
-      expect(activeRevisionResponse.active).toBe(2);
+      const result = await entity.getActiveRevision();
+      expect(result).toBe(2);
     });
 
     it('can throw for unauthorized user', async () => {

--- a/apps/configuration-service/src/configuration/repository/activeRevision.ts
+++ b/apps/configuration-service/src/configuration/repository/activeRevision.ts
@@ -4,5 +4,5 @@ import { ActiveRevisionDoc } from '../../mongo/types';
 
 export interface ActiveRevisionRepository {
   get(namespace: string, name: string, tenantId?: AdspId): Promise<ActiveRevisionDoc>;
-  setActiveRevision<C>(entity: ConfigurationEntity<C>, active: number): Promise<ConfigurationEntity<C>>;
+  setActiveRevision<C>(entity: ConfigurationEntity<C>, active: number): Promise<ActiveRevisionDoc>;
 }

--- a/apps/configuration-service/src/configuration/router/__snapshots__/configuration.spec.ts.snap
+++ b/apps/configuration-service/src/configuration/router/__snapshots__/configuration.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`router createServiceConfigurationRevision can create revision 1`] = `
+exports[`router configurationOperations can create revision 1`] = `
 {
   "latest": {
     "configuration": {},
@@ -12,7 +12,7 @@ exports[`router createServiceConfigurationRevision can create revision 1`] = `
 }
 `;
 
-exports[`router createServiceConfigurationRevision can set the active revision 1`] = `
+exports[`router configurationOperations can set the active revision 1`] = `
 {
   "active": 2,
   "name": "test-service",

--- a/apps/configuration-service/src/configuration/types/configuration.ts
+++ b/apps/configuration-service/src/configuration/types/configuration.ts
@@ -13,7 +13,6 @@ export interface Configuration<C = Record<string, unknown>> {
   description?: string;
   tenantId?: AdspId;
   latest?: ConfigurationRevision<C>;
-  active?: number;
 }
 
 export interface RevisionCriteria {

--- a/apps/configuration-service/src/mongo/activeRevisions.ts
+++ b/apps/configuration-service/src/mongo/activeRevisions.ts
@@ -26,7 +26,7 @@ export class MongoActiveRevisionRepository implements ActiveRevisionRepository {
     return activeDoc;
   }
 
-  async setActiveRevision<C>(entity: ConfigurationEntity<C>, active: number): Promise<ConfigurationEntity<C>> {
+  async setActiveRevision<C>(entity: ConfigurationEntity<C>, active: number): Promise<ActiveRevisionDoc> {
     if (!(active >= 0)) {
       throw new InvalidOperationError('Active revision value must be greater than or equal to 0.');
     }
@@ -55,8 +55,6 @@ export class MongoActiveRevisionRepository implements ActiveRevisionRepository {
       .findOneAndUpdate(query, update, { upsert: true, new: true, lean: true })
       .exec();
 
-    entity.active = doc.active;
-
-    return entity;
+    return doc;
   }
 }

--- a/apps/configuration-service/src/mongo/repository.ts
+++ b/apps/configuration-service/src/mongo/repository.ts
@@ -16,24 +16,22 @@ import { ConfigurationRevisionDoc } from './types';
 
 export class MongoConfigurationRepository implements ConfigurationRepository {
   private revisionModel: Model<ConfigurationRevisionDoc>;
-  private activeRevisionRepository: ActiveRevisionRepository;
 
   private readonly META_PREFIX = 'META_';
 
   constructor(
     private logger: Logger,
     private validationService: ValidationService,
-    activeRevisionRepository: ActiveRevisionRepository
+    private activeRevisionRepository: ActiveRevisionRepository
   ) {
     this.revisionModel = model<ConfigurationRevisionDoc>('revision', revisionSchema);
-    this.activeRevisionRepository = activeRevisionRepository;
   }
 
   async get<C>(
     namespace: string,
     name: string,
     tenantId?: AdspId,
-    definition?: ConfigurationDefinition,
+    definition?: ConfigurationDefinition
   ): Promise<ConfigurationEntity<C>> {
     const tenant = tenantId?.toString() || { $exists: false };
     const query = { namespace, name, tenant };
@@ -45,7 +43,6 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
         .exec((err, results: ConfigurationRevisionDoc[]) => (err ? reject(err) : resolve(results[0])));
     });
     const latest = this.fromDoc<C>(latestDoc);
-    const activeRevisionDoc = await this.activeRevisionRepository.get(namespace, name, tenantId);
 
     return new ConfigurationEntity<C>(
       namespace,
@@ -56,8 +53,7 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
       this.validationService,
       latest,
       tenantId,
-      definition?.configurationSchema,
-      activeRevisionDoc?.active
+      definition?.configurationSchema
     );
   }
 


### PR DESCRIPTION
Use property getter for lazy load of active revision from repo instead of always loading as part of entity load. This is to avoid an extra database read when active revision information isn't required (e.g. in the /latest endpoint currently used by the SDK).