### PR TITLE
fix-CS-4380-As a form designer I can search for all form definitions associated with a program

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/definitions.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/definitions/definitions.tsx
@@ -400,7 +400,7 @@ export const FormDefinitions = ({
                     setCurrentDefinition(formDefinition);
                   }}
                 />
-                {getNextEntries() && !ministryFilter && (
+                {getNextEntries() && !ministryFilter && !programFilter && (
                   <LoadMoreWrapper>
                     <GoAButton
                       testId="form-event-load-more-btn"


### PR DESCRIPTION
Updated the condition to display the 'Load More' button so it only appears when neither ministryFilter nor programFilter are set. This prevents loading more entries when filters are active.