### PR TITLE
Potential fix for code scanning alert no. 155: Database query built from user-controlled sources

### DIFF
--- a/apps/configuration-service/src/mongo/repository.ts
+++ b/apps/configuration-service/src/mongo/repository.ts
@@ -199,8 +199,10 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
         .findOneAndUpdate(
           query,
           {
-            ...update,
-            configuration: renamePrefixProperties(revision.configuration, '$', this.META_PREFIX),
+            $set: {
+              ...update,
+              configuration: renamePrefixProperties(revision.configuration, '$', this.META_PREFIX),
+            }
           },
           { upsert: true, new: true, lean: true }
         )


### PR DESCRIPTION
Potential fix for [https://github.com/GovAlta/adsp-monorepo/security/code-scanning/155](https://github.com/GovAlta/adsp-monorepo/security/code-scanning/155)

The best way to fix this problem is to ensure that the user-provided configuration data cannot be interpreted as a query operator object by MongoDB. You can do this by "defensively" wrapping the configuration data in a way that MongoDB only treats it as a literal value (using the `$set` update operator in an update context) or by thoroughly checking that the configuration does not include any property names that start with `$`. Given this is an `update` payload in a `findOneAndUpdate` call (not the filter), you must ensure the user-provided object is not used in a way that allows dangerous operators. Specifically, the `configuration` field should be assigned as a literal (not containing top-level keys starting with `$`), or even better, wrap the value in `$set`: `{ $set: { ...update, configuration: ... } }`.

To implement this fix, you should:

- Prevent any properties within `configuration` from starting with `$`, either by recursive check or sanitization.
- Alternatively, and more simply in the context of a MongoDB update operation, use the `$set` operator and assign `configuration` as a field – this is safest, since MongoDB will treat values inside `$set` as literal and not interpretable as operators.

Edit the upsert logic in `saveRevision` (`apps/configuration-service/src/mongo/repository.ts`, lines around 201-204) accordingly and, if necessary, add a utility to sanitize/validate the configuration recursively.
Add such a check before passing the value to MongoDB.
If using `$set`, the update payload becomes `{ $set: { ...update, configuration: ... } }`.

No new library dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
