### PR TITLE
feat(form-service): permit multi form user applicants without subscri…

### DIFF
--- a/apps/form-service/src/form/model/definition.spec.ts
+++ b/apps/form-service/src/form/model/definition.spec.ts
@@ -233,7 +233,11 @@ describe('FormDefinitionEntity', () => {
     });
 
     it('can return true for scheduled intake form without scheduled intake for testers', async () => {
-      const result = await scheduled.canApply({ tenantId, id: 'tester', roles: [FormServiceRoles.Tester, 'test-applicant'] } as User);
+      const result = await scheduled.canApply({
+        tenantId,
+        id: 'tester',
+        roles: [FormServiceRoles.Tester, 'test-applicant'],
+      } as User);
       expect(result).toBe(true);
     });
 
@@ -330,6 +334,10 @@ describe('FormDefinitionEntity', () => {
       queueTaskToProcess: {} as QueueTaskToProcess,
     });
 
+    beforeEach(() => {
+      notificationMock.subscribe.mockReset();
+    });
+
     it('can create form', async () => {
       notificationMock.subscribe.mockResolvedValueOnce(subscriber);
       const form = await entity.createForm(
@@ -343,6 +351,59 @@ describe('FormDefinitionEntity', () => {
     });
 
     it('can set applicant userId for user applicant', async () => {
+      notificationMock.subscribe.mockResolvedValueOnce(subscriber);
+      const form = await entity.createForm(user, repositoryMock, notificationMock, subscriber);
+      expect(form).toBeTruthy();
+      expect(notificationMock.subscribe).toHaveBeenCalledWith(
+        entity.tenantId,
+        entity,
+        expect.any(String),
+        expect.objectContaining({ userId: user.id })
+      );
+    });
+
+    it('can allow unset user applicant for definitions that allow multiple forms', async () => {
+      const entity = new FormDefinitionEntity(validationService, calendarService, tenantId, {
+        id: 'test',
+        name: 'test-form-definition',
+        description: null,
+        formDraftUrlTemplate: 'https://my-form/{{ id }}',
+        anonymousApply: true,
+        applicantRoles: ['test-applicant'],
+        assessorRoles: ['test-assessor'],
+        clerkRoles: [],
+        dataSchema: null,
+        submissionRecords: false,
+        submissionPdfTemplate: '',
+        supportTopic: false,
+        queueTaskToProcess: {} as QueueTaskToProcess,
+        oneFormPerApplicant: false,
+      });
+
+      notificationMock.subscribe.mockResolvedValueOnce(subscriber);
+      const form = await entity.createForm(user, repositoryMock, notificationMock);
+      expect(form).toBeTruthy();
+      expect(notificationMock.subscribe).not.toHaveBeenCalled();
+    });
+
+    it('can set applicant userId for definitions that allow multiple forms', async () => {
+      const entity = new FormDefinitionEntity(validationService, calendarService, tenantId, {
+        id: 'test',
+        name: 'test-form-definition',
+        description: null,
+        formDraftUrlTemplate: 'https://my-form/{{ id }}',
+        anonymousApply: true,
+        applicantRoles: ['test-applicant'],
+        assessorRoles: ['test-assessor'],
+        clerkRoles: [],
+        dataSchema: null,
+        submissionRecords: false,
+        submissionPdfTemplate: '',
+        supportTopic: false,
+        queueTaskToProcess: {} as QueueTaskToProcess,
+        oneFormPerApplicant: false,
+      });
+
       notificationMock.subscribe.mockResolvedValueOnce(subscriber);
       const form = await entity.createForm(user, repositoryMock, notificationMock, subscriber);
       expect(form).toBeTruthy();

--- a/apps/form-service/src/form/model/definition.ts
+++ b/apps/form-service/src/form/model/definition.ts
@@ -114,7 +114,9 @@ export class FormDefinitionEntity implements FormDefinition {
       throw new UnauthorizedUserError('create form', user);
     }
 
-    if (this.isUserApplicant(user)) {
+    // Update user applicant if applicant info is provided or if the form is on per applicant (for backwards compatibility).
+    // This means that form definitions that permit multiple forms allow a unset applicant (i.e. no notifications).
+    if (this.isUserApplicant(user) && (applicantInfo || this.oneFormPerApplicant)) {
       // In case where user is the applicant, the userId of the applicant must match the user's own ID.
       applicantInfo = {
         channels: [{ channel: Channel.email, address: user.email }],

--- a/apps/subscriber-app/src/app/components/SubscriptionsList.tsx
+++ b/apps/subscriber-app/src/app/components/SubscriptionsList.tsx
@@ -101,44 +101,46 @@ const SubscriptionsList = ({ subscriber, onUnsubscribe }: SubscriptionsListProps
 
   return (
     <>
-      {subscriptions.map((subscription: Subscription) => {
-        const typeChannels = subscription.type.channels;
-        return (
-          <tr key={`${subscription.typeId}`}>
-            <td data-testid="subscription-name">{subscription.type.name}</td>
-            <td>
-              <p>{subscription.type.description}</p>
-              {subscription.criteria?.filter((c) => c.description).length > 0 && (
-                <ul>
-                  {subscription.criteria
-                    .filter((c) => c.description)
-                    .map(({ correlationId, description }, idx) => (
-                      <li key={correlationId || idx}>{description}</li>
-                    ))}
-                </ul>
-              )}
-            </td>
-            <td>
-              <AvailableChannels channels={typeChannels} effectiveChannel={effectiveChannel?.channel as Channel} />
-            </td>
-            <td>
-              {subscription.type?.manageSubscribe ? (
-                <GoAButton
-                  size="compact"
-                  type="tertiary"
-                  key={`${subscription.typeId}`}
-                  onClick={() => onUnsubscribe(subscription.typeId)}
-                  testId="unsubscribe-button"
-                >
-                  Unsubscribe
-                </GoAButton>
-              ) : (
-                <UnsubscribeMessage />
-              )}
-            </td>
-          </tr>
-        );
-      })}
+      {subscriptions
+        .filter(({ type }) => !!type)
+        .map((subscription: Subscription) => {
+          const typeChannels = subscription.type?.channels;
+          return (
+            <tr key={`${subscription.typeId}`}>
+              <td data-testid="subscription-name">{subscription.type.name}</td>
+              <td>
+                <p>{subscription.type.description}</p>
+                {subscription.criteria?.filter((c) => c.description).length > 0 && (
+                  <ul>
+                    {subscription.criteria
+                      .filter((c) => c.description)
+                      .map(({ correlationId, description }, idx) => (
+                        <li key={correlationId || idx}>{description}</li>
+                      ))}
+                  </ul>
+                )}
+              </td>
+              <td>
+                <AvailableChannels channels={typeChannels} effectiveChannel={effectiveChannel?.channel as Channel} />
+              </td>
+              <td>
+                {subscription.type?.manageSubscribe ? (
+                  <GoAButton
+                    size="compact"
+                    type="tertiary"
+                    key={`${subscription.typeId}`}
+                    onClick={() => onUnsubscribe(subscription.typeId)}
+                    testId="unsubscribe-button"
+                  >
+                    Unsubscribe
+                  </GoAButton>
+                ) : (
+                  <UnsubscribeMessage />
+                )}
+              </td>
+            </tr>
+          );
+        })}
     </>
   );
 };


### PR DESCRIPTION
…ption

Normally we always create a subscription for user applicants (i.e. not a subscription app creating form on behalf of user), but this doesn't make sense for simple submit and forget form cases.