### PR TITLE
fix(deps): address pip Dependabot security alerts across Python projects

### DIFF
--- a/apps/pii-service/poetry.lock
+++ b/apps/pii-service/poetry.lock
@@ -840,15 +840,18 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.17"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
+    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
 ]
+
+[package.extras]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -2330,14 +2333,14 @@ markers = {dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -2445,4 +2448,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "3fb47aa76b7aadfa2dbe1c8da07b49feccff146334d3ac7cfca966ed4f524903"
+content-hash = "60d512e9ead2034cb58c46b98440768bec9c88c4f0cefd01c4434d07103d7acf"

--- a/apps/pii-service/pyproject.toml
+++ b/apps/pii-service/pyproject.toml
@@ -30,6 +30,8 @@ include = ["pii_service/resources/swagger.yml"]
   presidio-anonymizer = "^2.2.353"
   pyyaml = "^6.0.1"
   flask-cors = "^6.0.0"
+  idna = ">=3.15"
+  urllib3 = ">=2.7.0"
 
   [tool.poetry.group.dev.dependencies]
   flake8 = "6.0.0"

--- a/libs/adsp-py-common/poetry.lock
+++ b/libs/adsp-py-common/poetry.lock
@@ -495,15 +495,18 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.17"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
+    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
 ]
+
+[package.extras]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -1114,4 +1117,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "b4c178e267e7e28b25f5f42b85332294f9cbbd1562599cf220a52de3df9a70f5"
+content-hash = "a639b3ee61cc886a2104253579326ed80022c73a8c058bcd65a9f6140a249230"

--- a/libs/adsp-py-common/pyproject.toml
+++ b/libs/adsp-py-common/pyproject.toml
@@ -29,6 +29,7 @@ readme = 'README.md'
   httpx = "^0.28.1"
   more-itertools = "^10.8.0"
   urnparse = "^0.2.2"
+  idna = ">=3.15"
 
     [tool.poetry.dependencies.pyjwt]
     extras = [ "crypto" ]

--- a/libs/adsp-service-django-sdk/poetry.lock
+++ b/libs/adsp-service-django-sdk/poetry.lock
@@ -556,15 +556,18 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.17"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
+    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
 ]
+
+[package.extras]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -1207,4 +1210,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "3c406646dd262ed5f554b3c0c0125e1a891a88cabfc4c1b04a7f7185968b853f"
+content-hash = "97fa06ff84cbb4c29335a79a2e71058b347b510b751ba5e4a7b5a0ada5592f36"

--- a/libs/adsp-service-django-sdk/pyproject.toml
+++ b/libs/adsp-service-django-sdk/pyproject.toml
@@ -25,6 +25,7 @@ include = "adsp_service_django_sdk"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 django = "^4.2.30"
+idna = ">=3.15"
 
 [tool.poetry.dependencies.adsp-py-common]
 path = "../adsp-py-common"

--- a/libs/adsp-service-flask-sdk/poetry.lock
+++ b/libs/adsp-service-flask-sdk/poetry.lock
@@ -554,15 +554,18 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.17"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
+    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
 ]
+
+[package.extras]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -1205,4 +1208,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "81f66e7f3c0c87bee2cb8a1431871a0a3b404e768e7a82ed7cac6e43fe2972e0"
+content-hash = "5f4bc44752534ef1404e26c1f203c5e74a00a2f3fb42138d463de2d5094b2cc7"

--- a/libs/adsp-service-flask-sdk/pyproject.toml
+++ b/libs/adsp-service-flask-sdk/pyproject.toml
@@ -25,6 +25,7 @@ readme = "README.md"
   [tool.poetry.dependencies]
   python = ">=3.10,<3.12"
   flask = "^3.1.3"
+  idna = ">=3.15"
 
     [tool.poetry.dependencies.adsp-py-common]
     path = "../adsp-py-common"


### PR DESCRIPTION
## Summary

Targeted fix for all open pip Dependabot security alerts. Added explicit minimum-version constraints to each `pyproject.toml` and regenerated `poetry.lock` files.

### Changes per project

| Project | Package | Before | After | Severity |
|---------|---------|--------|-------|----------|
| `apps/pii-service` | `idna` | 3.7 | 3.17 | medium |
| `apps/pii-service` | `urllib3` | 2.6.3 | 2.7.0 | high |
| `libs/adsp-py-common` | `idna` | 3.7 | 3.17 | medium |
| `libs/adsp-service-django-sdk` | `idna` | 3.7 | 3.17 | medium |
| `libs/adsp-service-flask-sdk` | `idna` | 3.7 | 3.17 | medium |

Both packages were transitive dependencies — added as explicit constraints (`idna = ">=3.15"`, `urllib3 = ">=2.7.0"`) so Poetry resolves them to patched versions.

Closes Dependabot alerts: #744, #745, #769, #770, #771, #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)