### PR TITLE
feat(form-app): use user name and set applicant info for notification

### DIFF
--- a/apps/form-app/src/app/state/form.slice.ts
+++ b/apps/form-app/src/app/state/form.slice.ts
@@ -209,7 +209,14 @@ export const createForm = createAsyncThunk(
       const token = await getAccessToken();
       const { data } = await axios.post<SerializedForm>(
         new URL(`/form/v1/forms`, formServiceUrl).href,
-        { definitionId, applicant: { userId: user.user.id } },
+        {
+          definitionId,
+          applicant: {
+            userId: user.user.id,
+            addressAs: user.user.name,
+            channels: [{ channel: 'email', address: user.user.email }],
+          },
+        },
         { headers: { Authorization: `Bearer ${token}` } }
       );
 

--- a/apps/form-app/src/app/state/user.slice.ts
+++ b/apps/form-app/src/app/state/user.slice.ts
@@ -103,7 +103,7 @@ export const initializeUser = createAsyncThunk(
     if (client.tokenParsed) {
       return {
         id: client.tokenParsed.sub,
-        name: client.tokenParsed['preferred_username'] || client.tokenParsed['email'],
+        name: client.tokenParsed['name'] || client.tokenParsed['preferred_username'] || client.tokenParsed['email'],
         email: client.tokenParsed['email'],
         roles: Object.entries(client.tokenParsed.resource_access || {}).reduce(
           (roles, [client, clientAccess]) => [

--- a/apps/form-service/src/form/router/form.ts
+++ b/apps/form-service/src/form/router/form.ts
@@ -1,5 +1,4 @@
 import {
-  adspId,
   AdspId,
   DomainEvent,
   EventService,


### PR DESCRIPTION
Setting subscriber info from the app is needed since the backend can't assume the user is the applicant (e.g. clerk assisted application).