### PR TITLE
chore(value-service): handle configuration error and write

### DIFF
--- a/apps/value-service/src/values/router/value.ts
+++ b/apps/value-service/src/values/router/value.ts
@@ -263,7 +263,21 @@ export function writeValue(logger: Logger, eventService: EventService, repositor
         user: `${user.name} (ID: ${user.id})`,
       });
 
-      const [namespaces] = await req.getConfiguration<Record<string, NamespaceEntity>>(tenantId);
+      let namespaces: Record<string, NamespaceEntity>;
+      try {
+        [namespaces] = await req.getConfiguration<Record<string, NamespaceEntity>>(tenantId);
+      } catch (err) {
+        // Catch and log error on configuration retrieval.
+        // The value service is biased to writing the value even if the definition retrieval fails.
+        logger.warn(
+          `Error encountered retrieving value configuration; value will be written without definition: ${err}`,
+          {
+            context: 'value-router',
+            tenantId: tenantId?.toString(),
+            user: `${user.name} (ID: ${user.id})`,
+          }
+        );
+      }
 
       const results = [];
       const valuesToWrite = Array.isArray(req.body) ? req.body : [req.body];


### PR DESCRIPTION
Value service is biased to writing a value even if configuration cannot be retrieved. This means that definition schema is a best effort.