### PR TITLE
fix(form-service): handle missing definition in save

### DIFF
--- a/apps/form-service/src/form/model/form.spec.ts
+++ b/apps/form-service/src/form/model/form.spec.ts
@@ -462,6 +462,17 @@ describe('FormEntity', () => {
         UnauthorizedUserError
       );
     });
+
+    it('can throw unauthorized user for missing definition', async () => {
+      // Missing definition means that no user will pass authorization check for updating form.
+      const data = {};
+      const files = {};
+      const entity = new FormEntity(repositoryMock, tenantId, null, subscriber, formInfo);
+      await expect(
+        entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, data, files)
+      ).rejects.toThrow(UnauthorizedUserError);
+      expect(repositoryMock.save).not.toHaveBeenCalled();
+    });
   });
 
   describe('lock', () => {
@@ -622,6 +633,19 @@ describe('FormEntity', () => {
           repositoryMock
         )
       ).rejects.toThrow(InvalidOperationError);
+    });
+
+    it('can throw unauthorized user for missing definition', async () => {
+      // Missing definition means that no user will pass authorization check for submitting form.
+      const entity = new FormEntity(repositoryMock, tenantId, null, subscriber, formInfo);
+      await expect(
+        entity.submit(
+          { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
+          queueTaskServiceMock,
+          repositoryMock
+        )
+      ).rejects.toThrow(UnauthorizedUserError);
+      expect(repositoryMock.save).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/form-service/src/form/model/form.ts
+++ b/apps/form-service/src/form/model/form.ts
@@ -264,9 +264,7 @@ export class FormEntity implements Form {
       throw new UnauthorizedUserError('update form', user);
     }
 
-    if (this.data) {
-      this.definition.validateData('form submission', this.data);
-    }
+    this.definition.validateData('form submission', this.data);
 
     this.status = FormStatus.Submitted;
     this.submitted = new Date();

--- a/apps/form-service/src/form/types/form.ts
+++ b/apps/form-service/src/form/types/form.ts
@@ -12,7 +12,7 @@ export enum FormStatus {
 export type SecurityClassificationType = 'protected a' | 'protected b' | 'protected c' | 'public';
 
 export interface Form {
-  definition: FormDefinition;
+  definition?: FormDefinition;
   id: string;
   formDraftUrl: string;
   applicant?: Subscriber;

--- a/apps/form-service/src/main.ts
+++ b/apps/form-service/src/main.ts
@@ -203,9 +203,7 @@ const initializeApp = async (): Promise<express.Application> => {
   const queueTaskService = createQueueTaskService(serviceId, logger, directory, tokenProvider);
   const repositories = await createRepositories({
     ...environment,
-    serviceId,
     logger,
-    tokenProvider,
     configurationService,
     notificationService,
   });

--- a/apps/form-service/src/mongo/form.ts
+++ b/apps/form-service/src/mongo/form.ts
@@ -118,7 +118,7 @@ export class MongoFormRepository implements FormRepository {
       id: entity.id,
       formDraftUrl: entity.formDraftUrl,
       anonymousApplicant: entity.anonymousApplicant,
-      definitionId: entity.definition.id,
+      definitionId: entity.definition?.id,
       // NOTE: This is only set on insert (create).
       // The UUID is necessary due to backwards compatibility with a unique index on tenant, definition, and applicant IDs.
       // Setting form ID makes the unique context effectively tenant, definition, form IDs.

--- a/apps/form-service/src/mongo/index.ts
+++ b/apps/form-service/src/mongo/index.ts
@@ -1,4 +1,4 @@
-import { AdspId, ConfigurationService, TokenProvider } from '@abgov/adsp-service-sdk';
+import { ConfigurationService } from '@abgov/adsp-service-sdk';
 import { connect, connection, ConnectionStates } from 'mongoose';
 import { Logger } from 'winston';
 import { Repositories } from '../form';
@@ -13,9 +13,7 @@ interface MongoRepositoryProps {
   MONGO_USER: string;
   MONGO_PASSWORD: string;
   MONGO_TLS: boolean;
-  serviceId: AdspId;
   logger: Logger;
-  tokenProvider: TokenProvider;
   configurationService: ConfigurationService;
   notificationService: NotificationService;
 }
@@ -26,9 +24,7 @@ export const createRepositories = ({
   MONGO_USER,
   MONGO_PASSWORD,
   MONGO_TLS,
-  serviceId,
   logger,
-  tokenProvider,
   configurationService,
   notificationService,
 }: MongoRepositoryProps): Promise<Repositories> =>
@@ -44,11 +40,7 @@ export const createRepositories = ({
         if (err) {
           reject(err);
         } else {
-          const definitionRepository = new ConfigurationFormDefinitionRepository(
-            serviceId,
-            tokenProvider,
-            configurationService
-          );
+          const definitionRepository = new ConfigurationFormDefinitionRepository(logger, configurationService);
           const formRepository = new MongoFormRepository(definitionRepository, notificationService);
           const formSubmissionRepository = new MongoFormSubmissionRepository(formRepository);
           resolve({

--- a/apps/form-service/src/notification.spec.ts
+++ b/apps/form-service/src/notification.spec.ts
@@ -43,6 +43,7 @@ describe('notification', () => {
     axiosMock.get.mockReset();
     axiosMock.post.mockReset();
     axiosMock.delete.mockReset();
+    axiosMock.isAxiosError.mockReset();
     cacheMock.get.mockReset();
   });
 
@@ -101,6 +102,22 @@ describe('notification', () => {
 
         const result = await service.getSubscriber(tenantId, subscriberId);
         expect(result).toBeNull();
+      });
+
+      it('can return null for subscriber not found', async () => {
+        directoryMock.getResourceUrl.mockResolvedValueOnce(subscriberUrl);
+
+        axiosMock.isAxiosError.mockReturnValueOnce(true);
+        axiosMock.get.mockRejectedValueOnce(new Error('oh noes!'));
+
+        const result = await service.getSubscriber(tenantId, subscriberId);
+        expect(result).toBeNull();
+        expect(axiosMock.get).toHaveBeenCalledWith(
+          subscriberUrl.href,
+          expect.objectContaining({
+            params: expect.objectContaining({ tenantId: tenantId.toString() }),
+          })
+        );
       });
 
       it('can get subscriber from cache', async () => {

--- a/apps/form-service/src/notification.ts
+++ b/apps/form-service/src/notification.ts
@@ -1,6 +1,6 @@
 import { adspId, AdspId, Channel, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
 import { InvalidOperationError } from '@core-services/core-common';
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 import * as NodeCache from 'node-cache';
 import { Logger } from 'winston';
 import { FormDefinition } from './form';
@@ -67,10 +67,17 @@ class NotificationServiceImpl implements NotificationService {
 
       return subscriber;
     } catch (err) {
-      this.logger.error(`Error encountered getting subscriber from notification service. ${err}`, {
-        ...LOG_CONTEXT,
-        tenant: tenantId?.toString(),
-      });
+      if (isAxiosError(err) && err.status === 404) {
+        this.logger.info(`Notification service returned not found for subscriber ${urn}.`, {
+          ...LOG_CONTEXT,
+          tenant: tenantId?.toString(),
+        });
+      } else {
+        this.logger.error(`Error encountered getting subscriber from notification service. ${err}`, {
+          ...LOG_CONTEXT,
+          tenant: tenantId?.toString(),
+        });
+      }
 
       return null;
     }


### PR DESCRIPTION
Improving handling around missing definition, and removing retrieval of definition from old configuration location.