### PR TITLE
fix(jsonforms-components): CS-4836 ListOfDetail "No data" state has incorrect bottom padding in Formstepper

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -172,7 +172,7 @@ export interface EmptyListProps {
 }
 
 const EmptyList = ({ numColumns, noDataMessage }: EmptyListProps) => (
-  <GoabGrid minChildWidth="60ch">
+  <GoabGrid minChildWidth="60ch" mt="l" mb="l">
     <TextCenter>
       <b>{noDataMessage}</b>
     </TextCenter>


### PR DESCRIPTION
Fixes the ListWithDetail empty-state layout in Formstepper where No data had inconsistent bottom spacing.