### PR TITLE
feat: implement heartbeat mechanism and chunk dispatch throttling for rendering messages

### DIFF
--- a/apps/agent-service/src/agent/router.ts
+++ b/apps/agent-service/src/agent/router.ts
@@ -261,6 +261,21 @@ export function onIoConnection(logger: Logger) {
             const replyId = uuid();
 
             streaming = true;
+            // Send periodic heartbeats during streaming to prevent reverse proxy
+            // (e.g. OpenShift HAProxy route) from timing out the WebSocket connection
+            // during long LLM thinking or tool execution gaps.
+            const streamStartTime = Date.now();
+            const heartbeatInterval = setInterval(() => {
+              if (socket.connected) {
+                socket.emit('stream', {
+                  agent,
+                  threadId,
+                  messageId: replyId,
+                  replyTo: messageId,
+                  chunk: { type: 'heartbeat', payload: { timestamp: Date.now() } },
+                });
+              }
+            }, 15_000);
             try {
               if (rawChunks === true) {
                 const projector = await aiAgent.createProjector(user, threadId);
@@ -320,6 +335,7 @@ export function onIoConnection(logger: Logger) {
               }
 
               let output: unknown;
+              const streamLoopDurationMs = Date.now() - streamStartTime;
               try {
                 output = await result.object;
               } catch (err) {
@@ -334,6 +350,18 @@ export function onIoConnection(logger: Logger) {
                 );
               }
 
+              const totalDurationMs = Date.now() - streamStartTime;
+              logger.info(
+                `Stream complete for agent ${agent}: total=${totalDurationMs}ms, streamLoop=${streamLoopDurationMs}ms, resultObject=${totalDurationMs - streamLoopDurationMs}ms`,
+                {
+                  context: 'AgentRouter',
+                  tenant: tenant?.id?.toString(),
+                  user: `${user.name} (ID: ${user.id})`,
+                  totalDurationMs,
+                  streamLoopDurationMs,
+                },
+              );
+
               socket.emit('stream', {
                 agent,
                 threadId,
@@ -343,6 +371,7 @@ export function onIoConnection(logger: Logger) {
                 done: true,
               });
             } finally {
+              clearInterval(heartbeatInterval);
               streaming = false;
 
               // If a token-expiry disconnect was deferred while the stream was

--- a/apps/tenant-management-webapp/src/app/store/agent/actions.ts
+++ b/apps/tenant-management-webapp/src/app/store/agent/actions.ts
@@ -240,6 +240,20 @@ interface QueuedMessage {
 }
 let queuedMessages: QueuedMessage[] = [];
 
+// Throttle stream chunk dispatches to one batch per animation frame to prevent
+// "Maximum update depth exceeded" when chunks arrive faster than React can render.
+let pendingChunks: Array<{ threadId: string; messageId: string; chunk: unknown; done: boolean; output: unknown }> = [];
+let rafId: number | null = null;
+
+function flushStreamChunks(dispatch: Dispatch) {
+  const chunks = pendingChunks;
+  pendingChunks = [];
+  rafId = null;
+  for (const { threadId, messageId, chunk, done, output } of chunks) {
+    dispatch({ type: AGENT_RESPONSE_ACTION, threadId, messageId, chunk, done, output });
+  }
+}
+
 function clearGraceTimer() {
   if (disconnectGraceTimer !== null) {
     clearTimeout(disconnectGraceTimer);
@@ -260,6 +274,7 @@ export function connectAgent() {
     const { config } = getState();
 
     socket = io(config.serviceUrls?.agentServiceApiUrl || 'localhost:3380', {
+      transports: ['websocket'],
       withCredentials: true,
       reconnection: true,
       reconnectionDelay: 1000,
@@ -322,7 +337,15 @@ export function connectAgent() {
 
     socket.on('stream', (message) => {
       const { threadId, messageId, chunk, done, output } = message;
-      dispatch({ type: AGENT_RESPONSE_ACTION, threadId, messageId, chunk, done, output });
+      // Heartbeat chunks are keep-alive signals to prevent proxy timeouts; ignore them.
+      if (chunk?.type === 'heartbeat') {
+        return;
+      }
+      // Batch chunk dispatches to one per animation frame to avoid overwhelming React.
+      pendingChunks.push({ threadId, messageId, chunk, done, output });
+      if (rafId === null) {
+        rafId = requestAnimationFrame(() => flushStreamChunks(dispatch));
+      }
     });
     socket.on('error', (err) => {
       dispatch(ErrorNotification({ message: err }));


### PR DESCRIPTION
WebSocket-only transport — Switched socket.io from polling→websocket upgrade to websocket-only. Eliminates sticky-session cookie that was routing reconnects back to pods with zombie sessions.

15s heartbeat — Server sends keepalive during long AI tool executions so no proxy layer considers the connection idle.

Throttled UI updates — Batched stream chunk renders to 1/frame to fix React "maximum update depth" lag during fast streaming.