### PR TITLE
fix(configuration-service): removing use of aggregation pipeline

### DIFF
--- a/apps/configuration-service/src/mongo/types.ts
+++ b/apps/configuration-service/src/mongo/types.ts
@@ -18,5 +18,3 @@ export interface ActiveRevisionDoc {
 export type RevisionAggregateDoc<C = unknown> = Omit<ConfigurationRevisionDoc<C>, 'namespace' | 'name' | 'tenant'> & {
   _id: Pick<ConfigurationRevisionDoc<C>, 'namespace' | 'name' | 'tenant'>;
 };
-
-export type ActiveAggregateDoc<C = unknown> = ActiveRevisionDoc & { revision: ConfigurationRevisionDoc<C> []};


### PR DESCRIPTION
CosmosDb Mongo API to able to support the subquery needed for a left outer join to revisions. Switching back to two separate requests.