### PR TITLE
chore(directory-service): use event based config invalidation

### DIFF
--- a/apps/form-service/src/form/router/form.ts
+++ b/apps/form-service/src/form/router/form.ts
@@ -422,7 +422,7 @@ export function accessForm(logger: Logger, notificationService: NotificationServ
       end();
       res.send(mapFormData(result));
 
-      logger.info(`Accessed form with ID: ${form.id}) (definition ID: ${form.definition.id}) data.`, {
+      logger.info(`Accessed form with ID: ${form.id} (definition ID: ${form.definition.id}) data.`, {
         context: 'FormRouter',
         tenantId: form.tenantId.toString,
         user: user ? `${user.name} (ID: ${user.id})` : null,


### PR DESCRIPTION
Using long configuration cache TTL since event-driven invalidation is enabled. Also making small correction to form service log entry.