### PR TITLE
fix(postal code blank) - this will allow jsonform to enforce the requ…

### DIFF
--- a/libs/data-exchange-standard/src/standard.v1.schema.json
+++ b/libs/data-exchange-standard/src/standard.v1.schema.json
@@ -96,24 +96,24 @@
           "type": "string",
           "title": "Postal code",
           "description": "A0A 0A0",
-          "pattern": "^$|^[A-Z][0-9][A-Z] [0-9][A-Z][0-9]$"
+          "pattern": "^[A-Z][0-9][A-Z] [0-9][A-Z][0-9]$"
         },
         "usPostalCodeNineDigit": {
           "type": "string",
           "title": "Zip code",
           "description": "00000-0000",
-          "pattern": "^$|^[0-9]{5}-[0-9]{4}$"
+          "pattern": "^[0-9]{5}-[0-9]{4}$"
         },
         "usPostalCodeFiveDigit": {
           "type": "string",
           "title": "Zip code",
           "description": "00000",
-          "pattern": "^$|^[0-9]{5}$"
+          "pattern": "^[0-9]{5}$"
         },
         "internationalPostalCode": {
           "type": "string",
           "title": "Postal code",
-          "pattern": "^$|^[a-zA-Z0-9- ]{0,15}$"
+          "pattern": "^[a-zA-Z0-9- ]{0,15}$"
         }
       }
     }


### PR DESCRIPTION
…irement correctly - if we want to use a pattern, we don't want to allow blank, as jsonforms will then not enforce the required field correctly