### PR TITLE
feat(mail attachments): support file ids as attachments instead of blobs

### DIFF
--- a/apps/notification-service/src/notification/job/processEvent.ts
+++ b/apps/notification-service/src/notification/job/processEvent.ts
@@ -82,7 +82,9 @@ export const createProcessEventJob =
             subscriptionRepository,
             configuration,
             event,
-            { tenant }
+            { tenant },
+            directory,
+            token
           );
 
           for (const notification of notifications) {

--- a/apps/notification-service/src/notification/model/type.spec.ts
+++ b/apps/notification-service/src/notification/model/type.spec.ts
@@ -16,6 +16,13 @@ describe('NotificationTypeEntity', () => {
     error: jest.fn(),
   } as unknown as Logger;
 
+  const directory = {
+    getServiceUrl: jest.fn(() => Promise.resolve(new URL('https://verify-service'))),
+    getResourceUrl: jest.fn(),
+  };
+
+  const token = 'test123123123';
+
   const repositoryMock = {
     saveSubscription: jest.fn((entity: SubscriptionEntity) => {
       return Promise.resolve(entity);
@@ -428,7 +435,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant,
-        }
+        },
+        directory,
+        token
       );
       expect(templateServiceMock.generateMessage).toHaveBeenCalledTimes(1);
       expect(notification.to).toBe('test@testco.org');
@@ -508,7 +517,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant,
-        }
+        },
+        directory,
+        token
       );
       expect(templateServiceMock.generateMessage).toHaveBeenCalledWith(
         expect.any(Object),
@@ -594,7 +605,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant,
-        }
+        },
+        directory,
+        token
       );
       expect(templateServiceMock.generateMessage).toHaveBeenCalledWith(
         expect.any(Object),
@@ -673,7 +686,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant,
-        }
+        },
+        directory,
+        token
       );
       expect(notifications.length).toBe(0);
     });
@@ -751,7 +766,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant,
-        }
+        },
+        directory,
+        token
       );
       expect(notification.to).toBe('test@testco.org');
       expect(notification.channel).toBe(Channel.email);
@@ -830,7 +847,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant: null,
-        }
+        },
+        directory,
+        token
       );
       expect(notification.to).toBe('test@testco.org');
       expect(notification.channel).toBe(Channel.email);
@@ -903,7 +922,9 @@ describe('NotificationTypeEntity', () => {
         event,
         {
           tenant,
-        }
+        },
+        directory,
+        token
       );
       expect(notifications.length).toBe(0);
     });
