### PR TITLE
chore: add job for deployment approval

### DIFF
--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -150,9 +150,17 @@ jobs:
           cy-password-2: ${{ secrets.CY_PASSWORD2 }}
           cy-password-3: ${{ secrets.CY_PASSWORD3 }}
 
-  deployStaging:
+  deployStagingApproval:
     runs-on: ubuntu-22.04
     needs: [build, devSmokeTest]
+    environment:
+      name: Staging-gate
+    steps:
+      - run: echo "Staging deployment approved"
+
+  deployStaging:
+    runs-on: ubuntu-22.04
+    needs: [build, deployStagingApproval]
     strategy:
       fail-fast: true
       max-parallel: 2

--- a/apps/file-service/src/scan/clam.ts
+++ b/apps/file-service/src/scan/clam.ts
@@ -12,6 +12,7 @@ interface ClamScan {
   }>;
 }
 
+const CLAM_FILE_MAX_SIZE = 500 * 1e6;
 export const createClamScan = ({ host, port }: ScanProps): ScanService => {
   const user = { id: 'clam-scan-service', isCore: true, roles: [ServiceUserRoles.Admin] } as User;
 
@@ -26,6 +27,10 @@ export const createClamScan = ({ host, port }: ScanProps): ScanService => {
 
   const service: ScanService = {
     scan: async (file: FileEntity) => {
+      if (file.size > CLAM_FILE_MAX_SIZE) {
+        throw new Error(`File of size ${file.size / 1000}kb is too large for clam scan.`);
+      }
+
       const clamscan = await scanPromise;
       const stream = await file.readFile(user);
       const scan = await clamscan.scanStream(stream);

--- a/apps/notification-service/src/notification/router/subscription.swagger.yml
+++ b/apps/notification-service/src/notification/router/subscription.swagger.yml
@@ -238,25 +238,29 @@ components:
         description: Criteria for the subscriber of the subscription.
         in: query
         required: false
-        schema:
-          type: object
-          properties:
-            name:
-              type: string
-            email:
-              type: string
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
       - name: subscriptionMatch
         description: Criteria for the subscription criteria.
         in: query
         required: false
-        schema:
-          type: object
-          properties:
-            correlationId:
-              type: string
-            context:
+        content:
+          application/json:
+            schema:
               type: object
-              additionalProperties: true
+              properties:
+                correlationId:
+                  type: string
+                context:
+                  type: object
+                  additionalProperties: true
     responses:
       200:
         description: Subscriptions successfully retrieved.


### PR DESCRIPTION
Add a gate stage in the pipeline to support deployment approval to work around matrix strategy requiring multiple approvals. Also making some adjustments to notification API documentation.