### PR TITLE
feat(adsp-service-sdk): support name configuration in registration

### DIFF
--- a/apps/configuration-service/src/configuration/router/configuration.ts
+++ b/apps/configuration-service/src/configuration/router/configuration.ts
@@ -192,7 +192,8 @@ export function getConfigurationEntity(
       //if user is not logged in and is not authenticated we want
       //to do rate limiting for anonymous users.
       if (!req.isAuthenticated && !user) {
-        rateLimitHandler(req, res, handle);
+        // Note: this handler is actually awaitable (is async).
+        await rateLimitHandler(req, res, handle);
       } else {
         await handle();
       }

--- a/libs/adsp-service-sdk/src/configuration/configurationService.ts
+++ b/libs/adsp-service-sdk/src/configuration/configurationService.ts
@@ -146,7 +146,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
       // Active endpoint returns the revision instead of just the raw configuration value.
       if (useActive && isRevision<C>(data)) {
         value = data?.configuration;
-        revision = data.revision;
+        revision = data?.revision;
       }
 
       const configuration = (value ? this.#converter(value, tenantId, revision) : null) as C;

--- a/libs/adsp-service-sdk/src/registration/index.ts
+++ b/libs/adsp-service-sdk/src/registration/index.ts
@@ -177,7 +177,15 @@ export interface ServiceRegistration {
    * @type {{ serviceId: AdspId; configuration: Record<string, unknown> }[]}
    * @memberof ServiceRegistration
    */
-  serviceConfigurations?: { serviceId: AdspId; configuration: Record<string, unknown> }[];
+  serviceConfigurations?: {
+    serviceId: AdspId;
+    configuration: Record<string, unknown> | NamedConfiguration[];
+  }[];
+}
+
+interface NamedConfiguration {
+  name: string;
+  configuration: Record<string, unknown>;
 }
 
 interface ServiceRegistrarOptions {

--- a/libs/core-common/src/errors/handler.ts
+++ b/libs/core-common/src/errors/handler.ts
@@ -28,7 +28,13 @@ export const createErrorHandler =
     ) {
       ErrorResponseHelper(res, err);
     } else {
-      logger.warn(`Unexpected error encountered in handler for request ${req.path}. ${err}`);
-      res.sendStatus(500);
+      logger.warn(
+        `Unexpected error encountered in handler for request ${req.path} ${
+          res.statusCode ? `(status: ${res.statusCode})` : ''
+        }. ${err}`
+      );
+      if (!res.statusCode) {
+        res.sendStatus(500);
+      }
     }
   };


### PR DESCRIPTION
This is to allow registration of form definitions, and other service configuration that use a configuration namespace instead of a single document.