### PR TITLE
fix(jsonforms-components): CS-4842 Disabling address component also disables Previous/Next navigation buttons

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.spec.tsx
@@ -153,6 +153,30 @@ const categorizationPagesWithHide = {
   },
 };
 
+const categorizationWithDisabledAddressCategory = {
+  type: 'Categorization',
+  label: 'Test Categorization',
+  elements: [
+    nameCategory,
+    {
+      ...addressCategory,
+      rule: {
+        effect: 'DISABLE',
+        condition: {
+          scope: '#/properties/preQualification',
+          schema: { const: true },
+        },
+      },
+    },
+  ],
+  options: {
+    variant: 'stepper',
+    testId: 'stepper-test-disabled-category',
+    showNavButtons: true,
+    componentProps: { controlledNav: true },
+  },
+};
+
 const formData = {
   name: { firstName: undefined, lastName: undefined },
   address: { street: undefined, city: undefined },
@@ -352,6 +376,30 @@ describe('Form Stepper Control', () => {
 
       expect(mockDispatch.mock.calls[2][0].type === 'page/to/index');
       expect(mockDispatch.mock.calls[2][0].id === 0);
+    });
+
+    it('keeps Prev and Next enabled when current category is disabled by rule', () => {
+      const newStepperProps = {
+        ...stepperBaseProps,
+        uischema: categorizationWithDisabledAddressCategory,
+        data: { ...formData, preQualification: true },
+        activeId: 1,
+      };
+
+      const { baseElement } = render(
+        <JsonFormsStepperContextProvider
+          StepperProps={newStepperProps}
+          children={getForm(newStepperProps.data, categorizationWithDisabledAddressCategory)}
+        />
+      );
+
+      const prevButton = baseElement.querySelector("goa-button[testId='prev-button']");
+      const nextButton = baseElement.querySelector("goa-button[testId='next-button']");
+
+      expect(prevButton).toBeInTheDocument();
+      expect(nextButton).toBeInTheDocument();
+      expect(prevButton?.getAttribute('disabled')).not.toBe('true');
+      expect(nextButton?.getAttribute('disabled')).not.toBe('true');
     });
   });
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.tsx
@@ -50,7 +50,7 @@ export const FormStepper = (props: CategorizationStepperLayoutRendererProps) => 
 };
 
 export const FormStepperView = (props: CategorizationStepperLayoutRendererProps): JSX.Element => {
-  const { uischema, data, schema, path, cells, renderers, visible, t } = props;
+  const { uischema, data, schema, path, cells, renderers, visible, t, enabled } = props;
 
   const enumerators = useContext(JsonFormContext);
   const formStepperCtx = useContext(JsonFormsStepperContext);
@@ -59,7 +59,7 @@ export const FormStepperView = (props: CategorizationStepperLayoutRendererProps)
     formStepperCtx as JsonFormsStepperContextProps
   ).selectStepperState();
 
-  const { selectIsDisabled, goToPage } = formStepperCtx as JsonFormsStepperContextProps;
+  const { goToPage } = formStepperCtx as JsonFormsStepperContextProps;
   const submitFormFunction = enumerators?.submitFunction.get('submit-form');
   const submitForm = submitFormFunction && submitFormFunction();
 
@@ -139,7 +139,7 @@ export const FormStepperView = (props: CategorizationStepperLayoutRendererProps)
               {hasPrevButton ? (
                 <GoabButton
                   type={optionProps?.previousButtonType ? optionProps?.previousButtonType : 'secondary'}
-                  disabled={selectIsDisabled()}
+                  disabled={!enabled}
                   onClick={() => {
                     const element = document.getElementById(`${path || `goa`}-form-stepper`);
                     if (element) {
@@ -166,7 +166,7 @@ export const FormStepperView = (props: CategorizationStepperLayoutRendererProps)
               <RightAlignmentDiv>
                 <GoabButton
                   type={optionProps?.nextButtonType ? optionProps?.nextButtonType : 'primary'}
-                  disabled={selectIsDisabled()}
+                  disabled={!enabled}
                   onClick={() => {
                     headersRef.current[activeId + 1] &&
                       headersRef.current[activeId + 1]


### PR DESCRIPTION
Use the renderer enabled state for Prev/Next button disabling instead of the step-level disabled selector. Prevents navigation buttons from being incorrectly disabled when the active category is disabled by rule logic. Adds a regression test covering a categorization where a page is disabled via DISABLE rule and verifies Prev/Next remain enabled.
<img width="789" height="449" alt="image" src="https://github.com/user-attachments/assets/75c506fe-66d9-40c1-93bf-15128fd0726e" />
