### PR TITLE
feat(directory-service): support batch resource request

### DIFF
--- a/apps/directory-service/src/directory/mapper.ts
+++ b/apps/directory-service/src/directory/mapper.ts
@@ -43,8 +43,9 @@ export function mapResource(apiId: AdspId, resource: Resource) {
             href: `${apiId}:/resources`,
           },
         },
-        _embedded: resource.data && {
+        _embedded: {
           represents: resource.data,
+          tags: resource.tags?.map((tag) => mapTag(apiId, tag)),
         },
       }
     : null;

--- a/apps/directory-service/src/directory/router/resource.swagger.yml
+++ b/apps/directory-service/src/directory/router/resource.swagger.yml
@@ -274,6 +274,24 @@ components:
       - Resource
     description: Retrieves resources.
     parameters:
+      - name: top
+        description: Number of results to retrieve.
+        in: query
+        required: false
+        schema:
+          type: number
+      - name: after
+        description: Cursor for page of results to retrieve.
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: includeTags
+        description: Flag indicating if resource tags should be embedded in response.
+        in: query
+        required: false
+        schema:
+          type: boolean
       - name: criteria
         description: Criteria for the resources to return.
         in: query
@@ -281,10 +299,14 @@ components:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                typeEquals:
-                  type: string
+              oneOf:
+                - type: object
+                  properties:
+                    typeEquals:
+                      type: string
+                - type: array
+                  items:
+                    type: string
     responses:
       200:
         description: Request completed successfully

--- a/apps/directory-service/src/directory/types/resource.ts
+++ b/apps/directory-service/src/directory/types/resource.ts
@@ -13,6 +13,7 @@ export interface Resource {
   description?: string;
   type?: string;
   data?: unknown;
+  tags?: Tag[];
 }
 
 export interface TagCriteria {

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -148,13 +148,8 @@ export const loadDefinitions = createAsyncThunk(
           // Note: Not all configuration resources are form definitions.
           // Check the URN to confirm it's a form service namespace value.
           const [_, definitionId] = urn.match(/form-service\/([a-zA-Z0-9-_ ]{1,50})$/);
-          if (definitionId) {
-            if (_embedded?.represents?.['latest']?.configuration) {
-              definitions.push({ ..._embedded?.represents['latest'].configuration, urn });
-            } else {
-              const definition = await dispatch(loadDefinition(definitionId)).unwrap();
-              definitions.push(definition);
-            }
+          if (definitionId && _embedded?.represents?.['latest']?.configuration) {
+            definitions.push({ ..._embedded?.represents['latest'].configuration, urn });
           }
         }
 


### PR DESCRIPTION
Also support including resource tags. This combination is to allow batched requests for tags of specific resources.