### PR TITLE
fix(adsp-py-common): handle error in tenant metadata

### DIFF
--- a/libs/adsp-py-common/tests/test_access.py
+++ b/libs/adsp-py-common/tests/test_access.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import Mock, patch
 
 from adsp_py_common.adsp_id import AdspId


### PR DESCRIPTION
Handle error in tenant metadata retrieval so that one missing tenant does not cause the cache to fail initialization.