### PR TITLE
fix(jsonforms-components): Cannot specify a blank label for checkboxes

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseReviewControl.tsx
@@ -67,7 +67,7 @@ export const GoABaseInputReviewComponent = (props: WithBaseInputReviewProps): JS
     if (uischema.options?.radio === true) {
       reviewText = data ? `Yes` : `No`;
     } else {
-      reviewText = data ? `Yes (${checkboxLabel})` : `No (${checkboxLabel})`;
+      reviewText = data ? (checkboxLabel ? `Yes (${checkboxLabel})` : `Yes`) : (checkboxLabel ? `No (${checkboxLabel})` : `No`);
     }
   }
 

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -422,7 +422,7 @@ describe('InputBaseTableReviewControl', () => {
               options: { stepId: 0 },
             }}
             enabled={true}
-            errors={undefined}
+            errors=""
             cells={[]}
             required={false}
             id="whichOfThemAppliesOther"
@@ -440,7 +440,7 @@ describe('InputBaseTableReviewControl', () => {
 
   it('shows validation error for empty array when required', () => {
     const mockGoToPage = jest.fn();
-    const contextValue: JsonFormsStepperContextProps = { goToPage: mockGoToPage } as JsonFormsStepperContextProps;
+    const contextValue: JsonFormsStepperContextProps = { goToPage: mockGoToPage } as unknown as JsonFormsStepperContextProps;
     const { baseElement } = render(
       <JsonFormsStepperContext.Provider value={contextValue}>
         <table>
@@ -462,7 +462,7 @@ describe('InputBaseTableReviewControl', () => {
                 label: 'Choose all options that best apply',
               }}
               enabled={true}
-              errors={undefined}
+              errors=""
               cells={[]}
               required={true}
               id="whichOfThemApplies"
@@ -479,6 +479,41 @@ describe('InputBaseTableReviewControl', () => {
     const errorFormItem = baseElement.querySelector(
       'goa-form-item[error="Choose all options that best apply is required"]'
     );
+    expect(errorFormItem).toBeInTheDocument();
+  });
+
+  it('shows only required error (no "No (...)" value) for unchecked required checkbox', () => {
+    const { baseElement, getByTestId } = render(
+      <table>
+        <tbody>
+          <GoAInputBaseTableReview
+            data={false}
+            visible={true}
+            label=""
+            path="isAttestationAccepted"
+            schema={{ type: 'boolean' }}
+            uischema={{
+              type: 'Control',
+              scope: '#/properties/isAttestationAccepted',
+              label: '',
+              options: { text: 'Is attestation accepted' },
+            }}
+            enabled={true}
+            errors={'Is Attestation Accepted must be equal to one of the allowed values'}
+            cells={[]}
+            required={true}
+            id="isAttestationAccepted"
+            rootSchema={{ type: 'object', properties: {} }}
+            config={{}}
+            renderers={[]}
+            handleChange={jest.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+
+    expect(getByTestId('review-value-').textContent).toBe('');
+    const errorFormItem = baseElement.querySelector('goa-form-item[error="Is attestation accepted is required"]');
     expect(errorFormItem).toBeInTheDocument();
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -174,8 +174,20 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
     activeError = `${labelToUpdate} is required`;
   }
 
+  // For required boolean fields (e.g. anyOf: [{enum: [true]}]), suppress the raw AJV
+  // "must be equal to one of the allowed values" error and show a friendly message instead.
+  if (schema?.type === 'boolean' && activeError && activeError.toLowerCase().includes('must be equal')) {
+    activeError = data === false ? `${labelToUpdate} is required` : undefined;
+  }
+
   if (required && isNilOrEmptyValue(data, true) && !activeError) {
     activeError = `${labelToUpdate} is required`;
+  }
+
+  // If a required checkbox is unchecked, show only the validation message in
+  // review mode (not a contradictory "No (...)" value line).
+  if (schema?.type === 'boolean' && data === false && activeError && /\sis required$/i.test(activeError)) {
+    reviewText = '';
   }
 
   // eslint-disable-next-line

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputbaseReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputbaseReviewControl.spec.tsx
@@ -357,6 +357,46 @@ describe('GoABaseInputReviewComponent', () => {
     const reviewControl = getByTestId('review-control-input-id');
     expect(reviewControl.textContent).toContain('Agreement is required');
   });
+
+  it('renders "No" without parentheses when uischema.label is "" and no options.text (CS-4826)', () => {
+    const props = {
+      ...baseProps,
+      data: false,
+      required: false,
+      label: '',
+      uischema: {
+        type: 'Control' as const,
+        scope: '#/properties/isAttestationAccepted',
+        label: '',
+        options: {
+          radio: false,
+        },
+      },
+      schema: { type: 'boolean' },
+    };
+    const { getByTestId } = render(<GoABaseInputReviewComponent {...props} />);
+    expect(getByTestId('review-control-input-id').textContent).toBe('No');
+  });
+
+  it('renders "Yes" without parentheses when uischema.label is "" and no options.text (CS-4826)', () => {
+    const props = {
+      ...baseProps,
+      data: true,
+      required: false,
+      label: '',
+      uischema: {
+        type: 'Control' as const,
+        scope: '#/properties/isAttestationAccepted',
+        label: '',
+        options: {
+          radio: false,
+        },
+      },
+      schema: { type: 'boolean' },
+    };
+    const { getByTestId } = render(<GoABaseInputReviewComponent {...props} />);
+    expect(getByTestId('review-control-input-id').textContent).toBe('Yes');
+  });
 });
 
 describe('Can render GoAInputBaseTableReview', () => {

--- a/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
@@ -137,6 +137,14 @@ describe('stringUtils string tests', () => {
     setIsVisited: () => {},
   };
 
+  const buildControlProps = (path: string, rootSchema: JsonSchema7): GoAInputTextProps & ControlProps => ({
+    ...schemaIfThenProps,
+    path,
+    uischema: { type: 'Control', scope: `#/properties/${path}` },
+    schema: {},
+    rootSchema,
+  });
+
   describe('rootSchema string tests', () => {
     it('test getIfThenRequired has If Then', () => {
       const result = getRequiredIfThen(schemaIfThenProps);
@@ -421,88 +429,68 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with if/then structure', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/firstName' },
-        schema: {},
-        rootSchema: {
+      const schema = buildControlProps('firstName', {
+        properties: {
+          firstName: { type: 'string' },
+        },
+        if: {
           properties: {
-            firstName: { type: 'string' },
-          },
-          if: {
-            properties: {
-              field1: { enum: ['option1'] },
-            },
-          },
-          then: {
-            required: ['firstName', 'lastName'],
+            field1: { enum: ['option1'] },
           },
         },
-        handleChange: () => {},
-      };
+        then: {
+          required: ['firstName', 'lastName'],
+        },
+      });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });
 
     it('getRequiredIfThen with nested else structure', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/firstName' },
-        schema: {},
-        rootSchema: {
-          properties: {
-            firstName: { type: 'string' },
-          },
-          allOf: [
-            {
-              if: { properties: {} },
-              else: { required: ['firstName'] },
-            },
-          ],
+      const schema = buildControlProps('firstName', {
+        properties: {
+          firstName: { type: 'string' },
         },
-        handleChange: () => {},
-      };
+        allOf: [
+          {
+            if: { properties: {} },
+            else: { required: ['firstName'] },
+          },
+        ],
+      });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });
 
     it('getRequiredIfThen with allOf if/else/then', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/field' },
-        schema: {},
-        rootSchema: {
-          properties: {
-            field: { type: 'string' },
-          },
-          allOf: [
-            {
-              if: { properties: {} },
-              then: { required: ['field'] },
-              else: { required: ['field'] },
-            },
-          ],
+      const schema = buildControlProps('field', {
+        properties: {
+          field: { type: 'string' },
         },
-        handleChange: () => {},
-      };
+        allOf: [
+          {
+            if: { properties: {} },
+            then: { required: ['field'] },
+            else: { required: ['field'] },
+          },
+        ],
+      });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });
 
     it('getRequiredIfThen with root schema if without then', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/field' },
-        schema: {},
-        rootSchema: {
-          properties: {
-            field: { type: 'string' },
-          },
-          if: {
-            properties: {},
-          },
-          else: {
-            required: ['field'],
-          },
+      const schema = buildControlProps('field', {
+        properties: {
+          field: { type: 'string' },
         },
-        handleChange: () => {},
-      };
+        if: {
+          properties: {},
+        },
+        else: {
+          required: ['field'],
+        },
+      });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });
@@ -646,23 +634,18 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with complex nested structure', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/test' },
-        schema: {},
-        rootSchema: {
-          properties: {
-            test: { type: 'string' },
-          },
-          allOf: [
-            {
-              if: { properties: {} },
-              then: { required: ['test'] },
-              else: { required: ['test'] },
-            },
-          ],
+      const schema = buildControlProps('test', {
+        properties: {
+          test: { type: 'string' },
         },
-        handleChange: () => {},
-      };
+        allOf: [
+          {
+            if: { properties: {} },
+            then: { required: ['test'] },
+            else: { required: ['test'] },
+          },
+        ],
+      });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });
@@ -693,17 +676,12 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with rootSchema if but no then or else', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/field' },
-        schema: {},
-        rootSchema: {
-          properties: {
-            field: { type: 'string' },
-          },
-          if: { properties: {} },
+      const schema = buildControlProps('field', {
+        properties: {
+          field: { type: 'string' },
         },
-        handleChange: () => {},
-      };
+        if: { properties: {} },
+      });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });
@@ -832,12 +810,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('stringUtils: getRequiredIfThen without rootSchema property', () => {
-      const schema: any = {
-        uischema: { type: 'Control', scope: '#/properties/field' },
-        schema: {},
-        rootSchema: { properties: { field: { type: 'string' } } },
-        handleChange: () => {},
-      };
+      const schema = buildControlProps('field', { properties: { field: { type: 'string' } } });
       const result = getRequiredIfThen(schema);
       expect(Array.isArray(result)).toBe(true);
     });

--- a/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
@@ -14,6 +14,7 @@ import {
   controlScopeMatchesLabel,
   getLabelText,
   validateSinWithLuhn,
+  getControlLabelText,
 } from './stringUtils';
 import { describe } from 'node:test';
 import { GoAInputTextProps } from '../Controls';
@@ -199,19 +200,19 @@ describe('stringUtils string tests', () => {
 
   describe('string function test', () => {
     it('capitalizeFirstLetter is null', () => {
-      const testValue: string = null;
+      const testValue: string | null = null;
       const returnValue = capitalizeFirstLetter(testValue);
       expect(returnValue).toBe('');
     });
 
     it('convertToReadableFormat is null', () => {
-      const testValue: string = null;
+      const testValue: string | null = null;
       const returnValue = convertToReadableFormat(testValue);
       expect(returnValue).toBe(null);
     });
 
     it('convertToSentenceCase handles null input', () => {
-      const testValue: string = null;
+      const testValue: string | null = null;
       const returnValue = convertToSentenceCase(testValue);
       expect(returnValue).toBe(null);
     });
@@ -420,7 +421,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with if/then structure', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/firstName' },
         schema: {},
         rootSchema: {
@@ -443,7 +444,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with nested else structure', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/firstName' },
         schema: {},
         rootSchema: {
@@ -464,7 +465,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with allOf if/else/then', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/field' },
         schema: {},
         rootSchema: {
@@ -486,7 +487,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with root schema if without then', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/field' },
         schema: {},
         rootSchema: {
@@ -645,7 +646,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with complex nested structure', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/test' },
         schema: {},
         rootSchema: {
@@ -692,7 +693,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('getRequiredIfThen with rootSchema if but no then or else', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/field' },
         schema: {},
         rootSchema: {
@@ -831,7 +832,7 @@ describe('stringUtils string tests', () => {
     });
 
     it('stringUtils: getRequiredIfThen without rootSchema property', () => {
-      const schema: GoAInputTextProps & ControlProps = {
+      const schema: any = {
         uischema: { type: 'Control', scope: '#/properties/field' },
         schema: {},
         rootSchema: { properties: { field: { type: 'string' } } },
@@ -868,5 +869,48 @@ describe('stringUtils string tests', () => {
       expect(result2).toBeDefined();
       expect(result3).toBeDefined();
     });
+  });
+});
+
+describe('getControlLabelText blank label (CS-4826)', () => {
+  const makeProps = (label: unknown, scope = '#/properties/myField', optionsText?: string): ControlProps =>
+    ({
+      uischema: { type: 'Control', scope, label, options: optionsText ? { text: optionsText } : undefined } as ControlElement,
+      schema: {},
+      rootSchema: {},
+      handleChange: jest.fn(),
+      label: 'fallback',
+    } as unknown as ControlProps);
+
+  it('returns empty string when uischema.label is explicitly empty string', () => {
+    const result = getControlLabelText(makeProps(''));
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when uischema.label is whitespace-only', () => {
+    const result = getControlLabelText(makeProps('   '));
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when label is "" even if options.text is set (boolean checkbox case)', () => {
+    const result = getControlLabelText(makeProps('', '#/properties/myField', 'Is attestation accepted'));
+    expect(result).toBe('');
+  });
+
+  it('falls back to generated label when uischema.label is absent', () => {
+    const result = getControlLabelText(makeProps(undefined));
+    // generated from scope '#/properties/myField'
+    expect(result).toBeTruthy();
+    expect(result).not.toBe('');
+  });
+
+  it('uses options.text as form-item label when uischema.label is absent', () => {
+    const result = getControlLabelText(makeProps(undefined, '#/properties/myField', 'My checkbox text'));
+    expect(result).toBe('My checkbox text');
+  });
+
+  it('returns the provided label when uischema.label is a non-empty string', () => {
+    const result = getControlLabelText(makeProps('My custom label'));
+    expect(result).toBe('My custom label');
   });
 });

--- a/libs/jsonforms-components/src/lib/util/stringUtils.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.ts
@@ -49,17 +49,10 @@ const areAllUppercase = (label: string): boolean => {
 };
 
 const getExplicitControlLabel = (props: ControlProps): string | undefined => {
-  const optionText = props.uischema?.options?.text;
-  if (typeof optionText === 'string' && optionText.trim()) {
-    return optionText.trim();
-  }
-
-  if (typeof props.schema?.title === 'string' && props.schema.title.trim()) {
-    return props.schema.title.trim();
-  }
-
+  // uischema.label has highest priority. An explicit empty string suppresses the
+  // auto-generated label (and prevents options.text from leaking into the form-item label).
   const uiLabel = props.uischema?.label;
-  if (typeof uiLabel === 'string' && uiLabel.trim()) {
+  if (typeof uiLabel === 'string') {
     return uiLabel.trim();
   }
 
@@ -68,6 +61,15 @@ const getExplicitControlLabel = (props: ControlProps): string | undefined => {
     if (typeof text === 'string' && text.trim()) {
       return text.trim();
     }
+  }
+
+  const optionText = props.uischema?.options?.text;
+  if (typeof optionText === 'string' && optionText.trim()) {
+    return optionText.trim();
+  }
+
+  if (typeof props.schema?.title === 'string' && props.schema.title.trim()) {
+    return props.schema.title.trim();
   }
 
   return undefined;
@@ -85,7 +87,7 @@ export const getGeneratedLabelFromScope = (scope: string): string => {
 
 export const getControlLabelText = (props: ControlProps): string => {
   const explicitLabel = getExplicitControlLabel(props);
-  if (explicitLabel) {
+  if (explicitLabel !== undefined) {
     return explicitLabel;
   }
 


### PR DESCRIPTION
- respect explicit empty uischema labels so checkbox form-item labels can be suppressed
- replace raw boolean AJV review errors with a friendly required message
- hide contradictory review values for unchecked required checkboxes
- avoid rendering empty parentheses for Yes/No review text
- add regression tests and fix related test typing issues