### PR TITLE
feat(data-exchange-standard): add common schema for person objects

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/autoComplete/form.ts
+++ b/apps/tenant-management-webapp/src/app/lib/autoComplete/form.ts
@@ -6,10 +6,10 @@ export class FormCompletionItemProvider implements languages.CompletionItemProvi
   private scopeSuggestions: EditorSuggestion[];
   private refSuggestions: EditorSuggestion[];
   constructor(dataSchema: Record<string, unknown>) {
-    this.scopeSuggestions = this.convertDataSchemaToSuggestion(dataSchema, '#');
+    this.scopeSuggestions = this.convertDataSchemaToSuggestion(true, dataSchema, '#');
     this.refSuggestions = [
-      ...this.convertDataSchemaToSuggestion(standardV1JsonSchema, `${standardV1JsonSchema.$id}#`, 'standard.v1#'),
-      ...this.convertDataSchemaToSuggestion(commonV1JsonSchema, `${commonV1JsonSchema.$id}#`, 'common.v1#'),
+      ...this.convertDataSchemaToSuggestion(false, standardV1JsonSchema, `${standardV1JsonSchema.$id}#`, 'standard.v1#'),
+      ...this.convertDataSchemaToSuggestion(false, commonV1JsonSchema, `${commonV1JsonSchema.$id}#`, 'common.v1#'),
     ];
   }
 
@@ -81,6 +81,7 @@ export class FormCompletionItemProvider implements languages.CompletionItemProvi
   }
 
   private convertDataSchemaToSuggestion(
+    recurse: boolean,
     schema: Record<string, unknown>,
     path: string,
     labelPath?: string
@@ -98,8 +99,9 @@ export class FormCompletionItemProvider implements languages.CompletionItemProvi
         });
 
         // Resolve children if current property is an object.
-        if (typeof schema.properties[property] === 'object') {
+        if (recurse && typeof schema.properties[property] === 'object') {
           const children = this.convertDataSchemaToSuggestion(
+            recurse,
             schema.properties[property],
             currentPath,
             currentLabelPath
@@ -121,8 +123,9 @@ export class FormCompletionItemProvider implements languages.CompletionItemProvi
         });
 
         // Resolve children if current definition is an object.
-        if (typeof schema.definitions[definition] === 'object') {
+        if (recurse && typeof schema.definitions[definition] === 'object') {
           const children = this.convertDataSchemaToSuggestion(
+            recurse,
             schema.definitions[definition],
             currentPath,
             currentLabelPath
@@ -147,7 +150,7 @@ export class FormCompletionItemProvider implements languages.CompletionItemProvi
         // Filter text is used when completion is triggered and there is a partial word.
         // In the json language model, the double quotes are part of the word pattern, so the word of a value is like "#/properties...
         // Include the leading quote so that the filter text will match in case completion is triggered against an existing scope.
-        filterText: '"' + path,
+        filterText: `"${path}/`,
       });
     }
 

--- a/libs/data-exchange-standard/src/common.v1.schema.json
+++ b/libs/data-exchange-standard/src/common.v1.schema.json
@@ -30,7 +30,94 @@
         }
       }
     },
