### PR TITLE
fix(agent-service): require text confirmation after file writes

### DIFF
--- a/apps/agent-service/src/agent/agents/nxAdsp.ts
+++ b/apps/agent-service/src/agent/agents/nxAdsp.ts
@@ -142,6 +142,10 @@ export const nxAdspAgent: AgentConfiguration = {
       {tenant}, etc.) with actual names based on the conversation. Never leave template
       placeholders in output.
     - Write the complete content of modified files — do not describe changes, write them.
+    - **After writing all files, you MUST send a brief plain-text reply** (2-3 sentences)
+      summarising what was generated and any follow-up steps the developer needs to take
+      (e.g. register roles in tenant admin, dispatch load thunks on app start). Do not end
+      your turn silently after tool calls — the developer is waiting for confirmation.
     - The nx-adsp plugin version is provided in the initial message — use it to verify
       template compatibility via the compatibleWith field.
     - If the developer provides no useful domain information after a few exchanges,


### PR DESCRIPTION
## Summary

The agent was completing all tool calls (writing files to workspace) silently — no `text-delta` was emitted — leaving the developer staring at a `>` prompt with no indication the agent had finished.

Adds an explicit rule to the agent instructions: after writing all files, the agent **must** send a brief plain-text reply summarising what was generated and any follow-up steps (register roles, dispatch load thunks, etc.).

## Test plan

- [ ] Run express-service or mern generator, reply to the agent, verify a summary is sent automatically after file writes without needing to prompt "are you done?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)