### PR TITLE
fix(notification-service): send generation failed on first failure

### DIFF
--- a/apps/notification-service/src/notification/job/processEvent.ts
+++ b/apps/notification-service/src/notification/job/processEvent.ts
@@ -99,9 +99,7 @@ export const createProcessEventJob =
               }
             );
           } catch (err) {
-            if (!retryOnError) {
-              eventService.send(notificationGenerationFailed(generationId, event, type, err.message));
-            }
+            eventService.send(notificationGenerationFailed(generationId, event, type, err.message));
           }
         }
       }


### PR DESCRIPTION
Sending on no more retries doesn't generally work since the try catch is preventing the overall generation job from failing.