### PR TITLE
fix(form-service): save classification to form and submission

### DIFF
--- a/apps/form-service/src/form/events.ts
+++ b/apps/form-service/src/form/events.ts
@@ -341,20 +341,16 @@ export function formArchived(apiId: AdspId, user: User, form: FormEntity): Domai
   };
 }
 
-export function submissionDispositioned(
-  apiId: AdspId,
-  user: User,
-  form: FormEntity,
-  submission: FormSubmissionEntity
-): DomainEvent {
-  const formResponse = mapForm(apiId, form);
+export function submissionDispositioned(apiId: AdspId, user: User, submission: FormSubmissionEntity): DomainEvent {
+  const form = submission.form;
+  const formResponse = form ? mapForm(apiId, form) : null;
   return {
     name: SUBMISSION_DISPOSITIONED,
     timestamp: new Date(),
-    tenantId: form.tenantId,
+    tenantId: submission.tenantId,
     correlationId: getCorrelationId(formResponse),
     context: {
-      definitionId: form.definition.id,
+      definitionId: submission.definition?.id,
     },
     payload: {
       form: formResponse,

--- a/apps/form-service/src/form/model/form.ts
+++ b/apps/form-service/src/form/model/form.ts
@@ -31,7 +31,7 @@ export class FormEntity implements Form {
   status: FormStatus;
   data: Record<string, unknown>;
   files: Record<string, AdspId>;
-  securityClassification?: SecurityClassificationType;
+  securityClassification: SecurityClassificationType;
 
   static async create(
     user: User,
@@ -57,7 +57,7 @@ export class FormEntity implements Form {
       status: FormStatus.Draft,
       data: {},
       files: {},
-      securityClassification: definition?.securityClassification,
+      securityClassification: definition.securityClassification,
     });
 
     return await repository.save(form);
@@ -84,7 +84,8 @@ export class FormEntity implements Form {
     this.status = form.status;
     this.data = form.data || {};
     this.files = form.files || {};
-    this.securityClassification = form?.securityClassification;
+    // This is for backwards compatibility, but security classification should be saved against the form.
+    this.securityClassification = form.securityClassification || definition?.securityClassification;
   }
 
   /**

--- a/apps/form-service/src/form/model/formSubmission.spec.ts
+++ b/apps/form-service/src/form/model/formSubmission.spec.ts
@@ -105,7 +105,7 @@ describe('FormSubmission', () => {
     const entity = new FormSubmissionEntity(formSubmissionMock, tenantId, formSubmissionInfo);
 
     repositoryMock.save.mockResolvedValueOnce(entity);
-    FormSubmissionEntity.create(user, repositoryMock, {} as FormEntity, '21');
+    FormSubmissionEntity.create(user, repositoryMock, { definition: aDefinition } as FormEntity, '21');
 
     expect(repositoryMock.save).toBeCalled();
   });
@@ -141,7 +141,7 @@ describe('FormSubmission', () => {
 
   it('form submission can update disposition', async () => {
     const before = new Date();
-    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, {
+    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, aDefinition, {
       id: '242',
       definition: aDefinition,
     } as FormEntity);
@@ -156,7 +156,7 @@ describe('FormSubmission', () => {
   });
 
   it('form submission cannot update disposition - invalid status', async () => {
-    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, {
+    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, aDefinition, {
       id: '242',
       definition: aDefinition,
     } as FormEntity);
@@ -168,7 +168,7 @@ describe('FormSubmission', () => {
   });
 
   it('form submission cannot update disposition - unauthorized', async () => {
-    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, {
+    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, aDefinition, {
       id: 'fds435',
       definition: aDefinition,
     } as FormEntity);
@@ -180,7 +180,7 @@ describe('FormSubmission', () => {
   });
 
   it('can read definition is empty', async () => {
-    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, {
+    const entity = new FormSubmissionEntity(repositoryMock, tenantId, formSubmissionInfo, aDefinition, {
       id: 'fds435',
       definition: null,
     } as FormEntity);

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -211,7 +211,13 @@ describe('form router', () => {
     formInfo
   );
 
-  const formSubmissionEntity = new FormSubmissionEntity(formSubmissionMock, tenantId, formSubmissionInfo, entity);
+  const formSubmissionEntity = new FormSubmissionEntity(
+    formSubmissionMock,
+    tenantId,
+    formSubmissionInfo,
+    definition,
+    entity
+  );
 
   beforeEach(() => {
     axiosMock.get.mockClear();
@@ -1731,7 +1737,13 @@ describe('form router', () => {
 
       req.getServiceConfiguration.mockResolvedValueOnce([definition]);
 
-      const formSubmissionEntity = new FormSubmissionEntity(formSubmissionMock, tenantId, formSubmissionInfo, entity);
+      const formSubmissionEntity = new FormSubmissionEntity(
+        formSubmissionMock,
+        tenantId,
+        formSubmissionInfo,
+        definition,
+        entity
+      );
       formSubmissionMock.find.mockResolvedValueOnce({ results: [formSubmissionEntity], page });
 
       const handler = findSubmissions(apiId, formSubmissionMock);
@@ -1770,7 +1782,13 @@ describe('form router', () => {
 
       req.getServiceConfiguration.mockResolvedValueOnce([definition]);
 
-      const formSubmissionEntity = new FormSubmissionEntity(formSubmissionMock, tenantId, formSubmissionInfo, entity);
+      const formSubmissionEntity = new FormSubmissionEntity(
+        formSubmissionMock,
+        tenantId,
+        formSubmissionInfo,
+        definition,
+        entity
+      );
       formSubmissionMock.find.mockResolvedValueOnce({ results: [formSubmissionEntity], page });
 
       const handler = findSubmissions(apiId, formSubmissionMock);
@@ -1911,7 +1929,13 @@ describe('form router', () => {
       const res = { send: jest.fn() };
       const next = jest.fn();
 
-      const formSubmissionEntity = new FormSubmissionEntity(formSubmissionMock, tenantId, formSubmissionInfo, entity);
+      const formSubmissionEntity = new FormSubmissionEntity(
+        formSubmissionMock,
+        tenantId,
+        formSubmissionInfo,
+        definition,
+        entity
+      );
 
       repositoryMock.get.mockResolvedValueOnce(null);
 

--- a/apps/form-service/src/form/router/form.ts
+++ b/apps/form-service/src/form/router/form.ts
@@ -79,7 +79,7 @@ export function mapFormSubmissionData(apiId: AdspId, entity: FormSubmissionEntit
     formFiles: Object.entries(entity.formFiles || {}).reduce((f, [k, v]) => ({ ...f, [k]: v?.toString() }), {}),
     created: entity.created,
     createdBy: { id: entity.createdBy.id, name: entity.createdBy.name },
-    securityClassification: entity?.securityClassification,
+    securityClassification: entity.securityClassification,
     disposition: entity.disposition
       ? {
           id: entity.disposition.id,
@@ -503,7 +503,7 @@ export function updateFormSubmissionDisposition(
       end();
 
       res.send(mapFormSubmissionData(apiId, updated));
-      eventService.send(submissionDispositioned(apiId, user, updated.form, updated));
+      eventService.send(submissionDispositioned(apiId, user, updated));
 
       logger.info(
         `Updated disposition of form submission with ID: ${submissionId} (form ID: ${formId}) to '${dispositionStatus}'.`,

--- a/apps/form-service/src/mongo/form.ts
+++ b/apps/form-service/src/mongo/form.ts
@@ -168,7 +168,7 @@ export class MongoFormRepository implements FormRepository {
         submitted: doc.submitted,
         lastAccessed: doc.lastAccessed,
         data: doc.data,
-        securityClassification: definition?.securityClassification,
+        securityClassification: doc.securityClassification,
         files: Object.entries(doc.files).reduce((fs, [key, f]) => ({ ...fs, [key]: f ? AdspId.parse(f) : null }), {}),
       },
       doc.hash

--- a/apps/form-service/src/mongo/index.ts
+++ b/apps/form-service/src/mongo/index.ts
@@ -43,7 +43,7 @@ export const createRepositories = ({
         } else {
           const definitionRepository = new ConfigurationFormDefinitionRepository(logger, configurationService);
           const formRepository = new MongoFormRepository(logger, definitionRepository, notificationService);
-          const formSubmissionRepository = new MongoFormSubmissionRepository(logger, formRepository);
+          const formSubmissionRepository = new MongoFormSubmissionRepository(logger, definitionRepository, formRepository);
           resolve({
             formRepository,
             formSubmissionRepository,

--- a/apps/form-service/src/mongo/schema.ts
+++ b/apps/form-service/src/mongo/schema.ts
@@ -15,6 +15,9 @@ export const formSchema = new Schema(
       type: String,
       required: true,
     },
+    securityClassification: {
+      type: String,
+    },
     formDraftUrl: {
       type: String,
     },
@@ -22,6 +25,7 @@ export const formSchema = new Schema(
       type: Boolean,
       default: false,
     },
+
     applicantId: {
       type: String,
       required: true,
@@ -145,6 +149,9 @@ export const formSubmissionSchema = new Schema(
     submissionStatus: {
       type: String,
       required: false,
+    },
+    securityClassification: {
+      type: String,
     },
     disposition: { type: formDeposition, required: false },
     hash: String,


### PR DESCRIPTION
Security classification applies to the specific data in the form or submission record and shouldn't change indirectly via configuration update. Also, update submission repo to load definitions directly since associated forms can be deleted.