### PR TITLE
chore(content-service): use recreate strategy

### DIFF
--- a/.openshift/managed/content-service.yml
+++ b/.openshift/managed/content-service.yml
@@ -152,10 +152,11 @@ objects:
           securityContext: {}
           terminationGracePeriodSeconds: 30
       strategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 25%
-          maxSurge: 25%
+        type: Recreate
+        # type: RollingUpdate
+        # rollingUpdate:
+        #   maxUnavailable: 25%
+        #   maxSurge: 25%
       revisionHistoryLimit: 10
       progressDeadlineSeconds: 600
 

--- a/.openshift/managed/content-service.yml
+++ b/.openshift/managed/content-service.yml
@@ -104,6 +104,8 @@ objects:
               env:
                 - name: PORT
                   value: "3333"
+                - name: DATABASE_FILENAME
+                  value: /opt/app-root/data/data.db
               imagePullPolicy: IfNotPresent
               name: content-service
               ports:
@@ -120,8 +122,8 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /opt/app-root/src/apps/content-service/.tmp
-                  name: content-service-data
+                - name: content-service-data
+                  mountPath: /opt/app-root/data
               # readinessProbe:
               #   httpGet:
               #     path: /

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,8 +71,10 @@
     "recaptcha",
     "reduxjs",
     "signin",
+    "strapi",
     "testid",
     "traceparent",
+    "uischema",
     "uninstantiated",
     "upsert",
     "uuidv"


### PR DESCRIPTION
This is needed while we're using RWO persistent volume for sql lite database.