### PR TITLE
chore: adding examples to event payload schemas

### DIFF
--- a/apps/form-service/src/form/events.ts
+++ b/apps/form-service/src/form/events.ts
@@ -17,8 +17,8 @@ export const SUBMISSION_DISPOSITIONED = 'submission-dispositioned';
 const userInfoSchema = {
   type: 'object',
   properties: {
-    id: { type: 'string' },
-    name: { type: 'string' },
+    id: { type: 'string', examples: ['1c0fa56b-f818-4cc7-9254-7513aecb5d9f'] },
+    name: { type: 'string', examples: ['A.N.Other'] },
   },
 };
 
@@ -28,8 +28,8 @@ export const formSchema = {
     definition: {
       type: 'object',
       properties: {
-        id: { type: 'string' },
-        name: { type: 'string' },
+        id: { type: 'string', examples: ['adsp-support-request'] },
+        name: { type: 'string', examples: ['ADSP Support request'] },
       },
     },
     id: { type: 'string' },

--- a/apps/status-service/src/app/events.spec.ts
+++ b/apps/status-service/src/app/events.spec.ts
@@ -1,84 +1,145 @@
 import { AjvValidationService } from '@core-services/core-common';
-import { applicationNoticePublished } from './events';
+import {
+  applicationNoticePublished,
+  ApplicationNoticePublishedDefinition,
+  ApplicationStatusChangedDefinition,
+  HealthCheckHealthyDefinition,
+  HealthCheckStartedDefinition,
+  HealthCheckStoppedDefinition,
+  HealthCheckUnhealthyDefinition,
+  MonitoredServiceDownDefinition,
+  MonitoredServiceUpDefinition,
+} from './events';
 import { Logger } from 'winston';
 import { NoticeApplicationEntity } from './model/notice';
 import { adspId, User } from '@abgov/adsp-service-sdk';
 import { NewOrExisting } from '@core-services/core-common';
 import { NoticeApplication } from './types';
-describe(' application notices published definition', () => {
+
+describe('events', () => {
   const logger: Logger = {
     debug: jest.fn(),
     info: jest.fn(),
     error: jest.fn(),
   } as unknown as Logger;
 
-  const repositoryMock = {
-    get: jest.fn(),
-    find: jest.fn(),
-    save: jest.fn((entity) => Promise.resolve(entity)),
-    delete: jest.fn(),
-  };
-
-  const testNotice: NewOrExisting<NoticeApplication> = {
-    id: '6197eaf24b3a1f0013262c03',
-    message: 'Notice for application notice',
-    tennantServRef: '[{"id":"6148f920213a6f00121531b45","name":"status"}]',
-    startDate: new Date('2021-11-19T17:00:00.000Z'),
-    endDate: new Date('2021-11-19T21:00:00.000Z'),
-    mode: 'published',
-    created: new Date(),
-    tenantId: 'urn:ads:platform:tenant-service:v2:/tenants/6195674753ee940013a53b03',
-    isAllApplications: false,
-    tenantName: 'Test',
-  };
-
-  const noticeWithEmptyTenantServRef: NewOrExisting<NoticeApplication> = {
-    id: '6197eaf24b3a1f0013262c03',
-    message: 'Notice for application notice',
-    tennantServRef: '',
-    startDate: new Date('2021-11-19T17:00:00.000Z'),
-    endDate: new Date('2021-11-19T21:00:00.000Z'),
-    mode: 'published',
-    created: new Date(),
-    tenantId: 'urn:ads:platform:tenant-service:v2:/tenants/6195674753ee940013a53b03',
-    isAllApplications: false,
-    tenantName: 'Test',
-  };
-
-  const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/6195674753ee940013a53b03`;
-  const testUser: User = {
-    id: 'user-2',
-    name: 'testy',
-    email: 'test@testco.org',
-    roles: ['test-admin', 'status-admin'],
-    tenantId,
-    isCore: false,
-    token: null,
-  };
-
-  const emptyApplication = { description: '', id: '', name: '' };
-  it('Validate schema', async () => {
-    const validator = new AjvValidationService(logger);
-    const testEntity = await NoticeApplicationEntity.create(testUser, repositoryMock, testNotice);
-    const testNoticeEntity = await applicationNoticePublished(testEntity, testUser);
-
-    validator.setSchema('application', testNoticeEntity.payload);
-
-    validator.validate('application', 'application', testNoticeEntity);
+  it('health-check-started is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', HealthCheckStartedDefinition.payloadSchema);
   });
 
-  it('Check empty tenantServiceRef', async () => {
-    const testEntity = await NoticeApplicationEntity.create(testUser, repositoryMock, noticeWithEmptyTenantServRef);
-    const testNoticeEntity = await applicationNoticePublished(testEntity, testUser);
-
-    expect(testNoticeEntity.payload.application).toMatchObject(emptyApplication);
+  it('health-check-stopped is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', HealthCheckStoppedDefinition.payloadSchema);
   });
 
-  it('No application object when isAllApplications exist', async () => {
-    testNotice.isAllApplications = true;
-    const testEntity = await NoticeApplicationEntity.create(testUser, repositoryMock, testNotice);
-    const testNoticeEntity = await applicationNoticePublished(testEntity, testUser);
+  it('health-check-healthy is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', HealthCheckHealthyDefinition.payloadSchema);
+  });
 
-    expect(testNoticeEntity.payload.application).toBeUndefined();
+  it('health-check-unhealthy is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', HealthCheckUnhealthyDefinition.payloadSchema);
+  });
+
+  it('application-notice-published is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', ApplicationNoticePublishedDefinition.payloadSchema);
+  });
+
+  it('application-notice-changed is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', ApplicationStatusChangedDefinition.payloadSchema);
+  });
+
+  it('monitored-service-down is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', MonitoredServiceDownDefinition.payloadSchema);
+  });
+
+  it('monitored-service-up is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', MonitoredServiceUpDefinition.payloadSchema);
+  });
+
+  describe(' application notices published definition', () => {
+    const repositoryMock = {
+      get: jest.fn(),
+      find: jest.fn(),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+      delete: jest.fn(),
+    };
+
+    const testNotice: NewOrExisting<NoticeApplication> = {
+      id: '6197eaf24b3a1f0013262c03',
+      message: 'Notice for application notice',
+      tennantServRef: '[{"id":"6148f920213a6f00121531b45","name":"status"}]',
+      startDate: new Date('2021-11-19T17:00:00.000Z'),
+      endDate: new Date('2021-11-19T21:00:00.000Z'),
+      mode: 'published',
+      created: new Date(),
+      tenantId: 'urn:ads:platform:tenant-service:v2:/tenants/6195674753ee940013a53b03',
+      isAllApplications: false,
+      tenantName: 'Test',
+    };
+
+    const noticeWithEmptyTenantServRef: NewOrExisting<NoticeApplication> = {
+      id: '6197eaf24b3a1f0013262c03',
+      message: 'Notice for application notice',
+      tennantServRef: '',
+      startDate: new Date('2021-11-19T17:00:00.000Z'),
+      endDate: new Date('2021-11-19T21:00:00.000Z'),
+      mode: 'published',
+      created: new Date(),
+      tenantId: 'urn:ads:platform:tenant-service:v2:/tenants/6195674753ee940013a53b03',
+      isAllApplications: false,
+      tenantName: 'Test',
+    };
+
+    const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/6195674753ee940013a53b03`;
+    const testUser: User = {
+      id: 'user-2',
+      name: 'testy',
+      email: 'test@testco.org',
+      roles: ['test-admin', 'status-admin'],
+      tenantId,
+      isCore: false,
+      token: null,
+    };
+
+    const emptyApplication = { description: '', id: '', name: '' };
+    it('Validate schema', async () => {
+      const validator = new AjvValidationService(logger);
+      const testEntity = await NoticeApplicationEntity.create(testUser, repositoryMock, testNotice);
+      const testNoticeEntity = await applicationNoticePublished(testEntity, testUser);
+
+      validator.setSchema('application', testNoticeEntity.payload);
+
+      validator.validate('application', 'application', testNoticeEntity);
+    });
+
+    it('Check empty tenantServiceRef', async () => {
+      const testEntity = await NoticeApplicationEntity.create(testUser, repositoryMock, noticeWithEmptyTenantServRef);
+      const testNoticeEntity = await applicationNoticePublished(testEntity, testUser);
+
+      expect(testNoticeEntity.payload.application).toMatchObject(emptyApplication);
+    });
+
+    it('No application object when isAllApplications exist', async () => {
+      testNotice.isAllApplications = true;
+      const testEntity = await NoticeApplicationEntity.create(testUser, repositoryMock, testNotice);
+      const testNoticeEntity = await applicationNoticePublished(testEntity, testUser);
+
+      expect(testNoticeEntity.payload.application).toBeUndefined();
+    });
   });
 });

--- a/apps/status-service/src/app/events.ts
+++ b/apps/status-service/src/app/events.ts
@@ -6,9 +6,12 @@ import { Webhooks } from './model';
 const ApplicationDefinition = {
   type: 'object',
   properties: {
-    id: { type: 'string' },
-    name: { type: ['string', 'null'] },
-    description: { type: ['string', 'null'] },
+    id: { type: 'string', examples: ['status-service'] },
+    name: { type: ['string', 'null'], examples: ['Status service'] },
+    description: {
+      type: ['string', 'null'],
+      examples: ['This service allows for easy monitoring of application downtime.'],
+    },
     url: { type: ['string', 'null'] },
     monitorOnly: { type: ['boolean', 'null'] },
   },
@@ -114,22 +117,25 @@ export const ApplicationNoticePublishedDefinition: DomainEventDefinition = {
         properties: {
           description: {
             type: ['string', 'null'],
+            examples: ['Status service will be taking a maintenance holiday.'],
           },
           startTimestamp: {
             type: 'string',
             format: 'date-time',
+            examples: ['2024-02-05T05:00:00Z'],
           },
           endTimestamp: {
             type: 'string',
             format: 'date-time',
+            examples: ['2024-02-05T07:00:00Z'],
           },
         },
       },
       postedBy: {
         type: 'object',
         properties: {
-          userId: { type: 'string' },
-          userName: { type: 'string' },
+          userId: { type: 'string', examples: ['1c0fa56b-f818-4cc7-9254-7513aecb5d9f'] },
+          userName: { type: 'string', examples: ['A.N.Other'] },
         },
       },
     },

--- a/apps/tenant-management-webapp/src/app/lib/dynamicPlaceHolder.ts
+++ b/apps/tenant-management-webapp/src/app/lib/dynamicPlaceHolder.ts
@@ -2,137 +2,6 @@ import { EventDefinition } from '@store/event/models';
 import jsf from 'json-schema-faker';
 import { faker } from '@faker-js/faker/locale/en_CA';
 
-export const eventObject = {
-  application: {
-    id: '6196e231430bc60012299389',
-    url: 'https://status-app-core-services-dev.os99.gov.ab.ca/autotest',
-    name: 'Status',
-    description: 'application description',
-    newStatus: 'reported-issues',
-    updatedBy: {
-      userId: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-      userName: 'Auto Test',
-    },
-    originalStatus: 'operational',
-  },
-  subscriber: {
-    id: '61d61d3cba517c0013b3a333',
-    userId: 'bb566dfd-19fa-4238-90a7-89eba3ea57be',
-    addressAs: 'auto.test@gov.ab.ca',
-  },
-  type: {
-    id: 'status-application-health-change',
-    name: 'status-application-health-change',
-  },
-  event: {
-    id: '61d61d3cba517c0013b3a333',
-    name: 'application-healthy',
-    namespace: 'status-service',
-    description: 'Event for application',
-    end: '2021-11-19T21:00:00.000Z',
-    start: '2021-11-19T17:00:00.000Z',
-    isPublic: true,
-    isAllDay: true,
-  },
-  form: {
-    definition: {
-      id: 'form-application',
-      name: 'form-application',
-    },
-    id: '61d61d3cba517c0013b3a333',
-    status: 'operational',
-    created: '2021-11-19T21:00:00.000Z',
-    locked: '2021-11-19T21:00:00.000Z',
-    submitted: '2021-11-19T21:00:00.000Z',
-    lastAccessed: '2021-11-19T21:00:00.000Z',
-    supportEmail: 'auto.test@gov.ab.ca',
-    deleteOn: '2021-11-19T21:00:00.000Z',
-  },
-
-  message: {
-    body: '<!doctype html>\n<html>\n  <head>\n  </head>\n  <body>\n    <p>The healthcheck for File-service has succeeded multiple times</p>\n    <p>\n      File-service is available at <a href="https://file-service-core-services-dev.os99.gov.ab.ca">https://file-service-core-services-dev.os99.gov.ab.ca</a>\n    </p>\n  </body>\n</html>',
-    subject: 'File-service is healthy',
-  },
-  error: 'The application File-service with id 6196e1bd430bc6001229934d becomes unhealthy.',
-  updatedBy: {
-    id: 'bb566dfd-19fa-4238-90a7-89eba3ea57be',
-    name: 'auto.test@gov.ab.ca',
-  },
-  notice: {
-    description: 'Notice for application notice',
-    endTimestamp: '2021-11-19T21:00:00.000Z',
-    startTimestamp: '2021-11-19T17:00:00.000Z',
-  },
-  postedBy: {
-    userId: 'bb566dfd-19fa-4238-90a7-89eba3ea57be',
-    name: 'auto.test@gov.ab.ca',
-  },
-  file: {
-    id: '054aa569-79fa-4344-a7ef-ca83f84e5e97',
-    size: 16,
-    created: '2021-10-14T17:04:15.787Z',
-    filename: 'autotest-new.txt',
-    recordId: 'autotest-recordid-new',
-    createdBy: {
-      id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-      name: 'Auto Test',
-    },
-    lastAccessed: null,
-  },
-  deletedBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  writtenBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  uploadedBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  createdBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  lockedBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  unLockedBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  submittedBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  task: {
-    id: 'bb566dfd-19fa-4238-90a7-89eba3ea57be',
-    name: 'auto.test@gov.ab.ca',
-    description: 'Task for application task',
-  },
-  completedBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-  cancelledBy: {
-    id: '71e5fe2c-1f74-4b90-9b7c-3376ec75844d',
-    name: 'Auto Test',
-  },
-
-  calendar: {
-    name: 'calendar',
-    description: 'application description',
-    displayName: 'calendar displayName',
-  },
-  attendee: {
-    id: 'bb566dfd-19fa-4238-90a7-89eba3ea57be',
-    name: 'auto.test',
-    email: 'auto.test@gov.ab.ca',
-  },
-};
-
 export const dynamicGeneratePayload = (
   tenant: { name: string; realm: string },
   eventDef: EventDefinition,
@@ -145,6 +14,8 @@ export const dynamicGeneratePayload = (
     optionalsProbability: 1,
     maxItems: 3,
     fixedProbabilities: true,
+    useDefaultValue: true,
+    useExamplesValue: true,
   });
   let payload = {};
   const payloadSchema = eventDef?.payloadSchema;


### PR DESCRIPTION
Enabling use of examples in json schema faker to support configuration of notification templates.