### PR TITLE
fix(time validation) - time is not supported by ajv

### DIFF
--- a/apps/form-admin-app/src/lib/validations/checkInput.ts
+++ b/apps/form-admin-app/src/lib/validations/checkInput.ts
@@ -8,6 +8,7 @@ export interface ValidInput {
 export const ajv = new Ajv({ allErrors: true, verbose: true, strict: 'log' });
 
 ajv.addFormat('file-urn', /urn:[^:]+:[^:]+:[^:]+:[^:]+/);
+ajv.addFormat('time', /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/);
 
 /**
  * Given a list of validators and name of the input field, report on its cleanliness

--- a/apps/task-app/src/lib/validations/checkInput.ts
+++ b/apps/task-app/src/lib/validations/checkInput.ts
@@ -7,6 +7,7 @@ export interface ValidInput {
 
 export const ajv = new Ajv({ allErrors: true, verbose: true, strict: 'log' });
 
+ajv.addFormat('time', /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/);
 ajv.addFormat('file-urn', /urn:[^:]+:[^:]+:[^:]+:[^:]+/);
 
 /**

--- a/libs/core-common/src/jsonSchema/ajv.ts
+++ b/libs/core-common/src/jsonSchema/ajv.ts
@@ -1,6 +1,5 @@
 import { standardV1JsonSchema, commonV1JsonSchema } from '@abgov/data-exchange-standard';
 import Ajv from 'ajv';
-import addErrors from 'ajv-errors';
 import addFormats from 'ajv-formats';
 import * as schemaMigration from 'json-schema-migrate';
 import { Logger } from 'winston';
@@ -12,9 +11,9 @@ export class AjvValidationService implements ValidationService {
   protected ajvErrors: string[] = [];
 
   constructor(private logger: Logger) {
-    this.ajv.addFormat('file-urn', /^urn:ads:platform:file-service:v[0-9]:\/files\/[a-zA-Z0-9.-]*$/);
     addFormats(this.ajv);
-
+    this.ajv.addFormat('file-urn', /^urn:ads:platform:file-service:v[0-9]:\/files\/[a-zA-Z0-9.-]*$/);
+    this.ajv.addFormat('time', /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/);
     this.ajv.addSchema(standardV1JsonSchema);
     this.ajv.addSchema(commonV1JsonSchema);
   }

--- a/libs/jsonforms-components/src/lib/common/Ajv.ts
+++ b/libs/jsonforms-components/src/lib/common/Ajv.ts
@@ -7,9 +7,10 @@ export const createDefaultAjv = (...schemas: AnySchema[]) => {
   ajv.addSchema(schemas);
 
   addErrors(ajv);
+  addFormats(ajv);
 
   ajv.addFormat('file-urn', /^urn:ads:platform:file-service:v[0-9]:\/files\/[a-zA-Z0-9.-]*$/);
-  addFormats(ajv);
+  ajv.addFormat('time', /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/);
 
   return ajv;
 };


### PR DESCRIPTION
ajv by default only supports time if a timezone is added

but GoAInputTime itself doesn't support showing the time if a timezone is included in the data

so we would have to add and remove timezones before and after the data is displayed

The alternative is simply to add a simplified time format to ajv - I think this makes more sense in this case - we could do it the other way if we really want to support timezones, but it could add confusion and introduce bugs
