### PR TITLE
fix(jsonforms-components): CS-4850 Review Summary does not render primitive string array values (Tags) and shows No applicable renderer found

### DIFF
--- a/libs/jsonforms-components/src/index.ts
+++ b/libs/jsonforms-components/src/index.ts
@@ -170,6 +170,10 @@ export const GoABaseReviewRenderers: JsonFormsRendererRegistryEntry[] = [
     renderer: GoAInputBaseReviewControl,
   },
   {
+    tester: GoAPrimitiveArrayTester,
+    renderer: GoAInputBaseReviewControl,
+  },
+  {
     tester: GoAArrayControlTester,
     renderer: GoAArrayControlReviewRenderer,
   },
@@ -213,6 +217,10 @@ export const GoABaseTableReviewRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: GoABooleanRadioControlTester, renderer: GoAInputBaseTableReviewControl },
   {
     tester: MultiLineTextControlTester,
+    renderer: GoAInputBaseTableReviewControl,
+  },
+  {
+    tester: GoAPrimitiveArrayTester,
     renderer: GoAInputBaseTableReviewControl,
   },
   {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperReviewControl.tsx
@@ -31,7 +31,7 @@ import {
   GoABooleanRadioControlTester,
   MultiLineTextControlTester,
 } from '../Inputs';
-import { GoAArrayControlTester, GoAArrayControlReviewRenderer } from '../ObjectArray/ObjectArray';
+import { GoAArrayControlTester, GoAArrayControlReviewRenderer, GoAPrimitiveArrayTester } from '../ObjectArray/ObjectArray';
 import { GoAListWithDetailsTester } from '../ObjectArray/listWithDetails';
 
 import { GoAInputBaseTableReviewControl } from '../Inputs/InputBaseTableReviewControl';
@@ -78,6 +78,10 @@ export const GoABaseTableReviewRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: GoABooleanRadioControlTester, renderer: GoAInputBaseTableReviewControl },
   {
     tester: MultiLineTextControlTester,
+    renderer: GoAInputBaseTableReviewControl,
+  },
+  {
+    tester: GoAPrimitiveArrayTester,
     renderer: GoAInputBaseTableReviewControl,
   },
   {
@@ -130,6 +134,10 @@ export const GoABaseReviewRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: GoABooleanRadioControlTester, renderer: GoAInputBaseReviewControl },
   {
     tester: MultiLineTextControlTester,
+    renderer: GoAInputBaseReviewControl,
+  },
+  {
+    tester: GoAPrimitiveArrayTester,
     renderer: GoAInputBaseReviewControl,
   },
   {

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.test.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.test.tsx
@@ -369,6 +369,19 @@ const getPrimitiveForm = (formData: object, enabled = true) => {
   );
 };
 
+const getPrimitiveReviewForm = (formData: object) => {
+  return (
+    <JsonForms
+      uischema={primitiveUiSchema}
+      data={formData}
+      schema={primitiveSchema}
+      ajv={new Ajv({ allErrors: true, verbose: true })}
+      renderers={GoABaseReviewRenderers}
+      cells={GoACells}
+    />
+  );
+};
+
 it('shows empty state when no items', () => {
   const data = { files: [] };
   const { baseElement } = render(getPrimitiveForm(data));
@@ -444,4 +457,13 @@ it('primitive control handles non-array data and disabled add button', () => {
   const addButton = baseElement.querySelector('goa-button');
   expect(addButton).toBeInTheDocument();
   expect(addButton?.getAttribute('disabled')).toBe('true');
+});
+
+it('renders primitive array values in review without fallback error', () => {
+  const data = { files: ['test-one', 'test-two'] };
+  const { baseElement } = render(getPrimitiveReviewForm(data));
+
+  expect(baseElement.textContent).toContain('test-one');
+  expect(baseElement.textContent).toContain('test-two');
+  expect(baseElement.textContent).not.toContain('No applicable renderer found.');
 });


### PR DESCRIPTION
Register primitive array review renderers so string array values display in Review Summary instead of showing No applicable renderer found. Add regression coverage to ensure primitive array review values render and fallback error text does not appear.