### PR TITLE
Fix cs 4787 fix(tenant-management-webapp): remove classifiers from form definition dialogs

### DIFF
--- a/apps/tenant-management-webapp/src/app/store/form/action.ts
+++ b/apps/tenant-management-webapp/src/app/store/form/action.ts
@@ -14,10 +14,6 @@ export const CLEAR_FORM_DEFINITIONS_ACTION = 'form/CLEAR_FORM_DEFINITIONS_ACTION
 export const FETCH_FORM_DEFINITIONS_ACTION = 'form/FETCH_FORM_DEFINITIONS_ACTION';
 export const FETCH_FORM_DEFINITIONS_SUCCESS_ACTION = 'form/FETCH_FORM_DEFINITIONS_SUCCESS_ACTION';
 
-export const FETCH_FORM_DEFINITIONS_REGISTER_ID_ACTION = 'form/FETCH_FORM_DEFINITIONS_REGISTER_ID_ACTION';
-export const FETCH_FORM_DEFINITIONS_REGISTER_ID_SUCCESS_ACTION =
-  'form/FETCH_FORM_DEFINITIONS_REGISTER_ID_SUCCESS_ACTION';
-
 export const UPDATE_FORM_DEFINITION_ACTION = 'form/UPDATE_FORM_DEFINITION_ACTION';
 export const UPDATE_FORM_DEFINITION_SUCCESS_ACTION = 'form/UPDATE_FORM_DEFINITION_SUCCESS_ACTION';
 
@@ -80,8 +76,6 @@ export const DELETE_RESOURCE_TAGS = 'form/resource/delete-resource-tags';
 
 export const DELETE_RESOURCE_TAGS_SUCCESS = 'form/resource/delete-resource-tags/success';
 export const INITIALIZE_FORM_EDITOR = 'form/initialize-form-editor';
