### PR TITLE
fix:add css for long words in form editor data tab CS-4443

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/styled-components.ts
@@ -565,6 +565,12 @@ export const PRE = styled.div`
   font-size: var(--goa-font-size-1);
   line-height: var(--goa-line-height-05);
   padding: var(--goa-space-m);
+
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  max-height: 60vh;
+  overflow: auto;
+  max-width: 100%;
 `;
 
 export const FormPreviewScrollPane = styled.div`


### PR DESCRIPTION
Before 
<img width="1002" height="246" alt="image" src="https://github.com/user-attachments/assets/6bbf0ddc-2a98-49a8-b84c-98d4b8d88931" />
After
<img width="953" height="273" alt="image" src="https://github.com/user-attachments/assets/07ea7ff4-6025-46fc-bdd1-9e402c627670" />

If feel like this UI is better than a scroll bar.