### PR TITLE
fix(configuration-service): handle edge cases in log entry

### DIFF
--- a/apps/configuration-service/src/configuration/router/configuration.ts
+++ b/apps/configuration-service/src/configuration/router/configuration.ts
@@ -362,7 +362,7 @@ export const getActiveRevision =
 
       if (user) {
         logger.info(
-          `Active revision ${revision || `fallback to latest ${result.revision}`} ` +
+          `Active revision ${typeof revision === 'number' ? revision : `fallback to latest ${result?.revision}`} ` +
             `retrieved by ${user.name} (ID: ${user.id}).`,
           {
             tenant: configuration.tenantId?.toString(),
@@ -372,7 +372,7 @@ export const getActiveRevision =
         );
       } else {
         //If this an anonymous user, just log the tenant as there will be no user context information
-        logger.info(`Active revision ${revision} for ${configuration.tenantId?.toString()}.`, {
+        logger.info(`Active revision ${revision} for ${configuration.tenantId?.toString()} retrieved.`, {
           tenant: configuration.tenantId?.toString(),
           context: 'configuration-router',
         });


### PR DESCRIPTION
Handle: active revision is 0 (falsy value that is valid), and no active and no latest revision.