### PR TITLE
fix(form-service): use consistent correlationId for event and subscri…

### DIFF
--- a/apps/form-service/src/main.ts
+++ b/apps/form-service/src/main.ts
@@ -196,7 +196,7 @@ const initializeApp = async (): Promise<express.Application> => {
     configurationHandler
   );
 
-  const notificationService = createNotificationService(logger, directory, tokenProvider);
+  const notificationService = createNotificationService(adspId`${serviceId}:v1`, logger, directory, tokenProvider);
   const fileService = createFileService(logger, directory, tokenProvider);
   const commentService = await createCommentService({
     logger,

--- a/apps/form-service/src/notification.spec.ts
+++ b/apps/form-service/src/notification.spec.ts
@@ -10,6 +10,7 @@ jest.mock('axios');
 const axiosMock = axios as jest.Mocked<typeof axios>;
 
 describe('notification', () => {
+  const apiId = adspId`urn:ads:platform:form-service:v1`;
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
   const loggerMock = {
     debug: jest.fn(),
@@ -49,6 +50,7 @@ describe('notification', () => {
 
   it('can create service', () => {
     const service = createNotificationService(
+      apiId,
       loggerMock,
       directoryMock,
       tokenProviderMock,
@@ -59,6 +61,7 @@ describe('notification', () => {
 
   describe('NotificationService', () => {
     const service = createNotificationService(
+      apiId,
       loggerMock,
       directoryMock,
       tokenProviderMock,
@@ -154,6 +157,13 @@ describe('notification', () => {
         const result = await service.subscribe(tenantId, definition, 'form-1', subscriber);
 
         expect(result).toBe(subscriber);
+        expect(axios.post).toHaveBeenCalledWith(
+          'https://notification-service/notification/v1/types/form-status-updates/subscriptions',
+          expect.objectContaining({
+            criteria: expect.objectContaining({ correlationId: `${apiId}:/forms/form-1` }),
+          }),
+          expect.any(Object)
+        );
       });
 
       it('can throw for error', async () => {
@@ -177,6 +187,14 @@ describe('notification', () => {
 
         const deleted = await service.unsubscribe(tenantId, subscriberId, 'test');
         expect(deleted).toBeTruthy();
+        expect(axios.delete).toHaveBeenCalledWith(
+          'https://notification-service/notification/v1/types/form-status-updates/subscriptions/test/criteria',
+          expect.objectContaining({
+            params: expect.objectContaining({
+              criteria: JSON.stringify({ correlationId: `${apiId}:/forms/test` }),
+            }),
+          })
+        );
       });
 
       it('can return false for error', async () => {

--- a/apps/notification-service/src/notification/model/subscription.spec.ts
+++ b/apps/notification-service/src/notification/model/subscription.spec.ts
@@ -141,6 +141,31 @@ describe('SubscriptionEntity', () => {
       expect(send).toBe(true);
     });
 
+    it('can return true for correlation criteria using URN', () => {
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: {
+            correlationId: adspId`urn:ads:platform:form-service:v1:/forms/123`.toString(),
+          },
+          subscriberId: 'test',
+        },
+        type
+      );
+
+      const send = entity.shouldSend({
+        tenantId,
+        name: 'test-started',
+        timestamp: new Date(),
+        correlationId: adspId`urn:ads:platform:form-service:v1:/forms/123`.toString(),
+        payload: {},
+      });
+
+      expect(send).toBe(true);
+    });
+
     it('can return true for array correlation criteria matched', () => {
       const entity = new SubscriptionEntity(
         repositoryMock as unknown as SubscriptionRepository,

--- a/apps/notification-service/src/notification/model/subscription.ts
+++ b/apps/notification-service/src/notification/model/subscription.ts
@@ -38,10 +38,8 @@ export class SubscriptionEntity implements Subscription {
   }
 
   private evaluateCriteria(event: DomainEvent | SubscriptionCriteria, criteria: SubscriptionCriteria): boolean {
-    const eventCorrelationId = event.correlationId?.substring(event.correlationId?.lastIndexOf('/') + 1);
-
     return (
-      (!criteria?.correlationId || criteria.correlationId === eventCorrelationId) &&
+      (!criteria?.correlationId || criteria.correlationId === event.correlationId) &&
       !Object.entries(criteria.context || {}).find(([key, value]) => value !== event.context?.[key])
     );
   }


### PR DESCRIPTION
…ption

Also reverting change in notification service that makes arbitrary change to correlationId for evaluation.