### PR TITLE
feat(form-service): allow anonymous access to definition

### DIFF
--- a/apps/form-service/src/form/model/definition.spec.ts
+++ b/apps/form-service/src/form/model/definition.spec.ts
@@ -111,6 +111,27 @@ describe('FormDefinitionEntity', () => {
       } as User);
       expect(result).toBe(false);
     });
+
+    it('can return true for anonymous apply form', () => {
+      const entity = new FormDefinitionEntity(validationService, tenantId, {
+        id: 'test',
+        name: 'test-form-definition',
+        description: null,
+        formDraftUrlTemplate: 'https://my-form/{{ id }}',
+        anonymousApply: true,
+        applicantRoles: null,
+        assessorRoles: null,
+        clerkRoles: null,
+        dataSchema: null,
+        submissionRecords: false,
+        submissionPdfTemplate: '',
+        supportTopic: false,
+        queueTaskToProcess: {} as QueueTaskToProcess,
+      });
+
+      const result = entity.canAccessDefinition(null);
+      expect(result).toBe(true);
+    });
   });
 
   describe('canApply', () => {

--- a/apps/form-service/src/form/model/definition.ts
+++ b/apps/form-service/src/form/model/definition.ts
@@ -50,12 +50,15 @@ export class FormDefinitionEntity implements FormDefinition {
   }
 
   public canAccessDefinition(user: User): boolean {
-    return isAllowedUser(user, this.tenantId, [
-      FormServiceRoles.Admin,
-      FormServiceRoles.IntakeApp,
-      ...this.applicantRoles,
-      ...this.clerkRoles,
-    ]);
+    return (
+      this.anonymousApply ||
+      isAllowedUser(user, this.tenantId, [
+        FormServiceRoles.Admin,
+        FormServiceRoles.IntakeApp,
+        ...this.applicantRoles,
+        ...this.clerkRoles,
+      ])
+    );
   }
 
   public canApply(user: User): boolean {

--- a/apps/form-service/src/main.ts
+++ b/apps/form-service/src/main.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import { readFile } from 'fs';
 import { promisify } from 'util';
 import * as passport from 'passport';
+import { Strategy as AnonymousStrategy } from 'passport-anonymous';
 import * as compression from 'compression';
 import * as cors from 'cors';
 import * as helmet from 'helmet';
@@ -170,6 +171,7 @@ const initializeApp = async (): Promise<express.Application> => {
 
   passport.use('core', coreStrategy);
   passport.use('tenant', tenantStrategy);
+  passport.use('anonymous', new AnonymousStrategy());
 
   passport.serializeUser(function (user, done) {
     done(null, user);
@@ -185,7 +187,7 @@ const initializeApp = async (): Promise<express.Application> => {
   app.use(
     '/form',
     metricsHandler,
-    passport.authenticate(['core', 'tenant'], { session: false }),
+    passport.authenticate(['core', 'tenant', 'anonymous'], { session: false }),
     tenantHandler,
     configurationHandler
   );


### PR DESCRIPTION
Also, return 410 for definitions endpoint since previous implementation no longer returns correct information.