### PR TITLE
fix(notification-service): pass tenantId to getConfiguration

### DIFF
--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -1492,6 +1492,27 @@ describe('subscription router', () => {
       const res = { send: jest.fn() };
       const next = jest.fn();
 
+      req.getConfiguration.mockResolvedValueOnce(
+        new NotificationConfiguration({ test: notificationType }, {}, tenantId)
+      );
+
+      const subscription: Subscription = {
+        tenantId,
+        subscriberId: subscriber.id,
+        typeId: 'test',
+        criteria: {},
+      };
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({
+        results: [
+          new SubscriptionEntity(
+            repositoryMock,
+            subscription,
+            new NotificationTypeEntity(notificationType, tenantId),
+            subscriber
+          ),
+        ],
+      });
+
       const handler = getSubscriberDetails(apiId, repositoryMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(req.getConfiguration).toHaveBeenCalledWith(subscriber.tenantId);

--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -1466,6 +1466,42 @@ describe('subscription router', () => {
         })
       );
     });
+
+    it('can get subscriber with no request tenant context', async () => {
+      const subscriber = new SubscriberEntity(repositoryMock, {
+        id: 'subscriber',
+        tenantId,
+        addressAs: 'tester',
+        channels: [],
+      });
+
+      const req = {
+        user: {
+          isCore: true,
+          id: 'tester',
+          name: 'Tester',
+          email: 'tester@test.co',
+          roles: [],
+        },
+        query: {
+          includeSubscriptions: 'true',
+        },
+        subscriber,
+        getConfiguration: jest.fn(),
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = getSubscriberDetails(apiId, repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(req.getConfiguration).toHaveBeenCalledWith(subscriber.tenantId);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'subscriber',
+          addressAs: 'tester',
+        })
+      );
+    });
   });
 
   describe('deleteSubscriber', () => {

--- a/apps/notification-service/src/notification/router/subscription.ts
+++ b/apps/notification-service/src/notification/router/subscription.ts
@@ -585,7 +585,9 @@ export function getSubscriberDetails(apiId: AdspId, repository: SubscriptionRepo
 
       let subscriberDetails = mapSubscriber(apiId, subscriber);
       if (includeSubscriptions === 'true') {
-        const configuration = await req.getConfiguration<NotificationConfiguration, NotificationConfiguration>();
+        // Note that explicit tenantId is necessary here because there is sometimes no request tenant context
+        // and we're using the subscriber tenant Id.
+        const configuration = await req.getConfiguration<NotificationConfiguration, NotificationConfiguration>(tenantId);
         const { results } = await repository.getSubscriptions(configuration, tenantId, 0, undefined, {
           subscriberIdEquals: subscriber.id,
         });


### PR DESCRIPTION
This is required because the endpoint is used without tenant context from the subscriber gateway. In that case, the subscriber tenant Id is the tenant context and needs to be used for configuration retrieval.