### PR TITLE
feat(agent-service): add frontend templates and instructions for react-app and angular-app

### DIFF
--- a/apps/agent-service/src/agent/agents/nxAdsp.ts
+++ b/apps/agent-service/src/agent/agents/nxAdsp.ts
@@ -35,30 +35,71 @@ export const nxAdspAgent: AgentConfiguration = {
 
     ## Workflow
 
-    1. **Understand the service**: The developer will describe the service they are building.
-       Read the existing file content they provide in the initial message to understand
-       the current structure (main.ts, environment.ts).
+    The initial message identifies the project type. Use it to determine which templates
+    and file patterns apply.
 
-    2. **Ask focused questions** to understand what the service does, what domain events it
-       should emit, and what roles it needs. Ask 2-3 targeted questions — do not ask
-       everything at once. Examples:
+    ### For express-service projects
+
+    1. **Understand the service**: Read main.ts and environment.ts from the workspace to
+       understand the current structure.
+
+    2. **Ask focused questions** (2-3 turns max):
        - "What does this service manage? (e.g., cases, applications, documents)"
-       - "What significant things happen in the service that other systems should know about?"
+       - "What significant things happen that other systems should know about?"
        - "Who should have access — administrators only, or regular users too?"
 
-    3. **Retrieve relevant templates**: Once you understand the service, call
-       list-nx-adsp-templates to see what is available, then call get-nx-adsp-template
-       for each capability that fits.
+    3. **Retrieve relevant templates**: Call list-nx-adsp-templates, then get-nx-adsp-template
+       for each capability that fits. Use only templates with id starting with express-service-.
 
-    4. **Write files to workspace**: Adapt the template patterns to the specific service
-       domain (replace {projectName}, {entityName}, and other placeholders with actual names
-       from the conversation). Then:
-       - Write any new files (e.g., src/roles.ts, src/events.ts) using mastra_workspace_write_file.
-       - Write the modified main.ts using mastra_workspace_write_file with the full updated content
-         that integrates the new capabilities.
+    4. **Write files to workspace**: Adapt templates (replace {projectName}, {entityName},
+       {ServiceName} with actual names). Write new files and the full updated main.ts.
 
-    5. **Confirm**: After writing, briefly tell the developer what was generated and what
-       they need to do next (e.g., fill in CLIENT_SECRET, register roles in the tenant admin UI).
+    5. **Confirm**: Briefly tell the developer what was generated and what to do next
+       (register roles in the tenant admin UI, configure CLIENT_SECRET, etc.).
+
+    ### For react-app projects
+
+    1. **Understand the app**: Read store.ts, app.tsx, config.slice.ts, and intake.slice.ts
+       from the workspace to understand what's already set up.
+
+    2. **Ask one focused question** about what ADSP features the app should surface to users
+       — e.g., "Should users see a log of domain events, or upload files, or both?"
+
+    3. **Retrieve relevant templates**: Call list-nx-adsp-templates, then get-nx-adsp-template
+       for each capability. Use only templates with id starting with react-app-.
+
+    4. **Write files to workspace**: For each template:
+       - Write new slice files (e.g., src/app/events.slice.ts) using mastra_workspace_write_file.
+       - Read the current store.ts and write the updated version with new reducer imports and entries.
+       - Replace ALL placeholders ({projectName}, {ServiceName}, {tenant}) with actual values
+         from the conversation and the initial message context.
+
+    5. **Confirm**: Briefly state what slices were added and remind the developer to dispatch
+       the load thunks on app startup.
+
+    ### For angular-app projects
+
+    1. **Understand the app**: Read app.config.ts, app.routes.ts, and app.component.ts
+       from the workspace.
+
+    2. **Ask one focused question** about which ADSP features should appear in the app.
+
+    3. **Retrieve relevant templates**: Use only templates with id starting with angular-app-.
+
+    4. **Write files to workspace**: For each template:
+       - Write new service files (e.g., src/app/events/events.service.ts).
+       - Services use providedIn: 'root' — no changes to app.config.ts needed unless
+         the template explicitly states otherwise.
+       - Replace ALL placeholders with actual values.
+
+    5. **Confirm**: Briefly state what services were added and how to inject them.
+
+    ### For continuation conversations (frontend after service)
+
+    When the initial message says "I've also scaffolded a react-app / angular-app", this is a
+    continuation of a prior service discussion on the same thread. You already know the domain
+    from the service conversation — apply that context to suggest appropriate frontend capabilities
+    without asking the developer to re-describe the project.
 
     ## Rules
 
@@ -68,13 +109,14 @@ export const nxAdspAgent: AgentConfiguration = {
     - **One question per turn**: Ask at most one focused question. Do not ask several things
       at once. After 1-2 exchanges you have enough context — call the template tools and write
       the files immediately without asking for further confirmation.
-    - Replace ALL placeholders ({projectName}, {entityName}, {entity-name}, etc.) with
-      actual names based on the conversation. Never leave template placeholders in output.
+    - Replace ALL placeholders ({projectName}, {entityName}, {entity-name}, {ServiceName},
+      {tenant}, etc.) with actual names based on the conversation. Never leave template
+      placeholders in output.
     - Write the complete content of modified files — do not describe changes, write them.
     - The nx-adsp plugin version is provided in the initial message — use it to verify
       template compatibility via the compatibleWith field.
     - If the developer provides no useful domain information after a few exchanges,
-      write reasonable defaults using the service name as context and note what to customise.
+      write reasonable defaults using the service/app name as context and note what to customise.
   `,
   tools: ['listNxAdspTemplatesTool', 'getNxAdspTemplateTool'],
   userRoles: ['urn:ads:platform:agent-service:agent-user'],

--- a/apps/agent-service/src/agent/tools/nxAdspTemplates.ts
+++ b/apps/agent-service/src/agent/tools/nxAdspTemplates.ts
@@ -5,6 +5,10 @@ import z from 'zod';
 // Update this constant and the template content when the plugin's SDK patterns change.
 const COMPATIBLE_PLUGIN_VERSION = '>=12.3.0';
 
+// Frontend templates require the keycloak-js / Redux (React) or keycloak-angular /
+// injectable-service (Angular) patterns introduced in nx-adsp 12.8.0.
+const COMPATIBLE_FRONTEND_PLUGIN_VERSION = '>=12.8.0';
+
 interface NxAdspTemplate {
   id: string;
   description: string;
@@ -167,6 +171,578 @@ app.get('/{projectName}/v1/config', async (req, res) => {
   res.json(configuration || {});
 });`,
   },
+
+  // ── React (redux-toolkit slice pattern) ────────────────────────────────────
+
+  'react-app-roles': {
+    id: 'react-app-roles',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add a hasRole() helper to user.slice.ts for checking Keycloak resource roles. ' +
+      'Use it in components to conditionally show UI based on the user\'s roles in the service client.',
+    integrationChanges: {
+      'src/app/user.slice.ts': {
+        description:
+          'Export a hasRole() function that reads resource_access from the parsed Keycloak token. ' +
+          'The clientId defaults to the app\'s own client ID but can be overridden for service-specific roles.',
+        pattern: `// Add after the existing getAccessToken export:
+export function hasRole(role: string, clientId = environment.access.client_id): boolean {
+  const resourceAccess = keycloak?.tokenParsed?.resource_access as
+    Record<string, { roles?: string[] }> | undefined;
+  return resourceAccess?.[clientId]?.roles?.includes(role) ?? false;
+}`,
+      },
+    },
+    usageExample: `// In a component — import hasRole from user.slice:
+import { hasRole } from './user.slice';
+
+// Conditionally render admin UI:
+{hasRole('{projectName}-admin') && (
+  <GoabButton onClick={handleAdminAction}>Admin action</GoabButton>
+)}`,
+  },
+
+  'react-app-events': {
+    id: 'react-app-events',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add an events Redux slice that fetches domain events from the ADSP event service. ' +
+      'The event service URL is discovered from the directory loaded by config.slice.',
+    newFiles: {
+      'src/app/events.slice.ts': `import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { getAccessToken } from './user.slice';
+
+const EVENT_SERVICE_URN = 'urn:ads:platform:event-service:v1';
+
+export const EVENTS_FEATURE_KEY = 'events';
+
+export interface EventRecord {
+  namespace: string;
+  name: string;
+  timestamp: string;
+  correlationId?: string;
+  context?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+}
+
+export interface EventsState {
+  records: EventRecord[];
+  loadingStatus: 'not loaded' | 'loading' | 'loaded' | 'error';
+  error?: string;
+}
+
+export const loadEvents = createAsyncThunk(
+  'events/load',
+  async (
+    criteria: { namespace?: string; name?: string },
+    { getState }
+  ) => {
+    const state = getState() as { config: { directory: Record<string, string> } };
+    const eventServiceUrl = state.config.directory[EVENT_SERVICE_URN];
+    if (!eventServiceUrl) throw new Error('Event service not found in directory.');
+
+    const token = await getAccessToken();
+    const params = new URLSearchParams();
+    if (criteria.namespace) params.set('namespace', criteria.namespace);
+    if (criteria.name) params.set('name', criteria.name);
+
+    const response = await fetch(
+      eventServiceUrl + '/api/event/v1/events?' + params.toString(),
+      { headers: { Authorization: 'Bearer ' + token } }
+    );
+    if (!response.ok) throw new Error('Failed to load events: ' + response.status);
+
+    const data = await response.json();
+    return (data.results ?? []) as EventRecord[];
+  }
+);
+
+export const initialEventsState: EventsState = {
+  records: [],
+  loadingStatus: 'not loaded',
+};
+
+const eventsSlice = createSlice({
+  name: EVENTS_FEATURE_KEY,
+  initialState: initialEventsState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(loadEvents.pending, (state) => { state.loadingStatus = 'loading'; })
+      .addCase(loadEvents.fulfilled, (state, { payload }) => {
+        state.records = payload;
+        state.loadingStatus = 'loaded';
+      })
+      .addCase(loadEvents.rejected, (state, { error }) => {
+        state.loadingStatus = 'error';
+        state.error = error.message;
+      });
+  },
+});
+
+export const eventsReducer = eventsSlice.reducer;
+export const eventsSelector = (state: { [EVENTS_FEATURE_KEY]: EventsState }) =>
+  state[EVENTS_FEATURE_KEY];
+`,
+    },
+    integrationChanges: {
+      'src/store.ts': {
+        description: 'Import eventsReducer and EVENTS_FEATURE_KEY and add to the store reducer map.',
+        pattern: `// Add import:
+import { EVENTS_FEATURE_KEY, eventsReducer } from './app/events.slice';
+
+// Add to configureStore reducer map:
+[EVENTS_FEATURE_KEY]: eventsReducer,`,
+      },
+    },
+    usageExample: `// In a component — dispatch loadEvents and display results:
+import { useDispatch, useSelector } from 'react-redux';
+import { loadEvents, eventsSelector } from './events.slice';
+
+const dispatch = useDispatch();
+const { records, loadingStatus } = useSelector(eventsSelector);
+
+useEffect(() => {
+  dispatch(loadEvents({ namespace: '{projectName}' }));
+}, [dispatch]);`,
+  },
+
+  'react-app-configuration': {
+    id: 'react-app-configuration',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add a configuration Redux slice that fetches the service configuration from the ADSP ' +
+      'configuration service. Tenants set values via the ADSP tenant admin app.',
+    newFiles: {
+      'src/app/configuration.slice.ts': `import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { getAccessToken } from './user.slice';
+
+const CONFIGURATION_SERVICE_URN = 'urn:ads:platform:configuration-service:v2';
+
+export const CONFIGURATION_FEATURE_KEY = 'configuration';
+
+export interface {ServiceName}Configuration {
+  // Add your configuration properties here.
+  [key: string]: unknown;
+}
+
+export interface ConfigurationState {
+  value: {ServiceName}Configuration | null;
+  loadingStatus: 'not loaded' | 'loading' | 'loaded' | 'error';
+  error?: string;
+}
+
+export const loadConfiguration = createAsyncThunk(
+  'configuration/load',
+  async (
+    _: void,
+    { getState }
+  ) => {
+    const state = getState() as { config: { directory: Record<string, string> } };
+    const configServiceUrl = state.config.directory[CONFIGURATION_SERVICE_URN];
+    if (!configServiceUrl) throw new Error('Configuration service not found in directory.');
+
+    const token = await getAccessToken();
+    const response = await fetch(
+      configServiceUrl + '/api/configuration/v2/configuration/{tenant}/{projectName}/current',
+      { headers: { Authorization: 'Bearer ' + token } }
+    );
+    if (!response.ok) throw new Error('Failed to load configuration: ' + response.status);
+
+    const data = await response.json();
+    return (data.latest?.configuration ?? {}) as {ServiceName}Configuration;
+  }
+);
+
+export const initialConfigurationState: ConfigurationState = {
+  value: null,
+  loadingStatus: 'not loaded',
+};
+
+const configurationSlice = createSlice({
+  name: CONFIGURATION_FEATURE_KEY,
+  initialState: initialConfigurationState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(loadConfiguration.pending, (state) => { state.loadingStatus = 'loading'; })
+      .addCase(loadConfiguration.fulfilled, (state, { payload }) => {
+        state.value = payload;
+        state.loadingStatus = 'loaded';
+      })
+      .addCase(loadConfiguration.rejected, (state, { error }) => {
+        state.loadingStatus = 'error';
+        state.error = error.message;
+      });
+  },
+});
+
+export const configurationReducer = configurationSlice.reducer;
+export const configurationSelector = (state: { [CONFIGURATION_FEATURE_KEY]: ConfigurationState }) =>
+  state[CONFIGURATION_FEATURE_KEY];
+`,
+    },
+    integrationChanges: {
+      'src/store.ts': {
+        description: 'Import configurationReducer and CONFIGURATION_FEATURE_KEY and add to the store reducer map.',
+        pattern: `// Add import:
+import { CONFIGURATION_FEATURE_KEY, configurationReducer } from './app/configuration.slice';
+
+// Add to configureStore reducer map:
+[CONFIGURATION_FEATURE_KEY]: configurationReducer,`,
+      },
+    },
+    usageExample: `// Dispatch on app load and read configuration in components:
+import { loadConfiguration, configurationSelector } from './configuration.slice';
+
+const { value: config } = useSelector(configurationSelector);
+// Dispatch once after config.slice initializes:
+dispatch(loadConfiguration());`,
+  },
+
+  'react-app-file-upload': {
+    id: 'react-app-file-upload',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add a files Redux slice for uploading and downloading files via the ADSP file service. ' +
+      'File types must be registered on the backend service; this slice manages the upload flow.',
+    newFiles: {
+      'src/app/files.slice.ts': `import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { getAccessToken } from './user.slice';
+
+const FILE_SERVICE_URN = 'urn:ads:platform:file-service:v1';
+
+export const FILES_FEATURE_KEY = 'files';
+
+export interface FileRecord {
+  id: string;
+  filename: string;
+  size: number;
+  created: string;
+  urn: string;
+}
+
+export interface FilesState {
+  files: FileRecord[];
+  uploadStatus: 'idle' | 'uploading' | 'done' | 'error';
+  error?: string;
+}
+
+export const uploadFile = createAsyncThunk(
+  'files/upload',
+  async (
+    { file, typeId }: { file: File; typeId: string },
+    { getState }
+  ) => {
+    const state = getState() as { config: { directory: Record<string, string> } };
+    const fileServiceUrl = state.config.directory[FILE_SERVICE_URN];
+    if (!fileServiceUrl) throw new Error('File service not found in directory.');
+
+    const token = await getAccessToken();
+    const form = new FormData();
+    form.append('file', file);
+    form.append('type', typeId);
+    form.append('filename', file.name);
+
+    const response = await fetch(
+      fileServiceUrl + '/api/file/v1/files',
+      { method: 'POST', headers: { Authorization: 'Bearer ' + token }, body: form }
+    );
+    if (!response.ok) throw new Error('Upload failed: ' + response.status);
+
+    return (await response.json()) as FileRecord;
+  }
+);
+
+export const getFileUrl = (fileServiceUrl: string, fileId: string, token: string) =>
+  fileServiceUrl + '/api/file/v1/files/' + fileId + '/download?token=' + encodeURIComponent(token);
+
+export const initialFilesState: FilesState = {
+  files: [],
+  uploadStatus: 'idle',
+};
+
+const filesSlice = createSlice({
+  name: FILES_FEATURE_KEY,
+  initialState: initialFilesState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(uploadFile.pending, (state) => { state.uploadStatus = 'uploading'; })
+      .addCase(uploadFile.fulfilled, (state, { payload }) => {
+        state.files.push(payload);
+        state.uploadStatus = 'done';
+      })
+      .addCase(uploadFile.rejected, (state, { error }) => {
+        state.uploadStatus = 'error';
+        state.error = error.message;
+      });
+  },
+});
+
+export const filesReducer = filesSlice.reducer;
+export const filesSelector = (state: { [FILES_FEATURE_KEY]: FilesState }) =>
+  state[FILES_FEATURE_KEY];
+`,
+    },
+    integrationChanges: {
+      'src/store.ts': {
+        description: 'Import filesReducer and FILES_FEATURE_KEY and add to the store reducer map.',
+        pattern: `// Add import:
+import { FILES_FEATURE_KEY, filesReducer } from './app/files.slice';
+
+// Add to configureStore reducer map:
+[FILES_FEATURE_KEY]: filesReducer,`,
+      },
+    },
+    usageExample: `// Upload a file from an input element:
+import { uploadFile, filesSelector } from './files.slice';
+
+const { uploadStatus } = useSelector(filesSelector);
+const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const file = e.target.files?.[0];
+  if (file) dispatch(uploadFile({ file, typeId: '{projectName}-file' }));
+};`,
+  },
+
+  // ── Angular (injectable service pattern) ────────────────────────────────────
+
+  'angular-app-roles': {
+    id: 'angular-app-roles',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add a hasRole() helper using the injected Keycloak instance for checking resource roles. ' +
+      'Use it in components to conditionally render UI based on the user\'s Keycloak roles.',
+    integrationChanges: {
+      'src/app/protected/protected.component.ts': {
+        description:
+          'Inject Keycloak and add a hasRole() method that checks resource_access on the parsed token. ' +
+          'The clientId defaults to the app client ID from environment.',
+        pattern: `// Add import:
+import { environment } from '../../environments/environment';
+
+// Inside the component class (Keycloak is already injected via inject(Keycloak)):
+hasRole(role: string, clientId = environment.access.client_id): boolean {
+  const resourceAccess = this.keycloak.tokenParsed?.['resource_access'] as
+    Record<string, { roles?: string[] }> | undefined;
+  return resourceAccess?.[clientId]?.roles?.includes(role) ?? false;
+}`,
+      },
+    },
+    usageExample: `<!-- In the component template — show admin content conditionally: -->
+@if (hasRole('{projectName}-admin')) {
+  <goab-button (_click)="handleAdminAction()">Admin action</goab-button>
+}`,
+  },
+
+  'angular-app-events': {
+    id: 'angular-app-events',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add an EventService that fetches domain events from the ADSP event service using HttpClient. ' +
+      'Bearer token is automatically attached by the includeBearerTokenInterceptor configured in app.config.ts.',
+    newFiles: {
+      'src/app/events/events.service.ts': `import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+export interface EventRecord {
+  namespace: string;
+  name: string;
+  timestamp: string;
+  correlationId?: string;
+  context?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EventService {
+  private http = inject(HttpClient);
+
+  // Bearer token is attached automatically by includeBearerTokenInterceptor.
+  // Event service URL is derived from the ADSP directory service.
+  private readonly eventServiceUrl = environment.directory.url.replace(
+    '/directory',
+    // The directory resolves urn:ads:platform:event-service:v1 at runtime;
+    // for simplicity, use the well-known path on the same host.
+    ''
+  );
+
+  getEvents(namespace?: string, name?: string): Observable<EventRecord[]> {
+    const params: Record<string, string> = {};
+    if (namespace) params['namespace'] = namespace;
+    if (name) params['name'] = name;
+
+    return this.http
+      .get<{ results: EventRecord[] }>(
+        environment.access.url.replace('/auth', '') + '/api/event/v1/events',
+        { params }
+      )
+      .pipe(map((r) => r.results ?? []));
+  }
+}
+`,
+    },
+    integrationChanges: {
+      'src/environments/environment.ts': {
+        description:
+          'Add a directory.url field pointing to the ADSP directory service. ' +
+          'This is pre-populated from the tenant configuration during generation.',
+        pattern: `// Add directory URL alongside the existing access config:
+directory: {
+  url: '<directoryServiceUrl>',  // Replace with the actual URL from adsp config
+},`,
+      },
+    },
+    usageExample: `// Inject EventService and use in a component:
+import { Component, inject, OnInit } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { EventService, EventRecord } from '../events/events.service';
+
+@Component({
+  imports: [AsyncPipe],
+  template: \`@for (event of events; track event.correlationId) {
+    <p>{{ event.name }} — {{ event.timestamp }}</p>
+  }\`,
+})
+export class MyComponent implements OnInit {
+  private eventService = inject(EventService);
+  events: EventRecord[] = [];
+
+  ngOnInit() {
+    this.eventService.getEvents('{projectName}').subscribe(e => this.events = e);
+  }
+}`,
+  },
+
+  'angular-app-configuration': {
+    id: 'angular-app-configuration',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add a ConfigurationService that fetches the service configuration from the ADSP configuration service. ' +
+      'Tenants set values via the ADSP tenant admin app; bearer token is attached automatically.',
+    newFiles: {
+      'src/app/configuration/configuration.service.ts': `import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface {ServiceName}Configuration {
+  // Add your configuration properties here.
+  [key: string]: unknown;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ConfigurationService {
+  private http = inject(HttpClient);
+
+  // Bearer token is attached automatically by includeBearerTokenInterceptor.
+  getConfiguration(
+    configServiceBaseUrl: string,
+    tenant: string,
+    serviceName: string
+  ): Observable<{ServiceName}Configuration> {
+    return this.http
+      .get<{ latest?: { configuration?: {ServiceName}Configuration } }>(
+        configServiceBaseUrl + '/api/configuration/v2/configuration/' + tenant + '/' + serviceName + '/current'
+      )
+      .pipe(map((r) => r.latest?.configuration ?? {}));
+  }
+}
+`,
+    },
+    integrationChanges: {
+      'src/environments/environment.ts': {
+        description:
+          'Add a directory.url field if not already present. The ConfigurationService uses the ' +
+          'ADSP configuration service URL derived from the directory.',
+        pattern: `// Add directory URL alongside the existing access config:
+directory: {
+  url: '<directoryServiceUrl>',  // Replace with the actual URL from adsp config
+},`,
+      },
+    },
+    usageExample: `// Inject ConfigurationService and call during initialization:
+private configService = inject(ConfigurationService);
+
+ngOnInit() {
+  this.configService
+    .getConfiguration(configServiceBaseUrl, '{tenant}', '{projectName}')
+    .subscribe(config => {
+      // Use config.someProperty
+    });
+}`,
+  },
+
+  'angular-app-file-upload': {
+    id: 'angular-app-file-upload',
+    compatibleWith: COMPATIBLE_FRONTEND_PLUGIN_VERSION,
+    description:
+      'Add a FileService for uploading and downloading files via the ADSP file service. ' +
+      'File types must be registered on the backend service. Bearer token is attached automatically.',
+    newFiles: {
+      'src/app/files/files.service.ts': `import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export interface FileRecord {
+  id: string;
+  filename: string;
+  size: number;
+  created: string;
+  urn: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class FileService {
+  private http = inject(HttpClient);
+
+  // Bearer token is attached automatically by includeBearerTokenInterceptor.
+  upload(fileServiceBaseUrl: string, file: File, typeId: string): Observable<FileRecord> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('type', typeId);
+    form.append('filename', file.name);
+
+    return this.http.post<FileRecord>(
+      fileServiceBaseUrl + '/api/file/v1/files',
+      form
+    );
+  }
+
+  getDownloadUrl(fileServiceBaseUrl: string, fileId: string): string {
+    return fileServiceBaseUrl + '/api/file/v1/files/' + fileId + '/download';
+  }
+}
+`,
+    },
+    integrationChanges: {
+      'src/environments/environment.ts': {
+        description:
+          'Add a directory.url field if not already present. The FileService derives the ' +
+          'file service URL from the ADSP directory.',
+        pattern: `// Add directory URL alongside the existing access config:
+directory: {
+  url: '<directoryServiceUrl>',  // Replace with the actual URL from adsp config
+},`,
+      },
+    },
+    usageExample: `// Inject FileService and wire up a file input:
+private fileService = inject(FileService);
+
+onFileSelected(event: Event): void {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (file) {
+    this.fileService
+      .upload(fileServiceBaseUrl, file, '{projectName}-file')
+      .subscribe(record => console.log('Uploaded:', record.id));
+  }
+}`,
+  },
+
+  // ── Backend (express-service) ───────────────────────────────────────────────
 
   'express-service-file-types': {
     id: 'express-service-file-types',


### PR DESCRIPTION
## Summary

Extends the nxAdspAgent template model to cover React and Angular frontend generators.

**8 new templates** (4 React, 4 Angular):

| Template | What it adds |
|----------|-------------|
| `react-app-roles` | `hasRole()` helper on `user.slice.ts` using `keycloak.tokenParsed.resource_access` |
| `react-app-events` | `events.slice.ts` — async thunk fetching events via ADSP event service URL from `config.slice` directory |
| `react-app-configuration` | `configuration.slice.ts` — async thunk fetching service configuration from ADSP configuration service |
| `react-app-file-upload` | `files.slice.ts` — upload/download thunks using file service URL from `config.slice` directory |
| `angular-app-roles` | `hasRole()` method on injected `Keycloak` checking `resource_access` |
| `angular-app-events` | `EventService` injectable using `HttpClient` (bearer token via `includeBearerTokenInterceptor`) |
| `angular-app-configuration` | `ConfigurationService` injectable fetching from ADSP configuration service |
| `angular-app-file-upload` | `FileService` injectable for upload/download via ADSP file service |

**Updated agent instructions** to handle `react-app`, `angular-app`, and `express-service` projectTypes separately, with a continuation mode when the frontend interaction follows a prior service discussion on the same thread.

## Test plan

- [ ] All agent-service tests pass
- [ ] Run nx-adsp react-app generator with --tenant and verify agent suggests react-app-* templates
- [ ] Run nx-adsp mern generator and verify continuation message references service context

🤖 Generated with [Claude Code](https://claude.com/claude-code)