### PR TITLE
fix(jsonforms-components): CS-4825 Incorrect Rendering: HorizontalLayout Appears as VerticalLayout in UAT

### DIFF
--- a/libs/jsonforms-components/src/lib/layouts/HorizontalLayoutControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/layouts/HorizontalLayoutControl.spec.tsx
@@ -46,7 +46,7 @@ describe('HorizontalLayoutControl', () => {
       // Execution covers 'row' branch
     });
 
-    it('sets direction to column when HelpContent is present', () => {
+    it('keeps rendering when HelpContent is present', () => {
       const uischema: HorizontalLayout = {
         type: 'HorizontalLayout',
         elements: [
@@ -55,7 +55,7 @@ describe('HorizontalLayoutControl', () => {
         ]
       };
       render(<GoAHorizontalLayoutComponent {...baseProps} uischema={uischema} />);
-      // Execution covers 'column' branch
+      // Execution covers HelpContent branch
     });
   });
 

--- a/libs/jsonforms-components/src/lib/layouts/HorizontalLayoutControl.tsx
+++ b/libs/jsonforms-components/src/lib/layouts/HorizontalLayoutControl.tsx
@@ -15,13 +15,14 @@ export const GoAHorizontalLayoutComponent = ({
   visible,
 }: LayoutProps) => {
   const layout = uischema as HorizontalLayout;
-  const hasHelpContent = layout.elements?.some((element) => element.type === 'HelpContent');
-  const childProps: LayoutRendererProps = {
-    elements: layout.elements,
+  const elements = layout.elements || [];
+  const helpElements = elements.filter((element) => element.type === 'HelpContent');
+  const contentElements = elements.filter((element) => element.type !== 'HelpContent');
+
+  const childProps: Omit<LayoutRendererProps, 'elements' | 'direction'> = {
     schema,
     path,
     enabled,
-    direction: hasHelpContent ? 'column' : 'row',
     visible,
     width: uischema?.options?.width || '300px',
     option: {
@@ -29,7 +30,16 @@ export const GoAHorizontalLayoutComponent = ({
     },
   };
 
-  return <LayoutRenderer {...childProps} renderers={renderers} cells={cells} />;
+  return (
+    <>
+      {helpElements.length > 0 && (
+        <LayoutRenderer {...childProps} direction="column" elements={helpElements} renderers={renderers} cells={cells} />
+      )}
+      {contentElements.length > 0 && (
+        <LayoutRenderer {...childProps} direction="row" elements={contentElements} renderers={renderers} cells={cells} />
+      )}
+    </>
+  );
 };
 
 export const GoAHorizontalReviewLayoutComponent = ({

--- a/libs/jsonforms-components/src/lib/layouts/LayoutControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/layouts/LayoutControl.spec.tsx
@@ -57,6 +57,32 @@ const getUiSchema = (type: string) => {
   };
 };
 
+const getHorizontalUiSchemaWithHelpContent = () => {
+  return {
+    type: 'HorizontalLayout',
+    elements: [
+      {
+        type: 'HelpContent',
+        options: {
+          help: 'Help text for horizontal layout',
+        },
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/firstName',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/middleInitial',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/lastName',
+      },
+    ],
+  };
+};
+
 const getForm = (schema: object, uiSchema: UISchemaElement, data: object = {}) => {
   return (
     <JsonForms
@@ -73,6 +99,13 @@ const getForm = (schema: object, uiSchema: UISchemaElement, data: object = {}) =
 describe('Horizontal Layout control', () => {
   it('renders a horizontal row with a grid', () => {
     const form = getForm(schema, getUiSchema('HorizontalLayout'));
+    const { container } = render(form);
+    const grid = container.querySelector('div > :scope goa-grid');
+    expect(grid).toBeInTheDocument();
+  });
+
+  it('renders a horizontal row with a grid when HelpContent is present', () => {
+    const form = getForm(schema, getHorizontalUiSchemaWithHelpContent());
     const { container } = render(form);
     const grid = container.querySelector('div > :scope goa-grid');
     expect(grid).toBeInTheDocument();


### PR DESCRIPTION

Root cause: layout direction switched to column when HelpContent existed in HorizontalLayout. Updated renderer to split elements:
render HelpContent separately in column flow
render non-help controls in horizontal grid flow
Added regression test coverage for HorizontalLayout with HelpContent.

<img width="717" height="508" alt="image" src="https://github.com/user-attachments/assets/49d1c52f-6299-4b70-aa20-c5ce4d48c5a6" />
