### PR TITLE
fix(file upload) - Id is not required and creates duplicates of itsel…

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/FileUploader/FileUploaderControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FileUploader/FileUploaderControl.tsx
@@ -116,7 +116,7 @@ export const FileUploader = ({ data, path, handleChange, uischema, ...props }: F
   const helpText = uischema?.options?.help;
   const sentenceCaseLabel = convertToSentenceCase(label);
   return (
-    <FileUploaderStyle id="file-upload" className="FileUploader">
+    <FileUploaderStyle className="FileUploader">
       {required ? (
         <GoAFormItem label={sentenceCaseLabel} requirement="required"></GoAFormItem>
       ) : (


### PR DESCRIPTION
…f if we have more than 1 file upload


 • Error: Duplicate id attribute value "file-upload" found on the web page.
   ├── WCAG2AA.Principle4.Guideline4_1.4_1_1.F77
   ├── #file-upload
   └── <div id="file-upload" class="sc-eXvyUU bLnZWz FileUploader"><div class="label">File uploade...</div>