-export const RESET_REGISTERED_ID_ACTION = 'form/reset-registered-id';
-export const RENAME_ACT_ACTION = 'form/rename-act';
 
 export interface ClearFormDefinitions {
   type: typeof CLEAR_FORM_DEFINITIONS_ACTION;
@@ -90,20 +84,9 @@ export interface FetchFormDefinitionsAction {
   type: typeof FETCH_FORM_DEFINITIONS_ACTION;
   next: string;
 }
-export interface FetchFormDefinitionsRegisterIdAction {
-  type: typeof FETCH_FORM_DEFINITIONS_REGISTER_ID_ACTION;
-  registeredId: string;
-}
 
 export interface FetchFormDefinitionsSuccessAction {
   type: typeof FETCH_FORM_DEFINITIONS_SUCCESS_ACTION;
-  payload: Record<string, FormDefinition>;
-  next: string;
-  after: string;
-}
-
-export interface FetchFormDefinitionsRegisterIdSuccessAction {
-  type: typeof FETCH_FORM_DEFINITIONS_REGISTER_ID_SUCCESS_ACTION;
   payload: Record<string, FormDefinition>;
   next: string;
   after: string;
@@ -247,20 +230,10 @@ export interface DeleteResourceSuccessTagsAction {
 export interface InitializeFormEditorAction {
   type: typeof INITIALIZE_FORM_EDITOR;
 }
-export interface ResetRegisteredIdAction {
-  type: typeof RESET_REGISTERED_ID_ACTION;
-}
-export interface RenameActAction {
-  type: typeof RENAME_ACT_ACTION;
-  oldName: string;
-  newName: string;
-}
 
 export type FormActionTypes =
-  | ResetRegisteredIdAction
   | ClearFormDefinitions
   | FetchFormDefinitionsSuccessAction
-  | FetchFormDefinitionsRegisterIdSuccessAction
   | FetchFormDefinitionsAction
   | ExportFormInfoAction
   | ExportFormInfoSuccessAction
@@ -301,8 +274,7 @@ export type FormActionTypes =
   | SetSelectedTagAction
   | DeleteResourceTagsAction
   | DeleteResourceSuccessTagsAction
-  | ClearAllTagsAction
-  | RenameActAction;
+  | ClearAllTagsAction;
 
 export interface FetchAllTagsAction {
   type: typeof FETCH_ALL_TAGS_ACTION;
@@ -408,10 +380,6 @@ export const getFormDefinitions = (next?: string): FetchFormDefinitionsAction =>
   type: FETCH_FORM_DEFINITIONS_ACTION,
   next,
 });
-export const getFormDefinitionsRegisterId = (registeredId?: string): FetchFormDefinitionsRegisterIdAction => ({
-  type: FETCH_FORM_DEFINITIONS_REGISTER_ID_ACTION,
-  registeredId,
-});
 
 export const getFormDefinitionsSuccess = (
   results: Record<string, FormDefinition>,
@@ -419,17 +387,6 @@ export const getFormDefinitionsSuccess = (
   after: string
 ): FetchFormDefinitionsSuccessAction => ({
   type: FETCH_FORM_DEFINITIONS_SUCCESS_ACTION,
-  payload: results,
-  next,
-  after,
-});
-
-export const getFormDefinitionsRegisterIdSuccess = (
-  results: Record<string, FormDefinition>,
-  next: string,
-  after: string
-): FetchFormDefinitionsRegisterIdSuccessAction => ({
-  type: FETCH_FORM_DEFINITIONS_REGISTER_ID_SUCCESS_ACTION,
   payload: results,
   next,
   after,
@@ -619,9 +576,6 @@ export const fetchResourcesByTagSuccess = (
   type: FETCH_RESOURCES_BY_TAG_SUCCESS,
   payload: { tag, resources, next, after },
 });
-export const resetRegisteredId = (): ResetRegisteredIdAction => ({
-  type: RESET_REGISTERED_ID_ACTION,
-});
 
 export const fetchResourcesByTagFailure = (error: string): FetchResourcesByTagFailureAction => ({
   type: FETCH_RESOURCES_BY_TAG_FAILURE,
@@ -646,9 +600,4 @@ export const deleteResourceSuccessTags = (urn: string, formDefinitionId: string)
 });
 export const initializeFormEditor = (): InitializeFormEditorAction => ({
   type: INITIALIZE_FORM_EDITOR,
-});
-export const renameAct = (oldName: string, newName: string): RenameActAction => ({
-  type: RENAME_ACT_ACTION,
-  oldName,
-  newName,
 });

--- a/apps/tenant-management-webapp/src/app/store/form/model.ts
+++ b/apps/tenant-management-webapp/src/app/store/form/model.ts
@@ -26,10 +26,6 @@ export interface FormDefinition {
   securityClassification?: SecurityClassification;
   resourceTags?: FormResourceTagResult[];
   dryRun?: boolean;
-  ministry?: string;
-  registeredId?: string;
-  programName?: string | null;
-  actsOfLegislation?: string[];
 }
 
 export interface FormResourceTagResponse {
@@ -74,7 +70,6 @@ export const defaultFormDefinition: FormDefinition = {
   formDraftUrlTemplate: '',
   anonymousApply: false,
   oneFormPerApplicant: true,
-  registeredId: null,
   scheduledIntakes: false,
   dispositionStates: [],
   submissionRecords: false,
@@ -82,8 +77,6 @@ export const defaultFormDefinition: FormDefinition = {
   queueTaskToProcess: { queueName: '', queueNameSpace: '' } as QueueTaskToProcess,
   supportTopic: false,
   securityClassification: SecurityClassification.ProtectedB,
-  programName: null,
-  actsOfLegislation: [],
 };
 export interface Stream {
   namespace: string;
@@ -132,7 +125,6 @@ export interface FormState {
   socket: Socket;
 
   formResourceTag: FormResourceTag;
-  registerIdDefinition: Record<string, FormDefinition>;
 }
 
 export interface FormResourceTag {

--- a/apps/tenant-management-webapp/src/app/store/form/reducers.ts
+++ b/apps/tenant-management-webapp/src/app/store/form/reducers.ts
@@ -34,9 +34,6 @@ import {
   SET_SELECTED_TAG,
   DELETE_RESOURCE_TAGS_SUCCESS,
   CLEAR_ALL_TAGS_ACTION,
-  FETCH_FORM_DEFINITIONS_REGISTER_ID_SUCCESS_ACTION,
-  RESET_REGISTERED_ID_ACTION,
-  RENAME_ACT_ACTION,
 } from './action';
 
 import { FormResourceTag, FormState } from './model';
@@ -61,7 +58,6 @@ export const defaultState: FormState = {
   socket: null,
   metrics: {},
   formResourceTag: {} as FormResourceTag,
-  registerIdDefinition: null,
 };
 
 export default function (state: FormState = defaultState, action: FormActionTypes): FormState {
@@ -70,7 +66,6 @@ export default function (state: FormState = defaultState, action: FormActionType
       return {
         ...state,
         definitions: {},
-        registerIdDefinition: null,
       };
 
     case FETCH_FORM_DEFINITIONS_SUCCESS_ACTION:
@@ -82,17 +77,6 @@ export default function (state: FormState = defaultState, action: FormActionType
           ? action.payload
           : state.definitions,
         nextEntries: action.next,
-      };
-
-    case FETCH_FORM_DEFINITIONS_REGISTER_ID_SUCCESS_ACTION:
-      return {
-        ...state,
-        registerIdDefinition: action.payload,
-      };
-    case RESET_REGISTERED_ID_ACTION:
-      return {
-        ...state,
-        registerIdDefinition: null,
       };
 
     case UPDATE_FORM_DEFINITION_ACTION:
@@ -409,26 +393,6 @@ export default function (state: FormState = defaultState, action: FormActionType
         formResourceTag: {
           ...toDeleteResourceTags,
         },
-      };
-    }
-
-    case RENAME_ACT_ACTION: {
-      const { oldName, newName } = action;
-      const updatedDefinitions = { ...state.definitions };
-
-      Object.keys(updatedDefinitions).forEach((id) => {
-        const def = updatedDefinitions[id];
-        if (def.actsOfLegislation?.includes(oldName)) {
-          updatedDefinitions[id] = {
-            ...def,
-            actsOfLegislation: def.actsOfLegislation.map((a) => (a === oldName ? newName : a)),
-          };
-        }
-      });
-
-      return {
-        ...state,
-        definitions: updatedDefinitions,
       };
     }
 

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinition.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinition.tsx
@@ -16,8 +16,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { uischema } from './categorization-stepper-nav-buttons';
 import { schema } from './categorization';
 import { selectDefaultFormUrl } from '@store/form/selectors';
-import { renameAct } from '@store/form/action';
-
 import {
   GoabTextArea,
   GoabInput,
@@ -28,12 +26,8 @@ import {
   GoabCheckbox,
   GoabDropdown,
   GoabDropdownItem,
-  GoabIconButton,
-  GoabTooltip,
-  GoabFilterChip,
 } from '@abgov/react-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import { ministryOptions } from './ministryOptions';
 import {
   GoabTextAreaOnKeyPressDetail,
   GoabInputOnChangeDetail,
@@ -91,9 +85,6 @@ export const AddEditFormDefinition = ({
     return state?.form?.definitions;
   });
   const definitionIds = Object.values(definitions).map((x) => x.name);
-  const registeredIds = Object.values(definitions)
-    .map((x) => x.registeredId)
-    .filter((item) => item != null);
 
   const indicator = useSelector((state: RootState) => {
     return state?.session?.indicator;
@@ -126,114 +117,11 @@ export const AddEditFormDefinition = ({
     isNotEmptyCheck('name')
   )
     .add('duplicate', 'name', duplicateNameCheck(definitionIds, 'definition'))
-    .add('duplicateRegisteredId', 'registeredId', duplicateNameCheck(registeredIds, 'Registered ID'))
     .add('description', 'description', wordMaxLengthCheck(180, 'Description'))
     .add('formDraftUrlTemplate', 'formDraftUrlTemplate', checkFormDefaultUrl())
     .build();
 
-  const [programOptions, setProgramOptions] = useState<string[]>([
-    'Farmers Market',
-    'Food Safety Program',
-    'Liquor Licensing',
-    'Cannabis Licensing',
-    'Small Business Grants',
-  ]);
 
-  const [showAddProgram, setShowAddProgram] = useState(false);
-  const [newProgramName, setNewProgramName] = useState('');
-
-  const [showRemoveProgram, setShowRemoveProgram] = useState(false);
-  const [removeSelections, setRemoveSelections] = useState<Record<string, boolean>>({});
-
-  const [showEditProgram, setShowEditProgram] = useState(false);
-  const [editTarget, setEditTarget] = useState<string>('');
-  const [editProgramName, setEditProgramName] = useState<string>('');
-  const [newAct, setNewAct] = useState<string>('');
-  const [actError, setActError] = useState<string | null>(null);
-  const [showEditAct, setShowEditAct] = useState(false);
-  const [editActTarget, setEditActTarget] = useState<string>('');
-  const [editActName, setEditActName] = useState<string>('');
-  const [editActError, setEditActError] = useState<string | null>(null);
-
-  const dispatch = useDispatch();
-
-  const addProgram = () => {
-    const val = newProgramName.trim();
-    if (!val) return;
-    const exists = programOptions.some((p) => p.toLowerCase() === val.toLowerCase());
-    if (exists) return;
-    setProgramOptions([...programOptions, val].sort((a, b) => a.localeCompare(b)));
-    setNewProgramName('');
-    setShowAddProgram(false);
-  };
-
-  const removePrograms = () => {
-    const toRemove = Object.keys(removeSelections).filter((k) => removeSelections[k]);
-    if (toRemove.length === 0) {
-      setShowRemoveProgram(false);
-      return;
-    }
-    const updated = programOptions.filter((p) => !toRemove.includes(p));
-    setProgramOptions(updated);
-    if (definition?.programName && toRemove.includes(definition.programName)) {
-      setDefinition({ ...definition, programName: null });
-    }
-    setRemoveSelections({});
-    setShowRemoveProgram(false);
-  };
-
-  const startEditProgram = () => {
-    if (!editTarget) return;
-    const val = editProgramName.trim();
-    if (!val) return;
-    const exists = programOptions.some(
-      (p) => p.toLowerCase() === val.toLowerCase() && p.toLowerCase() !== editTarget.toLowerCase()
-    );
-    if (exists) return;
-
-    const updated = programOptions.map((p) => (p === editTarget ? val : p)).sort((a, b) => a.localeCompare(b));
-    setProgramOptions(updated);
-    if (definition?.programName === editTarget) {
-      setDefinition({ ...definition, programName: val });
-    }
-    setShowEditProgram(false);
-    setEditTarget('');
-    setEditProgramName('');
-  };
-
-  const addAct = () => {
-    const val = newAct.trim();
-    if (!val) {
-      setActError('Please enter an Act.');
-      return;
-    }
-
-    const existing = (definition.actsOfLegislation ?? []).map((a) => a.toLowerCase());
-    if (existing.includes(val.toLowerCase())) {
-      setActError(`Duplicate Act name ${val}. Must be unique.`);
-      return;
-    }
-
-    setDefinition({
-      ...definition,
-      actsOfLegislation: [...(definition.actsOfLegislation ?? []), val],
-    });
-    setNewAct('');
-    setActError(null);
-  };
-  const removeAct = (act: string) => {
-    setDefinition({
-      ...definition,
-      actsOfLegislation: (definition.actsOfLegislation ?? []).filter((a) => a !== act),
-    });
-  };
-  useEffect(() => {
-    if (!open) return;
-    const p = definition?.programName?.trim();
-    if (p && !programOptions.includes(p)) {
-      setProgramOptions((prev) => [...prev, p].sort((a, b) => a.localeCompare(b)));
-    }
-  }, [open, definition?.programName]);
 
   return (
     <GoabModal
@@ -277,14 +165,7 @@ export const AddEditFormDefinition = ({
                 if (definition?.formDraftUrlTemplate === '') {
                   definition.formDraftUrlTemplate = defaultFormUrl;
                 }
-                if (definition.registeredId === null) {
-                  delete definition.registeredId;
-                }
-                const cleanActs = Array.from(
-                  new Set((definition.actsOfLegislation ?? []).map((a) => a.trim()).filter(Boolean))
-                );
-
-                onSave({ ...definition, actsOfLegislation: cleanActs });
+                onSave(definition);
               }
             }}
           >
@@ -400,85 +281,6 @@ export const AddEditFormDefinition = ({
               />
             </FormFormItem>
           </GoabFormItem>
-          <GoabFormItem label="Ministry" mt="s">
-            <FormFormItem>
-              <GoabDropdown
-                value={definition?.ministry ?? ''}
-                onChange={(detail: GoabDropdownOnChangeDetail) => {
-                  const value = Array.isArray(detail.values) ? detail.values[0] ?? '' : detail.value;
-                  setDefinition({ ...definition, ministry: value });
-                }}
-                width="100%"
-              >
-                {ministryOptions.map((o) => (
-                  <GoabDropdownItem key={o.value} value={o.value} label={o.label} />
-                ))}
-              </GoabDropdown>
-            </FormFormItem>
-          </GoabFormItem>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <GoabFormItem label="Program (optional)">
-              <FormFormItem>
-                <GoabDropdown
-                  value={definition?.programName ?? ''}
-                  onChange={(detail: GoabDropdownOnChangeDetail) => {
-                    const value = Array.isArray(detail.values) ? (detail.values[0] as string) : detail.value;
-                    setDefinition({ ...definition, programName: value || null });
-                  }}
-                  width="35ch"
-                >
-                  <GoabDropdownItem value="" label="--Select--" />
-                  {programOptions.map((p) => (
-                    <GoabDropdownItem key={p} value={p} label={p} />
-                  ))}
-                </GoabDropdown>
-              </FormFormItem>
-            </GoabFormItem>
-
-            <div
-              style={{
-                display: 'flex',
-                gap: '0.4rem',
-                paddingLeft: '0.5rem',
-                marginTop: '15px',
-              }}
-            >
-              <GoabTooltip content="Add a new program" position="top">
-                <GoabIconButton
-                  variant="color"
-                  size="medium"
-                  icon="add-circle"
-                  ariaLabel="Add program"
-                  onClick={() => setShowAddProgram(true)}
-                />
-              </GoabTooltip>
-
-              <GoabTooltip content="Remove existing program(s)" position="top">
-                <GoabIconButton
-                  variant="color"
-                  size="medium"
-                  icon="remove-circle"
-                  ariaLabel="Remove program(s)"
-                  onClick={() => setShowRemoveProgram(true)}
-                />
-              </GoabTooltip>
-
-              <GoabTooltip content="Edit a selected program" position="top">
-                <GoabIconButton
-                  variant="color"
-                  size="medium"
-                  icon="pencil"
-                  ariaLabel="Edit program"
-                  onClick={() => {
-                    const current = definition?.programName || programOptions[0] || '';
-                    setEditTarget(current);
-                    setEditProgramName(current);
-                    setShowEditProgram(true);
-                  }}
-                />
-              </GoabTooltip>
-            </div>
-          </div>
 
           {!isEdit && (
             <GoabCheckbox
@@ -494,283 +296,6 @@ export const AddEditFormDefinition = ({
               Populate form with a default multi-page form
             </GoabCheckbox>
           )}
-          <GoabFormItem error={errors?.['registeredId']} label="Registered ID">
-            <GoabInput
-              type="text"
-              name="form-definition-registeredId"
-              value={definition.registeredId}
-              testId="form-definition-registeredId"
-              aria-label="form-definition-registeredId"
-              width="100%"
-              onChange={(detail: GoabInputOnChangeDetail) => {
-                if (!detail.value.trim()) {
-                  const updated = { ...definition };
-                  delete updated.registeredId;
-                  validators.remove('registeredId');
-                  setDefinition(updated);
-                } else {
-                  const validations = {
-                    registeredId: detail.value,
-                  };
-
-                  validators.remove('registeredId');
-                  validations['duplicateRegisteredId'] = detail.value;
-                  validators.checkAll({
-                    duplicateRegisteredId: detail.value,
-                  });
-
-                  setDefinition({ ...definition, registeredId: detail.value });
-                }
-              }}
-              onBlur={() => {
-                validators.checkAll({
-                  duplicateRegisteredId: definition.registeredId,
-                });
-              }}
-            />
-          </GoabFormItem>
-          <GoabFormItem label="Acts of Legislation" mt={'l'} error={actError ?? undefined}>
-            <div style={{ display: 'grid', gap: '0.5rem' }}>
-              <GoabInput
-                error={!!actError}
-                name="new-act-input"
-                width="100%"
-                value={newAct}
-                placeholder="Type an Act"
-                onChange={(detail: GoabInputOnChangeDetail) => {
-                  setNewAct(detail.value);
-                  if (actError) setActError(null);
-                }}
-              />
-              <GoabButton type="secondary" onClick={addAct} disabled={!newAct.trim()}>
-                Add
-              </GoabButton>
-
-              {(definition.actsOfLegislation ?? []).length === 0 ? (
-                <div style={{ fontStyle: 'italic', color: '#666' }}>No Acts added.</div>
-              ) : (
-                <div>
-                  {(definition.actsOfLegislation ?? [])
-                    .slice()
-                    .sort((a, b) => a.localeCompare(b))
-                    .map((act) => (
-                      <span
-                        key={act}
-                        style={{ display: 'inline-block', marginRight: '0.5rem', marginBottom: '0.5rem' }}
-                      >
-                        <GoabFilterChip
-                          content={act}
-                          testId={`act-chip-${act}`}
-                          onClick={() => {
-                            setDefinition({
-                              ...definition,
-                              actsOfLegislation: (definition.actsOfLegislation ?? []).filter((a) => a !== act),
-                            });
-                          }}
-                        />
-                        <span
-                          style={{
-                            position: 'relative',
-                            top: '-1.8rem',
-                            left: '0.5rem',
-                            display: 'inline-block',
-                            width: 'calc(100% - 1.5rem)',
-                            height: '1.5rem',
-                            cursor: 'pointer',
-                          }}
-                          onClick={() => {
-                            setEditActTarget(act);
-                            setEditActName(act);
-                            setShowEditAct(true);
-                          }}
-                        />
-                      </span>
-                    ))}
-                </div>
-              )}
-            </div>
-          </GoabFormItem>
-
-          <GoabModal
-            open={showAddProgram}
-            heading="Add program"
-            maxWidth="25%"
-            actions={
-              <GoabButtonGroup alignment="end">
-                <GoabButton
-                  type="secondary"
-                  onClick={() => {
-                    setShowAddProgram(false);
-                    setNewProgramName('');
-                  }}
-                >
-                  Cancel
-                </GoabButton>
-                <GoabButton type="primary" onClick={addProgram}>
-                  Add
-                </GoabButton>
-              </GoabButtonGroup>
-            }
-          >
-            <GoabFormItem label="Program name">
-              <GoabInput
-                name="new-program-name"
-                width="100%"
-                value={newProgramName}
-                onChange={(detail: GoabInputOnChangeDetail) => setNewProgramName(detail.value)}
-              />
-            </GoabFormItem>
-          </GoabModal>
-
-          <GoabModal
-            open={showRemoveProgram}
-            heading="Remove program(s)"
-            maxWidth="25%"
-            actions={
-              <GoabButtonGroup alignment="end">
-                <GoabButton
-                  type="secondary"
-                  onClick={() => {
-                    setRemoveSelections({});
-                    setShowRemoveProgram(false);
-                  }}
-                >
-                  Cancel
-                </GoabButton>
-                <GoabButton type="primary" onClick={removePrograms}>
-                  Remove
-                </GoabButton>
-              </GoabButtonGroup>
-            }
-          >
-            <div style={{ display: 'grid', gap: '0.25rem' }}>
-              {programOptions.length === 0 ? (
-                <div>No programs to remove.</div>
-              ) : (
-                programOptions.map((opt) => (
-                  <GoabCheckbox
-                    key={opt}
-                    name={`rm-${opt}`}
-                    checked={!!removeSelections[opt]}
-                    onChange={(detail) => setRemoveSelections((prev) => ({ ...prev, [opt]: detail.checked }))}
-                  >
-                    {opt}
-                  </GoabCheckbox>
-                ))
-              )}
-            </div>
-          </GoabModal>
-
-          <GoabModal
-            open={showEditProgram}
-            heading="Edit program"
-            maxWidth="25%"
-            actions={
-              <GoabButtonGroup alignment="end">
-                <GoabButton
-                  type="secondary"
-                  onClick={() => {
-                    setShowEditProgram(false);
-                    setEditTarget('');
-                    setEditProgramName('');
-                  }}
-                >
-                  Cancel
-                </GoabButton>
-                <GoabButton type="primary" onClick={startEditProgram}>
-                  Save
-                </GoabButton>
-              </GoabButtonGroup>
-            }
-          >
-            <GoabFormItem label="Choose program">
-              <GoabDropdown
-                value={editTarget}
-                onChange={(detail: GoabDropdownOnChangeDetail) => {
-                  const value = Array.isArray(detail.values) ? (detail.values[0] as string) : detail.value;
-                  setEditTarget(value);
-                  setEditProgramName(value);
-                }}
-                width="100%"
-              >
-                {programOptions.map((p) => (
-                  <GoabDropdownItem key={p} value={p} label={p} />
-                ))}
-              </GoabDropdown>
-            </GoabFormItem>
-
-            <GoabFormItem label="New name">
-              <GoabInput
-                name="edit-program-name"
-                width="100%"
-                value={editProgramName}
-                onChange={(detail: GoabInputOnChangeDetail) => setEditProgramName(detail.value)}
-              />
-            </GoabFormItem>
-          </GoabModal>
-          <GoabModal
-            open={showEditAct}
-            heading="Edit Act"
-            maxWidth="25%"
-            actions={
-              <GoabButtonGroup alignment="end">
-                <GoabButton
-                  type="secondary"
-                  onClick={() => {
-                    setShowEditAct(false);
-                    setEditActTarget('');
-                    setEditActName('');
-                    setEditActError(null);
-                  }}
-                >
-                  Cancel
-                </GoabButton>
-                <GoabButton
-                  type="primary"
-                  onClick={() => {
-                    const newName = editActName.trim();
-                    if (!newName) {
-                      setEditActError('Please enter an Act name.');
-                      return;
-                    }
-
-                    const existing = (definition.actsOfLegislation ?? []).map((a) => a.toLowerCase());
-
-                    if (
-                      existing.includes(newName.toLowerCase()) &&
-                      newName.toLowerCase() !== editActTarget.toLowerCase()
-                    ) {
-                      setEditActError(`Duplicate Act name ${newName}. Must be unique.`);
-                      return;
-                    }
-                    dispatch(renameAct(editActTarget, newName));
-                    const updatedActs = (definition.actsOfLegislation ?? []).map((a) =>
-                      a === editActTarget ? newName : a
-                    );
-                    setDefinition({ ...definition, actsOfLegislation: updatedActs });
-                    setShowEditAct(false);
-                    setEditActTarget('');
-                    setEditActName('');
-                    setEditActError(null);
-                  }}
-                >
-                  Save
-                </GoabButton>
-              </GoabButtonGroup>
-            }
-          >
-            <GoabFormItem label="New Act name" error={editActError ?? undefined}>
-              <GoabInput
-                name="edit-act-name"
-                width="100%"
-                value={editActName}
-                onChange={(detail: GoabInputOnChangeDetail) => {
-                  setEditActName(detail.value);
-                  if (editActError) setEditActError(null);
-                }}
-              />
-            </GoabFormItem>
-          </GoabModal>
         </>
       )}
     </GoabModal>

--- a/libs/form-editor-common/src/lib/definitions/definitions.tsx
+++ b/libs/form-editor-common/src/lib/definitions/definitions.tsx
@@ -21,7 +21,6 @@ import {
   fetchResourcesByTag,
   setSelectedTag,
   deleteResourceTags,
-  resetRegisteredId,
 } from '@store/form/action';
 import { RootState } from '@store/index';
 import { ResourceTagFilterCriteria, ResourceTagResult, Service, Tag, ResourceTag } from '@store/directory/models';
@@ -71,7 +70,6 @@ export const FormDefinitions = ({
   const tagNext = useSelector((state: RootState) => state.form.formResourceTag.nextEntries) || null;
   const formResourceTag = useSelector((state: RootState) => state.form.formResourceTag);
   const selectedTag = useSelector((state: RootState) => state.form?.formResourceTag?.selectedTag as Tag | null);
-  const registerIdDefinition = useSelector((state: RootState) => state.form?.registerIdDefinition);
   const tagResources = formResourceTag.tagResources;
 
   const orderedFormDefinitions = (state: RootState) => {
@@ -190,7 +188,7 @@ export const FormDefinitions = ({
     return null;
   };
 
-  const displayDefinitions = registerIdDefinition ? registerIdDefinition : selectedTag ? tagResources : formDefinitions;
+  const displayDefinitions = selectedTag ? tagResources : formDefinitions;
 
   const filteredDefinitions = useMemo(() => {
     return displayDefinitions || {};
@@ -206,7 +204,6 @@ export const FormDefinitions = ({
           value={selectedTag?.value || ''}
           disabled={false}
           onChange={(detail: GoabDropdownOnChangeDetail) => {
-            dispatch(resetRegisteredId());
             const selectedTagObj = tags.find((tag) => tag?.value === detail.value);
             if (selectedTagObj) {
               dispatch(setSelectedTag(selectedTagObj));
@@ -232,7 +229,6 @@ export const FormDefinitions = ({
         <GoabButton
           testId="add-definition"
           onClick={() => {
-            dispatch(resetRegisteredId());
             setOpenAddFormDefinition(true);
           }}
           mb={'l'}


### PR DESCRIPTION
Remove ministry, programs, registration ID, and acts of legislation from the
Tenant Management Webapp form definition create/edit experience.

- Delete classifier UI and handlers from shared form definition dialog usage.
- Remove classifier-specific fields from form model defaults/interfaces.
- Remove obsolete Redux actions and reducer branches for classifier state.
- Simplify definitions flow by removing registration ID reset/filter coupling.