### PR TITLE
feat: update the form service api

### DIFF
--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -73,6 +73,7 @@ describe('definition router', () => {
     axiosMock.get.mockReset();
     axiosMock.patch.mockReset();
     axiosMock.delete.mockReset();
+    jest.mocked(axiosMock.isAxiosError).mockReturnValue(false);
     directoryMock.getServiceUrl.mockReset();
     tokenProviderMock.getAccessToken.mockReturnValue(Promise.resolve('token'));
   });
@@ -300,6 +301,34 @@ describe('definition router', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
+    it('calls next with 400 when configuration service rejects the patch', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+      const axiosError = Object.assign(new Error('Bad Request'), {
+        isAxiosError: true,
+        response: { data: { errorMessage: 'Schema validation failed.' } },
+      });
+      jest.mocked(axiosMock.isAxiosError).mockReturnValue(true);
+      axiosMock.patch.mockRejectedValue(axiosError);
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: 'Test', anonymousApply: false, applicantRoles: [], assessorRoles: [] },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ extra: expect.objectContaining({ statusCode: 400 }) }),
+      );
+      expect(res.send).not.toHaveBeenCalled();
+    });
+
     describe('formDraftUrlTemplate validation', () => {
       const FORM_DRAFT_URL_PATTERN = /^https?:\/\/.+$/;
 
@@ -349,9 +378,16 @@ describe('definition router', () => {
           data: { latest: { revision: 1, configuration: { id: 'test-def', name: 'Test' } } },
         });
 
+        // express-validator's .default() middleware injects these values into req.body before
+        // the handler runs; simulate that here by providing the defaulted values.
         const req = {
           user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-          body: { name: 'Test', anonymousApply: false },
+          body: {
+            name: 'Test',
+            anonymousApply: false,
+            applicantRoles: ['urn:ads:platform:form-service:form-applicant'],
+            assessorRoles: [],
+          },
           tenant: { id: tenantId },
           getServiceConfiguration: jest.fn().mockResolvedValue([null]),
         };
@@ -697,6 +733,37 @@ describe('definition router', () => {
         }),
       );
       expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with 400 when configuration service rejects the patch', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: { id: 'test', name: 'Test' } });
+
+      const axiosError = Object.assign(new Error('Bad Request'), {
+        isAxiosError: true,
+        response: { data: { errorMessage: 'Schema validation failed.' } },
+      });
+      jest.mocked(axiosMock.isAxiosError).mockReturnValue(true);
+      axiosMock.patch.mockRejectedValue(axiosError);
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { name: 'Patched' },
+        tenant: { id: tenantId },
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = patchFormDefinition(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ extra: expect.objectContaining({ statusCode: 400 }) }),
+      );
+      expect(res.send).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -158,8 +158,6 @@ export function createFormDefinition(
       }
 
       const definition: FormDefinition = {
-        applicantRoles: ['urn:ads:platform:form-service:form-applicant'],
-        assessorRoles: [],
         ...req.body,
         id: generatedId,
       };
@@ -184,14 +182,24 @@ export function createFormDefinition(
         });
       }
 
-      const { data } = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
-        new URL(`v2/configuration/form-service/${definition.id}`, configurationApiUrl).href,
-        { operation: 'REPLACE', configuration: definition },
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          params: { tenantId: tenantId?.toString() },
-        },
-      );
+      let data: { latest: { revision: number; configuration: FormDefinition } };
+      try {
+        const response = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
+          new URL(`v2/configuration/form-service/${definition.id}`, configurationApiUrl).href,
+          { operation: 'REPLACE', configuration: definition },
+          {
+            headers: { Authorization: `Bearer ${token}` },
+            params: { tenantId: tenantId?.toString() },
+          },
+        );
+        data = response.data;
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const message = err.response?.data?.errorMessage || 'Configuration service rejected the request.';
+          throw new InvalidOperationError(message, { statusCode: HttpStatusCodes.BAD_REQUEST });
+        }
+        throw err;
+      }
 
       res.status(HttpStatusCodes.CREATED).send(mapFormDefinition(data.latest.configuration, data.latest.revision));
     } catch (err) {
@@ -242,10 +250,6 @@ export function patchFormDefinition(directory: ServiceDirectory, tokenProvider: 
         throw new UnauthorizedUserError('patch form definition', user);
       }
 
-      if (!/^[a-zA-Z0-9-]{1,50}$/.test(definitionId)) {
-        throw new InvalidOperationError('Invalid form definition ID.');
-      }
-
       const encodedDefinitionId = encodeURIComponent(definitionId);
 
       const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
@@ -275,14 +279,24 @@ export function patchFormDefinition(directory: ServiceDirectory, tokenProvider: 
         id: definitionId,
       };
 
-      const { data } = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
-        new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href,
-        { operation: 'REPLACE', configuration: patchedDefinition },
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          params: { tenantId: tenantId?.toString() },
-        },
-      );
+      let data: { latest: { revision: number; configuration: FormDefinition } };
+      try {
+        const response = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
+          new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href,
+          { operation: 'REPLACE', configuration: patchedDefinition },
+          {
+            headers: { Authorization: `Bearer ${token}` },
+            params: { tenantId: tenantId?.toString() },
+          },
+        );
+        data = response.data;
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const message = err.response?.data?.errorMessage || 'Configuration service rejected the request.';
+          throw new InvalidOperationError(message, { statusCode: HttpStatusCodes.BAD_REQUEST });
+        }
+        throw err;
+      }
 
       res.status(HttpStatusCodes.OK).send(mapFormDefinition(data.latest.configuration, data.latest.revision));
     } catch (err) {
@@ -344,9 +358,12 @@ export function createFormDefinitionRouter({
         .isLength({ min: 1, max: 50 })
         .matches(/^[a-zA-Z0-9-]+$/),
       body('name').isString().isLength({ min: 1 }),
-      body('anonymousApply').isBoolean(),
-      body('applicantRoles').isArray(),
-      body('assessorRoles').isArray(),
+      body('anonymousApply').optional().default(false).isBoolean(),
+      body('description').optional().isString(),
+      body('dataSchema').optional().isObject(),
+      body('uiSchema').optional().isObject(),
+      body('applicantRoles').optional().default(['urn:ads:platform:form-service:form-applicant']).isArray(),
+      body('assessorRoles').optional().default([]).isArray(),
       body('formDraftUrlTemplate')
         .optional()
         .isString()


### PR DESCRIPTION
feat(form-service): return all configuration fields from form definition API

Return all FormDefinition fields (submissionPdfTemplate, queueTaskToProcess, securityClassification, dryRun, includeDataInSubmission, customSubmissionEvent) from the mapper. Also move POST defaults for anonymousApply, applicantRoles, and assessorRoles into the validator layer using .optional().default().