### PR TITLE
fix(ci): add timeout and --prefer-offline to npm ci

### DIFF
--- a/.github/actions/nx-cypress-e2e/action.yml
+++ b/.github/actions/nx-cypress-e2e/action.yml
@@ -44,6 +44,8 @@ runs:
         cypress_password: ${{ inputs.cy-password }}
         cypress_password2: ${{ inputs.cy-password-2 }}
         cypress_password3: ${{ inputs.cy-password-3 }}
+        PUPPETEER_SKIP_DOWNLOAD: 'true'
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       with:
         install-command: npm ci
         command: npx nx e2e ${{ inputs.app }}-e2e --dev-server-target='' --browser chrome --headed --cypress-config="apps/${{ inputs.app }}-e2e/cypress.${{ inputs.environment }}.config.js"

--- a/.github/workflows/clean-code-review.yml
+++ b/.github/workflows/clean-code-review.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install @octokit/rest
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
       - name: Run Clean Code Review
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,6 +56,7 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -29,8 +29,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          # cache disabled temporarily to bypass corrupted cache causing npm ci hangs
-          # cache: "npm"
+          cache: "npm"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -29,23 +29,27 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10
       - uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: "17"
           distribution: temurin
           cache: maven
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
-      - run: npm ci --prefer-offline
-        timeout-minutes: 10
+          version: "1.6.1"
+      - run: |
+          npm config set fetch-retries 5
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm ci --prefer-offline --loglevel verbose
+        timeout-minutes: 15
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Get last successful commit
@@ -94,7 +98,7 @@ jobs:
           app: ${{ matrix.app }}
           redhat-io-username: ${{ secrets.REGISTRY_REDHAT_IO_USER }}
           redhat-io-password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