-    "albertaPostalAddress": {
+    "personFullNameAndDob": {
+      "$comment": "Person full name and date of birth.",
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/personName"
+        },
+        "middleName": {
+          "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/personName"
+        },
+        "lastName": {
+          "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/personName"
+        },
+        "dateOfBirth": {
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "required": [
+        "firstName",
+        "lastName",
+        "dateOfBirth"
+      ],
+      "errorMessage": {
+        "properties": {
+          "firstName": "Include period (.) if providing your initial",
+          "middleName": "Include period (.) if providing your initial",
+          "lastName": "Include period (.) if providing your initial"
+        }
+      }
+    },
+    "personDependent": {
+      "$comment": "Dependent of a person of a specific type.",
+      "title": "Dependent",
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/personName"
+        },
+        "middleName": {
+          "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/personName"
+        },
+        "lastName": {
+          "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/personName"
+        },
+        "dateOfBirth": {
+          "type": "string",
+          "format": "date"
+        },
+        "dependentType": {
+          "$ref": "#/definitions/personDependent/definitions/craDependentType"
+        }
+      },
+      "required": [
+        "firstName",
+        "lastName",
+        "dateOfBirth",
+        "dependentType"
+      ],
+      "errorMessage": {
+        "properties": {
+          "firstName": "Include period (.) if providing your initial",
+          "middleName": "Include period (.) if providing your initial",
+          "lastName": "Include period (.) if providing your initial"
+        }
+      },
+      "definitions": {
+        "craDependentType": {
+          "type": "string",
+          "enum": [
+            "Parent or grandparent",
+            "Child, grandchild, brother, or sister under 18 years of age",
+            "Child, grandchild, brother, or sister 18 years of age or older with an impairment in physical or mental functions"
+          ]
+        }
+      }
+    },
+    "personDependents": {
+      "$comment": "Dependents of a person.",
+      "title": "Dependents",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/personDependent"
+      }
+    },
+    "postalAddressAlberta": {
+      "$comment": "Postal address in Alberta.",
+      "title": "Alberta postal address",
       "type": "object",
       "properties": {
         "addressLine1": {
@@ -63,7 +150,9 @@
         }
       }
     },
-    "canadaPostalAddress": {
+    "postalAddressCanada": {
+      "$comment": "Postal address in Canada.",
+      "title": "Canadian postal address",
       "type": "object",
       "properties": {
         "addressLine1": {

--- a/libs/data-exchange-standard/src/standard.v1.schema.json
+++ b/libs/data-exchange-standard/src/standard.v1.schema.json
@@ -7,7 +7,7 @@
     "personName": {
       "$comment": "The name (first, middle, last, preferred, other, etc.) of a person.",
       "type": "string",
-      "pattern": "^\\p{L}[\\p{L}\\p{M}.'\\- ]{0,58}[\\p{L}.']$"
+      "pattern": "^$|^\\p{L}[\\p{L}\\p{M}.'\\- ]{0,58}[\\p{L}.']$"
     },
     "postalAddress": {
       "$comment": "Address line contains the primary address number, predirectional information, street name, suffix, postdirectional information, secondary address identifier and/or secondary address.The address line can contain information for a civic, rural, or postal box address.",
@@ -48,7 +48,7 @@
         "subdivisionCode": {
           "type": "string",
           "$comment": "A three-letter code identifying the applicable province, state, or territory.",
-          "pattern": "^[A-Z]{2,3}$"
+          "pattern": "^$|^[A-Z]{2,3}$"
         },
         "postalCode": {
           "$ref": "https://adsp.alberta.ca/standard.v1.schema.json#/definitions/postalCode"
@@ -96,24 +96,24 @@
           "type": "string",
           "title": "Postal code",
           "description": "A0A 0A0",
-          "pattern": "^[A-Z][0-9][A-Z] [0-9][A-Z][0-9]$"
+          "pattern": "^$|^[A-Z][0-9][A-Z] [0-9][A-Z][0-9]$"
         },
         "usPostalCodeNineDigit": {
           "type": "string",
           "title": "Zip code",
           "description": "00000-0000",
-          "pattern": "^[0-9]{5}-[0-9]{4}$"
+          "pattern": "^$|^[0-9]{5}-[0-9]{4}$"
         },
         "usPostalCodeFiveDigit": {
           "type": "string",
           "title": "Zip code",
           "description": "00000",
-          "pattern": "^[0-9]{5}$"
+          "pattern": "^$|^[0-9]{5}$"
         },
         "internationalPostalCode": {
           "type": "string",
           "title": "Postal code",
-          "pattern": "^[a-zA-Z0-9- ]{0,15}$"
+          "pattern": "^$|^[a-zA-Z0-9- ]{0,15}$"
         }
       }
     }


### PR DESCRIPTION
Also adjusting patterns to allow empty string. Required property validation will cover required fields, and empty string should be allowed for non-required values. Also including only top level definitions in $ref completion suggestions to simplify use of common schemas.