### PR TITLE
fix(agent-service): clarify enableConfigurationInvalidation placement in template

### DIFF
--- a/apps/agent-service/src/agent/tools/nxAdspTemplates.ts
+++ b/apps/agent-service/src/agent/tools/nxAdspTemplates.ts
@@ -155,7 +155,8 @@ export const configurationSchema = {
         pattern: `// Add import at top:
 import { configurationSchema } from './configuration';
 
-// Add inside the initializeService({}) config object:
+// Add inside the FIRST argument of initializeService (the service configuration object,
+// NOT the second platform-options argument that contains logLevel etc.):
 configuration: {
   description: 'Configuration for {projectName}.',
   schema: configurationSchema,


### PR DESCRIPTION
## Summary

`enableConfigurationInvalidation: true` was being placed in the second (platform options) argument of `initializeService` instead of the first (service configuration) argument, breaking the service at runtime.

The integration pattern comment now explicitly states: "Add inside the FIRST argument of initializeService (the service configuration object, NOT the second platform-options argument that contains logLevel etc.)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)