### PR TITLE
Fix: AI connection issues and socket disconnection on modal close

### DIFF
--- a/apps/agent-service/src/agent/agents/data/form-examples/anti-patterns.json
+++ b/apps/agent-service/src/agent/agents/data/form-examples/anti-patterns.json
@@ -146,17 +146,15 @@
       "bad": {
         "toolInput": {
           "formDefinitionId": "my-form-id",
-          "name": "My Form",
           "dataSchema": {}
         }
       },
       "good": {
         "toolInput": {
-          "name": "My Form",
           "dataSchema": {}
         }
       },
-      "explanation": "formDefinitionId comes from request context automatically. Including it in tool input causes an error. Only pass name, dataSchema, uiSchema, anonymousApply, applicantRoles, and assessorRoles."
+      "explanation": "formDefinitionId comes from request context automatically. Including it in tool input causes an error. Only pass dataSchema, uiSchema, anonymousApply, applicantRoles, and assessorRoles. The form name cannot be changed and must not be passed."
     }
   ],
 

--- a/apps/agent-service/src/agent/agents/form.spec.ts
+++ b/apps/agent-service/src/agent/agents/form.spec.ts
@@ -337,6 +337,45 @@ describe('formGenerationAgent', () => {
     expect(instructions).toContain('cheat-sheet.html');
   });
 
