### PR TITLE
fix(notification-service): send appropriate event for criteria update

### DIFF
--- a/apps/notification-service/src/notification/model/subscription.spec.ts
+++ b/apps/notification-service/src/notification/model/subscription.spec.ts
@@ -442,8 +442,9 @@ describe('SubscriptionEntity', () => {
       const criteria = {
         correlationId: 'test2',
       };
-      const result = await entity.deleteCriteria(user, criteria);
+      const [result, deletedSubscription] = await entity.deleteCriteria(user, criteria);
       expect(result).toBe(true);
+      expect(deletedSubscription).toBe(false);
       expect(repositoryMock.saveSubscription).toHaveBeenCalledWith(entity);
       expect(entity.criteria).toMatchObject(
         expect.arrayContaining([expect.objectContaining({ context: expect.objectContaining({ test1: 1 }) })])
@@ -466,8 +467,9 @@ describe('SubscriptionEntity', () => {
       const criteria = {
         correlationId: 'test2',
       };
-      const result = await entity.deleteCriteria(user, criteria);
+      const [result, deletedSubscription] = await entity.deleteCriteria(user, criteria);
       expect(result).toBe(true);
+      expect(deletedSubscription).toBe(true);
       expect(repositoryMock.saveSubscription).not.toHaveBeenCalled();
       expect(repositoryMock.deleteSubscriptions).toHaveBeenCalledWith(tenantId, 'test', 'test');
     });
@@ -488,8 +490,9 @@ describe('SubscriptionEntity', () => {
       const criteria = {
         correlationId: 'test',
       };
-      const result = await entity.deleteCriteria(user, criteria);
+      const [result, deletedSubscription] = await entity.deleteCriteria(user, criteria);
       expect(result).toBe(false);
+      expect(deletedSubscription).toBe(false);
       expect(repositoryMock.saveSubscription).not.toHaveBeenCalled();
       expect(repositoryMock.deleteSubscriptions).not.toHaveBeenCalled();
     });

--- a/apps/notification-service/src/notification/model/subscription.ts
+++ b/apps/notification-service/src/notification/model/subscription.ts
@@ -121,7 +121,7 @@ export class SubscriptionEntity implements Subscription {
     return this.repository.saveSubscription(this);
   }
 
-  async deleteCriteria(user: User, toDelete: SubscriptionCriteria): Promise<boolean> {
+  async deleteCriteria(user: User, toDelete: SubscriptionCriteria): Promise<[boolean, boolean]> {
     if (!this.type.canSubscribe(user, this.subscriber)) {
       throw new UnauthorizedUserError('update subscription', user);
     }
@@ -145,15 +145,16 @@ export class SubscriptionEntity implements Subscription {
       }
     });
 
+    let subscriptionDeleted = false;
     if (hasUpdate) {
       if (keep.length === 0) {
         // Delete the subscription entirely if no criteria objects remain.
-        await this.repository.deleteSubscriptions(this.tenantId, this.typeId, this.subscriberId);
+        subscriptionDeleted = await this.repository.deleteSubscriptions(this.tenantId, this.typeId, this.subscriberId);
       } else {
-        await this.updateCriteria(user, keep);
+        this.criteria = (await this.updateCriteria(user, keep)).criteria;
       }
     }
 
-    return hasUpdate;
+    return [hasUpdate, subscriptionDeleted];
   }
 }

--- a/apps/notification-service/src/notification/router/subscription.swagger.yml
+++ b/apps/notification-service/src/notification/router/subscription.swagger.yml
@@ -42,11 +42,11 @@ components:
                 type: object
                 properties:
                   email:
-                    $ref: '#/components/schemas/Template'
+                    $ref: "#/components/schemas/Template"
                   bot:
-                    $ref: '#/components/schemas/Template'
+                    $ref: "#/components/schemas/Template"
                   sms:
-                    $ref: '#/components/schemas/Template'
+                    $ref: "#/components/schemas/Template"
     Subscriber:
       type: object
       properties:
@@ -71,7 +71,7 @@ components:
         subscriptions:
           type: array
           items:
-            $ref: '#/components/schemas/Subscription'
+            $ref: "#/components/schemas/Subscription"
     SubscriptionCriteria:
       type: object
       properties:
@@ -88,13 +88,13 @@ components:
         typeId:
           type: string
         subscriber:
-          $ref: '#/components/schemas/Subscriber'
+          $ref: "#/components/schemas/Subscriber"
         criteria:
           anyOf:
-            - $ref: '#/components/schemas/SubscriptionCriteria'
+            - $ref: "#/components/schemas/SubscriptionCriteria"
             - type: array
               items:
-                $ref: '#/components/schemas/SubscriptionCriteria'
+                $ref: "#/components/schemas/SubscriptionCriteria"
     SendVerifyCodeOperation:
       type: object
       properties:
@@ -115,13 +115,13 @@ components:
         typeId:
           type: string
         subscriber:
-          $ref: '#/components/schemas/Subscriber'
+          $ref: "#/components/schemas/Subscriber"
         criteria:
           anyOf:
-            - $ref: '#/components/schemas/SubscriptionCriteria'
+            - $ref: "#/components/schemas/SubscriptionCriteria"
             - type: array
               items:
-                $ref: '#/components/schemas/SubscriptionCriteria'
+                $ref: "#/components/schemas/SubscriptionCriteria"
     MySubscriberDetails:
       type: object
       properties:
@@ -146,7 +146,7 @@ components:
         subscriptions:
           type: array
           items:
-            $ref: '#/components/schemas/MySubscriberSubscriptions'
+            $ref: "#/components/schemas/MySubscriberSubscriptions"
     CheckCodeOperation:
       type: object
       properties:
@@ -189,7 +189,7 @@ components:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/NotificationType'
+                $ref: "#/components/schemas/NotificationType"
 /subscription/v1/types/{type}:
   get:
     tags:
@@ -208,7 +208,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationType'
+              $ref: "#/components/schemas/NotificationType"
 /subscription/v1/types/{type}/subscriptions:
   parameters:
     - name: type
@@ -256,7 +256,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscription'
+                    $ref: "#/components/schemas/Subscription"
                 page:
                   type: object
                   properties:
@@ -285,7 +285,7 @@ components:
             type: object
             properties:
               criteria:
-                $ref: '#/components/schemas/SubscriptionCriteria'
+                $ref: "#/components/schemas/SubscriptionCriteria"
               id:
                 type: string
               userId:
@@ -309,7 +309,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscription'
+              $ref: "#/components/schemas/Subscription"
 
 /subscription/v1/types/{type}/subscriptions/{subscriber}:
   parameters:
@@ -335,7 +335,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscription'
+              $ref: "#/components/schemas/Subscription"
   post:
     tags:
       - Subscription
@@ -349,10 +349,10 @@ components:
             properties:
               criteria:
                 anyOf:
-                  - $ref: '#/components/schemas/SubscriptionCriteria'
+                  - $ref: "#/components/schemas/SubscriptionCriteria"
                   - type: array
                     items:
-                      $ref: '#/components/schemas/SubscriptionCriteria'
+                      $ref: "#/components/schemas/SubscriptionCriteria"
 
     responses:
       200:
@@ -360,7 +360,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscription'
+              $ref: "#/components/schemas/Subscription"
 
   delete:
     tags:
@@ -396,7 +396,7 @@ components:
       in: query
       required: true
       schema:
-        $ref: '#/components/schemas/SubscriptionCriteria'
+        $ref: "#/components/schemas/SubscriptionCriteria"
 
   delete:
     tags:
@@ -418,6 +418,37 @@ components:
     tags:
       - Subscription
     description: Retrieves subscribers.
+    parameters:
+      - name: top
+        description: Number of results to retrieve.
+        in: query
+        required: false
+        schema:
+          type: number
+      - name: after
+        description: Cursor for page of results to retrieve.
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: email
+        description: Email address of subscriber.
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: sms
+        description: SMS number of subscriber.
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: name
+        description: Name (address as) of subscriber.
+        in: query
+        required: false
+        schema:
+          type: string
     responses:
       200:
         description: Subscribers successfully retrieved.
@@ -429,7 +460,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscriber'
+                    $ref: "#/components/schemas/Subscriber"
                 page:
                   type: object
                   properties:
@@ -482,7 +513,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscriber'
+                    $ref: "#/components/schemas/Subscriber"
                 page:
                   type: object
                   properties:
@@ -517,7 +548,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscriber'
+              $ref: "#/components/schemas/Subscriber"
   patch:
     tags:
       - Subscription
@@ -547,7 +578,7 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Subscriber'
+              $ref: "#/components/schemas/Subscriber"
   post:
     tags:
       - Subscription
@@ -558,15 +589,15 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: '#/components/schemas/SendVerifyCodeOperation'
-              - $ref: '#/components/schemas/VerifyChannelOperation'
-              - $ref: '#/components/schemas/CheckCodeOperation'
+              - $ref: "#/components/schemas/SendVerifyCodeOperation"
+              - $ref: "#/components/schemas/VerifyChannelOperation"
+              - $ref: "#/components/schemas/CheckCodeOperation"
             discriminator:
               propertyName: operation
               mapping:
-                send-code: '#/components/schemas/SendVerifyCodeOperation'
-                check-code: '#/components/schemas/CheckCodeOperation'
-                verify-channel: '#/components/schemas/VerifyChannelOperation'
+                send-code: "#/components/schemas/SendVerifyCodeOperation"
+                check-code: "#/components/schemas/CheckCodeOperation"
+                verify-channel: "#/components/schemas/VerifyChannelOperation"
     responses:
       200:
         description: Subscriber successfully updated.
@@ -632,7 +663,7 @@ components:
                 results:
                   type: array
                   items:
-                    $ref: '#/components/schemas/Subscription'
+                    $ref: "#/components/schemas/Subscription"
                 page:
                   type: object
                   properties:
@@ -661,4 +692,4 @@ components:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MySubscriberDetails'
+              $ref: "#/components/schemas/MySubscriberDetails"


### PR DESCRIPTION
Send a subscription deleted event when the net effect of a criteria removal is unsubscribe. Update the subscription entity criteria in the behaviour so that subscription set event reflects new state of the subscription.