### PR TITLE
feat(CS-4961): add Jira integration to unit test agent

### DIFF
--- a/.github/scripts/jest.config.js
+++ b/.github/scripts/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  displayName: 'github-scripts',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.js'],
+};

--- a/.github/scripts/jira-client.js
+++ b/.github/scripts/jira-client.js
@@ -1,0 +1,161 @@
+/**
+ * jira-client.js
+ * Jira Cloud REST API client — ADSP Monorepo (CS-4961)
+ *
+ * Fetches ticket summary, description, and acceptance criteria from
+ * the Jira Cloud REST API v3.  Used by the unit test agent to provide
+ * ticket context when generating or reviewing tests.
+ *
+ * Requires environment variables:
+ *   JIRA_BASE_URL    — e.g. https://goa-dio.atlassian.net
+ *   JIRA_EMAIL       — Atlassian account email for Basic Auth
+ *   JIRA_API_TOKEN   — Atlassian API token for Basic Auth
+ */
+
+// ─────────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────────
+const JIRA_BASE_URL = process.env.JIRA_BASE_URL;
+const JIRA_EMAIL = process.env.JIRA_EMAIL;
+const JIRA_API_TOKEN = process.env.JIRA_API_TOKEN;
+
+// ─────────────────────────────────────────────────────────────
+// Build the Basic Auth header value from email and API token
+// ─────────────────────────────────────────────────────────────
+function buildAuthHeader(email, token) {
+  return 'Basic ' + Buffer.from(`${email}:${token}`).toString('base64');
+}
+
+// ─────────────────────────────────────────────────────────────
+// Recursively extract plain text from an Atlassian Document Format (ADF) node.
+// Jira Cloud REST API v3 returns description as ADF, not plain text.
+// ─────────────────────────────────────────────────────────────
+function adfToText(node) {
+  if (!node) return '';
+  if (node.type === 'text') return node.text || '';
+  if (node.type === 'hardBreak') return '\n';
+  if (!Array.isArray(node.content)) return '';
+
+  const childText = node.content.map(adfToText).join('');
+
+  if (node.type === 'paragraph' || node.type === 'heading') return childText + '\n';
+  if (node.type === 'listItem') return '- ' + childText;
+
+  return childText;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Pull out the "Acceptance Criteria" section from an ADF description.
+// Scans top-level nodes for a heading whose text matches, then collects
+// all following content nodes until the next heading is encountered.
+// ─────────────────────────────────────────────────────────────
+function extractAcceptanceCriteria(descriptionAdf) {
+  if (!descriptionAdf || !Array.isArray(descriptionAdf.content)) return null;
+
+  const nodes = descriptionAdf.content;
+  let capturing = false;
+  const parts = [];
+
+  for (const node of nodes) {
+    if (node.type === 'heading') {
+      const headingText = adfToText(node).trim().toLowerCase();
+      if (headingText === 'acceptance criteria') {
+        capturing = true;
+        continue;
+      }
+      if (capturing) break;
+    }
+    if (capturing) {
+      const text = adfToText(node).trim();
+      if (text) parts.push(text);
+    }
+  }
+
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Fetch a Jira ticket and return its summary, description, and
+// acceptance criteria.  Returns null with a logged warning if
+// credentials are missing, the network is unreachable, or the
+// ticket does not exist.
+// ─────────────────────────────────────────────────────────────
+async function fetchTicket(ticketId) {
+  if (!JIRA_BASE_URL || !JIRA_EMAIL || !JIRA_API_TOKEN) {
+    console.warn(
+      '  Jira credentials not configured — skipping ticket fetch' +
+        ' (JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN are required)',
+    );
+    return null;
+  }
+
+  const url = `${JIRA_BASE_URL.replace(/\/$/, '')}/rest/api/3/issue/${encodeURIComponent(ticketId)}`;
+
+  let response;
+  try {
+    response = await globalThis.fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: buildAuthHeader(JIRA_EMAIL, JIRA_API_TOKEN),
+      },
+    });
+  } catch (err) {
+    console.warn(`  Jira unreachable — skipping ticket fetch for ${ticketId}: ${err.message}`);
+    return null;
+  }
+
+  if (response.status === 404) {
+    console.warn(`  Jira ticket ${ticketId} not found (404) — skipping`);
+    return null;
+  }
+
+  if (!response.ok) {
+    console.warn(`  Jira API returned ${response.status} for ${ticketId} — skipping ticket fetch`);
+    return null;
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (err) {
+    console.warn(`  Could not parse Jira response for ${ticketId}: ${err.message}`);
+    return null;
+  }
+
+  const fields = data.fields || {};
+  const summary = fields.summary || null;
+  const description = fields.description ? adfToText(fields.description).trim() || null : null;
+  const acceptanceCriteria = fields.description ? extractAcceptanceCriteria(fields.description) : null;
+
+  return { summary, description, acceptanceCriteria };
+}
+
+// Guard against auto-execution when this module is require()'d by the test suite
+if (require.main === module) {
+  const ticketId = process.argv[2];
+  if (!ticketId) {
+    console.error('Usage: node .github/scripts/jira-client.js <TICKET-ID>');
+    process.exit(1);
+  }
+  fetchTicket(ticketId)
+    .then((ticket) => {
+      if (ticket) {
+        console.log(JSON.stringify(ticket, null, 2));
+      } else {
+        console.log('Could not fetch ticket.');
+        process.exit(1);
+      }
+    })
+    .catch((err) => {
+      console.error('❌ jira-client failed:', err);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  buildAuthHeader,
+  adfToText,
+  extractAcceptanceCriteria,
+  fetchTicket,
+};

--- a/.github/scripts/jira-client.js
+++ b/.github/scripts/jira-client.js
@@ -27,6 +27,16 @@ function buildAuthHeader(email, token) {
 }
 
 // ─────────────────────────────────────────────────────────────
+// Shared failure handler — logs a warning and returns null.
+// Centralizes the warn-and-return pattern used on every failure path in
+// fetchTicket so the logic is not duplicated (Rule 2.14).
+// ─────────────────────────────────────────────────────────────
+function warnAndReturn(message) {
+  console.warn(message);
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────
 // Recursively extract plain text from an Atlassian Document Format (ADF) node.
 // Jira Cloud REST API v3 returns description as ADF, not plain text.
 // ─────────────────────────────────────────────────────────────
@@ -75,60 +85,86 @@ function extractAcceptanceCriteria(descriptionAdf) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Fetch a Jira ticket and return its summary, description, and
-// acceptance criteria.  Returns null with a logged warning if
-// credentials are missing, the network is unreachable, or the
-// ticket does not exist.
+// Returns true only when all three Jira credentials are present
 // ─────────────────────────────────────────────────────────────
-async function fetchTicket(ticketId) {
-  if (!JIRA_BASE_URL || !JIRA_EMAIL || !JIRA_API_TOKEN) {
-    console.warn(
+function areJiraCredentialsConfigured() {
+  return Boolean(JIRA_BASE_URL && JIRA_EMAIL && JIRA_API_TOKEN);
+}
+
+// ─────────────────────────────────────────────────────────────
+// Returns true when the Jira response indicates the ticket was not found
+// ─────────────────────────────────────────────────────────────
+function isTicketNotFound(response) {
+  return response.status === 404;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Build the fetch options (method + auth headers) for a Jira REST request
+// ─────────────────────────────────────────────────────────────
+function buildJiraRequest(url) {
+  return {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: buildAuthHeader(JIRA_EMAIL, JIRA_API_TOKEN),
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Extract summary, description text, and acceptance criteria from
+// the raw fields object returned by the Jira REST API
+// ─────────────────────────────────────────────────────────────
+function parseTicketFields(fields) {
+  const summary = fields.summary || null;
+  const description = fields.description ? adfToText(fields.description).trim() || null : null;
+  const acceptanceCriteria = fields.description ? extractAcceptanceCriteria(fields.description) : null;
+  return { summary, description, acceptanceCriteria };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Fetch a Jira ticket and return its summary, description, and
+// acceptance criteria.
+// ─────────────────────────────────────────────────────────────
+/**
+ * Fetches a Jira ticket by ID and returns its key fields.
+ * Logs a warning on every failure path — this is intentional diagnostic
+ * output so callers can see why context is missing without throwing.
+ * @returns {Promise<{summary: string|null, description: string|null, acceptanceCriteria: string|null}|null>}
+ */
+async function fetchTicket(ticketId) { // clean-code-ignore: 2.18 — logging is intentional diagnostic output, not a side effect of the function's purpose
+  if (!areJiraCredentialsConfigured()) {
+    return warnAndReturn(
       '  Jira credentials not configured — skipping ticket fetch' +
         ' (JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN are required)',
     );
-    return null;
   }
 
   const url = `${JIRA_BASE_URL.replace(/\/$/, '')}/rest/api/3/issue/${encodeURIComponent(ticketId)}`;
 
   let response;
   try {
-    response = await globalThis.fetch(url, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: buildAuthHeader(JIRA_EMAIL, JIRA_API_TOKEN),
-      },
-    });
+    response = await globalThis.fetch(url, buildJiraRequest(url));
   } catch (err) {
-    console.warn(`  Jira unreachable — skipping ticket fetch for ${ticketId}: ${err.message}`);
-    return null;
+    return warnAndReturn(`  Jira unreachable — skipping ticket fetch for ${ticketId}: ${err.message}`);
   }
 
-  if (response.status === 404) {
-    console.warn(`  Jira ticket ${ticketId} not found (404) — skipping`);
-    return null;
+  if (isTicketNotFound(response)) {
+    return warnAndReturn(`  Jira ticket ${ticketId} not found (404) — skipping`);
   }
 
   if (!response.ok) {
-    console.warn(`  Jira API returned ${response.status} for ${ticketId} — skipping ticket fetch`);
-    return null;
+    return warnAndReturn(`  Jira API returned ${response.status} for ${ticketId} — skipping ticket fetch`);
   }
 
   let data;
   try {
     data = await response.json();
   } catch (err) {
-    console.warn(`  Could not parse Jira response for ${ticketId}: ${err.message}`);
-    return null;
+    return warnAndReturn(`  Could not parse Jira response for ${ticketId}: ${err.message}`);
   }
 
-  const fields = data.fields || {};
-  const summary = fields.summary || null;
-  const description = fields.description ? adfToText(fields.description).trim() || null : null;
-  const acceptanceCriteria = fields.description ? extractAcceptanceCriteria(fields.description) : null;
-
-  return { summary, description, acceptanceCriteria };
+  return parseTicketFields(data.fields || {});
 }
 
 // Guard against auto-execution when this module is require()'d by the test suite
@@ -155,7 +191,12 @@ if (require.main === module) {
 
 module.exports = {
   buildAuthHeader,
+  warnAndReturn,
   adfToText,
   extractAcceptanceCriteria,
+  areJiraCredentialsConfigured,
+  isTicketNotFound,
+  buildJiraRequest,
+  parseTicketFields,
   fetchTicket,
 };

--- a/.github/scripts/jira-client.test.js
+++ b/.github/scripts/jira-client.test.js
@@ -1,0 +1,288 @@
+'use strict';
+
+/**
+ * Unit tests for jira-client.js
+ *
+ * All network access is mocked via globalThis.fetch so no real HTTP calls
+ * are made during the test run.  Env vars are set before the module is
+ * required to mirror the CI environment.
+ */
+
+// Set required env vars before requiring the module so module-level
+// constants are populated — same pattern as github-pr-clean-code-review.test.js
+process.env.JIRA_BASE_URL = 'https://goa-dio.atlassian.net';
+process.env.JIRA_EMAIL = 'test@example.com';
+process.env.JIRA_API_TOKEN = 'test-token';
+
+const { buildAuthHeader, adfToText, extractAcceptanceCriteria, fetchTicket } = require('./jira-client');
+
+// ─── buildAuthHeader ──────────────────────────────────────────────────────────
+
+describe('buildAuthHeader', () => {
+  test('returns a Base64-encoded Basic Auth string', () => {
+    const header = buildAuthHeader('user@example.com', 'secret');
+    const decoded = Buffer.from(header.replace('Basic ', ''), 'base64').toString('utf8');
+    expect(decoded).toBe('user@example.com:secret');
+  });
+
+  test('starts with "Basic "', () => {
+    expect(buildAuthHeader('a', 'b')).toMatch(/^Basic /);
+  });
+});
+
+// ─── adfToText ────────────────────────────────────────────────────────────────
+
+describe('adfToText', () => {
+  test('returns an empty string when node is null', () => {
+    expect(adfToText(null)).toBe('');
+  });
+
+  test('returns an empty string when node is undefined', () => {
+    expect(adfToText(undefined)).toBe('');
+  });
+
+  test('extracts text from a simple text node', () => {
+    expect(adfToText({ type: 'text', text: 'hello' })).toBe('hello');
+  });
+
+  test('returns a newline for a hardBreak node', () => {
+    expect(adfToText({ type: 'hardBreak' })).toBe('\n');
+  });
+
+  test('appends a newline after a paragraph node', () => {
+    const node = { type: 'paragraph', content: [{ type: 'text', text: 'line' }] };
+    expect(adfToText(node)).toBe('line\n');
+  });
+
+  test('appends a newline after a heading node', () => {
+    const node = { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Title' }] };
+    expect(adfToText(node)).toBe('Title\n');
+  });
+
+  test('prefixes list items with "- "', () => {
+    const node = { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'item' }] }] };
+    expect(adfToText(node)).toContain('- ');
+  });
+
+  test('recursively concatenates nested content in a doc node', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'first' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'second' }] },
+      ],
+    };
+    const result = adfToText(doc);
+    expect(result).toContain('first');
+    expect(result).toContain('second');
+  });
+});
+
+// ─── extractAcceptanceCriteria ────────────────────────────────────────────────
+
+describe('extractAcceptanceCriteria', () => {
+  test('returns null when descriptionAdf is null', () => {
+    expect(extractAcceptanceCriteria(null)).toBeNull();
+  });
+
+  test('returns null when there is no Acceptance Criteria heading', () => {
+    const adf = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Some description' }] }],
+    };
+    expect(extractAcceptanceCriteria(adf)).toBeNull();
+  });
+
+  test('returns the text content that follows an "Acceptance Criteria" heading', () => {
+    const adf = {
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Acceptance Criteria' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Must pass all tests' }] },
+      ],
+    };
+    expect(extractAcceptanceCriteria(adf)).toContain('Must pass all tests');
+  });
+
+  test('stops collecting content at the next heading after Acceptance Criteria', () => {
+    const adf = {
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Acceptance Criteria' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'AC text' }] },
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Notes' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'should not appear' }] },
+      ],
+    };
+    const result = extractAcceptanceCriteria(adf);
+    expect(result).toContain('AC text');
+    expect(result).not.toContain('should not appear');
+  });
+
+  test('is case-insensitive for the Acceptance Criteria heading', () => {
+    const adf = {
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'ACCEPTANCE CRITERIA' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'criteria text' }] },
+      ],
+    };
+    expect(extractAcceptanceCriteria(adf)).toContain('criteria text');
+  });
+});
+
+// ─── fetchTicket ──────────────────────────────────────────────────────────────
+
+describe('fetchTicket', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  const makeAdfDescription = (text) => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  });
+
+  const makeSuccessResponse = (fields) => ({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ fields }),
+  });
+
+  test('returns null and logs a warning when Jira credentials are not configured', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Credentials are module-level constants captured at require() time, so we must
+    // re-require the module with env vars cleared inside an isolated module registry.
+    const savedBase = process.env.JIRA_BASE_URL;
+    const savedEmail = process.env.JIRA_EMAIL;
+    const savedToken = process.env.JIRA_API_TOKEN;
+
+    delete process.env.JIRA_BASE_URL;
+    delete process.env.JIRA_EMAIL;
+    delete process.env.JIRA_API_TOKEN;
+
+    let fetchTicketWithoutCredentials;
+    jest.isolateModules(() => {
+      ({ fetchTicket: fetchTicketWithoutCredentials } = require('./jira-client'));
+    });
+
+    process.env.JIRA_BASE_URL = savedBase;
+    process.env.JIRA_EMAIL = savedEmail;
+    process.env.JIRA_API_TOKEN = savedToken;
+
+    const result = await fetchTicketWithoutCredentials('CS-1234');
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('credentials not configured'));
+  });
+
+  test('calls the Jira REST API with the correct URL for the given ticket ID', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue(makeSuccessResponse({ summary: 'Test ticket', description: null }));
+
+    await fetchTicket('CS-1234');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://goa-dio.atlassian.net/rest/api/3/issue/CS-1234',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('includes a Basic Auth header in the request', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue(makeSuccessResponse({ summary: 'x', description: null }));
+
+    await fetchTicket('CS-1234');
+
+    const [, options] = globalThis.fetch.mock.calls[0];
+    expect(options.headers.Authorization).toMatch(/^Basic /);
+  });
+
+  test('returns summary and null description when fields.description is absent', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(makeSuccessResponse({ summary: 'My ticket', description: null }));
+
+    const result = await fetchTicket('CS-1234');
+
+    expect(result).toEqual({ summary: 'My ticket', description: null, acceptanceCriteria: null });
+  });
+
+  test('returns parsed description text from ADF when description is present', async () => {
+    const descriptionAdf = makeAdfDescription('Implement the feature');
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(makeSuccessResponse({ summary: 'Feature ticket', description: descriptionAdf }));
+
+    const result = await fetchTicket('CS-1234');
+
+    expect(result.description).toContain('Implement the feature');
+  });
+
+  test('returns acceptanceCriteria when an Acceptance Criteria heading is present in the description', async () => {
+    const descriptionAdf = {
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Acceptance Criteria' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Must be unit tested' }] },
+      ],
+    };
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue(makeSuccessResponse({ summary: 'AC ticket', description: descriptionAdf }));
+
+    const result = await fetchTicket('CS-9999');
+
+    expect(result.acceptanceCriteria).toContain('Must be unit tested');
+  });
+
+  test('returns null and logs a warning when the network call throws', async () => {
+    globalThis.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchTicket('CS-1234');
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Jira unreachable'));
+  });
+
+  test('returns null and logs a warning when the response status is 404', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchTicket('CS-0000');
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not found (404)'));
+  });
+
+  test('returns null and logs a warning when the response status is not ok', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchTicket('CS-1234');
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('500'));
+  });
+
+  test('returns null and logs a warning when the response body cannot be parsed as JSON', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error('invalid json')),
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchTicket('CS-1234');
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Could not parse'));
+  });
+});

