### PR TITLE
feat(form-service): load definitions from configuration namespace

### DIFF
--- a/apps/feedback-service/project.json
+++ b/apps/feedback-service/project.json
@@ -28,6 +28,7 @@
           "optimization": true,
           "extractLicenses": true,
           "inspect": false,
+          "sourceMap": false,
           "fileReplacements": []
         }
       }

--- a/apps/form-service/project.json
+++ b/apps/form-service/project.json
@@ -15,13 +15,15 @@
         "webpackConfig": "apps/form-service/webpack.config.js",
         "target": "node",
         "compiler": "tsc",
-        "babelUpwardRootMode": true
+        "babelUpwardRootMode": true,
+        "sourceMap": true
       },
       "configurations": {
         "production": {
           "optimization": true,
           "extractLicenses": true,
           "inspect": false,
+          "sourceMap": false,
           "fileReplacements": []
         }
       }

--- a/apps/form-service/project.json
+++ b/apps/form-service/project.json
@@ -15,7 +15,6 @@
         "webpackConfig": "apps/form-service/webpack.config.js",
         "target": "node",
         "compiler": "tsc",
-        "isolatedConfig": true,
         "babelUpwardRootMode": true
       },
       "configurations": {

--- a/apps/form-service/src/form/configuration.ts
+++ b/apps/form-service/src/form/configuration.ts
@@ -1,40 +1,34 @@
 export const configurationSchema = {
   type: 'object',
-  patternProperties: {
-    '^[a-zA-Z0-9-_ ]{1,50}$': {
-      type: 'object',
-      properties: {
-        id: { type: 'string', pattern: '^[a-zA-Z0-9-_ ]{1,50}$' },
-        name: { type: 'string' },
-        description: { type: 'string' },
-        formDraftUrlTemplate: { type: 'string', pattern: '^http[s]?://.{0,500}$' },
-        anonymousApply: { type: 'boolean' },
-        applicantRoles: { type: 'array', items: { type: 'string' } },
-        assessorRoles: { type: 'array', items: { type: 'string' } },
-        clerkRoles: { type: 'array', items: { type: 'string' } },
-        dataSchema: { $ref: 'http://json-schema.org/draft-07/schema#' },
-        uiSchema: { type: 'object' },
-        dispositionStates: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              id: { type: 'string' },
-              name: { type: 'string' },
-              description: { type: 'string' },
-            },
-            required: ['id', 'name'],
-          },
+  properties: {
+    id: { type: 'string', pattern: '^[a-zA-Z0-9-_ ]{1,50}$' },
+    name: { type: 'string' },
+    description: { type: 'string' },
+    formDraftUrlTemplate: { type: 'string', pattern: '^http[s]?://.{0,500}$' },
+    anonymousApply: { type: 'boolean' },
+    applicantRoles: { type: 'array', items: { type: 'string' } },
+    assessorRoles: { type: 'array', items: { type: 'string' } },
+    clerkRoles: { type: 'array', items: { type: 'string' } },
+    dataSchema: { $ref: 'http://json-schema.org/draft-07/schema#' },
+    uiSchema: { type: 'object' },
+    dispositionStates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          description: { type: 'string' },
         },
-        queueTaskToProcess: {
-          type: 'object',
-          properties: { queueNameSpace: { type: 'string' }, queueName: { type: 'string' } },
-        },
-        submissionRecords: { type: 'boolean' },
-        supportTopic: { type: 'boolean' },
+        required: ['id', 'name'],
       },
-      required: ['id', 'name', 'formDraftUrlTemplate', 'anonymousApply', 'applicantRoles', 'assessorRoles'],
     },
-    additionalProperties: false,
+    queueTaskToProcess: {
+      type: 'object',
+      properties: { queueNameSpace: { type: 'string' }, queueName: { type: 'string' } },
+    },
+    submissionRecords: { type: 'boolean' },
+    supportTopic: { type: 'boolean' },
   },
+  required: ['id', 'name', 'formDraftUrlTemplate', 'anonymousApply', 'applicantRoles', 'assessorRoles'],
 };

--- a/apps/form-service/src/form/model/definition.spec.ts
+++ b/apps/form-service/src/form/model/definition.spec.ts
@@ -1,15 +1,18 @@
 import { adspId, Channel, User } from '@abgov/adsp-service-sdk';
 import { FormServiceRoles } from '../roles';
