### PR TITLE
fix(cpu/memory puppeteer) - increased because generation issue

### DIFF
--- a/.openshift/managed/pdf-service.yml
+++ b/.openshift/managed/pdf-service.yml
@@ -409,11 +409,11 @@ objects:
                   protocol: TCP
               resources:
                 limits:
-                  cpu: 300m
-                  memory: 500Mi
+                  cpu: 1
+                  memory: 1Gi
                 requests:
-                  cpu: 200m
-                  memory: 300Mi
+                  cpu: 500m
+                  memory: 500Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               readinessProbe:

--- a/apps/pdf-service/src/puppeteer.ts
+++ b/apps/pdf-service/src/puppeteer.ts
@@ -15,7 +15,8 @@ class PuppeteerPdfService implements PdfService {
       page = await this.browser.newPage();
       await page.setJavaScriptEnabled(false);
       await page.setContent(content, { waitUntil: 'networkidle0', timeout: 2 * 60 * 1000 });
-      await delay(500);
+      //just touching pdf service so I can update the memory limits and have it redeploy
+      await delay(499);
 
       let result: Buffer;
       if (header || footer) {


### PR DESCRIPTION
Based on how Puppeteer uses Chromium under the hood, we recommend the following resource settings to ensure stability and performance:

resources:
  requests:
    cpu: 500m     # Guarantees baseline performance (half a core)
    memory: 500Mi # Ensures enough memory for standard PDF rendering
  limits:
    cpu: 1        # Allows Chromium to leverage multi-threading (1 full core)
    memory: 1Gi   # Gives Chromium room for rendering larger or more complex PDFs
📌 Notes:
CPU: Puppeteer (via Chromium) is multi-core capable and can spike during rendering. Throttling it below 1 CPU can cause slowness or timeouts.

Memory: PDF rendering often involves fonts, images, layout computation, and compression — 500Mi is the safe minimum, but 1Gi prevents out-of-memory crashes for larger documents.