--- a/.github/scripts/unit-test-agent.js
+++ b/.github/scripts/unit-test-agent.js
@@ -16,6 +16,7 @@ const { Octokit } = require('@octokit/rest');
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { fetchTicket } = require('./jira-client');
 
 // ─────────────────────────────────────────────────────────────
 // Environment
@@ -174,7 +175,11 @@ function buildUserPrompt(sourceFile, sourceContent, existingTestContent, jiraCon
   const parts = [];
 
   if (jiraContext) {
-    parts.push(`JIRA CONTEXT:\nTicket(s): ${jiraContext}`);
+    const jiraLines = ['JIRA CONTEXT:'];
+    if (jiraContext.summary) jiraLines.push(`Summary: ${jiraContext.summary}`);
+    if (jiraContext.description) jiraLines.push(`Description:\n${jiraContext.description}`);
+    if (jiraContext.acceptanceCriteria) jiraLines.push(`Acceptance Criteria:\n${jiraContext.acceptanceCriteria}`);
+    parts.push(jiraLines.join('\n'));
   }
 
   const truncatedSource =
@@ -377,7 +382,7 @@ function findUntestedFiles(projectName, config) {
 // ─────────────────────────────────────────────────────────────
 // Process a single source file: call GPT and write or print result
 // ─────────────────────────────────────────────────────────────
-async function processSourceFile(relativeSourcePath, args, config, systemPrompt) {
+async function processSourceFile(relativeSourcePath, args, config, systemPrompt, jiraTicket = null) {
   const absSourcePath = path.isAbsolute(relativeSourcePath)
     ? relativeSourcePath
     : path.join(process.cwd(), relativeSourcePath);
@@ -397,7 +402,7 @@ async function processSourceFile(relativeSourcePath, args, config, systemPrompt)
     console.log(`  Existing test file found: ${testFilePath}`);
   }
 
-  const userPrompt = buildUserPrompt(relativeSourcePath, sourceContent, existingTestContent, args.ticket || null, null);
+  const userPrompt = buildUserPrompt(relativeSourcePath, sourceContent, existingTestContent, jiraTicket, null);
 
   let result;
   try {
@@ -445,8 +450,13 @@ async function runLocalMode(args, config) {
 
   const systemPrompt = buildSystemPrompt(config, args.mode);
 
+  const jiraTicket = args.ticket ? await fetchTicket(args.ticket) : null;
+  if (jiraTicket) {
+    console.log(`  Jira ticket: ${args.ticket} — ${jiraTicket.summary || '(no summary)'}`);
+  }
+
   if (args.file) {
-    const result = await processSourceFile(args.file, args, config, systemPrompt);
+    const result = await processSourceFile(args.file, args, config, systemPrompt, jiraTicket);
 
     if (result && !args.dryRun) {
       // Infer project name from the file path — apps/<project>/... or libs/<project>/...
@@ -472,7 +482,7 @@ async function runLocalMode(args, config) {
     console.log(`  Found ${untestedFiles.length} untested file(s) in ${args.project}`);
     for (const absPath of untestedFiles) {
       const rel = path.relative(process.cwd(), absPath).replace(/\\/g, '/');
-      await processSourceFile(rel, args, config, systemPrompt);
+      await processSourceFile(rel, args, config, systemPrompt, jiraTicket);
     }
 
     if (!args.dryRun) {
@@ -508,9 +518,12 @@ async function runPrMode(args, config) {
     repo: REPO_NAME,
     pull_number: prNumber,
   });
-  const jiraContext = extractJiraTicket(prData.data.title, prData.data.body);
-  if (jiraContext) {
-    console.log(`  Jira context: ${jiraContext}`);
+  const ticketId = extractJiraTicket(prData.data.title, prData.data.body);
+  const jiraTicket = ticketId ? await fetchTicket(ticketId) : null;
+  if (jiraTicket) {
+    console.log(`  Jira ticket: ${ticketId} — ${jiraTicket.summary || '(no summary)'}`);
+  } else if (ticketId) {
+    console.log(`  Jira ticket ID found (${ticketId}) but fetch returned null — continuing without Jira context`);
   }
   const headSha = HEAD_SHA || prData.data.head.sha;
 
@@ -578,7 +591,7 @@ async function runPrMode(args, config) {
       file.filename,
       sourceContent,
       existingTestContent,
-      jiraContext,
+      jiraTicket,
       file.patch || null,
     );
 


### PR DESCRIPTION
Fetches ticket summary, description and acceptance criteria from Jira Cloud and includes them in the prompt alongside the source code so generated tests are based on expected behaviour from the ticket, not just what the code happens to do.

Files added:
- jira-client.js: Jira Cloud REST API client with ADF to plain text parsing
- jira-client.test.js: 25 unit tests, all passing
- jest.config.js: test runner for .github/scripts, covers both test files

Files updated:
- unit-test-agent.js: wired up jira-client, ticket context now passed into the prompt when --ticket flag or PR title contains a ticket ID

How to test locally:
  $env:GITHUB_TOKEN="ghp_your_token" $env:JIRA_BASE_URL="https://goa-dio.atlassian.net" $env:JIRA_EMAIL="your.email@gov.ab.ca" $env:JIRA_API_TOKEN="your_jira_token"

  # Replace <path> with any source file and <CS-XXXX> with a real ticket ID node .github/scripts/unit-test-agent.js --mode generate \ --file <path> --ticket <CS-XXXX> --dry-run

  # Run jira-client unit tests npx jest --config .github/scripts/jest.config.js --testPathPattern="jira-client"