### PR TITLE
Update addEditFormDefinitionEditor.tsx

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.spec.tsx
@@ -148,7 +148,7 @@ describe('Test AddEditFormDefinitionEditor', () => {
       name: 'new pending',
       description: 'new pending data state',
     };
-    const currentIndex = definition.dispositionStates.findIndex((y) => (y.id = updateDispositionState.id));
+    const currentIndex = definition.dispositionStates.findIndex((y) => (y.id === updateDispositionState.id));
     const [updatedDefinition, index] = onSaveDispositionForModal(
       false,
       updateDispositionState,
@@ -176,7 +176,7 @@ describe('Test AddEditFormDefinitionEditor', () => {
     );
     const updatedIndex = updatedDefinition.dispositionStates.findIndex((y) => y.name === updateDispositionState1.name);
 
-    expect(updatedDefinition && updatedIndex < 0).toBe(true);
+    expect(updatedIndex).toBeGreaterThan(-1);
     expect(index).toBeNull();
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/addEditFormDefinitionEditor.tsx
@@ -96,21 +96,22 @@ export const formEditorJsonConfig = {
 };
 
 export const onSaveDispositionForModal = (
-  isNewDisposition: boolean,
+  newDisposition: boolean,
   currentDisposition: Disposition,
   definition: FormDefinition,
-  selectedEditModalIndex: number | null
+  selectedEditModalIndex: number | null,
 ): [FormDefinition, number | null] => {
-  if (isNewDisposition) {
-    const currentDispositionStates = [...definition.dispositionStates] || [];
+  const currentDispositionStates = [...definition.dispositionStates] || [];
+  if (newDisposition) {
     if (currentDisposition) {
       currentDispositionStates.push(currentDisposition);
       definition.dispositionStates = currentDispositionStates;
     }
-  } else {
-    definition.dispositionStates[selectedEditModalIndex] = currentDisposition;
+  }else{
+    currentDispositionStates.splice(selectedEditModalIndex,1);
+    currentDispositionStates.push(currentDisposition);
+    definition.dispositionStates = currentDispositionStates;
   }
-
   return [definition, null];
 };
 


### PR DESCRIPTION
Fix CS-3551-Save button isn't enabled when disposition state is changed

- Adjusted the logic for updating disposition states when saving a new or existing disposition.
- This change ensures proper handling for both adding new and updating existing disposition states.