### PR TITLE
fix(jsonforms-components): CS-4858 improve list-with-detail review summary rendering

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -552,7 +552,17 @@ const SummaryDisplay = ({ rowData, uischema, schema }: SummaryDisplayProps) => {
                 paddingBottom: 'var(--goa-space-xs)',
               }}
             >
-              {String(pair.value)}
+              {typeof pair.value === 'boolean'
+                ? pair.value ? 'Yes' : 'No'
+                : pair.value !== null && typeof pair.value === 'object'
+                  ? (() => {
+                      const v = pair.value as Record<string, unknown>;
+                      if (('day' in v || 'date' in v) && 'month' in v && 'year' in v) {
+                        return `${v.year}-${v.month}-${'day' in v ? v.day : v.date}`;
+                      }
+                      return Object.values(v).filter(x => x !== undefined && x !== null && x !== '').join(' ');
+                    })()
+                  : String(pair.value)}
             </td>
           </tr>
         ))}

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -25,7 +25,6 @@ import merge from 'lodash/merge';
 import range from 'lodash/range';
 import React, { useCallback, useContext, useEffect, useReducer, useState } from 'react';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
-import { GoAReviewRenderers } from '../../../index';
 import { capitalizeFirstLetter, isEmptyBoolean, isEmptyNumber, Visible } from '../../util';
 import { humanizeAjvError } from './ListWithDetailControl';
 import {
@@ -215,56 +214,118 @@ export const NonEmptyCellComponent = React.memo(function NonEmptyCellComponent(
 
   return (
     <NonEmptyCellStyle>
-      {(uischema as Layout)?.elements?.map((element: UISchemaElement) => {
-        return (
-          <JsonFormsDispatch
-            data-testid={`jsonforms-object-list-defined-elements-dispatch`}
-            key={rowPath}
-            schema={schema}
-            uischema={element}
-            path={rowPath}
-            enabled={enabled}
-            renderers={isInReview ? GoAReviewRenderers : renderers}
-            cells={cells}
-          />
-        );
-      })}
+      {!isInReview &&
+        (uischema as Layout)?.elements?.map((element: UISchemaElement) => {
+          return (
+            <JsonFormsDispatch
+              data-testid={`jsonforms-object-list-defined-elements-dispatch`}
+              key={rowPath}
+              schema={schema}
+              uischema={element}
+              path={rowPath}
+              enabled={enabled}
+              renderers={renderers}
+              cells={cells}
+            />
+          );
+        })}
       {properties && Object.keys(properties).length > 0 && (
         <>
+          {isInReview ? (
+            <div style={{ padding: '0.75rem 0' }}>
+              {range(count || 0).map((i) => {
+                const rowData = data && data[i];
+                if (!rowData) return null;
+                const hasAnyValue = Object.keys(tableKeys).some((key) => {
+                  const value = rowData[key];
+                  return value !== undefined && value !== null && (value as unknown) !== '';
+                });
+                const hasRowErrors = (errors || []).some((e) =>
+                  e.instancePath.includes(`/${props.rowPath.replace(/\./g, '/')}/${i}`),
+                );
+                if (!hasAnyValue && !hasRowErrors) return null;
+                return (
+                  <div key={i} style={{ marginBottom: '1.5rem' }}>
+                    {Object.entries(tableKeys).map(([key, label]) => {
+                      const value = rowData[key];
+                      const isRequiredField = required?.includes(key) ?? false;
+                      const fieldPath = `/${props.rowPath.replace(/\./g, '/')}/${i}/${key}`;
+                      const rowPathMatch = `/${props.rowPath.replace(/\./g, '/')}/${i}`;
+                      const fieldError = (errors || []).find((e) => {
+                        const msg = (e as ErrorObject).message || '';
+                        const requiredProperty = msg.match(/'([^']+)'/)?.[1];
+                        return (
+                          e.instancePath === fieldPath ||
+                          (e.instancePath === rowPathMatch && msg.includes(key)) ||
+                          (e.instancePath === rowPathMatch && requiredProperty === key)
+                        );
+                      });
+                      const isEmptyValue = value === undefined || value === null || (value as unknown) === '';
+                      if (isEmptyValue && !isRequiredField && !fieldError) return null;
+
+                      let reviewError = '';
+                      if (fieldError) {
+                        const raw = (fieldError as ErrorObject).message || '';
+                        reviewError = raw.includes('required')
+                          ? `${capitalizeFirstLetter(key.replace(/[_-]/g, ' '))} is required`
+                          : raw;
+                      } else if (isRequiredField && isEmptyValue) {
+                        reviewError = `${capitalizeFirstLetter(key.replace(/[_-]/g, ' '))} is required`;
+                      }
+
+                      return (
+                        <div key={key} style={{ display: 'flex', marginBottom: '0.5rem', alignItems: 'center' }}>
+                          <strong style={{ width: '50%', flexShrink: 0 }}>
+                            {properties?.[key]?.title ||
+                              (label !== key
+                                ? label
+                                : key
+                                    .replace(/([A-Z])/g, ' $1')
+                                    .replace(/[_-]/g, ' ')
+                                    .replace(/^./, (c) => c.toUpperCase()))}
+                            {isRequiredField && <RequiredSpan> (required)</RequiredSpan>} :
+                          </strong>
+                          <span
+                            style={{ marginLeft: '1rem' }}
+                            data-testid={`#/properties/${key}-input-${i}-review`}
+                          >
+                            {renderCellColumn({
+                              data: isEmptyValue ? undefined : (value as unknown as string),
+                              error: reviewError,
+                              isRequired: isRequiredField,
+                              errors: errors !== undefined ? errors : [],
+                              count: -1,
+                              element: key,
+                              rowPath,
+                              index: i,
+                            })}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
           <FixTableHeaderAlignment>
             <GoabTable width="100%">
               <thead>
                 <tr key={0}>
                   {Object.entries(tableKeys).map(([value, index]) => {
                     const currentProperty = properties[value];
-                    if (!isInReview) {
-                      return (
-                        <th key={index}>
-                          <p>
-                            {currentProperty?.title || index}
-                            {required?.includes(value) && <RequiredSpan>(required)</RequiredSpan>}
-                          </p>
-                        </th>
-                      );
-                    }
                     return (
-                      <TableTHHeader key={index}>
+                      <th key={index}>
                         <p>
-                          {`${currentProperty?.title || index}`}
-                          {required?.includes(value) && (
-                            <RequiredSpan>
-                              <br /> (required)
-                            </RequiredSpan>
-                          )}
+                          {currentProperty?.title || index}
+                          {required?.includes(value) && <RequiredSpan>(required)</RequiredSpan>}
                         </p>
-                      </TableTHHeader>
+                      </th>
                     );
                   })}
-                  {isInReview !== true && (
-                    <th>
-                      <p>Actions</p>
-                    </th>
-                  )}
+                  <th>
+                    <p>Actions</p>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -332,31 +393,6 @@ export const NonEmptyCellComponent = React.memo(function NonEmptyCellComponent(
                           (isEmptyBoolean(schema, currentData) || isEmptyNumber(schema, currentData))
                         ) {
                           humanMessage = `${capitalizeFirstLetter(schemaName)} is required`;
-                        }
-
-                        if (isInReview === true) {
-                          return (
-                            <td key={ix}>
-                              <div
-                                data-testid={`#/properties/${schemaName}-input-${i}-review`}
-                                style={{ display: 'block' }}
-                              >
-                                {renderCellColumn({
-                                  data:
-                                    currentData !== '' && currentData !== null && currentData !== undefined
-                                      ? currentData
-                                      : undefined,
-                                  error: humanMessage,
-                                  isRequired: required?.includes(element) ?? false,
-                                  errors: errors !== undefined ? errors : [],
-                                  count: count !== undefined ? count : -1,
-                                  element,
-                                  rowPath,
-                                  index: i,
-                                })}
-                              </div>
-                            </td>
-                          );
                         }
 
                         return (
@@ -439,6 +475,7 @@ export const NonEmptyCellComponent = React.memo(function NonEmptyCellComponent(
               </tbody>
             </GoabTable>
           </FixTableHeaderAlignment>
+          )}
           {hasAnyErrors && isInReview && (
             <GoabFormItem error={`There are validation errors for '${capitalizeFirstLetter(rowPath)}'`}></GoabFormItem>
           )}

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.spec.tsx
@@ -258,7 +258,7 @@ describe('renderCellColumn', () => {
     expect(container.querySelector('goa-icon')).toBeTruthy();
   });
 
-  it('returns null for non-string primitive data', () => {
+  it('returns formatted string for number data', () => {
     const result = renderCellColumn({
       data: 123 as unknown as string,
       error: '',
@@ -269,6 +269,6 @@ describe('renderCellColumn', () => {
       isRequired: false,
     });
 
-    expect(result).toBeNull();
+    expect(result).toBe('123');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.tsx
@@ -150,7 +150,11 @@ export const renderCellColumn = ({
   const nestedErrors = errors?.filter((e: ErrorObject) => e.instancePath.includes(path));
 
   /* istanbul ignore next */
-  if (typeof data === 'string') {
+  if (typeof data === 'boolean') {
+    return data ? 'Yes' : 'No';
+  } else if (typeof data === 'number') {
+    return String(data);
+  } else if (typeof data === 'string') {
     return data;
   } else if (typeof data === 'object' || Array.isArray(data)) {
     const result = Object.keys(data);
@@ -159,10 +163,11 @@ export const renderCellColumn = ({
       if (
         'year' in (data as Record<string, unknown>) &&
         'month' in (data as Record<string, unknown>) &&
-        'day' in (data as Record<string, unknown>)
+        ('day' in (data as Record<string, unknown>) || 'date' in (data as Record<string, unknown>))
       ) {
-        const dateObj = data as { year: number; month: number; day: number };
-        return `${dateObj.year}-${dateObj.month}-${dateObj.day}`;
+        const dateObj = data as { year: unknown; month: unknown; day?: unknown; date?: unknown };
+        const dayValue = 'day' in dateObj ? dateObj.day : dateObj.date;
+        return `${dateObj.year}-${dateObj.month}-${dayValue}`;
       }
       return <pre>{JSON.stringify(data, null, 2)}</pre>;
     } else if (result.length === 0) {


### PR DESCRIPTION
stop rendering edit controls in review mode to remove duplicate card content replace fragile review table behavior with stable label-value summary rendering for object arrays restore required indicators and required-field validation display in review summary fix value formatting in review:
date objects render as readable date instead of object output booleans render as Yes/No
numbers render correctly (for example age values)
prettify property-name labels for review display when titles are not provided align answer/value column consistently for better readability ensure list-with-detail summary avoids object-object rendering and shows readable values