### PR TITLE
feat(pdf-service): support job context

### DIFF
--- a/apps/pdf-service/src/pdf/events.ts
+++ b/apps/pdf-service/src/pdf/events.ts
@@ -106,12 +106,13 @@ export const pdfGenerationQueued = (
   tenantId: AdspId,
   jobId: string,
   templateId: string,
+  context: Record<string, unknown>,
   requestedBy: { id: string; name: string }
 ): DomainEvent => ({
   name: PDF_GENERATION_QUEUED,
   tenantId,
   correlationId: jobId,
-  context: { jobId, templateId },
+  context: { ...context, jobId, templateId },
   timestamp: new Date(),
   payload: {
     jobId,
@@ -124,13 +125,14 @@ export const pdfGenerated = (
   tenantId: AdspId,
   jobId: string,
   templateId: string,
+  context: Record<string, unknown>,
   file: FileResult,
   requestedBy: { id: string; name: string }
 ): DomainEvent => ({
   name: PDF_GENERATED,
   tenantId,
   correlationId: jobId,
-  context: { jobId, templateId },
+  context: { ...context, jobId, templateId },
   timestamp: new Date(),
   payload: {
     jobId,
@@ -148,13 +150,14 @@ export const pdfGenerationFailed = (
   tenantId: AdspId,
   jobId: string,
   templateId: string,
+  context: Record<string, unknown>,
   requestedBy: { id: string; name: string },
   payload: { [key: string]: string }
 ): DomainEvent => ({
   name: PDF_GENERATION_FAILED,
   tenantId,
   correlationId: jobId,
-  context: { jobId, templateId },
+  context: { ...context, jobId, templateId },
   timestamp: new Date(),
   payload: {
     jobId,

--- a/apps/pdf-service/src/pdf/job/generate.spec.ts
+++ b/apps/pdf-service/src/pdf/job/generate.spec.ts
@@ -97,6 +97,7 @@ describe('generate', () => {
         fileType: GENERATED_PDF,
         recordId: 'my-domain-record-1',
         data: {},
+        context: {},
         filename: 'test.pdf',
         requestedBy: {
           id: 'tester',
@@ -137,6 +138,7 @@ describe('generate', () => {
             id: '262f0da7-f375-493a-bd96-c6035ca16bf7',
           },
         },
+        context: {},
         filename: 'test.pdf',
         requestedBy: {
           id: 'tester',
@@ -232,6 +234,7 @@ describe('generate', () => {
             },
           },
         },
+        context: {},
         filename: 'test.pdf',
         requestedBy: {
           id: 'tester',
@@ -272,6 +275,7 @@ describe('generate', () => {
         fileType: GENERATED_PDF,
         recordId: 'my-domain-record-1',
         data: {},
+        context: {},
         filename: 'test.pdf',
         requestedBy: {
           id: 'tester',
@@ -297,6 +301,7 @@ describe('generate', () => {
         fileType: GENERATED_PDF,
         recordId: 'my-domain-record-1',
         data: {},
+        context: {},
         filename: 'test.pdf',
         requestedBy: {
           id: 'tester',
@@ -335,6 +340,7 @@ describe('generate', () => {
         fileType: GENERATED_PDF,
         recordId: 'my-domain-record-1',
         data: {},
+        context: {},
         filename: 'test.pdf',
         requestedBy: {
           id: 'tester',

--- a/apps/pdf-service/src/pdf/job/generate.ts
+++ b/apps/pdf-service/src/pdf/job/generate.ts
@@ -28,7 +28,17 @@ export function createGenerateJob({
   eventService,
 }: GenerateJobProps) {
   return async (
-    { tenantId: tenantIdValue, jobId, fileType, filename, recordId, templateId, data, requestedBy }: PdfServiceWorkItem,
+    {
+      tenantId: tenantIdValue,
+      jobId,
+      fileType,
+      filename,
+      recordId,
+      templateId,
+      context,
+      data,
+      requestedBy,
+    }: PdfServiceWorkItem,
     retryOnError: boolean,
     done: (err?: Error) => void
   ): Promise<void> => {
@@ -62,7 +72,7 @@ export function createGenerateJob({
 
       const result = await fileService.upload(tenantId, fileType, recordId, pdfFilename, pdf);
 
-      eventService.send(pdfGenerated(tenantId, jobId, templateId, result, requestedBy));
+      eventService.send(pdfGenerated(tenantId, jobId, templateId, context, result, requestedBy));
 
       logger.info(`Generated PDF (ID: ${jobId}) file ${pdfFilename} and uploaded to file service at: ${result.urn}`, {
         context,
@@ -74,7 +84,7 @@ export function createGenerateJob({
     } catch (err) {
       if (!retryOnError) {
         await repository.update(jobId, 'failed');
-        eventService.send(pdfGenerationFailed(tenantId, jobId, templateId, requestedBy, { error: err.toString() }));
+        eventService.send(pdfGenerationFailed(tenantId, jobId, templateId, context, requestedBy, { error: err.toString() }));
         logger.error(`Generation of PDF (ID: ${jobId}) failed with error. ${err}`);
       }
 

--- a/apps/pdf-service/src/pdf/job/types.ts
+++ b/apps/pdf-service/src/pdf/job/types.ts
@@ -4,6 +4,7 @@ export interface PdfServiceWorkItem {
   jobId: string;
   tenantId: string;
   templateId: string;
+  context: Record<string, unknown>;
   data: DataContent;
   fileType: string;
   filename: string;

--- a/apps/pdf-service/src/pdf/router/pdf.swagger.yml
+++ b/apps/pdf-service/src/pdf/router/pdf.swagger.yml
@@ -76,9 +76,14 @@ components:
           description: An arbitrary identifier that can be used by your application to cross reference the PDF document being generated.
           type: string
           example: user-jane-doe
+        context:
+          description: The context in which the PDF is being generated. This is an arbitrary JSON object that can include any relevant information about the generation request.
+          example: { "requestId": "12345", "source": "user-action" }
+          type: object
         data:
           description: The variable (Handlebars) assignments to be applied to the template when generating a PDF.  This is an arbitrary JSON object, but its properties must match those expected by the template.
           example: { "user": { "name": "Jane Doe" } }
+          type: object
         filename:
           description: The name of the file that will be given to the generated PDF document.  It must be unique within your tenant.
           type: string


### PR DESCRIPTION
Allow request to include context in job which is then used in pdf generation events. This is to support triggering on pdf generation events based on a context criteria. The recordId has more specific meaning since it is used to associate the output file to a record and not just for event based trigger.