### PR TITLE
fix(status-service): map entities for response

### DIFF
--- a/apps/status-service/src/app/model/index.ts
+++ b/apps/status-service/src/app/model/index.ts
@@ -1,2 +1,3 @@
 export * from './serviceStatus';
 export * from './notice';
+export * from './endpointStatusEntry';

--- a/apps/status-service/src/app/router/serviceStatus.ts
+++ b/apps/status-service/src/app/router/serviceStatus.ts
@@ -7,7 +7,7 @@ import {
 } from '@core-services/core-common';
 import { Router, RequestHandler } from 'express';
 import { Logger } from 'winston';
-import { ApplicationConfiguration } from '../model';
+import { ApplicationConfiguration, EndpointStatusEntryEntity } from '../model';
 import { EndpointStatusEntryRepository } from '../repository/endpointStatusEntry';
 import { ServiceStatusRepository } from '../repository/serviceStatus';
 import { PublicServiceStatusType } from '../types';
@@ -27,6 +27,20 @@ export interface ServiceStatusRouterProps {
   directory: ServiceDirectory;
   serviceId: AdspId;
   configurationService: ConfigurationService;
+}
+
+function mapEndpointStatusEntry(entity: EndpointStatusEntryEntity) {
+  return entity
+    ? {
+        ok: entity.ok,
+        timestamp: entity.timestamp,
+        responseTime: entity.responseTime,
+        status: entity.status,
+        applicationId: entity.applicationId,
+        url: entity.url,
+        appKey: entity.applicationId,
+      }
+    : null;
 }
 
 export const getApplications = (logger: Logger, applicationRepo: ApplicationRepo): RequestHandler => {
@@ -277,15 +291,7 @@ export const getApplicationEntries =
       }
 
       const entries = await endpointStatusEntryRepository.findRecentByUrlAndApplicationId(app.url, app.appKey, top);
-      res.send(
-        entries.map((e) => {
-          return {
-            ...e,
-            url: app.url,
-            appKey: appKey,
-          };
-        })
-      );
+      res.send(entries.map(mapEndpointStatusEntry));
     } catch (err) {
       logger.error(`Failed to get application: ${err.message}`);
       next(err);

--- a/apps/status-service/src/app/router/spec/notice.spec.ts
+++ b/apps/status-service/src/app/router/spec/notice.spec.ts
@@ -119,6 +119,9 @@ describe('Notice service', () => {
     startDate: '2022-04-07T16:00:00.000',
     endDate: '2022-04-07T20:00:00.000Z',
     isAllApplications: true,
+    update: jest.fn((_user, update) => Promise.resolve(update)),
+    delete: jest.fn(),
+    canAccessById: jest.fn(() => true),
   };
 
   const findApplicationsResponseMock = {
@@ -213,7 +216,7 @@ describe('Notice service', () => {
     });
 
     it('Can get notice by id', async () => {
-      noticeRepositoryMock.get.mockResolvedValueOnce(applicationsMock[1]);
+      noticeRepositoryMock.get.mockResolvedValueOnce(statusNoticeMock);
       const handler = getNoticeById(loggerMock, noticeRepositoryMock);
       const reqMock = {
         user: { tenantId, id: 'test', roles: ['status-admin'] },
@@ -227,14 +230,14 @@ describe('Notice service', () => {
       await handler(reqMock, resMock, nextMock);
       expect(resMock.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          _id: applicationsMock[1]._id,
+          message: statusNoticeMock.message,
         })
       );
     });
   });
   describe('Can delete notice', () => {
     it('Can delete notice', async () => {
-      noticeRepositoryMock.get.mockResolvedValueOnce(applicationsMock[1]);
+      noticeRepositoryMock.get.mockResolvedValueOnce(statusNoticeMock);
 
       const handler = deleteNotice(loggerMock, noticeRepositoryMock);
       const reqMock = {
@@ -246,7 +249,7 @@ describe('Notice service', () => {
       await handler(reqMock, resMock, nextMock);
       expect(resMock.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          _id: applicationsMock[1]._id,
+          message: statusNoticeMock.message,
         })
       );
     });
@@ -254,7 +257,7 @@ describe('Notice service', () => {
 
   describe('Can update notice', () => {
     it('Can update notice', async () => {
-      noticeRepositoryMock.get.mockResolvedValueOnce(applicationsMock[1]);
+      noticeRepositoryMock.get.mockResolvedValueOnce(statusNoticeMock);
 
       const handler = updateNotice(loggerMock, eventServiceMock, noticeRepositoryMock);
       const reqMock = {
@@ -269,7 +272,11 @@ describe('Notice service', () => {
       await handler(reqMock, resMock, nextMock);
       expect(resMock.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'updated-app',
+          message: updateNoticePayloadMock.message,
+          tennantServRef: updateNoticePayloadMock.tennantServRef,
+          startDate: updateNoticePayloadMock.startDate,
+          endDate: updateNoticePayloadMock.endDate,
+          isAllApplications: updateNoticePayloadMock.isAllApplications,
         })
       );
     });

--- a/apps/status-service/src/app/router/spec/status.spec.ts
+++ b/apps/status-service/src/app/router/spec/status.spec.ts
@@ -305,7 +305,16 @@ describe('Service router', () => {
       endpointRepositoryMock.findRecentByUrlAndApplicationId.mockResolvedValueOnce([entriesMock[1]]);
       configurationService.getConfiguration.mockResolvedValueOnce(configurationMock);
       await handler(req, resMock, nextMock);
-      expect(resMock.send).toHaveBeenCalledWith(expect.arrayContaining([entriesMock[1]]));
+      expect(resMock.send).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            url: entriesMock[1].url,
+            responseTime: entriesMock[1].responseTime,
+            timestamp: entriesMock[1].timestamp,
+            status: entriesMock[1].status,
+          }),
+        ])
+      );
     });
   });
 


### PR DESCRIPTION
Remove direct use of entity in res.send so serializer isn't processing functions and references.