### PR TITLE
chore(event-service): using imagestream for statefulset images

### DIFF
--- a/.openshift/managed/event-service.yml
+++ b/.openshift/managed/event-service.yml
@@ -185,7 +185,16 @@ objects:
                 "namespace": "adsp-build"
               },
               "fieldPath": "spec.template.spec.containers[0].image",
-              "paused": true
+              "paused": false
+            },
+            {
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "busybox:1.37",
+                "namespace": "adsp-build"
+              },
+              "fieldPath": "spec.template.spec.initContainers[0].image",
+              "paused": false
             }
           ]
     spec:
@@ -205,7 +214,7 @@ objects:
           terminationGracePeriodSeconds: 30
           initContainers:
             - name: rm-erlang-cookie
-              image: 'busybox:1.37'
+              image: ''
               command:
                 - sh
                 - '-c'
@@ -228,7 +237,7 @@ objects:
               args:
                 - -c
                 - cp -v /etc/rabbitmq/rabbitmq.conf ${RABBITMQ_CONFIG_FILE}.conf; exec docker-entrypoint.sh rabbitmq-server
-              image: rabbitmq:4.0-management
+              image: ''
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: config-volume


### PR DESCRIPTION
This with local reference policy avoids direct requests to docker hub.