-import { FormDefinitionEntity } from './definition';
-import { ValidationService } from '@core-services/core-common';
 import { QueueTaskToProcess } from '../types';
+import { FormDefinitionEntity } from './definition';
 
 describe('FormDefinitionEntity', () => {
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
-  const validationService: ValidationService = {
+  const validationService = {
     validate: jest.fn(),
     setSchema: jest.fn(),
   };
+
+  beforeEach(() => {
+    validationService.setSchema.mockClear();
+  });
 
   it('can be created', () => {
     const entity = new FormDefinitionEntity(validationService, tenantId, {
@@ -27,7 +30,7 @@ describe('FormDefinitionEntity', () => {
       queueTaskToProcess: {} as QueueTaskToProcess,
     });
     expect(entity).toBeTruthy();
-    expect(validationService.setSchema).toHaveBeenCalledWith(entity.id, expect.any(Object));
+    expect(validationService.setSchema).toHaveBeenCalledWith(`${tenantId.resource}:${entity.id}`, expect.any(Object));
   });
 
   it('can be created with null roles', () => {
@@ -195,7 +198,11 @@ describe('FormDefinitionEntity', () => {
     it('can validate data', () => {
       const data = {};
       entity.validateData('form submission test', data);
-      expect(validationService.validate).toHaveBeenCalledWith(expect.any(String), entity.id, data);
+      expect(validationService.validate).toHaveBeenCalledWith(
+        expect.any(String),
+        `${tenantId.resource}:${entity.id}`,
+        data
+      );
     });
   });
 

--- a/apps/form-service/src/form/model/definition.ts
+++ b/apps/form-service/src/form/model/definition.ts
@@ -42,7 +42,7 @@ export class FormDefinitionEntity implements FormDefinition {
     this.urlTemplate = compile(definition.formDraftUrlTemplate || '');
     this.dataSchema = definition.dataSchema || {};
     this.uiSchema = definition.uiSchema || {};
-    this.validationService.setSchema(this.id, this.dataSchema);
+    this.validationService.setSchema(`${this.tenantId.resource}:${this.id}`, this.dataSchema);
   }
 
   public canAccessDefinition(user: User): boolean {
@@ -72,7 +72,7 @@ export class FormDefinitionEntity implements FormDefinition {
   }
 
   public validateData(context: string, data: Record<string, unknown>) {
-    return this.validationService.validate(context, this.id, data);
+    return this.validationService.validate(context, `${this.tenantId.resource}:${this.id}`, data);
   }
 
   public async createForm(

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -275,7 +275,7 @@ describe('form router', () => {
       req.getServiceConfiguration.mockResolvedValueOnce([definition]);
       await getFormDefinition(req as unknown as Request, res as unknown as Response, next);
 
-      expect(req.getServiceConfiguration).toHaveBeenCalled();
+      expect(req.getServiceConfiguration).toHaveBeenCalledWith('test');
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'test', name: 'test-form-definition' }));
     });
 

--- a/apps/form-service/src/form/router/form.ts
+++ b/apps/form-service/src/form/router/form.ts
@@ -84,7 +84,7 @@ export const getFormDefinitions: RequestHandler = async (req, res, next) => {
 };
 
 async function getDefinitionFromConfiguration(req: Request, definitionId: string): Promise<FormDefinitionEntity> {
-  let [definition] = await req.getServiceConfiguration<FormDefinitionEntity>();
+  let [definition] = await req.getServiceConfiguration<FormDefinitionEntity>(definitionId);
 
   // TODO: Remove after configuration is transitioned to form-service namespace.
   if (!definition) {

--- a/apps/form-service/src/mongo/definition.ts
+++ b/apps/form-service/src/mongo/definition.ts
@@ -9,13 +9,19 @@ export class ConfigurationFormDefinitionRepository implements FormDefinitionRepo
   ) {}
 
   async getDefinition(tenantId: AdspId, id: string): Promise<FormDefinitionEntity> {
-    const token = await this.tokenProvider.getAccessToken();
-    const [configuration] = await this.configurationService.getConfiguration<Record<string, FormDefinitionEntity>>(
-      this.serviceId,
-      token,
-      tenantId
-    );
+    let [definition] = await this.configurationService.getServiceConfiguration<FormDefinitionEntity>(id, tenantId);
 
-    return configuration[id];
+    // TODO: Remove after configuration is transitioned to form-service namespace.
+    if (!definition) {
+      const token = await this.tokenProvider.getAccessToken();
+      const [configuration] = await this.configurationService.getConfiguration<Record<string, FormDefinitionEntity>>(
+        this.serviceId,
+        token,
+        tenantId
+      );
+      definition = configuration[id];
+    }
+
+    return definition;
   }
 }

--- a/apps/form-service/src/utils.ts
+++ b/apps/form-service/src/utils.ts
@@ -1,0 +1,5 @@
+import { FormDefinition } from './form';
+
+export function isFormDefinition(value: unknown): value is FormDefinition {
+  return typeof (value as FormDefinition)?.anonymousApply === 'boolean';
+}

--- a/libs/adsp-service-sdk/src/configuration/configurationService.spec.ts
+++ b/libs/adsp-service-sdk/src/configuration/configurationService.spec.ts
@@ -59,11 +59,26 @@ describe('ConfigurationService', () => {
     expect(result.value).toBe(config.value);
   });
 
-  it('can retrieve from API on cache miss', async () => {
+  it('can getConfiguration from cache with null value', async () => {
+    // Null value means the API received no value for the configuration (which is a valid state).
+    // This should still be a cache hit to avoid extraneous API requests.
     const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock);
 
     cacheMock.mockReturnValueOnce(null);
-    cacheMock.mockReturnValueOnce(null);
+    const [result] = await service.getConfiguration<{ value: string }>(
+      adspId`urn:ads:platform:test`,
+      'test',
+      adspId`urn:ads:platform:tenant-service:v2:/tenants/test`
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('can retrieve from API on cache miss', async () => {
+    const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock);
+
+    cacheMock.mockReturnValueOnce(undefined);
+    cacheMock.mockReturnValueOnce(undefined);
 
     const config = { value: 'this is config' };
     axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: config }));
@@ -83,8 +98,8 @@ describe('ConfigurationService', () => {
   it('can handle no configuration from API', async () => {
     const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock);
 
-    cacheMock.mockReturnValueOnce(null);
-    cacheMock.mockReturnValueOnce(null);
+    cacheMock.mockReturnValueOnce(undefined);
+    cacheMock.mockReturnValueOnce(undefined);
 
     axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: null }));
     const configOptions = { value: 'this is core' };
@@ -105,8 +120,8 @@ describe('ConfigurationService', () => {
     const converter = () => ({ value: 'converted' });
     const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock, false, converter);
 
-    cacheMock.mockReturnValueOnce(null);
-    cacheMock.mockReturnValueOnce(null);
+    cacheMock.mockReturnValueOnce(undefined);
+    cacheMock.mockReturnValueOnce(undefined);
 
     const config = { value: 'this is tenant' };
     axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: config }));
@@ -126,8 +141,8 @@ describe('ConfigurationService', () => {
   it('can use default if null converter provided', async () => {
     const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock, false, null);
 
-    cacheMock.mockReturnValueOnce(null);
-    cacheMock.mockReturnValueOnce(null);
+    cacheMock.mockReturnValueOnce(undefined);
+    cacheMock.mockReturnValueOnce(undefined);
 
     const config = { value: 'this is tenant' };
     axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: config }));
@@ -258,8 +273,8 @@ describe('ConfigurationService', () => {
     it('can retrieve from API on cache miss', async () => {
       const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock, true);
 
-      cacheMock.mockReturnValueOnce(null);
-      cacheMock.mockReturnValueOnce(null);
+      cacheMock.mockReturnValueOnce(undefined);
+      cacheMock.mockReturnValueOnce(undefined);
 
       const config = { value: 'this is config' };
       axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: { configuration: config } }));
@@ -278,8 +293,8 @@ describe('ConfigurationService', () => {
     it('can handle no configuration from API', async () => {
       const service = new ConfigurationServiceImpl(serviceId, logger, directoryMock, tokenProviderMock);
 
-      cacheMock.mockReturnValueOnce(null);
-      cacheMock.mockReturnValueOnce(null);
+      cacheMock.mockReturnValueOnce(undefined);
+      cacheMock.mockReturnValueOnce(undefined);
 
       axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: null }));
       axiosMock.get.mockReturnValueOnce(Promise.resolve({ data: { configuration: null } }));


### PR DESCRIPTION
For transition of configuration, load form definitions from both platform:form-service and form-service namespace.