### PR TITLE
Fix-CS-4180 Callout does not support show/hide rule condition

### DIFF
--- a/libs/jsonforms-components/src/lib/Additional/GoACalloutControl.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/GoACalloutControl.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { JsonFormsProps, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
-import { withJsonFormsRendererProps } from '@jsonforms/react';
+import { ControlProps, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoACallout, GoACalloutSize, GoACalloutType } from '@abgov/react-components';
+import { Visible } from '../util';
 
 export interface CalloutProps {
   size?: GoACalloutSize;
@@ -24,9 +25,20 @@ export const callout = (props: CalloutProps): JSX.Element => {
     </GoACallout>
   );
 };
+const GoACalloutController = (props: ControlProps) => {
+  const { uischema, visible, data } = props;
 
-const CalloutControl = (props: JsonFormsProps) => {
-  return callout(props?.uischema?.options?.componentProps || {});
+  let showCallout: boolean;
+
+  if (data === undefined || (Array.isArray(data) && data.length === 0)) {
+    showCallout = false;
+  } else {
+    showCallout = visible === true;
+  }
+
+  const calloutProps = uischema?.options?.componentProps || {};
+
+  return <Visible visible={showCallout}>{callout(calloutProps)}</Visible>;
 };
 
 export const CalloutReviewControl = () => {
@@ -34,5 +46,5 @@ export const CalloutReviewControl = () => {
 };
 
 export const GoACalloutControlTester: RankedTester = rankWith(1, uiTypeIs('Callout'));
-
-export default withJsonFormsRendererProps(CalloutControl);
+export const GoACalloutControl = withJsonFormsControlProps(GoACalloutController);
+export default GoACalloutControl;


### PR DESCRIPTION
1. Correctly wrapping the `GoACalloutController` component with `withJsonFormsControlProps` to ensure proper connection with the JsonForms state and rule engine.
2. Updating `GoACalloutController` to explicitly handle the initial undefined/empty data state, ensuring the callout defaults to hidden.
3. For subsequent state changes (when data is present), the component now correctly uses the `visible` prop, which is derived from the UI schema rule and passed by `withJsonFormsControlProps`.