### PR TITLE
fix(pdf generation) - increase memory for chromium

### DIFF
--- a/.openshift/managed/pdf-service.yml
+++ b/.openshift/managed/pdf-service.yml
@@ -436,11 +436,19 @@ objects:
                 periodSeconds: 60
                 successThreshold: 1
                 failureThreshold: 5
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: dshm
           restartPolicy: Always
           terminationGracePeriodSeconds: 30
           dnsPolicy: ClusterFirst
           securityContext: {}
           schedulerName: default-scheduler
+          volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 1Gi
       strategy:
         type: RollingUpdate
         rollingUpdate:


### PR DESCRIPTION
Increase /dev/shm size for the pdf-service-job pod to 1Gi using an emptyDir volume. Puppeteer (Chromium) relies on shared memory for rendering, and the default 64Mi limit can cause crashes (Protocol error: Connection closed) during PDF generation. Mounting a larger /dev/shm improves reliability and performance, especially for templates with complex layouts or large data sets.