### PR TITLE
fix(feedback): hide side menu in expanded view

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.spec.tsx
@@ -174,6 +174,7 @@ describe('Feedbacks Components', () => {
     const dropDown = baseElement.querySelector("goa-dropdown[testId='sites-dropdown']");
     fireEvent(dropDown, new CustomEvent('_change', { detail: { value: 'http://newsite.com' } }));
     expect(screen.getAllByText('No feedbacks found')).toBeTruthy();
+    expect(baseElement.querySelector("goa-button[testId='expand-feedback-view']")).toBeDisabled();
   });
 
   it('should open full screen when "Expand View" button is clicked', async () => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.tsx
@@ -222,7 +222,8 @@ export const FeedbacksList = (): JSX.Element => {
               type="secondary"
               trailingIcon="expand"
               onClick={() => setExpandView(true)}
-              disabled={!selectedSite}
+              disabled={!selectedSite || feedbacks.length === 0}
+              testId="expand-feedback-view"
             >
               Expand view
             </GoabButton>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/styled-components.ts
@@ -154,10 +154,11 @@ export const FeedbackHeader = styled.div`
 `;
 
 export const FullScreenModalWrapper = styled.div`
-  position: absolute;
+  position: fixed;
   top: 5.75rem;
+  right: 0;
+  bottom: 0;
   left: 0;
-  width: 100vw;
 
   background: #fff;
   padding: 0.5rem 2rem;


### PR DESCRIPTION
## Summary

Fixes the feedback service expanded view when there are no feedbacks or only a few feedback items.

## Changes

- Disables **Expand view** when no feedbacks are found.
- Ensures expanded view covers the side menu for short feedback lists.
- Adds unit test coverage for the disabled expand button.

<img width="1376" height="763" alt="Screenshot 2026-06-09 at 3 08 17 PM" src="https://github.com/user-attachments/assets/c2ff07d0-0876-47a4-a605-b639fe745a41" />
<img width="1370" height="711" alt="Screenshot 2026-06-09 at 3 48 55 PM" src="https://github.com/user-attachments/assets/1feb9891-5a04-4044-9e28-d22c64c1212c" />
