### PR TITLE
fix(submit button) - change to button to submit for accessibility

### DIFF
--- a/libs/adsp-feedback/src/main.ts
+++ b/libs/adsp-feedback/src/main.ts
@@ -1077,7 +1077,7 @@ export class AdspFeedback implements AdspFeedbackApi {
                         class="adsp-fb-form-primary"
                         id="start"
                         @click=${this.closeStartForm}
-                        type="button"
+                        type="submit"
                         tabindex="0"
                         aria-label="Start feedback button"
                       >
@@ -1202,7 +1202,7 @@ export class AdspFeedback implements AdspFeedbackApi {
                         ${ref(this.sendButtonRef)}
                         class="adsp-fb-form-primary"
                         @click=${this.sendFeedback}
-                        type="button"
+                        type="submit"
                         disabled
                         tabindex="0"
                         aria-label="Submit feedback button"


### PR DESCRIPTION
fixes

• Error: This form does not contain a submit button, which creates issues for those who cannot submit the form using the keyboard. Submit buttons are INPUT elements with type attribute "submit" or "image", or BUTTON elements with type "submit" or omitted/invalid.
   ├── WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2
   ├── html > body > div:nth-child(9) > div:nth-child(2) > div > div:nth-child(1) > form
   └── <form class="adsp-fb-form"> <h3 class=...</form>

