### PR TITLE
fix(jsonforms-components): remove unnecessary code to display text in review summary

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseReviewControl.tsx
@@ -88,14 +88,6 @@ export const GoABaseInputReviewComponent = (props: WithBaseInputReviewProps): JS
         })}
       </ul>
     );
-  } else if (data === undefined || data === false) {
-    const checkboxLabel =
-      uischema?.options?.text?.trim() || convertToSentenceCase(getLastSegmentFromPointer(uischema.scope));
-    reviewText = (
-      <ul>
-        <li>{`No (${checkboxLabel.trim()})`}</li>
-      </ul>
-    );
   }
 
   return (

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputbaseReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputbaseReviewControl.spec.tsx
@@ -52,7 +52,7 @@ describe('GoABaseInputReviewComponent', () => {
     };
     const { getByTestId } = render(<GoABaseInputReviewComponent {...props} />);
     const reviewControl = getByTestId('review-control-input-id');
-    expect(reviewControl.textContent).toBe('No (test)');
+    expect(reviewControl.textContent).toBe('No');
   });
 
   it('renders "No" for checkbox boolean false data', () => {
@@ -70,7 +70,7 @@ describe('GoABaseInputReviewComponent', () => {
     };
     const { getByTestId } = render(<GoABaseInputReviewComponent {...props} />);
     const reviewControl = getByTestId('review-control-input-id');
-    expect(reviewControl.textContent).toBe('No (test)');
+    expect(reviewControl.textContent).toBe('No');
   });
 
   it('renders "Yes" for checkbox boolean true data', () => {
@@ -129,7 +129,7 @@ describe('GoABaseInputReviewComponent', () => {
     };
     const { getByTestId } = render(<GoABaseInputReviewComponent {...props} />);
     const reviewControl = getByTestId('review-control-input-id');
-    expect(reviewControl.textContent).toBe('No (test)');
+    expect(reviewControl.textContent).toBe('');
   });
 
   it('renders checkbox label with scope without options text property', () => {


### PR DESCRIPTION
 remove the highlighted text when no data is entered in a text field.

![image](https://github.com/user-attachments/assets/a9516afc-e954-460f-a986-dea5e3d821e7)

