### PR TITLE
feat(agent-service): write-vs-edit workflow and inline SDK constraints in templates

### DIFF
--- a/apps/agent-service/src/agent/agents/nxAdsp.ts
+++ b/apps/agent-service/src/agent/agents/nxAdsp.ts
@@ -53,19 +53,27 @@ export const nxAdspAgent: AgentConfiguration = {
        content and integration patterns — you do NOT need any external files or a generator run.
        Use only templates with id starting with express-service-.
 
-    4. **Write files to workspace using the tool output**:
-       - Each template has a "newFiles" field mapping file paths to file content.
-         Write each file to the workspace using mastra_workspace_write_file with the EXACT path
-         from the template (e.g. src/roles.ts, src/events.ts, src/configuration.ts, src/fileTypes.ts).
-         Replace {projectName}, {entityName}, {ServiceName} placeholders with domain-specific names
-         but do NOT change the file path itself — keep src/events.ts, not src/case-events.ts.
-       - Each template also has an "integrationChanges" field showing what to add to main.ts.
-         Read main.ts from the workspace, apply the integration patterns, then write the full
-         updated main.ts.
-       - Correct SDK types in the tool output: DomainEventDefinition (not generic — no <T>),
-         EventService (not DomainEventService), FileType.
-       - enableConfigurationInvalidation: true belongs in the FIRST argument to initializeService
-         (the service config object), NOT in the second argument (platform options with logLevel).
+    4. **Write or edit capability files using the tool output**:
+       Each template has a "newFiles" field (files to create) and an "integrationChanges" field
+       (changes to make in main.ts). For each newFile path:
+
+       a. Check whether the file already exists in the workspace using mastra_workspace_read_file.
+
+       b. **File does not exist**: Use mastra_workspace_write_file with the template content,
+          substituting {projectName}, {entityName}, {ServiceName} etc. with domain values.
+          Make NO other changes — the template content is the complete correct file.
+          Do NOT add extra imports, wrapper types, helper functions, or interfaces beyond
+          what the template shows. The inline comments in the template explain the constraints.
+
+       c. **File already exists**: Use mastra_workspace_edit_file to add the new capability
+          alongside existing content. Follow the template pattern for what to add but do not
+          replace content that is already there. For example, if events.ts already has
+          caseCreatedDefinition and you are adding caseUpdatedDefinition, insert the new
+          definition — do not rewrite the file.
+
+       For integrationChanges, read main.ts, apply the pattern, then write the updated main.ts.
+       enableConfigurationInvalidation: true is a top-level property in the FIRST initializeService
+       argument — not inside the configuration object and not in the second (logLevel) argument.
 
     5. **Confirm**: Briefly tell the developer what was generated and what to do next
        (register roles in the tenant admin UI, configure CLIENT_SECRET, etc.).
@@ -81,11 +89,14 @@ export const nxAdspAgent: AgentConfiguration = {
     3. **Retrieve relevant templates**: Call list-nx-adsp-templates, then get-nx-adsp-template
        for each capability. Use only templates with id starting with react-app-.
 
-    4. **Write files to workspace**: For each template:
-       - Write new slice files (e.g., src/app/events.slice.ts) using mastra_workspace_write_file.
-       - Read the current store.ts and write the updated version with new reducer imports and entries.
-       - Replace ALL placeholders ({projectName}, {ServiceName}, {tenant}) with actual values
-         from the conversation and the initial message context.
+    4. **Write or edit slice files**: For each template's newFile path:
+       - Check if the slice file already exists (mastra_workspace_read_file).
+       - If it does NOT exist: write with template content + placeholder substitution only.
+         Make no other changes — the template is the complete correct file.
+       - If it EXISTS: use mastra_workspace_edit_file to add the new capability alongside
+         existing slices. Do not replace or rewrite existing content.
+       - Always read store.ts and write the updated version adding the new reducer import and
+         entry. Do not remove existing reducers.
 
     5. **Confirm**: Briefly state what slices were added and remind the developer to dispatch
        the load thunks on app startup.

--- a/apps/agent-service/src/agent/tools/nxAdspTemplates.ts
+++ b/apps/agent-service/src/agent/tools/nxAdspTemplates.ts
@@ -72,6 +72,8 @@ app.get('/{projectName}/v1/admin-resource', (req, res) => {
       'Add domain event definitions and event service integration for publishing domain events to the ADSP event service.',
     newFiles: {
       'src/events.ts': `import { DomainEventDefinition } from '@abgov/adsp-service-sdk';
+// SDK constraint: DomainEventDefinition is a plain interface, NOT generic (no <T>).
+// Only import DomainEventDefinition here — do not import EventService or DomainEventService.
 
 // Domain event definitions for {projectName}.
 // Event names use kebab-case. The namespace is set by the SDK from the serviceId.
@@ -127,7 +129,8 @@ app.post('/{projectName}/v1/{entities}', async (req, res) => {
     newFiles: {
       'src/configuration.ts': `// Service configuration schema and types.
 // Tenants configure this service via the ADSP tenant admin app.
-// The schema is validated against what tenants can store.
+// SDK constraint: there is no ConfigurationDefinition<T> type — export a plain configurationSchema object.
+// The configuration type ({ServiceName}Configuration) is only needed in route handler type annotations.
 
 export interface {ServiceName}Configuration {
   // Add your configuration properties here.
@@ -752,10 +755,11 @@ onFileSelected(event: Event): void {
       'download files in the ADSP file service for this service.',
     newFiles: {
       'src/fileTypes.ts': `import { FileType } from '@abgov/adsp-service-sdk';
+// SDK constraint: FileType has no description field.
+// Valid fields: id, name, anonymousRead, readRoles, updateRoles, rules (optional), securityClassification (optional).
 
 // File type definitions for {projectName}.
 // readRoles and updateRoles use the role strings defined in roles.ts.
-// Remove the SecurityClassification import/field if not needed.
 
 export const {EntityName}FileType: FileType = {
   id: '{entity-name}-file',


### PR DESCRIPTION
## Summary

Two complementary changes to reduce agent hallucination of SDK types.

### Write-vs-edit workflow (nxAdsp.ts)

The express-service and react-app workflows now explicitly distinguish between two cases:

- **File does not exist** → `mastra_workspace_write_file` with template content and placeholder substitution only. No extra imports, types, or functions beyond the template.
- **File already exists** → `mastra_workspace_edit_file` to add the new capability alongside existing content without replacing or rewriting it.

This preserves the model where templates are the authoritative reference maintained in one place, while making the agent's role explicit: copy for new files, merge for existing ones. The agent's "helpfulness" in adding domain-specific types and wrappers is what introduces hallucinated SDK types — this instruction removes the invitation to do so.

### Inline SDK constraints in template newFiles content (nxAdspTemplates.ts)

Constraints added as comments at the top of each template file, so they travel with the code the agent copies:

| Template | Inline constraint |
|----------|------------------|
| `events.ts` | `DomainEventDefinition` is NOT generic; do not import `EventService` or `DomainEventService` |
| `configuration.ts` | No `ConfigurationDefinition<T>` type exists; export plain `configurationSchema` object |
| `fileTypes.ts` | `FileType` has no `description` field; valid fields listed |

When the agent copies the template verbatim (even partially), it also copies the constraint comment, making it much harder to ignore than external instructions.

## Test plan

- [ ] All agent-service tests pass
- [ ] Run mern generator, verify agent checks for existing files before writing, uses edit for existing capability files, and does not add hallucinated SDK types

🤖 Generated with [Claude Code](https://claude.com/claude-code)