### PR TITLE
CS-4013 Add Markdown support to Callout for help text

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/categorization.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/categorization.ts
@@ -33,14 +33,24 @@ export const schema = {
   },
   required: ['fullName', 'birthDate', 'mailingAddress', 'phoneNumber', 'email', 'isAttestationAccepted'],
 };
-
 export const uischema = {
   type: 'Categorization',
   elements: [
     {
       type: 'Category',
-      label: '',
+      label: 'Representative form',
       elements: [
+        {
+          type: 'Callout',
+          options: {
+            componentProps: {
+              type: 'information',
+              markdown: true,
+              message:
+                'You should follow up on that Representative form. [here](https://govalta.github.io/adsp-monorepo/tutorials/form-service/building-forms.html)',
+            },
+          },
+        },
         {
           type: 'HorizontalLayout',
           elements: [
@@ -100,7 +110,6 @@ export const uischema = {
     },
   ],
 };
-
 export const data = {
   provideAddress: true,
   vegetarian: false,

--- a/libs/jsonforms-components/package.json
+++ b/libs/jsonforms-components/package.json
@@ -12,7 +12,8 @@
     "ajv": "^8.6.1",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
-    "@mdx-js/mdx": "^3.1.0"
+    "@mdx-js/mdx": "^3.1.0",
+    "react-markdown": "^8.0.7"
   },
   "dependencies": {
     "axios": "^1.6.7",

--- a/libs/jsonforms-components/src/lib/Additional/GoACalloutControl.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/GoACalloutControl.tsx
@@ -3,6 +3,7 @@ import { ControlProps, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core'
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoACallout, GoACalloutSize, GoACalloutType } from '@abgov/react-components';
 import { Visible } from '../util';
+import ReactMarkdown from 'react-markdown';
 
 export interface CalloutProps {
   size?: GoACalloutSize;
@@ -21,7 +22,7 @@ export const callout = (props: CalloutProps): JSX.Element => {
   const testid = componentProps.message?.replace(/\s/g, '');
   return (
     <GoACallout {...componentProps} data-testid={testid}>
-      {componentProps.message}
+      <ReactMarkdown>{componentProps.message || ''}</ReactMarkdown>
     </GoACallout>
   );
 };


### PR DESCRIPTION
- Implement help text callouts using GoACallout.
- Modify GoACalloutControl to render Markdown, enabling links. Update UI schema to include help text examples.
- add missing peer dependency react-markdown