### PR TITLE
fix(jsonforms-components): CS-4868 No validation error for SIN on form summary page

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -7,6 +7,7 @@ import Ajv from 'ajv';
 import { JsonForms } from '@jsonforms/react';
 import { GoAInputBaseTableReview } from './InputBaseTableReviewControl';
 import { JsonFormsStepperContext, JsonFormsStepperContextProps } from '../FormStepper/context/StepperContext';
+import { invalidSin } from '../../common/Constants';
 
 import { CategorizationStepperLayoutRendererProps } from '../FormStepper/types';
 import { JsonFormsStepperContextProvider } from '../FormStepper/context';
@@ -440,7 +441,9 @@ describe('InputBaseTableReviewControl', () => {
 
   it('shows validation error for empty array when required', () => {
     const mockGoToPage = jest.fn();
-    const contextValue: JsonFormsStepperContextProps = { goToPage: mockGoToPage } as unknown as JsonFormsStepperContextProps;
+    const contextValue: JsonFormsStepperContextProps = {
+      goToPage: mockGoToPage,
+    } as unknown as JsonFormsStepperContextProps;
     const { baseElement } = render(
       <JsonFormsStepperContext.Provider value={contextValue}>
         <table>
@@ -477,7 +480,7 @@ describe('InputBaseTableReviewControl', () => {
     );
 
     const errorFormItem = baseElement.querySelector(
-      'goa-form-item[error="Choose all options that best apply is required"]'
+      'goa-form-item[error="Choose all options that best apply is required"]',
     );
     expect(errorFormItem).toBeInTheDocument();
   });
@@ -514,6 +517,44 @@ describe('InputBaseTableReviewControl', () => {
 
     expect(getByTestId('review-value-').textContent).toBe('');
     const errorFormItem = baseElement.querySelector('goa-form-item[error="Is attestation accepted is required"]');
+    expect(errorFormItem).toBeInTheDocument();
+  });
+
+  it('shows SIN validation error on summary row for invalid SIN', () => {
+    const { baseElement } = render(
+      <table>
+        <tbody>
+          <GoAInputBaseTableReview
+            data="123 111 111"
+            visible={true}
+            label="Social insurance number"
+            path="sinControls.valueA"
+            schema={{
+              type: 'string',
+              title: 'Social insurance number',
+              errorMessage: 'Must be three groups of three digits.',
+            }}
+            uischema={{
+              type: 'Control',
+              scope: '#/properties/sinControls/properties/valueA',
+              label: 'Social insurance number',
+              options: { stepId: 1 },
+            }}
+            enabled={true}
+            errors=""
+            cells={[]}
+            required={false}
+            id="sin-controls-valueA"
+            rootSchema={{ type: 'object', properties: {} }}
+            config={{}}
+            renderers={[]}
+            handleChange={jest.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+
+    const errorFormItem = baseElement.querySelector(`goa-form-item[error="${invalidSin}"]`);
     expect(errorFormItem).toBeInTheDocument();
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -10,6 +10,7 @@ import {
   getLabelText,
   getLastSegmentFromPointer,
   isNilOrEmptyValue,
+  getSinValidationError,
 } from '../../util';
 import { humanizeAjvError } from '../ObjectArray/ListWithDetailControl';
 import { GoabButton, GoabFormItem } from '@abgov/react-components';
@@ -170,6 +171,12 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
   if (!activeError && typeof errors === 'string' && errors.trim() !== '') {
     activeError = errors;
   }
+
+  const sinValidationError = getSinValidationError(data, schema as JsonSchema);
+  if (sinValidationError) {
+    activeError = sinValidationError;
+  }
+
   if (activeError && /\sis required$/i.test(activeError)) {
     activeError = `${labelToUpdate} is required`;
   }

--- a/libs/jsonforms-components/src/lib/util/stringUtils.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.ts
@@ -148,6 +148,24 @@ interface extractSchema {
   errorMessage?: string;
 }
 
+export const getSinValidationError = (data: unknown, schema?: JsonSchema): string | undefined => {
+  const extraSchema = schema as JsonSchema & extractSchema;
+
+  if (!extraSchema || extraSchema.title !== sinTitle || typeof data !== 'string') {
+    return undefined;
+  }
+
+  if (data.length === 11 && !validateSinWithLuhn(Number(data.replace(/\D/g, '')))) {
+    return data === '' ? '' : invalidSin;
+  }
+
+  if (data.length > 0 && data.length < 11) {
+    return extraSchema.errorMessage;
+  }
+
+  return undefined;
+};
+
 /**
  * Gets the required fields in the If/Then/Else json schema condition.
  * @param props - ControlProps
@@ -202,14 +220,9 @@ export const getRequiredIfThen = (props: ControlProps) => {
 export const checkFieldValidity = (props: ControlProps, rootData?: unknown): string => {
   const { data, errors: ajvErrors, required, schema } = props;
   const labelToUpdate = getControlLabelText(props);
-  const extraSchema = schema as JsonSchema & extractSchema;
-
-  if (extraSchema && data && extraSchema?.title === sinTitle) {
-    if (data.length === 11 && !validateSinWithLuhn(data)) {
-      return data === '' ? '' : invalidSin;
-    } else if (data.length > 0 && data.length < 11) {
-      return extraSchema.errorMessage;
-    }
+  const sinValidationError = getSinValidationError(data, schema);
+  if (sinValidationError) {
+    return sinValidationError;
   }
 
   const rootRequired = getRequiredIfThen(props);


### PR DESCRIPTION

- Invalid social insurance numbers entered on the form page were not showing a validation error on the summary/review page.

- The Luhn-based SIN check was only applied inside checkFieldValidity (used by input controls). The summary renderer (GoAInputBaseTableReview) relied solely on AJV errors, which do not enforce Luhn validity.

- Extracted the SIN validation logic into a shared getSinValidationError helper in stringUtils.ts, and called it from both checkFieldValidity and the summary table review control so both surfaces produce the same error message ("Social insurance number is invalid").

- Added a unit test  to lock in this behavior and prevent regression.
<img width="680" height="397" alt="image" src="https://github.com/user-attachments/assets/4637646c-c68f-447e-bda6-10c877d8cd9b" />
