### PR TITLE
fix(adsp-service-spring-sdk): triggering spring sdk release

### DIFF
--- a/libs/adsp-service-spring-sdk/pom.xml
+++ b/libs/adsp-service-spring-sdk/pom.xml
@@ -98,7 +98,6 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 			<optional>true</optional>
 		</dependency>
-		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>


### PR DESCRIPTION
Need to trigger a release after update of maven semantic release plugin to make up for missed maven publish on spring boot 3 upgrade.