### PR TITLE
fix(tenant-management-webapp): duplicate roles in form definition form definition on save

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
@@ -138,6 +138,14 @@ const isFormUpdated = (prev: FormDefinition, next: FormDefinition): boolean => {
   return isUpdated;
 };
 
+const ensureRolesAreUniqueWithNoDuplicates = (definition: FormDefinition) => {
+  definition.applicantRoles = [...new Set(definition.applicantRoles)];
+  definition.clerkRoles = [...new Set(definition.clerkRoles)];
+  definition.assessorRoles = [...new Set(definition.assessorRoles)];
+
+  return definition;
+};
+
 export const formEditorJsonConfig = {
   'data-testid': 'templateForm-test-input',
   options: {
@@ -176,8 +184,8 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(FetchFileTypeService());
     dispatch(getConfigurationDefinitions());
+    dispatch(FetchFileTypeService());
   }, [dispatch]);
 
   const fileTypes = useSelector((state: RootState) => state.fileService.fileTypes);
@@ -376,17 +384,17 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
           if (type === applicantRoles.name) {
             setDefinition({
               ...definition,
-              applicantRoles: roles,
+              applicantRoles: [...new Set(roles)],
             });
           } else if (type === clerkRoles.name) {
             setDefinition({
               ...definition,
-              clerkRoles: roles,
+              clerkRoles: [...new Set(roles)],
             });
           } else {
             setDefinition({
               ...definition,
-              assessorRoles: roles,
+              assessorRoles: [...new Set(roles)],
             });
           }
         }}
@@ -507,18 +515,32 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
 
   const validateDefinitionRegisters = () => {
     const registers = getDataRegisters(JSON.parse(tempUiSchema), 'urn');
-    const foundRegisters = selectDefinitionRegisters.filter((register) => {
-      return registers.filter((reg) => reg.urn === register.urn);
-    });
+    const registersLength = registers.length;
+    const selectDefinitionRegistersLength = selectDefinitionRegisters.length;
 
-    if (registers.length > 0 || foundRegisters.length === 0) {
-      if (foundRegisters.length === 0) {
+    if (selectDefinitionRegisters.length > 0 && registersLength > 0) {
+      let isValidRegister = false;
+      for (let reg = 0; reg < selectDefinitionRegistersLength; reg++) {
+        for (let registersIndex = 0; registersIndex < registers.length; registersIndex++) {
+          if (selectDefinitionRegisters[reg].urn === registers[registersIndex]) {
+            isValidRegister = true;
+            break;
+          }
+        }
+      }
+      if (!isValidRegister) {
         dispatch(
           ErrorNotification({
             message: 'Data register not available or unauthorized',
           })
         );
       }
+    } else if (selectDefinitionRegistersLength === 0 && registersLength > 0) {
+      dispatch(
+        ErrorNotification({
+          message: 'Data register not available or unauthorized',
+        })
+      );
     }
   };
 
@@ -899,6 +921,7 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
                       validateDefinitionRegisters();
 
                       setCustomIndicator(true);
+
                       if (
                         !doesRoleExistForClientInKeyCloak(FORM_SERVICE_ID.toString(), FORM_APPLICANT_ID, elements) &&
                         isRoleUpdated(
@@ -909,6 +932,8 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
                       ) {
                         definition.applicantRoles.push(FORM_APPLICANT_SERVICE_ID);
                       }
+
+                      ensureRolesAreUniqueWithNoDuplicates(definition);
                       await dispatch(
                         updateFormDefinition({
                           ...definition,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/definitions.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/definitions.tsx
@@ -14,6 +14,7 @@ import { AddEditFormDefinition } from './addEditFormDefinition';
 import { fetchDirectory } from '@store/directory/actions';
 import { SecurityClassification } from '@store/common/models';
 import { LoadMoreWrapper } from './style-components';
+import { getConfigurationDefinitions } from '@store/configuration/action';
 
 interface FormDefinitionsProps {
   openAddDefinition: boolean;
@@ -50,6 +51,7 @@ export const FormDefinitions = ({ openAddDefinition }: FormDefinitionsProps) => 
   }, [openAddDefinition]);
 
   useEffect(() => {
+    dispatch(getConfigurationDefinitions());
     dispatch(getFormDefinitions());
     dispatch(fetchDirectory());
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This was causing errors related to PayloadTooLargeError exception while saving to the configuration service and partially related to the performance to the editor.

Also fix the data register notification from displaying when no data registers were added.