### PR TITLE
chore(pdf-service): use puppeteer from node_modules

### DIFF
--- a/apps/pdf-service/Dockerfile
+++ b/apps/pdf-service/Dockerfile
@@ -1,24 +1,11 @@
-# TODO: Sort out subscription entitlement for RHEL8 install of Chrome.
-# FROM registry.redhat.io/rhel8/nodejs-16
-
-# USER 0
-
-# SHELL ["/bin/bash", "-c"]
-# RUN echo $'[google-chrome]\n\
-# name=google-chrome\n\
-# baseurl=http://dl.google.com/linux/chrome/rpm/stable/$basearch\n\
-# enabled=1\n\
-# gpgcheck=1\n\
-# gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' > /etc/yum.repos.d/google-chrome.repo
-
-# RUN yum makecache \
-#   && yum install -y google-chrome-stable libXScrnSaver
-# # fipa-gothic-fonts wqy-zenhei-fonts thai-scalable-tlwgtypo-fonts kacst-one-fonts fonts-freefont-ttf
-
 FROM node:20
 
 USER 0
 
+ARG SERVICE
+COPY . .
+
+# Install the chrome for the puppeteer
 RUN apt-get update \
   && apt-get install -y wget gnupg \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -28,24 +15,12 @@ RUN apt-get update \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-# Install the chrome for the puppeteer
-# A chrome binary will be installed at /puppeteer/.cache/puppeteer/chrome.
-# We neeed to set the WORKDIR to run the `npm i` command.
-WORKDIR /usr/app
 # Puppeteer will check the $HOME/.cache for the chome.
 ENV HOME=/puppeteer
-# Puppeteer version shall be compatible with that in the package.json. Shall we add an arg here?
-RUN npm i puppeteer@^22.12.1
-# To avoid the potential OpenShift contianer permission issue.
-RUN chmod 777 -R /puppeteer
+RUN npx puppeteer browsers install chrome
+RUN chmod 777 -R dist node_modules /puppeteer
 
-ARG SERVICE
-
-RUN mkdir .npm
-
-# COPY command shall run after the `npm i` command. Otherwise, the presence of the node_modules folder will prevent the chrome installment.
-COPY . .
-RUN chmod 777 -R dist node_modules .npm
+USER 1001:0
 
 ENV SERVICE ${SERVICE}
 CMD npm run -d service dist/apps/${SERVICE}/main.js

--- a/apps/pdf-service/project.json
+++ b/apps/pdf-service/project.json
@@ -15,7 +15,6 @@
         "webpackConfig": "apps/pdf-service/webpack.config.js",
         "target": "node",
         "compiler": "tsc",
-        "isolatedConfig": true,
         "babelUpwardRootMode": true
       },
       "configurations": {

--- a/apps/pdf-service/src/puppeteer.ts
+++ b/apps/pdf-service/src/puppeteer.ts
@@ -33,6 +33,6 @@ class PuppeteerPdfService implements PdfService {
 }
 
 export async function createPdfService(): Promise<PdfService> {
-  const browser = await puppeteer.launch({ headless: true, args: ['--disable-dev-shm-usage', '--no-sandbox'] });
+  const browser = await puppeteer.launch({ headless: true, args: ['--disable-dev-shm-usage'] });
   return new PuppeteerPdfService(browser);
 }


### PR DESCRIPTION
Removing separate npm install of puppeteer in container build and use the one included in the copied in build output. Also enabling sandbox since that's recommended.