### PR TITLE
fix(notification-service): use proper channel title and subtitle

### DIFF
--- a/apps/notification-service/src/mongo/schema.ts
+++ b/apps/notification-service/src/mongo/schema.ts
@@ -33,10 +33,7 @@ export const subscriberSchema = new Schema({
     required: true,
   },
 });
-subscriberSchema.index(
-  { tenantId: 1, userId: 1 },
-  { unique: true, partialFilterExpression: { userId: { $exists: true } } }
-);
+subscriberSchema.index({ tenantId: 1, userId: 1 });
 
 export const subscriptionSchema = new Schema(
   {
@@ -58,7 +55,7 @@ export const subscriptionSchema = new Schema(
   { _id: false }
 );
 
-subscriptionSchema.index({ tenantId: 1, typeId: 1, subscriberId: 1 }, { unique: true });
+subscriptionSchema.index({ tenantId: 1, typeId: 1, subscriberId: 1 });
 
 export const botSchema = new Schema(
   {
@@ -75,4 +72,4 @@ export const botSchema = new Schema(
   }
 );
 
-botSchema.index({ channelId: 1, tenantId: 1, conversationId: 1 }, { unique: true });
+botSchema.index({ channelId: 1, tenantId: 1, conversationId: 1 });

--- a/apps/notification-service/src/notification/model/type.ts
+++ b/apps/notification-service/src/notification/model/type.ts
@@ -183,8 +183,8 @@ export class NotificationTypeEntity implements NotificationType {
         event,
         subscriber,
         managementUrl: subscriberAppUrl ? new URL(`/${subscriber.id}`, subscriberAppUrl).href : null,
-        title: eventNotification.templates[Channel.email].title ?? '',
-        subtitle: eventNotification.templates[Channel.email].subtitle ?? '',
+        title: eventNotification.templates[channel].title ?? '',
+        subtitle: eventNotification.templates[channel].subtitle ?? '',
       };
 
       return {


### PR DESCRIPTION
Removed hardcoding of title and subtitle to the values configured on the email channel template.