### PR TITLE
fix(data-exchange-standard): deprecating "emailStandard" and replacin…

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/autoComplete/form.ts
+++ b/apps/tenant-management-webapp/src/app/lib/autoComplete/form.ts
@@ -319,16 +319,19 @@ export class FormDataSchemaElementCompletionItemProvider extends JsonObjectCompl
     labelPath?: string
   ): EditorSuggestion[] {
     const suggestions: EditorSuggestion[] = [];
-    if (typeof schema?.definitions === 'object') {
-      for (const definition in schema.definitions) {
+    if (schema?.definitions && typeof schema.definitions === 'object') {
+      const definitions = schema.definitions;
+      for (const [definition, definitionSchema] of Object.entries(definitions)) {
         const currentPath = `${path}/definitions/${definition}`;
         const currentLabelPath = `${labelPath || path}/d.../${definition}`;
 
-        suggestions.push({
-          label: `Ref:"${currentLabelPath}"`,
-          insertText: `{ "$ref": "${currentPath}" }`,
-          path,
-        });
+        if (definitionSchema.deprecated !== true) {
+          suggestions.push({
+            label: `Ref:"${currentLabelPath}"`,
+            insertText: `{ "$ref": "${currentPath}" }`,
+            path,
+          });
+        }
       }
     }
 

--- a/libs/data-exchange-standard/src/common.v1.schema.json
+++ b/libs/data-exchange-standard/src/common.v1.schema.json
@@ -219,6 +219,7 @@
       "errorMessage": "Must be three groups of three digits."
     },
     "emailStandard": {
+      "deprecated": true,
       "type": "string",
       "format": "email",
       "label": "Email address",
@@ -228,6 +229,18 @@
       "errorMessage": {
         "pattern": "(e.g., name@example.com).",
         "maxLength": "Email must be less than 100 characters."
+      }
+    },
+    "email": {
+      "$comment": "Standard email address",
+      "title": "Email address",
+      "type": "string",
+      "format": "email",
+      "maxLength": 100,
+      "description": "a.n.other@example.com",
+      "errorMessage": {
+        "format": "Must be in a format like a.n.other@example.com",
+        "maxLength": "Must be less than 100 characters."
       }
     }
   }


### PR DESCRIPTION
…g with "email"

Also filtering out deprecated definitions in editor auto completion.