### PR TITLE
fix(jsonforms-components): CS-4823-Address component layout breaks: Province/Country overlap on small viewport

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressInputs.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressInputs.tsx
@@ -101,7 +101,7 @@ export const AddressInputs: React.FC<AddressInputsProps> = ({
         </GoabFormItem>
       </GoabGrid>
       <br />
-      <GoabGrid minChildWidth="0" gap="s">
+      <GoabGrid minChildWidth="18rem" gap="s">
         <GoabFormItem label="Province">
           {isAlbertaAddress && <LabelDiv data-testid="address-form-province">Alberta</LabelDiv>}
           {!isAlbertaAddress && (
@@ -114,7 +114,7 @@ export const AddressInputs: React.FC<AddressInputsProps> = ({
               onChange={(detail: GoabDropdownOnChangeDetail) =>
                 handleInputChange('subdivisionCode', detail.value as string)
               }
-              width="25ch"
+              width="100%"
             >
               {provinces.map((w) => (
                 <GoabDropdownItem key={w.value} value={w.value} label={w.label} />

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressViews.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressViews.tsx
@@ -69,7 +69,7 @@ export const AddressViews: React.FC<AddressInputsProps> = ({
           </GoabFormItem>
         </GoabGrid>
         <br />
-        <GoabGrid minChildWidth="0" gap="s">
+        <GoabGrid minChildWidth="18rem" gap="s">
           <GoabFormItem
             label="Province"
             error={!isAlbertaAddress && data?.subdivisionCode === undefined ? 'Province is required' : ''}


### PR DESCRIPTION
Adjust address layout responsiveness to stop Province and Country fields from overlapping on narrow screens. Update the Province/Country grid to use a minimum child width so fields stack when space is limited, and change the province dropdown width to 100% so it fits its container consistently. Also aligns the read-only address view with the same responsive behavior.