### PR TITLE
fix(pdf-service): add fallback unzip for Chrome extraction in buildah

### DIFF
--- a/apps/pdf-service/Dockerfile
+++ b/apps/pdf-service/Dockerfile
@@ -5,21 +5,32 @@ USER 0
 ARG SERVICE
 COPY . .
 
-# Install Chrome system library dependencies.
+# Install Chrome system library dependencies and unzip for reliable extraction.
 # Fonts and libs required by Chrome for Testing (bundled via puppeteer browsers install).
 RUN apt-get update \
   && apt-get install -y \
     fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
     libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxss1 \
+    unzip \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Chrome for Testing — version is automatically derived from the puppeteer package in
 # node_modules/puppeteer-core/lib/cjs/puppeteer/revisions.js, so it stays in sync with
 # whatever puppeteer version is installed. Uses the local binary to avoid npx prompt issues.
+# The yauzl-based extraction can silently fail for large binaries in buildah overlay builds,
+# so we fall back to system unzip if the chrome binary is missing after install.
 ENV HOME=/puppeteer
-RUN node_modules/.bin/puppeteer browsers install chrome
+RUN node_modules/.bin/puppeteer browsers install chrome \
+  && CHROME_DIR=$(find /puppeteer/.cache/puppeteer/chrome -maxdepth 1 -name 'linux-*' -type d | head -1) \
+  && if [ ! -f "$CHROME_DIR/chrome-linux64/chrome" ]; then \
+       ZIP=$(find /puppeteer/.cache/puppeteer/chrome -name '*-chrome-linux64.zip' | head -1) \
+       && unzip -o "$ZIP" -d "$CHROME_DIR" \
+       && echo "Fallback extraction used for Chrome binary"; \
+     fi \
+  && test -f "$CHROME_DIR/chrome-linux64/chrome" \
+  && rm -f /puppeteer/.cache/puppeteer/chrome/*-chrome-linux64.zip
 RUN chmod 777 -R dist node_modules /puppeteer
 
 USER 1001:0


### PR DESCRIPTION
The yauzl-based zip extraction used by @puppeteer/browsers silently fails to extract the chrome binary (~280MB) in buildah overlay builds, leaving only small files (ABOUT, MEIPreload, WidevineCdm) in the cache directory.

This adds:
- system unzip package for reliable fallback extraction
- verification that the chrome binary exists after install
- fallback to system unzip if puppeteer's extraction is incomplete
- cleanup of the zip file to reduce image size (~155MB savings)