### PR TITLE
fix(calendar-service): correct criteria value for activeOn filter

### DIFF
--- a/apps/calendar-service/src/calendar/router/calendar.ts
+++ b/apps/calendar-service/src/calendar/router/calendar.ts
@@ -383,8 +383,8 @@ export const createCalendarRouter = ({
         description: { optional: true, isString: true },
         isPublic: { optional: true, isBoolean: true },
         isAllDay: { optional: true, isBoolean: true },
-        recordId: { optional: true, isString: true },
-        context: { optional: true, isObject: true },
+        recordId: { optional: { options: { nullable: true } }, isString: true },
+        context: { optional: { options: { nullable: true } }, isObject: true },
       },
       ['body']
     )

--- a/apps/calendar-service/src/postgres/calendar.ts
+++ b/apps/calendar-service/src/postgres/calendar.ts
@@ -165,8 +165,8 @@ export class PostgresCalendarRepository implements CalendarRepository {
 
       if (criteria.activeOn) {
         // Where date and time is between start and end.
-        const activeOnDate = toDateId(criteria.endsBefore);
-        const activeOnTime = toTimeId(criteria.endsBefore);
+        const activeOnDate = toDateId(criteria.activeOn);
+        const activeOnTime = toTimeId(criteria.activeOn);
 
         query = query.andWhere((query) =>
           query


### PR DESCRIPTION
Also making validation forgiving of null for recordId and context.