### PR TITLE
feat(adsp-service-sdk): include qualified service client roles

### DIFF
--- a/libs/adsp-service-sdk/src/access/resolveRoles.spec.ts
+++ b/libs/adsp-service-sdk/src/access/resolveRoles.spec.ts
@@ -10,7 +10,14 @@ describe('resolveRoles', () => {
       },
     });
 
-    expect(roles).toEqual(expect.arrayContaining(['realm-role', 'aud-client-role', 'other-service:other-client-role']));
+    expect(roles).toEqual(
+      expect.arrayContaining([
+        'realm-role',
+        'aud-client-role',
+        'test-service:aud-client-role',
+        'other-service:other-client-role',
+      ])
+    );
   });
 
   it('can handle missing realm_access', () => {
@@ -21,7 +28,9 @@ describe('resolveRoles', () => {
       },
     });
 
-    expect(roles).toEqual(expect.arrayContaining(['aud-client-role', 'other-service:other-client-role']));
+    expect(roles).toEqual(
+      expect.arrayContaining(['aud-client-role', 'test-service:aud-client-role', 'other-service:other-client-role'])
+    );
   });
 
   it('can handle missing resource_access', () => {

--- a/libs/adsp-service-sdk/src/access/resolveRoles.ts
+++ b/libs/adsp-service-sdk/src/access/resolveRoles.ts
@@ -4,12 +4,16 @@ interface Token {
 }
 
 export function resolveRoles(aud: string, { realm_access, resource_access }: Token): string[] {
-  return Object.entries(resource_access || {}).reduce(
-    (roles, [client, clientRoles]) => [
-      ...roles,
-      ...((client === aud ? clientRoles?.roles : clientRoles?.roles.map((clientRole) => `${client}:${clientRole}`)) ||
-        []),
-    ],
-    [...(realm_access?.roles || [])]
-  );
+  return Object.entries(resource_access || {}).reduce((roles, [client, clientRoles]) => {
+    // Include client roles of the current service with unqualified names.
+    // These roles are included in both qualified and unqualified forms.
+    if (client === aud) {
+      roles.push(...(clientRoles?.roles || []));
+    }
+
+    // Include all client roles with qualified names.
+    roles.push(...(clientRoles?.roles?.map((clientRole) => `${client}:${clientRole}`) || []));
+
+    return roles;
+  }, realm_access?.roles || []);
 }


### PR DESCRIPTION
Add qualified name for roles of the current service the SDK is initialized against in addition to unqualified name to support cases where a client role of the service is included in configuration. Configuration need to use qualified names for end user configuration experience; otherwise the roles can be ambiguous across different services.