### PR TITLE
fix(agent-service): register nx-adsp template tools in createTools

### DIFF
--- a/apps/agent-service/src/agent/tools/index.ts
+++ b/apps/agent-service/src/agent/tools/index.ts
@@ -8,6 +8,7 @@ import { createRendererCatalogTools } from './rendererCatalog';
 import { createFormTools } from './form';
 import { createDataRegisterTools } from './dataRegister';
 import { createNotificationTemplateTools } from './notificationTemplate';
+import { createNxAdspTemplateTools } from './nxAdspTemplates';
 
 interface ToolsProps {
   logger: Logger;
@@ -42,6 +43,8 @@ export async function createTools({ logger, directory, tokenProvider }: ToolsPro
     tokenProvider,
   });
 
+  const { listNxAdspTemplatesTool, getNxAdspTemplateTool } = createNxAdspTemplateTools();
+
   return {
     fileDownloadTool,
     fileCopyTool,
@@ -57,6 +60,8 @@ export async function createTools({ logger, directory, tokenProvider }: ToolsPro
     dataRegisterGetTool,
     dataRegisterUpdateTool,
     emailNotificationGenerateTool,
+    listNxAdspTemplatesTool,
+    getNxAdspTemplateTool,
   };
 }
 


### PR DESCRIPTION
## Summary

`listNxAdspTemplatesTool` and `getNxAdspTemplateTool` were defined in `nxAdspTemplates.ts` and referenced in the `nxAdspAgent` configuration as `tools: ['listNxAdspTemplatesTool', 'getNxAdspTemplateTool']`, but `createNxAdspTemplateTools()` was never called in `createTools()` in `index.ts`.

When `configuration.ts` built the agent's tool set it looked up each tool name in `availableToolMap` — since neither was registered, both silently resolved to `undefined` and were dropped from the agent's toolset.

The agent was therefore **entirely correct** when it told users it could not call `list-nx-adsp-templates` or `get-nx-adsp-template`. Every generation to date has relied on LLM training data guided by instructions, not the maintained template library. This explains why the agent intermittently produced correct output (good training data + improved instructions) and intermittently hallucinated SDK types (no template to copy from).

## Impact

With this fix the agent will for the first time actually call `get-nx-adsp-template` to retrieve the vetted template content before writing files. Combined with the write-vs-edit workflow instructions (PR #5512), this should produce significantly more reliable output.

## Test plan

- [ ] All agent-service tests pass
- [ ] Start a new agent interaction, type a message — verify `[nx-adsp] Listing available ADSP templates` and `[nx-adsp] Getting template: express-service-events` appear in the output
- [ ] Verify generated files use the correct SDK types from the templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)