+  // --- CS-4960: preserving the existing form definition ---
+  describe('preserving the existing form definition (CS-4960)', () => {
+    it('includes the Preserving the Existing Form Definition section', () => {
+      const instructions = formGenerationAgent.instructions;
+      expect(instructions).toContain('Preserving the Existing Form Definition');
+    });
+
+    it('explains that the update tool REPLACES the dataSchema and uiSchema rather than merging', () => {
+      const instructions = formGenerationAgent.instructions;
+      expect(instructions).toContain('REPLACES the dataSchema and uiSchema');
+      expect(instructions).toContain('it does NOT merge them');
+    });
+
+    it('instructs never to delete existing content unless explicitly asked', () => {
+      const instructions = formGenerationAgent.instructions;
+      expect(instructions).toContain(
+        'NEVER delete or remove any existing field, property, UI element, validation, rule, or help content unless the user EXPLICITLY asks you to remove it.',
+      );
+    });
+
+    it('instructs never to completely rewrite or replace an existing schema unless explicitly asked', () => {
+      const instructions = formGenerationAgent.instructions;
+      expect(instructions).toContain('NEVER completely rewrite or "replace" an existing schema.');
+      expect(instructions).toContain(
+        'Only rewrite a schema from scratch if the user EXPLICITLY asks you to start over or replace the whole form.',
+      );
+    });
+
+    it('instructs never to change the name of the form definition', () => {
+      const instructions = formGenerationAgent.instructions;
+      expect(instructions).toContain('NEVER change the name of the form definition.');
+    });
+
+    it('instructs never to create a new form definition', () => {
+      const instructions = formGenerationAgent.instructions;
+      expect(instructions).toContain('NEVER create a new form definition.');
+    });
+  });
+
   it('has the correct tools configured', () => {
     expect(formGenerationAgent.tools).toEqual([
       'schemaDefinitionTool',

--- a/apps/agent-service/src/agent/agents/form.ts
+++ b/apps/agent-service/src/agent/agents/form.ts
@@ -18,6 +18,16 @@ export const formGenerationAgent: AgentConfiguration = {
     ## Workflow
     Your primary focus is building and refining the dataSchema and uiSchema - these define what the form collects and how it's displayed.
 
+    ## Preserving the Existing Form Definition (MANDATORY — HIGHEST PRIORITY)
+    You always work on the SINGLE form definition provided in the request context. The formConfigurationUpdateTool REPLACES the dataSchema and uiSchema objects you send — it does NOT merge them. Whatever you omit is lost. Therefore:
+    - ALWAYS call formConfigurationRetrievalTool first and use the returned dataSchema and uiSchema as your starting point. Apply each change on top of the CURRENT schemas.
+    - On EVERY update, send the COMPLETE current schema plus your change — existing properties/fields/UI elements MUST be carried forward intact. Never send only the new or changed fields.
+    - NEVER delete or remove any existing field, property, UI element, validation, rule, or help content unless the user EXPLICITLY asks you to remove it.
+    - NEVER completely rewrite or "replace" an existing schema. Make incremental, additive edits. Only rewrite a schema from scratch if the user EXPLICITLY asks you to start over or replace the whole form.
+    - NEVER change the name of the form definition. The name is fixed; do not rename it under any circumstances.
+    - NEVER create a new form definition. You only ever edit the one definition in the request context. If the user asks to create a brand-new form, explain that you can only modify the current form definition.
+    - When in doubt about whether a change would remove existing content, ASK the user before proceeding.
+
     IMPORTANT BEHAVIORAL RULES:
     - Be proactive: ask clarifying questions about fields, layout, validation, and help content to build the best form.
     - BEFORE creating any field from scratch, check if a Common Component matches (see the "Common Components" section). If it does, suggest the common component FIRST. Only create individual fields if the user declines.
@@ -52,11 +62,11 @@ export const formGenerationAgent: AgentConfiguration = {
     1. Load the existing form definition at the start of the conversation using formConfigurationRetrievalTool
     2. Understand what information needs to be collected (ask if purpose/requirements are unclear)
     3. CHECK FOR COMMON COMPONENTS FIRST: Before designing any field, check if it matches a Common Component (name, address, SIN, email, phone, dependents, etc.). If it does, suggest the common component to the user before proceeding. Use schemaDefinitionTool to load definitions, then wire them with $ref.
-    4. PLAN FIRST: Design the complete set of fields before making updates
+    4. PLAN THE CHANGE: Take the CURRENT schemas from formConfigurationRetrievalTool and design the change as an addition/modification ON TOP of them — never as a fresh, standalone set of fields.
     5. For fields with uncertain renderer support (objects, arrays, custom formats like file-urn), use rendererCatalogTool
-    6. Define ALL fields in dataSchema (properties object) and ALL UI controls in uiSchema
-    7. Make one formConfigurationUpdateTool call per request, typically including both dataSchema and uiSchema
-    8. Iterate based on user feedback with complete updates
+    6. Build the FULL updated dataSchema (properties object) and FULL updated uiSchema by merging your change into the existing schemas — keep every existing field and UI element unless the user explicitly asked to remove it.
+    7. Make one formConfigurationUpdateTool call per request, sending the COMPLETE merged dataSchema and uiSchema together (existing content + your change). Do NOT send the name.
+    8. Iterate based on user feedback with complete, merged updates that preserve prior content
 
     ## JSON Forms Rules Reference
     Rules control the visibility and editability of UI elements based on field values.

--- a/apps/agent-service/src/agent/agents/utils/__snapshots__/loadFormExamples.spec.ts.snap
+++ b/apps/agent-service/src/agent/agents/utils/__snapshots__/loadFormExamples.spec.ts.snap
@@ -4057,7 +4057,6 @@ Passing formDefinitionId as input to formConfigurationUpdateTool
 {
   "toolInput": {
     "formDefinitionId": "my-form-id",
-    "name": "My Form",
     "dataSchema": {}
   }
 }
@@ -4066,12 +4065,11 @@ Passing formDefinitionId as input to formConfigurationUpdateTool
 \`\`\`json
 {
   "toolInput": {
-    "name": "My Form",
     "dataSchema": {}
   }
 }
 \`\`\`
-**Why:** formDefinitionId comes from request context automatically. Including it in tool input causes an error. Only pass name, dataSchema, uiSchema, anonymousApply, applicantRoles, and assessorRoles.
+**Why:** formDefinitionId comes from request context automatically. Including it in tool input causes an error. Only pass dataSchema, uiSchema, anonymousApply, applicantRoles, and assessorRoles. The form name cannot be changed and must not be passed.
 
 ## Design Anti-Patterns
 ### ❌ Too Many Fields on a Single Page (medium)

--- a/apps/agent-service/src/agent/tools/formConfiguration.spec.ts
+++ b/apps/agent-service/src/agent/tools/formConfiguration.spec.ts
@@ -1,0 +1,162 @@
+import { createFormConfigurationTools } from './formConfiguration';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+const mockTokenProvider = {
+  getAccessToken: jest.fn().mockResolvedValue('test-token'),
+};
+
+const mockDirectory = {
+  getServiceUrl: jest.fn().mockResolvedValue(new URL('https://config-service.test/')),
+};
+
+const mockRequestContext = {
+  get: jest.fn((key: string) => {
+    if (key === 'tenantId') return { toString: () => 'test-tenant-id' };
+    if (key === 'formDefinitionId') return 'intake-form';
+    return undefined;
+  }),
+};
+
+describe('createFormConfigurationTools', () => {
+  let tools: Awaited<ReturnType<typeof createFormConfigurationTools>>;
+
+  beforeAll(async () => {
+    tools = await createFormConfigurationTools({
+      directory: mockDirectory as never,
+      tokenProvider: mockTokenProvider as never,
+      logger: mockLogger as never,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTokenProvider.getAccessToken.mockResolvedValue('test-token');
+  });
+
+  it('creates both form configuration tools', () => {
+    expect(tools.formConfigurationRetrievalTool).toBeDefined();
+    expect(tools.formConfigurationUpdateTool).toBeDefined();
+  });
+
+  describe('formConfigurationRetrievalTool', () => {
+    it('retrieves the form configuration for the definition in request context', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          name: 'Intake Form',
+          description: 'An intake form',
+          dataSchema: { type: 'object', properties: { firstName: { type: 'string' } } },
+          uiSchema: { type: 'VerticalLayout', elements: [] },
+          anonymousApply: false,
+          applicantRoles: [],
+          assessorRoles: [],
+        },
+      });
+
+      const result = await tools.formConfigurationRetrievalTool.execute({}, {
+        requestContext: mockRequestContext,
+      } as never);
+
+      expect(result.name).toBe('Intake Form');
+      const getUrl = mockedAxios.get.mock.calls[0][0] as string;
+      expect(getUrl).toContain('form-service/intake-form/latest');
+    });
+  });
+
+  describe('formConfigurationUpdateTool', () => {
+    const successResponse = {
+      status: 200,
+      data: {
+        latest: {
+          configuration: {
+            name: 'Intake Form',
+            description: 'An intake form',
+            dataSchema: { type: 'object', properties: { firstName: { type: 'string' } } },
+            uiSchema: { type: 'VerticalLayout', elements: [] },
+            anonymousApply: false,
+            applicantRoles: [],
+            assessorRoles: [],
+          },
+        },
+      },
+    };
+
+    it('forwards dataSchema, uiSchema and anonymousApply in the update payload', async () => {
+      mockedAxios.patch.mockResolvedValueOnce(successResponse);
+
+      const dataSchema = { type: 'object', properties: { firstName: { type: 'string' } } };
+      const uiSchema = { type: 'VerticalLayout', elements: [] };
+
+      await tools.formConfigurationUpdateTool.execute(
+        { dataSchema, uiSchema, anonymousApply: true },
+        { requestContext: mockRequestContext } as never,
+      );
+
+      const patchBody = mockedAxios.patch.mock.calls[0][1] as { operation: string; update: Record<string, unknown> };
+      expect(patchBody.operation).toBe('UPDATE');
+      expect(patchBody.update).toEqual(
+        expect.objectContaining({
+          dataSchema,
+          uiSchema,
+          anonymousApply: true,
+        }),
+      );
+    });
+
+    it('sets the update id from the formDefinitionId in request context', async () => {
+      mockedAxios.patch.mockResolvedValueOnce(successResponse);
+
+      await tools.formConfigurationUpdateTool.execute(
+        { dataSchema: { type: 'object' } },
+        { requestContext: mockRequestContext } as never,
+      );
+
+      const patchBody = mockedAxios.patch.mock.calls[0][1] as { update: { id: string } };
+      expect(patchBody.update.id).toBe('intake-form');
+    });
+
+    it('never forwards a name key in the update payload even when a caller passes one', async () => {
+      mockedAxios.patch.mockResolvedValueOnce(successResponse);
+
+      await tools.formConfigurationUpdateTool.execute(
+        { name: 'Renamed Form', dataSchema: { type: 'object' } } as never,
+        { requestContext: mockRequestContext } as never,
+      );
+
+      const patchBody = mockedAxios.patch.mock.calls[0][1] as { update: Record<string, unknown> };
+      expect(patchBody.update).not.toHaveProperty('name');
+    });
+
+    it('patches the configuration URL for the definition in request context', async () => {
+      mockedAxios.patch.mockResolvedValueOnce(successResponse);
+
+      await tools.formConfigurationUpdateTool.execute(
+        { dataSchema: { type: 'object' } },
+        { requestContext: mockRequestContext } as never,
+      );
+
+      const patchUrl = mockedAxios.patch.mock.calls[0][0] as string;
+      expect(patchUrl).toContain('form-service/intake-form');
+    });
+
+    it('returns the latest configuration from the response', async () => {
+      mockedAxios.patch.mockResolvedValueOnce(successResponse);
+
+      const result = await tools.formConfigurationUpdateTool.execute(
+        { dataSchema: { type: 'object' } },
+        { requestContext: mockRequestContext } as never,
+      );
+
+      expect(result.name).toBe('Intake Form');
+    });
+  });
+});

--- a/apps/agent-service/src/agent/tools/formConfiguration.ts
+++ b/apps/agent-service/src/agent/tools/formConfiguration.ts
@@ -97,9 +97,8 @@ export async function createFormConfigurationTools({ directory, tokenProvider, l
   const formConfigurationUpdateTool = createTool({
     id: 'update-form-configuration',
     description:
-      'Update the JSON form configuration. The form definition ID comes from request context. Typically update both dataSchema and uiSchema together in a single call.',
+      'Update the JSON form configuration. The form definition ID comes from request context. Typically update both dataSchema and uiSchema together in a single call. The form definition name cannot be changed through this tool.',
     inputSchema: z.object({
-      name: z.string().optional().describe('The name of the form.'),
       description: z.string().optional().describe('The description of the form.'),
       dataSchema: z.object({}).passthrough().optional().describe('The data schema for the JSON form.'),
       uiSchema: z.object({}).passthrough().optional().describe('The UI schema for the JSON form.'),
@@ -121,7 +120,7 @@ export async function createFormConfigurationTools({ directory, tokenProvider, l
       inputData,
       context: ToolExecutionContext,
     ) => {
-      const { name, dataSchema, uiSchema, anonymousApply } = inputData;
+      const { dataSchema, uiSchema, anonymousApply } = inputData;
 
       const requestContext = context.requestContext as AdspRequestContext<{ formDefinitionId: string }>;
       const tenantId = requestContext.get('tenantId');
@@ -139,7 +138,6 @@ export async function createFormConfigurationTools({ directory, tokenProvider, l
             operation: 'UPDATE',
             update: {
               id: formDefinitionId,
-              name,
               dataSchema,
               uiSchema,
               anonymousApply,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import useWindowDimensions from '@lib/useWindowDimensions';
 import { useDispatch, useSelector } from 'react-redux';
 import { v4 as uuid } from 'uuid';
@@ -85,6 +85,9 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
     "*GOA default header and footer wrapper is applied if the template doesn't include proper <html> opening and closing tags";
 
   const agentConnected = useSelector(agentConnectedSelector);
+  const notificationEmailAIEnabled = useSelector(
+    (state: RootState) => state.config.featureFlags?.NotificationEmailAI === true,
+  );
   const thread = useSelector((state: RootState) => threadSelector(state, aiThreadId));
   const [appliedProposalId, setAppliedProposalId] = useState<string | null>(null);
   const [aiDraft, setAiDraft] = useState('');
@@ -137,24 +140,31 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
     }
   }, [modelOpen, templates]);
 
-  // Connect/disconnect agent on component lifecycle (form agent pattern)
+  // The socket is opened lazily when the user lands on the AI (Email) tab (see
+  // the Tabs changeTabCallback below). Here we only ensure it's torn down when
+  // the editor unmounts.
   useEffect(() => {
-    dispatch(connectAgent());
+    if (!notificationEmailAIEnabled) return;
     return () => {
       dispatch(disconnectAgent());
     };
-  }, [dispatch]);
+  }, [dispatch, notificationEmailAIEnabled]);
+
+  // Tracks whether the agent socket has been requested for the current modal
+  // session so we only connect once, on the first visit to the AI tab.
+  const agentConnectionRequested = useRef(false);
 
   // Start a fresh thread each time the modal opens (form agent pattern)
   useEffect(() => {
-    if (modelOpen) {
+    if (notificationEmailAIEnabled && modelOpen) {
       const newThreadId = uuid();
       setAiThreadId(newThreadId);
       dispatch(startThread(agentName, newThreadId));
       setAppliedProposalId(null);
       setAiDraft('');
+      agentConnectionRequested.current = false;
     }
-  }, [modelOpen, dispatch, agentName]);
+  }, [modelOpen, dispatch, agentName, notificationEmailAIEnabled]);
 
   const switchTabPreview = (value) => {
     setPreview(value);
@@ -222,6 +232,10 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
           changeTabCallback={(index: number) => {
             if (index < validChannels.length) {
               switchTabPreview(validChannels[index]);
+            } else if (notificationEmailAIEnabled && !agentConnectionRequested.current) {
+              // AI (Email) tab selected — open the socket lazily on first visit.
+              agentConnectionRequested.current = true;
+              dispatch(connectAgent());
             }
           }}
         >
@@ -355,7 +369,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
               </>
             </Tab>
           ))}
-          {hasEmailChannel && (
+          {hasEmailChannel && notificationEmailAIEnabled && (
             <Tab label="AI (Email)">
               <TemplateAITab
                 threadId={aiThreadId}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -141,14 +141,20 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   }, [modelOpen, templates]);
 
   // The socket is opened lazily when the user lands on the AI (Email) tab (see
-  // the Tabs changeTabCallback below). Here we only ensure it's torn down when
-  // the editor unmounts.
+  // the Tabs changeTabCallback below). The host modal keeps this component
+  // mounted and only toggles CSS display, so closing the modal does NOT unmount
+  // us. Tear the socket down when the modal closes (modelOpen -> false), and
+  // also on unmount (e.g. navigating away entirely) as a safety net.
   useEffect(() => {
     if (!notificationEmailAIEnabled) return;
+    if (!modelOpen) {
+      dispatch(disconnectAgent());
+      return;
+    }
     return () => {
       dispatch(disconnectAgent());
     };
-  }, [dispatch, notificationEmailAIEnabled]);
+  }, [dispatch, notificationEmailAIEnabled, modelOpen]);
 
   // Tracks whether the agent socket has been requested for the current modal
   // session so we only connect once, on the first visit to the AI tab.

--- a/apps/tenant-management-webapp/src/app/store/agent/actions.ts
+++ b/apps/tenant-management-webapp/src/app/store/agent/actions.ts
@@ -273,7 +273,10 @@ export function connectAgent() {
 
     clearGraceTimer();
 
-    if (socket?.connected) {
+    // Tear down any existing socket regardless of its connection state. A socket
+    // that never connected is still actively retrying (reconnection: true), and
+    // guarding on `connected` would leave that retry loop running as a zombie.
+    if (socket) {
       socket.disconnect();
     }
 
@@ -365,7 +368,10 @@ export function disconnectAgent() {
     queuedMessages = [];
     dispatch({ type: DISCONNECT_AGENT_ACTION });
 
-    if (socket?.connected) {
+    // Disconnect whenever a socket exists, not only when it is connected.
+    // `socket.disconnect()` also aborts any in-progress reconnection attempts,
+    // which is exactly what a never-connected (failing) socket is doing.
+    if (socket) {
       socket.disconnect();
     }
   };

--- a/apps/tenant-management-webapp/src/app/store/config/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/config/models.ts
@@ -57,6 +57,7 @@ export interface FeatureFlags {
   Event: boolean;
   File: boolean;
   Notification: boolean;
+  NotificationEmailAI: boolean;
   PDF: boolean;
   Script: boolean;
   SharePoint: boolean;

--- a/apps/tenant-management-webapp/src/featureFlag.ts
+++ b/apps/tenant-management-webapp/src/featureFlag.ts
@@ -138,6 +138,7 @@ export const defaultFeaturesVisible = {
   Event: true,
   File: true,
   Notification: true,
+  NotificationEmailAI: true,
   PDF: true,
   Script: true,
   SharePoint: false,

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -87,7 +87,7 @@ import { StartEndDateEditor } from './startEndDateEditor';
 import type * as monacoNS from 'monaco-editor';
 import { AgentChat } from '@core-services/app-common';
 import { agentConnectedSelector, messagesSelector, threadSelector } from '@store/agent/selectors';
-import { messageAgent, startThread } from '@store/agent/actions';
+import { messageAgent, startThread, connectAgent } from '@store/agent/actions';
 import { v4 as uuid } from 'uuid';
 import { Attachment, UserContent } from '@core-services/app-common';
 import { AnyAction } from 'redux';
@@ -164,6 +164,9 @@ const ClientRole = ({ roleNames, clientId, anonymousRead, configuration, onUpdat
 };
 
 const NO_TASK_CREATED_OPTION = `No task created`;
+
+// Tab order in the editor: Data schema (0), UI schema (1), AI (2, when enabled).
+const AI_TAB_INDEX = 2;
 
 export function AddEditFormDefinitionEditor({
   definition,
@@ -435,6 +438,16 @@ export function AddEditFormDefinitionEditor({
       dispatch(startThread(agentName, threadId));
     }
   }, [dispatch, formAIEnabled, agentName, thread, threadId]);
+
+  // Open the agent socket lazily — only once the user actually lands on the AI
+  // tab, rather than immediately when the editor opens.
+  const agentConnectionRequested = useRef(false);
+  useEffect(() => {
+    if (formAIEnabled && activeIndex === AI_TAB_INDEX && !agentConnectionRequested.current) {
+      agentConnectionRequested.current = true;
+      dispatch(connectAgent());
+    }
+  }, [formAIEnabled, activeIndex, dispatch]);
 
   const handleAgentSend = useCallback(
     (tid: string, context: Record<string, unknown>, content: UserContent) => {

--- a/libs/form-editor-common/src/lib/definitions/formDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/formDefinitionEditor.tsx
@@ -18,7 +18,7 @@ import { modifiedDefinitionSelector } from '@store/form/selectors';
 import { rolesSelector } from '@store/access/selectors';
 import { selectRegisterData } from '@store/configuration/selectors';
 import { PageIndicator } from '@components/Indicator';
-import { connectAgent, disconnectAgent } from '@store/agent/actions';
+import { disconnectAgent } from '@store/agent/actions';
 
 export const FormDefinitionEditor = (): JSX.Element => {
   const navigate = useNavigate();
@@ -46,9 +46,11 @@ export const FormDefinitionEditor = (): JSX.Element => {
     dispatch(initializeFormEditor());
   }, [dispatch]);
 
+  // The socket is opened lazily when the user lands on the AI tab (see
+  // AddEditFormDefinitionEditor). Here we only ensure it's torn down when the
+  // editor is closed.
   useEffect(() => {
     if (formAIEnabled) {
-      dispatch(connectAgent());
       return () => {
         dispatch(disconnectAgent());
       };


### PR DESCRIPTION

- AI agent socket now connects lazily — only when the user opens the AI tab, not when the editor loads.
- Fixed socket cleanup to tear down any existing socket (even one that never connected), stopping the infinite background reconnect loop after closing the editor.
- Reconnecting now disconnects any lingering socket first, preventing zombie/duplicate sockets.
- Notification email editor now disconnects the socket on modal close (it stays mounted, so unmount cleanup alone never fired).
- Added `NotificationEmailAI` feature flag to gate the notification email AI experience (defaults on).
- Hardened the form-generation agent to always preserve the existing definition — no deleting, rewriting, renaming, or creating new form definitions unless explicitly asked.
- Form update tool no longer accepts or forwards a form name (name is fixed).
- Added unit tests for the agent guardrails and form configuration tool.

https://github.com/user-attachments/assets/f010bdfb-2e72-448f-919d-87825a2f88c2

