### PR TITLE
fix(configuration-service): removing use of unsupported feature

### DIFF
--- a/apps/configuration-service/src/mongo/repository.ts
+++ b/apps/configuration-service/src/mongo/repository.ts
@@ -201,15 +201,11 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
         $lookup: {
           from: 'revisions',
           as: 'revision',
-          let: { active: '$active' },
+          localField: 'active',
+          foreignField: 'revision',
           pipeline: [
             {
               $match: query,
-            },
-            {
-              $match: {
-                $expr: { $eq: ['$revision', '$$active'] },
-              },
             },
           ],
         },


### PR DESCRIPTION
Removing use of let in pipeline lookup stage since it is not supported in CosmosDb.