### PR TITLE
fix(form-app): support submit of form without files

### DIFF
--- a/apps/form-app/src/app/state/form.slice.spec.ts
+++ b/apps/form-app/src/app/state/form.slice.spec.ts
@@ -164,8 +164,8 @@ describe('form slice unit tests', () => {
       const definition = formReducer(clonedDefinitionToTest, action);
       expect(definition.definitions.TEST.id).not.toEqual(meta.args);
       expect(definition.form).toBeNull();
-      expect(definition.data).toBeNull();
-      expect(definition.files).toBeNull();
+      expect(Object.getOwnPropertyNames(definition.data)).toEqual(expect.arrayContaining([]));
+      expect(Object.getOwnPropertyNames(definition.files)).toEqual(expect.arrayContaining([]));
     });
 
     it('can return pending for selecting form definition', () => {

--- a/apps/form-app/src/app/state/form.slice.ts
+++ b/apps/form-app/src/app/state/form.slice.ts
@@ -497,8 +497,8 @@ export const formSlice = createSlice({
         if (state.form && state.form.definition.id !== meta.arg) {
           state.userForm = null;
           state.form = null;
-          state.data = null;
-          state.files = null;
+          state.data = {};
+          state.files = {};
           state.saved = null;
         }
       })
@@ -538,8 +538,8 @@ export const formSlice = createSlice({
       .addCase(loadForm.fulfilled, (state, { payload }) => {
         state.busy.loading = false;
         state.form = payload.form;
-        state.data = payload.data;
-        state.files = payload.files;
+        state.data = payload.data || {};
+        state.files = payload.files || {};
         state.saved = payload.digest;
       })
       .addCase(loadForm.rejected, (state) => {
@@ -554,8 +554,8 @@ export const formSlice = createSlice({
         // This isn't very clear, but empty string is indicating no result found.
         state.userForm = payload.form?.id || '';
         state.form = payload.form;
-        state.data = payload.data;
-        state.files = payload.files;
+        state.data = payload.data || {};
+        state.files = payload.files || {};
         state.saved = payload.digest;
       })
       .addCase(findUserForm.rejected, (state) => {


### PR DESCRIPTION
Default data and files values to be empty object consistent with default state.