### PR TITLE
feat(form-service): set unique constraint on oneFormPerApplicant config

### DIFF
--- a/apps/form-service/src/form/configuration.ts
+++ b/apps/form-service/src/form/configuration.ts
@@ -6,6 +6,7 @@ export const configurationSchema = {
     description: { type: 'string' },
     formDraftUrlTemplate: { type: 'string', pattern: '^http[s]?://.{0,500}$' },
     anonymousApply: { type: 'boolean' },
+    oneFormPerApplicant: { type: 'boolean', default: true },
     applicantRoles: { type: 'array', items: { type: 'string' } },
     assessorRoles: { type: 'array', items: { type: 'string' } },
     clerkRoles: { type: 'array', items: { type: 'string' } },

--- a/apps/form-service/src/form/model/definition.ts
+++ b/apps/form-service/src/form/model/definition.ts
@@ -14,6 +14,7 @@ export class FormDefinitionEntity implements FormDefinition {
   name: string;
   description: string;
   anonymousApply: boolean;
+  oneFormPerApplicant: boolean;
   applicantRoles: string[];
   assessorRoles: string[];
   clerkRoles: string[];
@@ -40,6 +41,9 @@ export class FormDefinitionEntity implements FormDefinition {
     this.name = definition.name;
     this.description = definition.description;
     this.anonymousApply = definition.anonymousApply || false;
+    // Defaults to true if the configuration value is not set.
+    this.oneFormPerApplicant =
+      typeof definition.oneFormPerApplicant === 'boolean' ? definition.oneFormPerApplicant : true;
     this.applicantRoles = definition.applicantRoles || [];
     this.assessorRoles = definition.assessorRoles || [];
     this.clerkRoles = definition.clerkRoles || [];

--- a/apps/form-service/src/form/types/definition.ts
+++ b/apps/form-service/src/form/types/definition.ts
@@ -4,6 +4,7 @@ export interface FormDefinition {
   name: string;
   description: string;
   anonymousApply: boolean;
+  oneFormPerApplicant?: boolean;
   applicantRoles: string[];
   assessorRoles: string[];
   clerkRoles: string[];

--- a/apps/form-service/src/mongo/schema.ts
+++ b/apps/form-service/src/mongo/schema.ts
@@ -25,10 +25,14 @@ export const formSchema = new Schema(
       type: Boolean,
       default: false,
     },
-
+    // Applicant URN no longer stored here, except for in old form records.
+    // Instead this property is used for the uniqueness constraint on application user ID.
     applicantId: {
       type: String,
       required: true,
+    },
+    subscriberId: {
+      type: String,
     },
     created: {
       type: Date,

--- a/apps/form-service/src/mongo/types.ts
+++ b/apps/form-service/src/mongo/types.ts
@@ -4,9 +4,11 @@ export type FormDoc = Omit<Form, 'definition' | 'applicant' | 'files'> & {
   tenantId: string;
   definitionId: string;
   applicantId: string;
+  subscriberId: string;
   hash: string;
   files: Record<string, string>;
 };
+
 export type FormSubmissionDoc = Omit<FormSubmission, 'updatedBy' | 'updated' | 'formFiles'> & {
   tenantId: string;
   hash: string;


### PR DESCRIPTION
Support for form definitions that permit multiple forms per applicant (when setting is set to false).