### PR TITLE
fix: Users are unable to open help text inline links in a new tab

### DIFF
--- a/libs/jsonforms-components/src/lib/Additional/HelpContent.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/HelpContent.spec.tsx
@@ -1,9 +1,11 @@
+import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { JsonForms } from '@jsonforms/react';
 import Ajv from 'ajv';
 import { GoACells, GoARenderers } from '../../index';
 import { UISchemaElement } from '@jsonforms/core';
+import { markdownComponents } from './HelpContent';
 
 /**
  * VERY IMPORTANT:  Rendering <JsonForms ... /> does not work unless the following
@@ -116,6 +118,17 @@ describe('Help Content Control', () => {
     const mainWrapper = renderer.container.querySelector('div > :scope goa-details');
     expect(mainWrapper).not.toBeNull();
     expect(mainWrapper?.getAttribute('heading')).toBe(helpSchema.label);
+  });
+
+  it('renders markdown links to open in a new window', () => {
+    const renderer = render(
+      React.createElement(markdownComponents.a, { href: 'https://www.alberta.ca' }, 'Open Alberta')
+    );
+    const link = renderer.getByRole('link', { name: 'Open Alberta' });
+
+    expect(link).toHaveAttribute('href', 'https://www.alberta.ca');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('will render image in help content', () => {

--- a/libs/jsonforms-components/src/lib/Additional/HelpContent.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/HelpContent.tsx
@@ -46,6 +46,12 @@ interface MdxMarkdownResponse {
   error: string;
 }
 
+export const markdownComponents = {
+  a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props} target="_blank" rel="noopener noreferrer" />
+  ),
+};
+
 const HelpContentReviewComponent = (): JSX.Element => {
   return <> </>;
 };
@@ -68,7 +74,7 @@ export const MarkdownComponent = ({ markdown }: MdxMarkdown): JSX.Element => {
   const response = checkMarkDownIsValid(markdown);
   if (response.isValid) {
     const { default: MDXContent } = evaluateSync(markdown, { ...runtime, Fragment: React.Fragment });
-    return React.createElement(MDXContent, {});
+    return React.createElement(MDXContent, { components: markdownComponents });
   }
   return <InvalidMarkdown>Help content markdown is invalid: {response.error} </InvalidMarkdown>;
 };


### PR DESCRIPTION
<img width="1677" height="825" alt="Screenshot 2026-04-30 at 4 31 51 PM" src="https://github.com/user-attachments/assets/2fa4ebd6-4c52-4ad5-ad10-566ce0a86ca7" />
