### PR TITLE
fix(adsp-service-sdk): suppress client span creation

### DIFF
--- a/libs/adsp-service-sdk/src/metrics/handler.ts
+++ b/libs/adsp-service-sdk/src/metrics/handler.ts
@@ -47,19 +47,16 @@ export async function writeMetrics(
       if (values.length > 0) {
         const token = await tokenProvider.getAccessToken();
 
-        // Suppress span context propagation: the traceparent header prevents the axios interceptor
-        // from injecting an active span as parent, since this write is deferred and unrelated to
-        // any HTTP request span.
-        const headers: Record<string, string> = {
-          Authorization: `Bearer ${token}`,
-          traceparent: '00-0000000000000000000000000000000-0000000000000000-00',
-        };
-
+        // Suppress tracing for deferred writes so throttled metric flushes do not attach to
+        // request spans that scheduled the write.
         await axios.post(valueUrl.href, values, {
-          headers,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
           params: { tenantId },
           timeout: 30000,
-        });
+          _otelSuppressTracing: true,
+        } as unknown as import('axios').InternalAxiosRequestConfig);
         logger.debug(`Wrote service metrics to value service.`, {
           context: 'MetricsHandler',
           tenant: tenantId,

--- a/libs/adsp-service-sdk/src/trace/handler.spec.ts
+++ b/libs/adsp-service-sdk/src/trace/handler.spec.ts
@@ -143,6 +143,29 @@ describe('handler', () => {
       );
     });
 
+    it('can bypass tracing when suppression header is set', () => {
+      const config = {
+        headers: {
+          has: jest.fn(),
+          set: jest.fn(),
+        },
+        _otelSuppressTracing: true,
+        method: 'post',
+        url: 'http://example.com/deferred',
+      };
+
+      const tracer = { startSpan: jest.fn() };
+      const injectSpy = jest.spyOn(propagation, 'inject');
+
+      traceRequestInterceptor(config as unknown as InternalAxiosRequestConfig, tracer as never);
+
+      expect(tracer.startSpan).not.toHaveBeenCalled();
+      expect(injectSpy).not.toHaveBeenCalled();
+      expect((config as { _otelSuppressTracing?: boolean })._otelSuppressTracing).toBeUndefined();
+
+      injectSpy.mockRestore();
+    });
+
     it('can end client span on axios error', async () => {
       const clientSpan = {
         addEvent: jest.fn(),

--- a/libs/adsp-service-sdk/src/trace/handler.ts
+++ b/libs/adsp-service-sdk/src/trace/handler.ts
@@ -15,6 +15,7 @@ interface TraceHandlerOptions {
 
 interface AxiosConfigWithSpan extends InternalAxiosRequestConfig {
   _otelClientSpan?: Span;
+  _otelSuppressTracing?: boolean;
 }
 
 function endClientSpan(span: Span | undefined, status: number, error?: unknown) {
@@ -43,6 +44,16 @@ function endClientSpan(span: Span | undefined, status: number, error?: unknown) 
 
 export function traceRequestInterceptor(config: InternalAxiosRequestConfig, tracer?: Tracer) {
   const configWithSpan = config as AxiosConfigWithSpan;
+  const suppressTracing = !!configWithSpan._otelSuppressTracing;
+
+  // Allow callers to opt out of tracing for deferred/background requests that should not
+  // inherit active request spans (e.g., throttled service-metrics writes). This is an
+  // in-process signal only and never sent on the wire.
+  if (suppressTracing) {
+    delete configWithSpan._otelSuppressTracing;
+    return config;
+  }
+
   const hasTraceparent =
     typeof config.headers?.has === 'function'
       ? config.headers.has(TRACE_PARENT_HEADER)


### PR DESCRIPTION
Client span creation in deferred metric write is still leading to incorrect duration metrics.