### PR TITLE
feat(directory-service): handle missing resource in resolve

### DIFF
--- a/apps/directory-service/src/directory/events.spec.ts
+++ b/apps/directory-service/src/directory/events.spec.ts
@@ -5,6 +5,7 @@ import {
   EntryDeletedDefinition,
   TaggedResourceDefinition,
   UntaggedResourceDefinition,
+  ResourceResolutionFailedDefinition,
 } from './events';
 
 describe('events', () => {
@@ -37,5 +38,11 @@ describe('events', () => {
     const service = new AjvValidationService(logger as unknown as Logger);
     service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
     service.validate('test', 'payload', UntaggedResourceDefinition.payloadSchema);
+  });
+
+  it('resource-resolution-failed is valid json schema', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('payload', { $ref: 'http://json-schema.org/draft-07/schema#' });
+    service.validate('test', 'payload', ResourceResolutionFailedDefinition.payloadSchema);
   });
 });

--- a/apps/directory-service/src/directory/events.ts
+++ b/apps/directory-service/src/directory/events.ts
@@ -1,6 +1,5 @@
 import type { DomainEvent, DomainEventDefinition, User, Stream } from '@abgov/adsp-service-sdk';
 import { Resource, Tag } from './types';
-import { ResourceType } from './model';
 
 const ENTRY_UPDATED = 'entry-updated';
 const ENTRY_DELETED = 'entry-deleted';

--- a/apps/directory-service/src/directory/events.ts
+++ b/apps/directory-service/src/directory/events.ts
@@ -1,10 +1,12 @@
 import type { DomainEvent, DomainEventDefinition, User, Stream } from '@abgov/adsp-service-sdk';
 import { Resource, Tag } from './types';
+import { ResourceType } from './model';
 
 const ENTRY_UPDATED = 'entry-updated';
 const ENTRY_DELETED = 'entry-deleted';
 export const TAGGED_RESOURCE = 'tagged-resource';
 const UNTAGGED_RESOURCE = 'untagged-resource';
+const RESOURCE_RESOLUTION_FAILED = 'resource-resolution-failed';
 
 export const EntryUpdatedDefinition: DomainEventDefinition = {
   name: ENTRY_UPDATED,
@@ -131,6 +133,24 @@ export const UntaggedResourceDefinition: DomainEventDefinition = {
   },
 };
 
+export const ResourceResolutionFailedDefinition: DomainEventDefinition = {
+  name: RESOURCE_RESOLUTION_FAILED,
+  description: 'Signalled when a resource associated with a resource type could not be resolved.',
+  payloadSchema: {
+    type: 'object',
+    properties: {
+      resource: {
+        type: 'object',
+        properties: {
+          urn: { type: 'string' },
+        },
+      },
+      type: { type: ['string', 'null'] },
+      error: { type: 'string' },
+    },
+  },
+};
+
 export const entryUpdated = (
   updatedBy: User,
   namespace: string,
@@ -233,6 +253,24 @@ export const untaggedResource = (resource: Resource, tag: Tag, updatedBy: User):
       id: updatedBy.id,
       name: updatedBy.name,
     },
+  },
+});
+
+export const resourceResolutionFailed = (resource: Resource, type: string, error: string): DomainEvent => ({
+  name: RESOURCE_RESOLUTION_FAILED,
+  timestamp: new Date(),
+  tenantId: resource.tenantId,
+  correlationId: type,
+  context: {
+    resources: resource.urn.toString(),
+    type,
+  },
+  payload: {
+    resource: {
+      urn: resource.urn.toString(),
+    },
+    type,
+    error,
   },
 });
 

--- a/apps/directory-service/src/directory/index.ts
+++ b/apps/directory-service/src/directory/index.ts
@@ -58,7 +58,7 @@ export const applyDirectoryMiddleware = (
   app.use('/directory/v2', directoryRouter);
   app.use('/resource/v1', assertAuthenticatedHandler, resourceRouter);
 
-  createDirectoryJobs({ serviceId, logger, configurationService, queueService });
+  createDirectoryJobs({ serviceId, logger, configurationService, eventService, queueService });
 
   return app;
 };

--- a/apps/directory-service/src/directory/job/resolve.ts
+++ b/apps/directory-service/src/directory/job/resolve.ts
@@ -23,11 +23,20 @@ export function createResolveJob({ logger, configurationService }: ResolveJobPro
         });
 
         const result = await type.resolve({ tenantId, urn });
-
-        logger.info(`Resolved resource ${urn} to name '${result.name}' and description '${result.description}'.`, {
-          context: 'ResolveJob',
-          tenant: tenantId.toString(),
-        });
+        if (result) {
+          logger.info(`Resolved resource ${urn} to name '${result.name}' and description '${result.description}'.`, {
+            context: 'ResolveJob',
+            tenant: tenantId.toString(),
+          });
+        } else {
+          logger.info(
+            `Resource ${urn} could not be found on associated API during resolve and was deleted for consistency.`,
+            {
+              context: 'ResolveJob',
+              tenant: tenantId.toString(),
+            }
+          );
+        }
       } else {
         logger.info(`Resource ${urn} did not match any type and will not be resolved.`, {
           context: 'ResolveJob',

--- a/apps/directory-service/src/main.ts
+++ b/apps/directory-service/src/main.ts
@@ -24,6 +24,7 @@ import {
   EntryUpdatesStream,
   TaggedResourceDefinition,
   UntaggedResourceDefinition,
+  ResourceResolutionFailedDefinition,
 } from './directory';
 import { createDirectoryQueueService } from './amqp';
 
@@ -89,7 +90,13 @@ const initializeApp = async (): Promise<express.Application> => {
           description: 'Resource resolver used by the directory. Resource APIs should give read access to the role.',
         },
       ],
-      events: [EntryUpdatedDefinition, EntryDeletedDefinition, TaggedResourceDefinition, UntaggedResourceDefinition],
+      events: [
+        EntryUpdatedDefinition,
+        EntryDeletedDefinition,
+        TaggedResourceDefinition,
+        UntaggedResourceDefinition,
+        ResourceResolutionFailedDefinition,
+      ],
       configuration: {
         description: 'Resource types for resolving browse name and description for tagged resources.',
         schema: configurationSchema,


### PR DESCRIPTION
If resolve encounters a missing resource, then delete it for consistency. Note that the directory resource API does not check if an API resource exists, but the resolve job will delete it after for eventual consistency if an associate type exists.