### PR TITLE
feat : form preview and submissions CS-4549

### DIFF
--- a/apps/form-management-app/src/app/app.module.scss
+++ b/apps/form-management-app/src/app/app.module.scss
@@ -24,4 +24,5 @@ main {
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }

--- a/apps/form-management-app/src/app/app.tsx
+++ b/apps/form-management-app/src/app/app.tsx
@@ -56,6 +56,7 @@ export function App() {
             <Route index element={<TenantManagement />} />
             <Route path="forms" element={<FormDefinitions />} />
             <Route path="editor/:formId" element={<FormEditor />} />
+            <Route path="preview" element={<FormPreview />} />
             <Route path="preview/:formId" element={<FormPreview />} />
           </Route>
         </Routes>

--- a/apps/form-management-app/src/app/components/BackButton.tsx
+++ b/apps/form-management-app/src/app/components/BackButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { BackButtonWrapper } from './styled-components';
+
+export interface BackButtonProps {
+  onClick: () => void;
+  children?: React.ReactNode;
+}
+
+export const BackButton: React.FC<BackButtonProps> = ({ onClick, children = 'Back' }) => {
+  return (
+    <BackButtonWrapper onClick={onClick} type="button">
+      <svg viewBox="0 0 24 24">
+        <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+      </svg>
+      {children}
+    </BackButtonWrapper>
+  );
+};

--- a/apps/form-management-app/src/app/components/BackButton.tsx
+++ b/apps/form-management-app/src/app/components/BackButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BackButtonWrapper } from './styled-components';
+import styles from './components.module.scss';
 
 export interface BackButtonProps {
   onClick: () => void;
@@ -8,11 +8,11 @@ export interface BackButtonProps {
 
 export const BackButton: React.FC<BackButtonProps> = ({ onClick, children = 'Back' }) => {
   return (
-    <BackButtonWrapper onClick={onClick} type="button">
+    <button onClick={onClick} type="button" className={styles.backButtonWrapper}>
       <svg viewBox="0 0 24 24">
         <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
       </svg>
       {children}
-    </BackButtonWrapper>
+    </button>
   );
 };

--- a/apps/form-management-app/src/app/components/components.module.scss
+++ b/apps/form-management-app/src/app/components/components.module.scss
@@ -1,6 +1,4 @@
-import styled from 'styled-components';
-
-export const BackButtonWrapper = styled.button`
+.backButtonWrapper {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -29,94 +27,93 @@ export const BackButtonWrapper = styled.button`
     height: 16px;
     fill: currentColor;
   }
-`;
+}
 
-export const MarginAdjustment = styled.h4`
+.marginAdjustment {
   margin-bottom: 0.5rem !important;
   margin-top: 2rem !important;
-`;
+}
 
-export const PaddingRem = styled.div`
+.paddingRem {
   padding-top: 1rem;
-`;
+}
 
-export const Padding = styled.div`
+.padding {
   padding-top: var(--goa-space-m);
   padding-bottom: var(--goa-space-m);
-`;
+}
 
-export const ActionButtonWrapper = styled.div`
+.actionButtonWrapper {
   display: flex;
   gap: 1em;
   justify-content: flex-end;
-`;
+}
 
-export const CenterActionWrapper = styled.div`
+.centerActionWrapper {
   display: flex;
   gap: 1em;
   justify-content: center;
-`;
+}
 
-export const SpaceAdjust = styled.h3`
+.spaceAdjust {
   padding-top: 3rem;
   padding-bottom: 1rem;
-`;
+}
 
-export const LoadMoreWrapper = styled.div`
+.loadMoreWrapper {
   padding-bottom: var(--goa-space-4xl);
   text-align: center;
-`;
+}
 
-export const GapAdjustment = styled.h3`
+.gapAdjustment {
   padding-top: 2rem;
   padding-bottom: 1rem;
-`;
+}
 
-export const TableWrapper = styled.div`
+.tableWrapper {
   width: 100%;
   overflow-x: auto;
-`;
+}
 
-export const ContentWrapper = styled.div`
+.contentWrapper {
   padding: 1rem;
-`;
+}
 
-export const SkeletonWrapper = styled.div`
+.skeletonWrapper {
   display: grid;
   gap: 1rem;
   margin-top: 2rem;
-`;
+}
 
-export const LoadingSkeletonWrapper = styled.div`
+.loadingSkeletonWrapper {
   display: grid;
   gap: 1rem;
   margin-bottom: 2rem;
-`;
+}
 
-export const ErrorMsg = styled.div`
+.errorMsg {
   display: inline-flex;
   color: var(--color-red);
   pointer-events: none;
   gap: 0.25rem;
-`;
+}
 
-export const HelpText = styled.div`
+.helpText {
   font: var(--goa-typography-body-xs);
   color: var(--color-gray-900);
   display: flex;
   justify-content: space-between;
   margin-top: 2px;
-`;
+}
 
-export const FormSection = styled.div`
+.formSection {
   margin-bottom: 2rem;
-`;
+}
 
-export const FormHeaderWrapper = styled.div`
+.formHeaderWrapper {
   margin-bottom: 1rem;
-`;
+}
 
-// Navigation styling
-export const NavigationWrapper = styled.div`
+.navigationWrapper {
   margin-bottom: 1rem;
-`;
+}

--- a/apps/form-management-app/src/app/components/index.ts
+++ b/apps/form-management-app/src/app/components/index.ts
@@ -1,2 +1,2 @@
 export { BackButton } from './BackButton';
-export * from './styled-components';
+export { default as styles } from './components.module.scss';

--- a/apps/form-management-app/src/app/components/index.ts
+++ b/apps/form-management-app/src/app/components/index.ts
@@ -1,0 +1,2 @@
+export { BackButton } from './BackButton';
+export * from './styled-components';

--- a/apps/form-management-app/src/app/components/styled-components.ts
+++ b/apps/form-management-app/src/app/components/styled-components.ts
@@ -1,0 +1,122 @@
+import styled from 'styled-components';
+
+export const BackButtonWrapper = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  color: var(--goa-color-interactive);
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: var(--goa-color-interactive-hover);
+    color: var(--goa-color-text-light);
+  }
+
+  &:focus {
+    outline: 2px solid var(--goa-color-interactive-focus);
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+  }
+`;
+
+export const MarginAdjustment = styled.h4`
+  margin-bottom: 0.5rem !important;
+  margin-top: 2rem !important;
+`;
+
+export const PaddingRem = styled.div`
+  padding-top: 1rem;
+`;
+
+export const Padding = styled.div`
+  padding-top: var(--goa-space-m);
+  padding-bottom: var(--goa-space-m);
+`;
+
+export const ActionButtonWrapper = styled.div`
+  display: flex;
+  gap: 1em;
+  justify-content: flex-end;
+`;
+
+export const CenterActionWrapper = styled.div`
+  display: flex;
+  gap: 1em;
+  justify-content: center;
+`;
+
+export const SpaceAdjust = styled.h3`
+  padding-top: 3rem;
+  padding-bottom: 1rem;
+`;
+
+export const LoadMoreWrapper = styled.div`
+  padding-bottom: var(--goa-space-4xl);
+  text-align: center;
+`;
+
+export const GapAdjustment = styled.h3`
+  padding-top: 2rem;
+  padding-bottom: 1rem;
+`;
+
+export const TableWrapper = styled.div`
+  width: 100%;
+  overflow-x: auto;
+`;
+
+export const ContentWrapper = styled.div`
+  padding: 1rem;
+`;
+
+export const SkeletonWrapper = styled.div`
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+`;
+
+export const LoadingSkeletonWrapper = styled.div`
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;
+
+export const ErrorMsg = styled.div`
+  display: inline-flex;
+  color: var(--color-red);
+  pointer-events: none;
+  gap: 0.25rem;
+`;
+
+export const HelpText = styled.div`
+  font: var(--goa-typography-body-xs);
+  color: var(--color-gray-900);
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2px;
+`;
+
+export const FormSection = styled.div`
+  margin-bottom: 2rem;
+`;
+
+export const FormHeaderWrapper = styled.div`
+  margin-bottom: 1rem;
+`;
+
+// Navigation styling
+export const NavigationWrapper = styled.div`
+  margin-bottom: 1rem;
+`;

--- a/apps/form-management-app/src/app/containers/FormSubmission.tsx
+++ b/apps/form-management-app/src/app/containers/FormSubmission.tsx
@@ -1,0 +1,112 @@
+import { GoAButton, GoAFormItem } from '@abgov/react-components';
+import { useDispatch, useSelector } from 'react-redux';
+import { FunctionComponent, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { DateTime } from 'luxon';
+import {
+  selectSubmission,
+  selectedSubmissionSelector,
+  formLoadingSelector,
+  selectedDefinitionSelector,
+} from '../state/form/form.slice';
+import { AppDispatch } from '../state/store';
+
+export const FormSubmission: FunctionComponent = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+
+  const { submissionId } = useParams();
+  const { submissions: loading } = useSelector(formLoadingSelector);
+  const definition = useSelector(selectedDefinitionSelector);
+  const submission = useSelector(selectedSubmissionSelector);
+
+  const [formSubmissionUrn, setFormSubmissionUrn] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (submissionId) {
+      dispatch(selectSubmission(submissionId));
+    }
+  }, [dispatch, submissionId]);
+
+  useEffect(() => {
+    if (submission) {
+      const urn = `urn:ads:platform:form-service:v1:/forms/${submission.formId}${
+        submission.id ? `/submissions/${submission.id}` : ''
+      }`;
+      setFormSubmissionUrn(urn);
+    }
+  }, [submission]);
+
+  if (!submission) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <div>
+        <GoAButton type="tertiary" onClick={() => navigate('../')}>
+          Back to submissions
+        </GoAButton>
+      </div>
+
+      <div style={{ padding: '1rem' }}>
+        <h1>Form Submission Details</h1>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+            gap: '1rem',
+            marginBottom: '2rem',
+          }}
+        >
+          <GoAFormItem label="Submitted by">{submission.createdBy.name}</GoAFormItem>
+          <GoAFormItem label="Submitted on">{DateTime.fromISO(submission.created).toFormat('LLL d, yyyy')}</GoAFormItem>
+          <GoAFormItem label="Form ID">{submission.formId}</GoAFormItem>
+          <GoAFormItem label="Definition ID">{submission.formDefinitionId}</GoAFormItem>
+        </div>
+
+        {submission.disposition && (
+          <div style={{ marginBottom: '2rem' }}>
+            <h3>Disposition</h3>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1rem' }}>
+              <GoAFormItem label="Status">{submission.disposition.status}</GoAFormItem>
+              <GoAFormItem label="Reason">{submission.disposition.reason}</GoAFormItem>
+              <GoAFormItem label="Date">
+                {DateTime.fromISO(submission.disposition.date).toFormat('LLL d, yyyy')}
+              </GoAFormItem>
+            </div>
+          </div>
+        )}
+
+        <div>
+          <h3>Form Data</h3>
+          <pre
+            style={{
+              background: '#f5f5f5',
+              padding: '1rem',
+              borderRadius: '4px',
+              overflow: 'auto',
+              fontSize: '0.875rem',
+            }}
+          >
+            {JSON.stringify(submission.formData, null, 2)}
+          </pre>
+        </div>
+
+        {submission.formFiles && Object.keys(submission.formFiles).length > 0 && (
+          <div style={{ marginTop: '2rem' }}>
+            <h3>Files</h3>
+            <ul>
+              {Object.entries(submission.formFiles).map(([key, urn]) => (
+                <li key={key}>
+                  {key}: {urn}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/form-management-app/src/app/containers/FormSubmissions.tsx
+++ b/apps/form-management-app/src/app/containers/FormSubmissions.tsx
@@ -10,7 +10,7 @@ import {
   GoASkeleton,
 } from '@abgov/react-components';
 import { useDispatch, useSelector } from 'react-redux';
-import { ContentWrapper, FormSection, LoadingSkeletonWrapper } from '../components';
+import { styles } from '../components';
 import { useNavigate } from 'react-router-dom';
 import {
   getFormSubmissions,
@@ -61,10 +61,10 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
   }, [dispatch, definitionId]);
 
   return (
-    <ContentWrapper>
+    <div className={styles.contentWrapper}>
       <h2>Form Submissions</h2>
 
-      <FormSection>
+      <div className={styles.formSection}>
         <GoAFormItem label="Disposition Status">
           <GoADropdown
             relative={true}
@@ -99,15 +99,15 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
             Find submissions
           </GoAButton>
         </GoAButtonGroup>
-      </FormSection>
+      </div>
 
       {loading && submissions.length === 0 && (
-        <LoadingSkeletonWrapper>
+        <div className={styles.loadingSkeletonWrapper}>
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
-        </LoadingSkeletonWrapper>
+        </div>
       )}
 
       {submissions && submissions.length > 0 ? (
@@ -154,6 +154,6 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
           </GoACallout>
         )
       )}
-    </ContentWrapper>
+    </div>
   );
 };

--- a/apps/form-management-app/src/app/containers/FormSubmissions.tsx
+++ b/apps/form-management-app/src/app/containers/FormSubmissions.tsx
@@ -1,0 +1,159 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import {
+  GoAButton,
+  GoAButtonGroup,
+  GoADropdown,
+  GoADropdownItem,
+  GoAFormItem,
+  GoATable,
+  GoACallout,
+  GoASkeleton,
+} from '@abgov/react-components';
+import { useDispatch, useSelector } from 'react-redux';
+import { ContentWrapper, FormSection, LoadingSkeletonWrapper } from '../components';
+import { useNavigate } from 'react-router-dom';
+import {
+  getFormSubmissions,
+  submissionsSelector,
+  submissionCriteriaSelector,
+  formActions,
+  formLoadingSelector,
+  selectSubmission,
+} from '../state/form/form.slice';
+import { AppDispatch } from '../state/store';
+
+interface RowLoadMoreProps {
+  next?: string;
+  columns: number;
+  loading: boolean;
+  onLoadMore: (after: string) => void;
+}
+const RowLoadMore: React.FC<RowLoadMoreProps> = ({ next, columns, loading, onLoadMore }) => {
+  if (!next) return null;
+  return (
+    <tr>
+      <td colSpan={columns} style={{ textAlign: 'center', padding: '16px' }}>
+        <GoAButton type="tertiary" disabled={loading} onClick={() => onLoadMore(next)}>
+          Load more
+        </GoAButton>
+      </td>
+    </tr>
+  );
+};
+
+interface FormSubmissionsProps {
+  definitionId: string;
+}
+
+export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ definitionId }) => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+
+  const { submissions: loading } = useSelector(formLoadingSelector);
+  const submissions = useSelector(submissionsSelector);
+  const criteria = useSelector(submissionCriteriaSelector);
+
+  useEffect(() => {
+    if (submissions.length < 1) {
+      dispatch(getFormSubmissions({ definitionId, criteria }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, definitionId]);
+
+  return (
+    <ContentWrapper>
+      <h2>Form Submissions</h2>
+
+      <FormSection>
+        <GoAFormItem label="Disposition Status">
+          <GoADropdown
+            relative={true}
+            name="submission-disposition"
+            value={criteria.dispositionStates?.join(',') || ''}
+            onChange={(_, values) =>
+              dispatch(
+                formActions.setSubmissionCriteria({
+                  ...criteria,
+                  dispositionStates: values === '' ? [] : [values as string],
+                })
+              )
+            }
+          >
+            <GoADropdownItem value="" label="All submissions" />
+            <GoADropdownItem value="submitted" label="Submitted" />
+            <GoADropdownItem value="approved" label="Approved" />
+            <GoADropdownItem value="rejected" label="Rejected" />
+          </GoADropdown>
+        </GoAFormItem>
+
+        <GoAButtonGroup alignment="end" mt="l">
+          <GoAButton type="secondary" onClick={() => dispatch(formActions.setSubmissionCriteria({}))}>
+            Reset filter
+          </GoAButton>
+          <GoAButton
+            type="primary"
+            leadingIcon="search"
+            disabled={loading}
+            onClick={() => dispatch(getFormSubmissions({ definitionId, criteria }))}
+          >
+            Find submissions
+          </GoAButton>
+        </GoAButtonGroup>
+      </FormSection>
+
+      {loading && submissions.length === 0 && (
+        <LoadingSkeletonWrapper>
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+        </LoadingSkeletonWrapper>
+      )}
+
+      {submissions && submissions.length > 0 ? (
+        <GoATable width="100%">
+          <thead>
+            <tr>
+              <th>Submitted on</th>
+              <th>Form ID</th>
+              <th>Disposition</th>
+              <th>Created By</th>
+              <th style={{ textAlign: 'center' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {submissions.map((submission) => (
+              <tr key={submission.urn}>
+                <td>{submission.created.toFormat('LLL d, yyyy')}</td>
+                <td>{submission.formId}</td>
+                <td>{submission.disposition?.status || 'No disposition'}</td>
+                <td>{submission.createdBy?.name || 'Unknown'}</td>
+                <td style={{ textAlign: 'center' }}>
+                  <GoAButtonGroup alignment="center">
+                    <GoAButton
+                      type="secondary"
+                      size="compact"
+                      onClick={() => {
+                        dispatch(selectSubmission(submission.id));
+                        navigate(`/admin/form-submission/${submission.id}`);
+                      }}
+                    >
+                      View Details
+                    </GoAButton>
+                  </GoAButtonGroup>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </GoATable>
+      ) : (
+        !loading &&
+        submissions.length === 0 && (
+          <GoACallout type="information" heading="No Submissions Found">
+            <p>No submissions have been found for this form definition. Users may not have submitted this form yet.</p>
+          </GoACallout>
+        )
+      )}
+    </ContentWrapper>
+  );
+};

--- a/apps/form-management-app/src/app/pages/admin/FormDefinitions/index.tsx
+++ b/apps/form-management-app/src/app/pages/admin/FormDefinitions/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   AppDispatch,
   getFormDefinitions,
-  selectFormDefinitions,
+  definitionsSelector,
   configInitializedSelector,
   userSelector,
   selectIsAuthenticated,
@@ -11,14 +11,14 @@ import {
 
 const FormDefinitions = (): JSX.Element => {
   const dispatch = useDispatch<AppDispatch>();
-  const definitions = useSelector(selectFormDefinitions);
+  const definitions = useSelector(definitionsSelector);
   const configInitialized = useSelector(configInitializedSelector);
   const { initialized: userInitialized } = useSelector(userSelector);
   const authenticated = useSelector(selectIsAuthenticated);
 
   useEffect(() => {
     if (configInitialized && userInitialized && authenticated) {
-      dispatch(getFormDefinitions());
+      dispatch(getFormDefinitions({}));
     }
   }, [dispatch, configInitialized, userInitialized, authenticated]);
 

--- a/apps/form-management-app/src/app/pages/admin/FormPreview/index.tsx
+++ b/apps/form-management-app/src/app/pages/admin/FormPreview/index.tsx
@@ -1,13 +1,205 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  GoAButton,
+  GoAButtonGroup,
+  GoADropdown,
+  GoADropdownItem,
+  GoAFormItem,
+  GoAContainer,
+  GoAGrid,
+  GoATable,
+  GoACallout,
+  GoASkeleton,
+  GoABadge,
+} from '@abgov/react-components';
+import { FormSubmissions } from '../../../containers/FormSubmissions';
+import {
+  getFormDefinitions,
+  definitionsSelector,
+  selectDefinition,
+  formLoadingSelector,
+  selectedDefinitionSelector,
+} from '../../../state/form/form.slice';
+import { AppDispatch } from '../../../state/store';
+import { configInitializedSelector, userSelector, selectIsAuthenticated } from '../../../state';
+import { BackButton, NavigationWrapper, SkeletonWrapper, LoadMoreWrapper } from '../../../components';
 
 const FormPreview = (): JSX.Element => {
-  const { formId } = useParams<{ formId: string }>();
+  const location = useLocation();
+  const { formId } = useParams<{ formId?: string }>();
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const [loadingVisible, setLoadingVisible] = useState(false);
+
+  const definitions = useSelector(definitionsSelector);
+  const selectedDefinition = useSelector(selectedDefinitionSelector);
+  const { definitions: loading } = useSelector(formLoadingSelector);
+  const configInitialized = useSelector(configInitializedSelector);
+  const { initialized: userInitialized } = useSelector(userSelector);
+  const authenticated = useSelector(selectIsAuthenticated);
+  const nextPage = useSelector((state: { form: { next: { definitions?: string } } }) => state.form.next.definitions);
+
+  useEffect(() => {
+    if (configInitialized && userInitialized && authenticated) {
+      setLoadingVisible(true);
+      dispatch(getFormDefinitions({})).finally(() => setLoadingVisible(false));
+    }
+  }, [dispatch, configInitialized, userInitialized, authenticated]);
+
+  const handleLoadMore = () => {
+    if (nextPage) {
+      dispatch(getFormDefinitions({ after: nextPage }));
+    }
+  };
+
+  // Determine view mode based on URL parameters
+  const isViewingSubmissions = !!formId;
+
+  useEffect(() => {
+    if (formId) {
+      dispatch(selectDefinition(formId));
+    }
+  }, [formId, dispatch]);
+
+  const handleViewSubmissions = (definitionId: string) => {
+    const pathParts = location.pathname.split('/');
+    const tenant = pathParts[1];
+    navigate(`/${tenant}/preview/${definitionId}`);
+  };
+
+  const handleBackToDefinitions = () => {
+    const pathParts = location.pathname.split('/');
+    const tenant = pathParts[1];
+    navigate(`/${tenant}/preview`);
+  };
+
+  const handleBackToLanding = () => {
+    const pathParts = location.pathname.split('/');
+    const tenant = pathParts[1];
+    navigate(`/${tenant}`);
+  };
+
+  if (loading && definitions.length === 0) {
+    return (
+      <GoAContainer>
+        <NavigationWrapper>
+          <BackButton onClick={handleBackToLanding}>Back to Landing</BackButton>
+        </NavigationWrapper>
+
+        <GoAGrid minChildWidth="100%">
+          <div>
+            <h1>Form Administration</h1>
+            <p>Loading form definitions...</p>
+          </div>
+        </GoAGrid>
+
+        <SkeletonWrapper>
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+          <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
+        </SkeletonWrapper>
+      </GoAContainer>
+    );
+  }
+
+  if (isViewingSubmissions && selectedDefinition) {
+    return (
+      <GoAContainer>
+        <NavigationWrapper>
+          <BackButton onClick={handleBackToDefinitions}>Back to Form Definitions</BackButton>
+          <h1>Submissions for: {selectedDefinition.name}</h1>
+          <p>{selectedDefinition.description}</p>
+        </NavigationWrapper>
+        <FormSubmissions definitionId={selectedDefinition.id} />
+      </GoAContainer>
+    );
+  }
 
   return (
-    <div>
-      <h1>Form Preview - {formId}</h1>
-    </div>
+    <GoAContainer>
+      <NavigationWrapper>
+        <BackButton onClick={handleBackToLanding}>Back to Landing</BackButton>
+      </NavigationWrapper>
+
+      <GoAGrid minChildWidth="100%">
+        <div>
+          <h1>Form Administration</h1>
+          <p>Manage and view form definitions and their submissions.</p>
+        </div>
+      </GoAGrid>
+
+      {definitions && definitions.length > 0 ? (
+        <>
+          <GoATable width="100%">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Anonymous Apply</th>
+                <th>Submission Records</th>
+                <th style={{ textAlign: 'center' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {definitions.map((definition) => (
+                <tr key={definition.id}>
+                  <td>
+                    <strong>{definition.name}</strong>
+                    <br />
+                    <small>ID: {definition.id}</small>
+                  </td>
+                  <td>{definition.description || 'No description available'}</td>
+                  <td>
+                    <GoABadge
+                      type={definition.anonymousApply ? 'success' : 'information'}
+                      content={definition.anonymousApply ? 'Yes' : 'No'}
+                    />
+                  </td>
+                  <td>
+                    <GoABadge
+                      type={definition.submissionRecords ? 'success' : 'information'}
+                      content={definition.submissionRecords ? 'Enabled' : 'Disabled'}
+                    />
+                  </td>
+                  <td style={{ textAlign: 'center' }}>
+                    <GoAButtonGroup alignment="center">
+                      <GoAButton type="secondary" size="compact" onClick={() => handleViewSubmissions(definition.id)}>
+                        View Submissions
+                      </GoAButton>
+                      <GoAButton
+                        type="tertiary"
+                        size="compact"
+                        onClick={() => navigate(`/admin/form-editor/${definition.id}`)}
+                      >
+                        Edit Form
+                      </GoAButton>
+                    </GoAButtonGroup>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </GoATable>
+
+          {nextPage && (
+            <LoadMoreWrapper>
+              <GoAButton type="secondary" disabled={loading} onClick={handleLoadMore}>
+                {loading ? 'Loading...' : 'Load More Definitions'}
+              </GoAButton>
+            </LoadMoreWrapper>
+          )}
+        </>
+      ) : (
+        !loading && (
+          <GoACallout type="information" heading="No Form Definitions">
+            <p>No form definitions have been found. Please check your configuration or contact your administrator.</p>
+          </GoACallout>
+        )
+      )}
+    </GoAContainer>
   );
 };
 

--- a/apps/form-management-app/src/app/pages/admin/FormPreview/index.tsx
+++ b/apps/form-management-app/src/app/pages/admin/FormPreview/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../state/form/form.slice';
 import { AppDispatch } from '../../../state/store';
 import { configInitializedSelector, userSelector, selectIsAuthenticated } from '../../../state';
-import { BackButton, NavigationWrapper, SkeletonWrapper, LoadMoreWrapper } from '../../../components';
+import { BackButton, styles } from '../../../components';
 
 const FormPreview = (): JSX.Element => {
   const location = useLocation();
@@ -84,9 +84,9 @@ const FormPreview = (): JSX.Element => {
   if (loading && definitions.length === 0) {
     return (
       <GoAContainer>
-        <NavigationWrapper>
+        <div className={styles.navigationWrapper}>
           <BackButton onClick={handleBackToLanding}>Back to Landing</BackButton>
-        </NavigationWrapper>
+        </div>
 
         <GoAGrid minChildWidth="100%">
           <div>
@@ -95,13 +95,13 @@ const FormPreview = (): JSX.Element => {
           </div>
         </GoAGrid>
 
-        <SkeletonWrapper>
+        <div className={styles.skeletonWrapper}>
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
           <GoASkeleton type="card" lineCount={3} maxWidth="100%" />
-        </SkeletonWrapper>
+        </div>
       </GoAContainer>
     );
   }
@@ -109,11 +109,11 @@ const FormPreview = (): JSX.Element => {
   if (isViewingSubmissions && selectedDefinition) {
     return (
       <GoAContainer>
-        <NavigationWrapper>
+        <div className={styles.navigationWrapper}>
           <BackButton onClick={handleBackToDefinitions}>Back to Form Definitions</BackButton>
           <h1>Submissions for: {selectedDefinition.name}</h1>
           <p>{selectedDefinition.description}</p>
-        </NavigationWrapper>
+        </div>
         <FormSubmissions definitionId={selectedDefinition.id} />
       </GoAContainer>
     );
@@ -121,9 +121,9 @@ const FormPreview = (): JSX.Element => {
 
   return (
     <GoAContainer>
-      <NavigationWrapper>
+      <div className={styles.navigationWrapper}>
         <BackButton onClick={handleBackToLanding}>Back to Landing</BackButton>
-      </NavigationWrapper>
+      </div>
 
       <GoAGrid minChildWidth="100%">
         <div>
@@ -185,11 +185,11 @@ const FormPreview = (): JSX.Element => {
           </GoATable>
 
           {nextPage && (
-            <LoadMoreWrapper>
+            <div className={styles.loadMoreWrapper}>
               <GoAButton type="secondary" disabled={loading} onClick={handleLoadMore}>
                 {loading ? 'Loading...' : 'Load More Definitions'}
               </GoAButton>
-            </LoadMoreWrapper>
+            </div>
           )}
         </>
       ) : (

--- a/apps/form-management-app/src/app/state/form/form.slice.ts
+++ b/apps/form-management-app/src/app/state/form/form.slice.ts
@@ -1,64 +1,286 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, createSelector } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { DateTime } from 'luxon';
 import { AppState } from '../store';
-import { FormDefinition, FORM_SERVICE_ID } from '../types';
+import { FormDefinition, FormSubmission, PagedResults, FORM_SERVICE_ID, CONFIGURATION_SERVICE_ID } from '../types';
 import { getAccessToken } from '../user/user.slice';
 
 export const FORM_FEATURE_KEY = 'form';
 
+interface FormSubmissionCriteria {
+  definitionId?: string;
+  dispositionStates?: string[];
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
 export interface FormState {
-  definitions: FormDefinition[];
-  loading: boolean;
+  definitions: Record<string, FormDefinition>;
+  submissions: Record<string, FormSubmission>;
+  results: {
+    definitions: string[];
+    submissions: string[];
+  };
+  selectedDefinition?: string;
+  selectedSubmission?: string;
+  next: {
+    definitions?: string;
+    submissions?: string;
+  };
+  submissionCriteria: FormSubmissionCriteria;
+  loading: {
+    definitions: boolean;
+    submissions: boolean;
+  };
 }
 
 export const initialFormState: FormState = {
-  definitions: [],
-  loading: false,
+  definitions: {},
+  submissions: {},
+  results: {
+    definitions: [],
+    submissions: [],
+  },
+  next: {},
+  submissionCriteria: {},
+  loading: {
+    definitions: false,
+    submissions: false,
+  },
 };
 
-export const getFormDefinitions = createAsyncThunk('form/get-definitions', async (_, { getState, rejectWithValue }) => {
-  try {
-    const { config } = getState() as AppState;
-    const formServiceUrl = config.directory[FORM_SERVICE_ID];
-    const accessToken = await getAccessToken();
+export const getFormDefinitions = createAsyncThunk(
+  'form/get-definitions',
+  async (params: { after?: string } = {}, { getState, rejectWithValue }) => {
+    try {
+      const { config } = getState() as AppState;
+      const formServiceUrl = config.directory[FORM_SERVICE_ID];
+      const accessToken = await getAccessToken();
 
-    const { data } = await axios.get<{ results: FormDefinition[] }>(
-      new URL('/form/v1/definitions', formServiceUrl).href,
-      {
-        headers: { Authorization: `Bearer ${accessToken}` },
+      const { data } = await axios.get<PagedResults<FormDefinition>>(
+        new URL('/form/v1/definitions', formServiceUrl).href,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { top: 50, after: params?.after },
+        }
+      );
+
+      return {
+        ...data,
+        results:
+          data.results?.map((result) => ({
+            ...result,
+            oneFormPerApplicant: typeof result.oneFormPerApplicant !== 'boolean' || result.oneFormPerApplicant,
+            urn: `${CONFIGURATION_SERVICE_ID}:v2:/configuration/form-service/${result.id}`,
+          })) || [],
+      };
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        return rejectWithValue({
+          status: err.response?.status,
+          message: err.response?.data?.errorMessage || err.message,
+        });
+      } else {
+        throw err;
       }
-    );
-
-    return data.results;
-  } catch (err) {
-    if (axios.isAxiosError(err)) {
-      return rejectWithValue({
-        status: err.response?.status,
-        message: err.response?.data?.errorMessage || err.message,
-      });
-    } else {
-      throw err;
     }
   }
+);
+
+export const getFormSubmissions = createAsyncThunk(
+  'form/get-submissions',
+  async (
+    params: {
+      definitionId: string;
+      after?: string;
+      criteria?: FormSubmissionCriteria;
+    },
+    { getState, rejectWithValue }
+  ) => {
+    try {
+      const { config } = getState() as AppState;
+      const formServiceUrl = config.directory[FORM_SERVICE_ID];
+      const accessToken = await getAccessToken();
+
+      const { data } = await axios.get<PagedResults<FormSubmission>>(
+        new URL('/form/v1/submissions', formServiceUrl).href,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: {
+            top: 20,
+            after: params.after,
+            criteria: JSON.stringify({
+              ...params.criteria,
+              definitionIdEquals: params.definitionId,
+            }),
+          },
+        }
+      );
+
+      return data;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        return rejectWithValue({
+          status: err.response?.status,
+          message: err.response?.data?.errorMessage || err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
+  }
+);
+
+export const getFormSubmission = createAsyncThunk(
+  'form/get-submission',
+  async (submissionId: string, { getState, rejectWithValue }) => {
+    try {
+      const { config } = getState() as AppState;
+      const formServiceUrl = config.directory[FORM_SERVICE_ID];
+      const accessToken = await getAccessToken();
+
+      const { data } = await axios.get<FormSubmission>(
+        new URL(`/form/v1/submissions/${submissionId}`, formServiceUrl).href,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      );
+
+      return data;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        return rejectWithValue({
+          status: err.response?.status,
+          message: err.response?.data?.errorMessage || err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
+  }
+);
+
+export const selectDefinition = createAsyncThunk('form/select-definition', (definitionId: string, { dispatch }) => {
+  dispatch(formActions.setSelectedDefinition(definitionId));
+  dispatch(getFormSubmissions({ definitionId }));
+  return definitionId;
+});
+
+export const selectSubmission = createAsyncThunk('form/select-submission', (submissionId: string, { dispatch }) => {
+  dispatch(formActions.setSelectedSubmission(submissionId));
+  dispatch(getFormSubmission(submissionId));
+  return submissionId;
 });
 
 const formSlice = createSlice({
   name: FORM_FEATURE_KEY,
   initialState: initialFormState,
-  reducers: {},
+  reducers: {
+    setSelectedDefinition: (state, { payload }: { payload: string }) => {
+      if (state.selectedDefinition !== payload) {
+        state.results.submissions = [];
+        state.next.submissions = undefined;
+      }
+      state.selectedDefinition = payload;
+    },
+    setSelectedSubmission: (state, { payload }: { payload: string }) => {
+      state.selectedSubmission = payload;
+    },
+    setSubmissionCriteria: (state, { payload }: { payload: FormSubmissionCriteria }) => {
+      state.submissionCriteria = payload;
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getFormDefinitions.pending, (state) => {
-        state.loading = true;
+        state.loading.definitions = true;
       })
       .addCase(getFormDefinitions.fulfilled, (state, { payload }) => {
-        state.definitions = payload;
-        state.loading = false;
+        state.loading.definitions = false;
+        state.definitions = payload.results.reduce(
+          (definitions, definition) => ({ ...definitions, [definition.id]: definition }),
+          state.definitions as Record<string, FormDefinition>
+        );
+        state.results.definitions = [
+          ...(payload.page.after ? state.results.definitions : []),
+          ...payload.results.map((result) => result.id),
+        ];
+        state.next.definitions = payload.page.next;
       })
       .addCase(getFormDefinitions.rejected, (state) => {
-        state.loading = false;
+        state.loading.definitions = false;
+      })
+      .addCase(getFormSubmissions.pending, (state) => {
+        state.loading.submissions = true;
+      })
+      .addCase(getFormSubmissions.fulfilled, (state, { payload }) => {
+        state.loading.submissions = false;
+        state.submissions = payload.results.reduce(
+          (submissions, submission) => ({ ...submissions, [submission.id]: submission }),
+          state.submissions as Record<string, FormSubmission>
+        );
+        state.results.submissions = [
+          ...(payload.page.after ? state.results.submissions : []),
+          ...payload.results.map((result) => result.id),
+        ];
+        state.next.submissions = payload.page.next;
+      })
+      .addCase(getFormSubmissions.rejected, (state) => {
+        state.loading.submissions = false;
+      })
+      .addCase(getFormSubmission.fulfilled, (state, { payload }) => {
+        state.submissions[payload.id] = payload;
+      })
+      .addCase(selectDefinition.fulfilled, (state, { payload }) => {
+        state.selectedDefinition = payload;
+      })
+      .addCase(selectSubmission.fulfilled, (state, { payload }) => {
+        state.selectedSubmission = payload;
       });
   },
 });
 
 export const formReducer = formSlice.reducer;
+export const formActions = formSlice.actions;
+
+export const definitionsSelector = createSelector(
+  (state: AppState) => state.form.definitions,
+  (state: AppState) => state.form.results.definitions,
+  (definitions, results) => {
+    return results.map((result) => definitions[result]).filter((result) => !!result);
+  }
+);
+
+export const selectedDefinitionSelector = createSelector(
+  (state: AppState) => state.form.definitions,
+  (state: AppState) => state.form.selectedDefinition,
+  (definitions, selectedId) => {
+    return selectedId ? definitions[selectedId] : undefined;
+  }
+);
+
+export const submissionsSelector = createSelector(
+  (state: AppState) => state.form.submissions,
+  (state: AppState) => state.form.results.submissions,
+  (submissions, results) => {
+    return results
+      .map((result) => submissions[result])
+      .filter((result) => !!result)
+      .map(({ created, updated, ...result }) => ({
+        ...result,
+        created: DateTime.fromISO(created),
+        updated: updated ? DateTime.fromISO(updated) : null,
+      }));
+  }
+);
+
+export const selectedSubmissionSelector = createSelector(
+  (state: AppState) => state.form.submissions,
+  (state: AppState) => state.form.selectedSubmission,
+  (submissions, selectedId) => {
+    return selectedId ? submissions[selectedId] : undefined;
+  }
+);
+
+export const formLoadingSelector = (state: AppState) => state.form.loading;
+export const submissionCriteriaSelector = (state: AppState) => state.form.submissionCriteria;

--- a/apps/form-management-app/src/app/state/form/selectors.ts
+++ b/apps/form-management-app/src/app/state/form/selectors.ts
@@ -1,4 +1,3 @@
-import { AppState } from '../store';
+// The selectors have been moved to form.slice.ts to keep them close to the state definition.
 
-export const selectFormDefinitions = (state: AppState) => state.form.definitions;
-export const selectFormLoading = (state: AppState) => state.form.loading;
+export * from './form.slice';


### PR DESCRIPTION
- Load definitions in table (preview mode)
- Loads submissions for the selected definitions
<img width="1836" height="901" alt="image" src="https://github.com/user-attachments/assets/134d834e-81c0-4276-b561-5b191d9a25f1" />
<img width="1795" height="867" alt="image" src="https://github.com/user-attachments/assets/c2c43052-5eb5-46f0-92b7-c3755d7bed95" />
<img width="1802" height="853" alt="image" src="https://github.com/user-attachments/assets/17488f5a-e82d-48b3-bb92-324880d4f14d" />


- We can improve this as we go.