### PR TITLE
fix(form app): fix login banner - i see no case for login from banner

### DIFF
--- a/apps/form-app/src/app/containers/FormTenant.tsx
+++ b/apps/form-app/src/app/containers/FormTenant.tsx
@@ -6,10 +6,8 @@ import styled from 'styled-components';
 import {
   AppDispatch,
   configInitializedSelector,
-  definitionSelector,
   formSelector,
   initializeTenant,
-  loginUser,
   logoutUser,
   tenantSelector,
   userSelector,
@@ -33,7 +31,6 @@ export const FormTenant = () => {
   const dispatch = useDispatch<AppDispatch>();
   const tenant = useSelector(tenantSelector);
   const userForm = useSelector(formSelector);
-  const { definition } = useSelector(definitionSelector);
 
   const configInitialized = useSelector(configInitializedSelector);
   const { initialized: userInitialized, user } = useSelector(userSelector);
@@ -49,42 +46,33 @@ export const FormTenant = () => {
     <React.Fragment>
       <GoAMicrositeHeader type="alpha" feedbackUrlTarget="self" headerUrlTarget="self" feedbackUrl="#" />
       <GoAAppHeader url="/" heading={`${tenant?.name || tenantName} - Form`}>
-        {userInitialized && !definition?.anonymousApply && (
-          <AccountActionsSpan>
-            {user ? (
-              <>
-                <span className="username">{user?.name}</span>
-                <GoAButton
-                  mt="s"
-                  mr="s"
-                  type="tertiary"
-                  data-testid="form-sign-out"
-                  onClick={() => {
-                    if (userForm?.definition) {
-                      dispatch(logoutUser({ tenant, from: `/${tenant.name}/${userForm.definition.id}` }));
-                    } else {
-                      dispatch(logoutUser({ tenant, from: `${location.pathname}` }));
-                    }
-                  }}
-                >
-                  Sign out
-                </GoAButton>
-              </>
-            ) : (
-              <GoAButton
-                mt="s"
-                mr="s"
-                type="tertiary"
-                data-testid="form-sign-in"
-                onClick={() => {
-                  dispatch(loginUser({ tenant, from: `${location.pathname}?autoCreate=true` }));
-                }}
-              >
-                Sign in
-              </GoAButton>
-            )}
-          </AccountActionsSpan>
-        )}
+        <>
+          <span style={{ display: 'none' }}></span>
+          {userInitialized && (
+            <AccountActionsSpan>
+              {user && (
+                <>
+                  <span className="username">{user?.name}</span>
+                  <GoAButton
+                    mt="s"
+                    mr="s"
+                    type="tertiary"
+                    data-testid="form-sign-out"
+                    onClick={() => {
+                      if (userForm?.definition) {
+                        dispatch(logoutUser({ tenant, from: `/${tenant.name}/${userForm.definition.id}` }));
+                      } else {
+                        dispatch(logoutUser({ tenant, from: `${location.pathname}` }));
+                      }
+                    }}
+                  >
+                    Sign out
+                  </GoAButton>
+                </>
+              )}
+            </AccountActionsSpan>
+          )}
+        </>
       </GoAAppHeader>
       <FeedbackNotification />
       <main>


### PR DESCRIPTION
using a hidden span ensures the React rendering engine passes a valid children prop to GoAAppHeader. Otherwise the children are skipped entirely if they are null at any point, and won't get reloaded on dynamic changes

Removed login for now as we don't support login in the middle of a half-filled in form yet