### PR TITLE
chore: set job deployments to paused

### DIFF
--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -109,7 +109,7 @@ jobs:
           openshift_token: ${{ secrets.ARO_TOKEN }}
           namespace: adsp-build
           insecure_skip_tls_verify: true
-      - name: Build container
+      - name: Deploy to dev
         uses: ./.github/actions/deploy-app
         with:
           app: ${{ matrix.app }}
@@ -170,7 +170,7 @@ jobs:
           openshift_token: ${{ secrets.ARO_TOKEN }}
           namespace: adsp-build
           insecure_skip_tls_verify: true
-      - name: Build container
+      - name: Deploy to uat
         uses: ./.github/actions/deploy-app
         with:
           app: ${{ matrix.app }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -102,7 +102,7 @@ jobs:
           openshift_token: ${{ secrets.ARO_TOKEN }}
           namespace: adsp-build
           insecure_skip_tls_verify: true
-      - name: Build container
+      - name: Deploy to prod
         uses: ./.github/actions/deploy-app
         with:
           app: ${{ matrix.app }}

--- a/.openshift/managed/dashboard-metrics.yml
+++ b/.openshift/managed/dashboard-metrics.yml
@@ -344,7 +344,8 @@ objects:
                 "name": "${APP_NAME}:${DEPLOY_TAG}",
                 "namespace": "${INFRA_NAMESPACE}"
               },
-              "fieldPath": "spec.template.spec.containers[0].image"
+              "fieldPath": "spec.template.spec.containers[0].image",
+              "paused": true
             }
           ]
     spec:

--- a/.openshift/managed/event-service.yml
+++ b/.openshift/managed/event-service.yml
@@ -492,7 +492,8 @@ objects:
                 "name": "${APP_NAME}:${DEPLOY_TAG}",
                 "namespace": "${INFRA_NAMESPACE}"
               },
-              "fieldPath": "spec.template.spec.containers[0].image"
+              "fieldPath": "spec.template.spec.containers[0].image",
+              "paused": true
             }
           ]
     spec:

--- a/.openshift/managed/file-service.yml
+++ b/.openshift/managed/file-service.yml
@@ -386,7 +386,8 @@ objects:
                 "name": "${APP_NAME}:${DEPLOY_TAG}",
                 "namespace": "${INFRA_NAMESPACE}"
               },
-              "fieldPath": "spec.template.spec.containers[0].image"
+              "fieldPath": "spec.template.spec.containers[0].image",
+              "paused": true
             }
           ]
     spec:

--- a/.openshift/managed/notification-service.yml
+++ b/.openshift/managed/notification-service.yml
@@ -256,7 +256,8 @@ objects:
                 "name": "${APP_NAME}:${DEPLOY_TAG}",
                 "namespace": "${INFRA_NAMESPACE}"
               },
-              "fieldPath": "spec.template.spec.containers[0].image"
+              "fieldPath": "spec.template.spec.containers[0].image",
+              "paused": true
             }
           ]
       labels:

--- a/.openshift/managed/pdf-service.yml
+++ b/.openshift/managed/pdf-service.yml
@@ -366,7 +366,8 @@ objects:
                 "name": "${APP_NAME}:${DEPLOY_TAG}",
                 "namespace": "${INFRA_NAMESPACE}"
               },
-              "fieldPath": "spec.template.spec.containers[0].image"
+              "fieldPath": "spec.template.spec.containers[0].image",
+              "paused": true
             }
           ]
       labels:

--- a/.openshift/managed/status-service.yml
+++ b/.openshift/managed/status-service.yml
@@ -185,7 +185,8 @@ objects:
                 "name": "${APP_NAME}:${DEPLOY_TAG}",
                 "namespace": "${INFRA_NAMESPACE}"
               },
-              "fieldPath": "spec.template.spec.containers[0].image"
+              "fieldPath": "spec.template.spec.containers[0].image",
+              "paused": true
             }
           ]
     spec:


### PR DESCRIPTION
The pipeline will orchestrate rollouts instead of letting the image stream tag update automatically trigger updates.