### PR TITLE
fix(push-service): always include tenantId in event

### DIFF
--- a/apps/push-service/src/push/model/stream.ts
+++ b/apps/push-service/src/push/model/stream.ts
@@ -69,20 +69,16 @@ export class StreamEntity implements Stream {
     );
   }
 
-  private mapEvent({ tenantId, ...event }: DomainEvent, streamEvent: StreamEvent): StreamItem {
+  private mapEvent(event: DomainEvent, streamEvent: StreamEvent): StreamItem {
     const item: StreamItem = streamEvent.map
       ? Object.entries(streamEvent.map).reduce((o, [k, p]) => ({ ...o, [k]: _.get(event, p, undefined) }), {
+          tenantId: event.tenantId,
           namespace: event.namespace,
           name: event.name,
           correlationId: event.correlationId,
           context: event.context,
         })
       : { ...event };
-
-    // Include the tenant context in case the stream is retrieved in a core context (cross-tenant).
-    if (!this.tenantId) {
-      item.tenantId = tenantId;
-    }
 
     return item;
   }


### PR DESCRIPTION
Configuration invalidation using event stream always requires the tenantId for cache invalidation for either platform or tenant services.