@@ -1221,6 +1242,13 @@ describe('DirectNotificationTypeEntity', () => {
   describe('generateNotifications', () => {
     const subscriberAppUrl = new URL('https://subscriptions');
 
+    const directory = {
+      getServiceUrl: jest.fn(() => Promise.resolve(new URL('https://verify-service'))),
+      getResourceUrl: jest.fn(),
+    };
+
+    const token = 'test123123123';
+
     const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
     const tenant = { id: tenantId, name: 'test', realm: 'test' };
 
@@ -1269,7 +1297,9 @@ describe('DirectNotificationTypeEntity', () => {
         repositoryMock as unknown as SubscriptionRepository,
         configurationMock as NotificationConfiguration,
         event,
-        { tenant }
+        { tenant },
+        directory,
+        token
       );
 
       expect(result).toMatchObject({ tenantId: tenantId.toString(), message, to: event.payload.details.email });
@@ -1298,7 +1328,9 @@ describe('DirectNotificationTypeEntity', () => {
         repositoryMock as unknown as SubscriptionRepository,
         configurationMock as NotificationConfiguration,
         event,
-        { tenant }
+        { tenant },
+        directory,
+        token
       );
 
       expect(results).toMatchObject(expect.arrayContaining([]));
@@ -1349,7 +1381,9 @@ describe('DirectNotificationTypeEntity', () => {
         repositoryMock as unknown as SubscriptionRepository,
         configurationMock as NotificationConfiguration,
         event,
-        { tenant }
+        { tenant },
+        directory,
+        token
       );
 
       expect(results).toMatchObject(expect.arrayContaining([]));
@@ -1400,7 +1434,9 @@ describe('DirectNotificationTypeEntity', () => {
         repositoryMock as unknown as SubscriptionRepository,
         configurationMock as NotificationConfiguration,
         event,
-        { tenant }
+        { tenant },
+        directory,
+        token
       );
 
       expect(result).toMatchObject({ tenantId: tenantId.toString(), message, to: entity.address });
@@ -1449,7 +1485,9 @@ describe('DirectNotificationTypeEntity', () => {
         repositoryMock as unknown as SubscriptionRepository,
         configurationMock as NotificationConfiguration,
         event,
-        { tenant }
+        { tenant },
+        directory,
+        token
       );
 
       expect(results).toMatchObject(expect.arrayContaining([]));

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/addEditNotification/addEditNotification.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/addEditNotification/addEditNotification.tsx
@@ -391,7 +391,7 @@ export const NotificationTypeModalForm: FunctionComponent<NotificationTypeFormPr
                 type="text"
                 name="bcc"
                 value={type.bccPath}
-                testId={`address-notification-modal-input`}
+                testId={`bccPath-notification-modal-input`}
                 aria-label="input-path-address"
                 width="60%"
                 onChange={(_, value) => {
@@ -404,11 +404,24 @@ export const NotificationTypeModalForm: FunctionComponent<NotificationTypeFormPr
                 type="text"
                 name="cc"
                 value={type.ccPath}
-                testId={`address-notification-modal-input`}
+                testId={`ccPath-notification-modal-input`}
                 aria-label="input-path-address"
                 width="60%"
                 onChange={(_, value) => {
                   setType({ ...type, ccPath: value });
+                }}
+              />
+            </GoAFormItem>
+            <GoAFormItem label="attachment in event payload at Json schema path">
+              <GoAInput
+                type="text"
+                name="attachment"
+                value={type.attachmentPath}
+                testId={`attachmentPath-notification-modal-input`}
+                aria-label="input-path-address"
+                width="60%"
+                onChange={(_, value) => {
+                  setType({ ...type, attachmentPath: value });
                 }}
               />
             </GoAFormItem>

--- a/apps/tenant-management-webapp/src/app/store/notification/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/notification/models.ts
@@ -13,6 +13,7 @@ export interface NotificationItem {
   addressPath?: string;
   bccPath?: string;
   ccPath?: string;
+  attachmentPath?: string;
   subjectPath?: string;
   titlePath?: string;
   subTitlePath?: string;

--- a/apps/tenant-management-webapp/src/app/store/notification/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/notification/sagas.ts
@@ -205,6 +205,7 @@ export function* updateNotificationType({ payload }: UpdateNotificationTypeActio
                 addressPath: payload.addressPath,
                 bccPath: payload.bccPath,
                 ccPath: payload.ccPath,
+                attachmentPath: payload.attachmentPath,
               },
             },
           },

--- a/libs/adsp-service-sdk/src/notification/types.ts
+++ b/libs/adsp-service-sdk/src/notification/types.ts
@@ -31,6 +31,7 @@ export interface NotificationType {
   addressPath?: string;
   ccPath?: string;
   bccPath?: string;
+  attachmentPath?: string;
   subjectPath?: string;
   titlePath?: string;
   subTitlePath?: string;


### PR DESCRIPTION
POST http://localhost:3334/event/v1/events

{
  "namespace": "form",
  "name": "invite-issued",
  "correlationId": "test-user-001",
  "timestamp": "2025-04-28T18:00:00Z",
  "payload": {
    "emailAddress": "weyermannx@gmail.com",
    "bcc": "jonathan.weyermann@gov.ab.ca",
    "cc": "jonathanweyermannx@gmail.com",

    "name": "Bob Smith",
    "inviteLink": "https://premier-meeting-invite-app-adsp-apps-uat.apps.aro.gov.ab.ca/meeting-request?secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

    "myAttachments": ["d215bae7-1fc2-4bf3-af72-87ff7446b3c0","dca7cf76-56ac-4efa-9686-549b291bbcc4","2e4c5287-dfc5-4697-87ae-6a3240146c9b"]
  }
}

<img width="580" height="861" alt="image" src="https://github.com/user-attachments/assets/4d8dec16-95d1-4341-9ad7-11492740ffe5" />
<img width="718" height="767" alt="image" src="https://github.com/user-attachments/assets/4c1de791-0b70-401e-a9ad-a799a7e36835" />
