### PR TITLE
chore(event-service): rabbitmq init container ignore missing file

### DIFF
--- a/.openshift/managed/event-service.yml
+++ b/.openshift/managed/event-service.yml
@@ -185,7 +185,7 @@ objects:
               command:
                 - sh
                 - '-c'
-                - rm /var/lib/rabbitmq/.erlang.cookie
+                - rm -f /var/lib/rabbitmq/.erlang.cookie
               resources:
                 limits:
                   cpu: 200m


### PR DESCRIPTION
Update init container to ignore missing cookie file in cases where the storage is recreated (i.e. when cluster node / pod can't restart with existing files).