### PR TITLE
fix(file-service): use query string for bulk file deletion

### DIFF
--- a/apps/file-service/src/file/router/file.spec.ts
+++ b/apps/file-service/src/file/router/file.spec.ts
@@ -933,7 +933,7 @@ describe('file router', () => {
       expect(handler).toBeTruthy();
     });
 
-    it('can delete multiple files from bracketed query parameter', async () => {
+    it('can delete multiple files from a comma-separated query parameter', async () => {
       const firstFile = createFile('file-1');
       const secondFile = createFile('file-2');
       const req = {
@@ -943,7 +943,7 @@ describe('file router', () => {
           name: 'Tester',
           roles: ['test-updater'],
         },
-        query: { files: '[file-1, file-2]' },
+        query: { files: 'file-1,file-2' },
       };
       const res = {
         send: jest.fn(),

--- a/apps/file-service/src/file/router/file.swagger.yml
+++ b/apps/file-service/src/file/router/file.swagger.yml
@@ -286,8 +286,8 @@ components:
     description: Marks multiple files for deletion. File deletion is not immediate, but files will eventually disappear.
     parameters:
       - name: files
-        description: File IDs to delete, provided as a bracketed comma-separated list.
-        example: '[53fca659-362d-407f-9c4d-c2c8c6427bdb, ced3fbdd-7597-455e-84c6-1d0b3d03a274]'
+        description: File IDs to delete, provided as a comma-separated query string.
+        example: '53fca659-362d-407f-9c4d-c2c8c6427bdb,ced3fbdd-7597-455e-84c6-1d0b3d03a274'
         in: query
         required: true
         schema:

--- a/apps/tenant-management-webapp/src/app/store/file/api.spec.ts
+++ b/apps/tenant-management-webapp/src/app/store/file/api.spec.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosInstance } from 'axios';
+import { ConfigState } from '@store/config/models';
+import { FileApi } from './api';
+
+describe('FileApi', () => {
+  const deleteMock = jest.fn();
+  const httpMock = {
+    delete: deleteMock,
+    interceptors: {
+      request: {
+        use: jest.fn(),
+      },
+    },
+  };
+  const config = {
+    fileApi: {
+      host: 'https://file-service.example.com',
+      endpoints: {
+        fileAdmin: '/file/v1/files',
+      },
+    },
+  } as ConfigState;
+
+  beforeEach(() => {
+    jest.spyOn(axios, 'create').mockReturnValue(httpMock as unknown as AxiosInstance);
+    deleteMock.mockResolvedValue({ data: { deleted: true } });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('deletes multiple files using a comma-separated query string', async () => {
+    const api = new FileApi(config, 'token');
+
+    await api.deleteFiles(['file-1', 'file 2']);
+
+    expect(deleteMock).toHaveBeenCalledWith('/file/v1/files?files=file-1,file%202');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/store/file/api.ts
+++ b/apps/tenant-management-webapp/src/app/store/file/api.ts
@@ -61,7 +61,7 @@ export class FileApi {
 
   async deleteFiles(ids: string[]): Promise<FileService> {
     const files = ids.map((id) => encodeURIComponent(id)).join(',');
-    const url = `${this.fileConfig.endpoints.fileAdmin}?files=[${files}]`;
+    const url = `${this.fileConfig.endpoints.fileAdmin}?files=${files}`;
     const res = await this.http.delete(url);
     return res.data;
   }


### PR DESCRIPTION
## Summary

Updates bulk file deletion to send file IDs as a comma-separated query string instead of a bracketed string array.

Example:

`DELETE /file/v1/files?files=<file-id-1>,<file-id-2>`

## Changes

- Updated the frontend bulk deletion request.
- Updated file-service API tests.
- Updated Swagger documentation.
- Added frontend API unit test coverage.
- Preserved support for existing bracketed requests.