### PR TITLE
fix: Clicking eye icon on a form definition from a tag-filtered list …

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/formDefinitionItem.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/formDefinitionItem.tsx
@@ -118,7 +118,7 @@ const FormDefinitionDetails = ({ formDefinition }: { formDefinition: FormDefinit
         {formDefinition.submissionRecords ? 'true' : 'false'}
       </div>
 
-      {formDefinition.dispositionStates.length > 0 && (
+      {formDefinition.dispositionStates && formDefinition.dispositionStates.length > 0 && (
         <div>
           <DetailsTagHeading>Disposition States</DetailsTagHeading>
           {formDefinition.dispositionStates.map((x) => (


### PR DESCRIPTION
…makes the whole page blank with console errors