### PR TITLE
feat(form-app): remove default idp hint

### DIFF
--- a/apps/form-app/src/app/state/user.slice.ts
+++ b/apps/form-app/src/app/state/user.slice.ts
@@ -154,7 +154,6 @@ export const loginUser = createAsyncThunk(
 
     const client = await initializeKeycloakClient(dispatch, tenant.realm, config);
     await client.login({
-      idpHint: 'core',
       redirectUri: new URL(`/auth/callback?from=${from}`, window.location.href).href,
     });
 


### PR DESCRIPTION
This is to allow tenant realm configuration to determine the IDP to use for public users accessing forms.