### PR TITLE
bug fix for CS-3531 Console error deleting disposition states of a form definition.

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
@@ -830,7 +830,8 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
         }
         onDelete={() => {
           const dispositionStates = [...(definition.dispositionStates || [])];
-          delete dispositionStates[selectedDeleteDispositionIndex];
+          // delete dispositionStates[selectedDeleteDispositionIndex];
+          dispositionStates.splice(selectedDeleteDispositionIndex, 1);
           setDefinition({ dispositionStates });
           setSelectedDeleteDispositionIndex(null);
         }}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
@@ -830,7 +830,6 @@ export function AddEditFormDefinitionEditor(): JSX.Element {
         }
         onDelete={() => {
           const dispositionStates = [...(definition.dispositionStates || [])];
-          // delete dispositionStates[selectedDeleteDispositionIndex];
           dispositionStates.splice(selectedDeleteDispositionIndex, 1);
           setDefinition({ dispositionStates });
           setSelectedDeleteDispositionIndex(null);


### PR DESCRIPTION
Removing an item from the array does not automatically update the array's length. The item is removed from the disposition array, but using splice ensures both the array and its length are updated correctly
