### PR TITLE
feat(adsp-service-sdk): benchmark to otel metrics

### DIFF
--- a/libs/adsp-service-sdk/src/metrics/benchmark.ts
+++ b/libs/adsp-service-sdk/src/metrics/benchmark.ts
@@ -1,32 +1,48 @@
 import { Request } from 'express';
+import { trace } from '@opentelemetry/api';
 import { EndBenchmark, RequestBenchmark, REQ_BENCHMARK } from './types';
 
+/**
+ * @deprecated Value service benchmark recording is deprecated. Benchmark timings are now recorded as OpenTelemetry
+ * span events when tracing is enabled. The value service write path will be removed in a future release.
+ */
 export function benchmark(req: Request, metric: string, value?: number): void {
   const benchmark: RequestBenchmark = req[REQ_BENCHMARK];
   if (benchmark) {
     // Record the value if this is just setting it; otherwise calculate timings.
     if (value) {
       benchmark.metrics[metric] = value;
+      trace.getActiveSpan()?.addEvent(`adsp.benchmark.${metric}`, { 'benchmark.value': value });
     } else {
       const startAt = benchmark.timings[metric];
       if (startAt) {
         const [sec, nano] = process.hrtime(startAt);
-        benchmark.metrics[metric] = sec * 1e3 + nano * 1e-6;
+        const duration = sec * 1e3 + nano * 1e-6;
+        benchmark.metrics[metric] = duration;
+        trace.getActiveSpan()?.addEvent(`adsp.benchmark.${metric}`, { 'benchmark.duration_ms': duration });
       } else {
         benchmark.timings[metric] = process.hrtime();
+        trace.getActiveSpan()?.addEvent(`adsp.benchmark.${metric}.start`);
       }
     }
   }
 }
 
+/**
+ * @deprecated Value service benchmark recording is deprecated. Benchmark timings are now recorded as OpenTelemetry
+ * span events when tracing is enabled. The value service write path will be removed in a future release.
+ */
 export function startBenchmark(req: Request, metric: string): EndBenchmark {
   const benchmark: RequestBenchmark = req[REQ_BENCHMARK];
   if (benchmark) {
     const startAt = process.hrtime();
+    const span = trace.getActiveSpan();
+    span?.addEvent(`adsp.benchmark.${metric}.start`);
     return () => {
       const [sec, nano] = process.hrtime(startAt);
       const value = sec * 1e3 + nano * 1e-6;
       benchmark.metrics[metric] = (benchmark.metrics[metric] || 0) + value;
+      trace.getActiveSpan()?.addEvent(`adsp.benchmark.${metric}`, { 'benchmark.duration_ms': value });
     };
   } else {
     return () => {

--- a/libs/adsp-service-sdk/src/metrics/definition.ts
+++ b/libs/adsp-service-sdk/src/metrics/definition.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Value service metrics recording is deprecated. Use OpenTelemetry instrumentation via the
+ * `meterProvider` option of `createMetricsHandler` instead.
+ */
 export const ServiceMetricsValueDefinition = {
   id: 'service-metrics',
   name: 'Service metrics',

--- a/libs/adsp-service-sdk/src/metrics/handler.ts
+++ b/libs/adsp-service-sdk/src/metrics/handler.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { Request, RequestHandler, Response } from 'express';
 import { throttle } from 'lodash';
 import type { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { context, ROOT_CONTEXT } from '@opentelemetry/api';
 import * as responseTime from 'response-time';
 import { Logger } from 'winston';
 import { TokenProvider } from '../access';
@@ -26,6 +27,10 @@ function getMetricAttributes(req: Request, res: Response): Record<string, string
   };
 }
 
+/**
+ * @deprecated Value service metrics recording is deprecated. Use OpenTelemetry instrumentation via the
+ * `meterProvider` option of `createMetricsHandler` instead.
+ */
 export async function writeMetrics(
   serviceId: AdspId,
   directory: ServiceDirectory,
@@ -63,6 +68,14 @@ export async function writeMetrics(
 
 // Throttle the metric writes so that there isn't a write request per measured request at higher request volumes.
 const WRITE_THROTTLE_MS = 60000;
+
+/**
+ * Creates an Express middleware handler for service request metrics.
+ *
+ * @deprecated The value service metrics recording path (requires `serviceId`, `tokenProvider`, `directory`) is
+ * deprecated. Provide a `meterProvider` and omit the value service dependencies to use OpenTelemetry instrumentation
+ * only. Value service metric recording will be removed in a future release.
+ */
 export async function createMetricsHandler(
   serviceId: AdspId,
   logger: Logger,
@@ -148,7 +161,9 @@ export async function createMetricsHandler(
         valuesBuffer[value.tenantId] = [];
       }
       valuesBuffer[value.tenantId].push(value);
-      writeBuffer(serviceId, directory, logger, tokenProvider, valuesBuffer);
+      // Detach from the current request's trace context so the throttled write
+      // does not create spans parented to the originating HTTP request span.
+      context.with(ROOT_CONTEXT, () => writeBuffer(serviceId, directory, logger, tokenProvider, valuesBuffer));
     }
   });
 


### PR DESCRIPTION
Also, detach value service metric write to avoid skewing span duration.