-          build-context: './'
+          build-context: "./"
           container-file: ${{ hashFiles(format('./apps/{0}/Dockerfile', matrix.app)) && format('./apps/{0}/Dockerfile', matrix.app) || hashFiles(format('./dist/apps/{0}/index.html', matrix.app)) && './.openshift/app/Dockerfile' || './.openshift/service/Dockerfile' }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,13 +141,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - name: E2E Test
         uses: ./.github/actions/nx-cypress-e2e
         with:
           app: ${{ matrix.app }}
           environment: dev
-          tags: '@smoke-test and not @ignore'
+          tags: "@smoke-test and not @ignore"
           core-api-client-secret: ${{ secrets.CY_CORE_API_CLIENT_SECRET }}
           core-api-user-password: ${{ secrets.CY_CORE_API_USER_PASSWORD }}
           api-client-secret: ${{ secrets.CY_CLIENT_SECRET }}
@@ -198,13 +202,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - name: E2E Test
         uses: ./.github/actions/nx-cypress-e2e
         with:
           app: ${{ matrix.app }}
           environment: staging
-          tags: '@smoke-test and not @ignore'
+          tags: "@smoke-test and not @ignore"
           core-api-client-secret: ${{ secrets.CY_CORE_API_CLIENT_SECRET }}
           core-api-user-password: ${{ secrets.CY_CORE_API_USER_PASSWORD }}
           api-client-secret: ${{ secrets.CY_CLIENT_SECRET }}

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -29,27 +29,22 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "npm"
+          cache: 'npm'
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10
       - uses: actions/setup-java@v5
         with:
-          java-version: "17"
+          java-version: '17'
           distribution: temurin
           cache: maven
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: '3.11'
       - uses: snok/install-poetry@v1
         with:
-          version: "1.6.1"
-      - run: |
-          npm config set fetch-retries 5
-          npm config set fetch-retry-mintimeout 20000
-          npm config set fetch-retry-maxtimeout 120000
-          npm ci --prefer-offline --loglevel verbose
-        timeout-minutes: 15
+          version: '1.6.1'
+      - run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -99,7 +94,7 @@ jobs:
           app: ${{ matrix.app }}
           redhat-io-username: ${{ secrets.REGISTRY_REDHAT_IO_USER }}
           redhat-io-password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
-          build-context: "./"
+          build-context: './'
           container-file: ${{ hashFiles(format('./apps/{0}/Dockerfile', matrix.app)) && format('./apps/{0}/Dockerfile', matrix.app) || hashFiles(format('./dist/apps/{0}/index.html', matrix.app)) && './.openshift/app/Dockerfile' || './.openshift/service/Dockerfile' }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -142,13 +137,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "npm"
+          cache: 'npm'
       - name: E2E Test
         uses: ./.github/actions/nx-cypress-e2e
         with:
           app: ${{ matrix.app }}
           environment: dev
-          tags: "@smoke-test and not @ignore"
+          tags: '@smoke-test and not @ignore'
           core-api-client-secret: ${{ secrets.CY_CORE_API_CLIENT_SECRET }}
           core-api-user-password: ${{ secrets.CY_CORE_API_USER_PASSWORD }}
           api-client-secret: ${{ secrets.CY_CLIENT_SECRET }}
@@ -203,13 +198,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "npm"
+          cache: 'npm'
       - name: E2E Test
         uses: ./.github/actions/nx-cypress-e2e
         with:
           app: ${{ matrix.app }}
           environment: staging
-          tags: "@smoke-test and not @ignore"
+          tags: '@smoke-test and not @ignore'
           core-api-client-secret: ${{ secrets.CY_CORE_API_CLIENT_SECRET }}
           core-api-user-password: ${{ secrets.CY_CORE_API_USER_PASSWORD }}
           api-client-secret: ${{ secrets.CY_CLIENT_SECRET }}

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -53,6 +53,7 @@ jobs:
         timeout-minutes: 15
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - name: Get last successful commit
         id: last_successful_commit
         uses: nrwl/nx-set-shas@v5

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -44,7 +44,8 @@ jobs:
       - uses: snok/install-poetry@v1
         with:
           version: '1.6.1'
-      - run: npm ci
+      - run: npm ci --prefer-offline
+        timeout-minutes: 10
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Get last successful commit

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "npm"
+          # cache disabled temporarily to bypass corrupted cache causing npm ci hangs
+          # cache: "npm"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10

--- a/.github/workflows/image-clean-up.yml
+++ b/.github/workflows/image-clean-up.yml
@@ -24,6 +24,7 @@ jobs:
       - run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - shell: bash
         run: echo "ALL_APPS=$(npx nx show projects --type=app | tr "\n" ", ")" >> $GITHUB_ENV
       - name: Delete ADSP containers older than a week

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -38,6 +38,7 @@ jobs:
       - run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - name: Get last successful commit
         uses: nrwl/nx-set-shas@v5
         id: last_successful_commit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "npm"
+          # cache disabled temporarily to bypass corrupted cache causing npm ci hangs
+          # cache: "npm"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,27 +16,22 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "npm"
+          cache: 'npm'
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10
       - uses: actions/setup-java@v5
         with:
-          java-version: "17"
+          java-version: '17'
           distribution: temurin
           cache: maven
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: '3.11'
       - uses: snok/install-poetry@v1
         with:
-          version: "1.6.1"
-      - run: |
-          npm config set fetch-retries 5
-          npm config set fetch-retry-mintimeout 20000
-          npm config set fetch-retry-maxtimeout 120000
-          npm ci --prefer-offline --loglevel verbose
-        timeout-minutes: 15
+          version: '1.6.1'
+      - run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,8 +16,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          # cache disabled temporarily to bypass corrupted cache causing npm ci hangs
-          # cache: "npm"
+          cache: "npm"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,6 +40,7 @@ jobs:
         timeout-minutes: 15
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       # Run with the target branch as the base.
       - name: Build
         uses: ./.github/actions/nx-production-build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,23 +16,27 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10
       - uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: "17"
           distribution: temurin
           cache: maven
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
-      - run: npm ci --prefer-offline
-        timeout-minutes: 10
+          version: "1.6.1"
+      - run: |
+          npm config set fetch-retries 5
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm ci --prefer-offline --loglevel verbose
+        timeout-minutes: 15
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Run with the target branch as the base.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,8 @@ jobs:
       - uses: snok/install-poetry@v1
         with:
           version: '1.6.1'
-      - run: npm ci
+      - run: npm ci --prefer-offline
+        timeout-minutes: 10
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Run with the target branch as the base.


### PR DESCRIPTION
npm ci is hanging indefinitely (50+ min) on GitHub-hosted runners due to transient npm registry connectivity issues. This adds:
- skips chromium download for stages its not needed