### PR TITLE
fix(jsonforms-components): in this case there is no reason to overrid…

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -716,16 +716,20 @@ export function humanizeAjvError(error: ErrorObject, schema: JsonSchema, uischem
   const path = getEffectiveInstancePath(error);
   const label = resolveLabel(path, schema, uischema);
 
-  console.log('Do we get here?', { error, path, label });
-
   switch (error.keyword) {
     case VALIDATION_KEYWORDS.REQUIRED:
       return `${label} is required`;
 
     case VALIDATION_KEYWORDS.MIN_LENGTH:
+      if (error?.message) {
+        return error.message;
+      }
       return `${label} must be at least ${error.params.limit} characters`;
 
     case VALIDATION_KEYWORDS.MAX_LENGTH:
+      if (error?.message) {
+        return error.message;
+      }
       return `${label} must be at most ${error.params.limit} characters`;
 
     case VALIDATION_KEYWORDS.FORMAT:

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/listWithDetails.test.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/listWithDetails.test.tsx
@@ -348,7 +348,7 @@ it('errors are visible', async () => {
   expect(messageFormItem).not.toBeNull();
 
   // Check the error text
-  expect(messageFormItem).toHaveAttribute('error', 'Message must be at most 5 characters');
+  expect(messageFormItem).toHaveAttribute('error', 'must NOT have more than 5 characters');
 });
 it('required errors work', async () => {
   const data = { messages: [] };


### PR DESCRIPTION
…e errors with different custom error
INPUT:
<img width="484" height="141" alt="image" src="https://github.com/user-attachments/assets/1e08b813-4df9-4ee8-99c0-de0c34bf3d9e" />


REVIEW:
<img width="261" height="95" alt="image" src="https://github.com/user-attachments/assets/2048c9b6-2875-489a-8eba-6542804117ba" />
