### PR TITLE
fix(pdf-service): increase allow filename length size

### DIFF
--- a/apps/pdf-service/src/pdf/router/pdf.ts
+++ b/apps/pdf-service/src/pdf/router/pdf.ts
@@ -179,7 +179,7 @@ export function createPdfRouter({
       body('operation').isIn(['generate']),
       body('templateId').isString().isLength({ min: 1, max: 50 }),
       body('data').optional().isObject(),
-      body('filename').isString().isLength({ min: 1, max: 50 }),
+      body('filename').isString().isLength({ min: 1, max: 60 }),
       body('fileType').optional().isString().isLength({ min: 1, max: 50 }),
       body('recordId').optional().isString()
     ),


### PR DESCRIPTION
Increase filename size in situations where the pdf template name can be more than 30 characters and ISO time stamp is 23 characters combined as the file name is more than 50 characters.