### PR TITLE
fix(cache test) - tenant cache wasn't working and now it is

### DIFF
--- a/apps/cache-service/src/cache/model/cacheTarget.ts
+++ b/apps/cache-service/src/cache/model/cacheTarget.ts
@@ -152,7 +152,8 @@ export class CacheTarget implements Target {
     }
 
     const relative = req.originalUrl.substring(`${req.baseUrl}/cache/${this.serviceId}`.length);
-    const targetPath = path.join(upstreamUrl.pathname, relative);
+    const targetPath = new URL(relative, upstreamUrl).pathname;
+ 
     if (!targetPath.includes(upstreamUrl.pathname)) {
       throw new InvalidOperationError('Request path not supported.');
     }

--- a/apps/cache-service/src/main.ts
+++ b/apps/cache-service/src/main.ts
@@ -84,7 +84,12 @@ const initializeApp = async (): Promise<express.Application> => {
           directory,
           tenantService,
           cacheProvider,
-          { ...config, ...coreConfig },
+          {
+            targets: {
+              ...config.targets,
+              ...coreConfig.targets,
+            },
+          },
           tenantId
         );
       },


### PR DESCRIPTION
* Make path OS agnostic
* no longer override tenant target with core target
![image](https://github.com/user-attachments/assets/45c29f6a-7c90-4225-b44e-0fcb614115c7)
![image](https://github.com/user-attachments/assets/511d0894-7c0c-4787-bba3-cc346906d536)
![image](https://github.com/user-attachments/assets/21e36cee-fbed-43b5-b515-c7dfa6d5cf22)
