### PR TITLE
feat: update the form post api

### DIFF
--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -180,7 +180,7 @@ describe('definition router', () => {
     it('can call next with unauthorized for non-admin', async () => {
       const req = {
         user: { tenantId, id: 'tester', roles: ['test-applicant'] },
-        body: { id: 'test', name: 'test', anonymousApply: false, applicantRoles: [], assessorRoles: [] },
+        body: { name: 'test' },
         tenant: { id: tenantId },
       };
       const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -192,25 +192,10 @@ describe('definition router', () => {
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
     });
 
-    it('can reject id with path traversal characters', async () => {
-      const req = {
-        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-        body: { id: '../../etc/passwd', name: 'bad', anonymousApply: false, applicantRoles: [], assessorRoles: [] },
-        tenant: { id: tenantId },
-      };
-      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
-      const next = jest.fn();
-
-      // The route validator would block this before reaching the handler.
-      // Verify the handler also rejects it by checking the id fails the safe pattern.
-      const unsafeId = req.body.id;
-      expect(/^[a-z0-9-]+$/.test(unsafeId)).toBe(false);
-    });
-
     it('can return 409 if definition already exists', async () => {
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-        body: { id: 'test', name: 'Existing', anonymousApply: false, applicantRoles: [], assessorRoles: [] },
+        body: { name: 'Test' },
         tenant: { id: tenantId },
         getServiceConfiguration: jest.fn().mockResolvedValue([definition]),
       };
@@ -229,21 +214,23 @@ describe('definition router', () => {
     it('can create a definition', async () => {
       const configurationServiceUrl = new URL('http://configuration-service');
       directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      const newDefinition = {
-        id: 'new-def',
+      const createdDefinition = {
+        id: 'new-definition',
         name: 'New Definition',
+        description: '',
         anonymousApply: false,
         applicantRoles: [],
         assessorRoles: [],
+        clerkRoles: [],
+        dataSchema: {},
       };
-      // Existence check returns null — definition does not exist yet.
       axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: newDefinition } },
+        data: { latest: { revision: 1, configuration: createdDefinition } },
       });
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-        body: newDefinition,
+        body: { name: 'New Definition' },
         tenant: { id: tenantId },
         getServiceConfiguration: jest.fn().mockResolvedValue([null]),
       };
@@ -254,50 +241,12 @@ describe('definition router', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(axiosMock.patch).toHaveBeenCalledWith(
-        expect.stringContaining('new-def'),
-        expect.objectContaining({ operation: 'REPLACE', configuration: newDefinition }),
+        expect.stringContaining('new-definition'),
+        expect.objectContaining({ operation: 'REPLACE', configuration: createdDefinition }),
         expect.any(Object),
       );
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'new-def' }));
-      expect(next).not.toHaveBeenCalled();
-    });
-
-    it('can auto-generate id from name when id not provided', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      const newDefinition = {
-        name: 'My New Form',
-        anonymousApply: false,
-        applicantRoles: [],
-        assessorRoles: [],
-      };
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: { ...newDefinition, id: 'my-new-form' } } },
-      });
-
-      const req = {
-        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-        body: newDefinition,
-        tenant: { id: tenantId },
-        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
-      };
-      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
-      const next = jest.fn();
-
-      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
-      await handler(req as unknown as Request, res as unknown as Response, next);
-
-      expect(axiosMock.patch).toHaveBeenCalledWith(
-        expect.stringContaining('my-new-form'),
-        expect.objectContaining({
-          operation: 'REPLACE',
-          configuration: expect.objectContaining({ id: 'my-new-form', name: 'My New Form' }),
-        }),
-        expect.any(Object),
-      );
-      expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'my-new-form', name: 'My New Form' }));
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'new-definition' }));
       expect(next).not.toHaveBeenCalled();
     });
 
@@ -313,7 +262,7 @@ describe('definition router', () => {
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-        body: { name: 'Test', anonymousApply: false, applicantRoles: [], assessorRoles: [] },
+        body: { name: 'Test' },
         tenant: { id: tenantId },
         getServiceConfiguration: jest.fn().mockResolvedValue([null]),
       };
@@ -370,111 +319,176 @@ describe('definition router', () => {
       });
     });
 
-    describe('default roles', () => {
-      it('applies default applicantRoles when not provided in body', async () => {
-        const configurationServiceUrl = new URL('http://configuration-service');
-        directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-        axiosMock.patch.mockResolvedValue({
-          data: { latest: { revision: 1, configuration: { id: 'test-def', name: 'Test' } } },
-        });
-
-        // express-validator's .default() middleware injects these values into req.body before
-        // the handler runs; simulate that here by providing the defaulted values.
-        const req = {
-          user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-          body: {
-            name: 'Test',
-            anonymousApply: false,
-            applicantRoles: ['urn:ads:platform:form-service:form-applicant'],
-            assessorRoles: [],
-          },
-          tenant: { id: tenantId },
-          getServiceConfiguration: jest.fn().mockResolvedValue([null]),
-        };
-        const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
-        const next = jest.fn();
-
-        const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
-        await handler(req as unknown as Request, res as unknown as Response, next);
-
-        expect(axiosMock.patch).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            configuration: expect.objectContaining({
-              applicantRoles: ['urn:ads:platform:form-service:form-applicant'],
-              assessorRoles: [],
-            }),
-          }),
-          expect.any(Object),
-        );
+    it('always sets anonymousApply=false, applicantRoles=[], assessorRoles=[] regardless of body', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+      axiosMock.patch.mockResolvedValue({
+        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
       });
 
-      it('overrides default applicantRoles when provided in body', async () => {
-        const configurationServiceUrl = new URL('http://configuration-service');
-        directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-        axiosMock.patch.mockResolvedValue({
-          data: { latest: { revision: 1, configuration: { id: 'test-def', name: 'Test' } } },
-        });
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: 'Test' },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
 
-        const req = {
-          user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-          body: { name: 'Test', anonymousApply: false, applicantRoles: ['custom-role'], assessorRoles: ['assessor'] },
-          tenant: { id: tenantId },
-          getServiceConfiguration: jest.fn().mockResolvedValue([null]),
-        };
-        const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
-        const next = jest.fn();
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
 
-        const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
-        await handler(req as unknown as Request, res as unknown as Response, next);
-
-        expect(axiosMock.patch).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            configuration: expect.objectContaining({
-              applicantRoles: ['custom-role'],
-              assessorRoles: ['assessor'],
-            }),
-          }),
-          expect.any(Object),
-        );
-      });
-
-      it('passes formDraftUrlTemplate through to configuration service', async () => {
-        const configurationServiceUrl = new URL('http://configuration-service');
-        directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-        axiosMock.patch.mockResolvedValue({
-          data: { latest: { revision: 1, configuration: { id: 'test-def', name: 'Test' } } },
-        });
-
-        const req = {
-          user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
-          body: {
-            name: 'Test',
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          configuration: expect.objectContaining({
             anonymousApply: false,
             applicantRoles: [],
             assessorRoles: [],
-            formDraftUrlTemplate: 'https://example.com/form/{{id}}',
-          },
-          tenant: { id: tenantId },
-          getServiceConfiguration: jest.fn().mockResolvedValue([null]),
-        };
-        const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
-        const next = jest.fn();
-
-        const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
-        await handler(req as unknown as Request, res as unknown as Response, next);
-
-        expect(axiosMock.patch).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            configuration: expect.objectContaining({
-              formDraftUrlTemplate: 'https://example.com/form/{{id}}',
-            }),
           }),
-          expect.any(Object),
-        );
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('derives kebab-case id from multi-word name', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+      axiosMock.patch.mockResolvedValue({
+        data: { latest: { revision: 1, configuration: { id: 'my-application-form', name: 'My Application Form' } } },
       });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: 'My Application Form' },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.stringContaining('my-application-form'),
+        expect.objectContaining({ configuration: expect.objectContaining({ id: 'my-application-form' }) }),
+        expect.any(Object),
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with invalid operation error when name cannot produce a valid id', async () => {
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: '   ' },
+        tenant: { id: tenantId },
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+    });
+
+    it('accepts description from body and ignores all other extra fields', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+      axiosMock.patch.mockResolvedValue({
+        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
+      });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: {
+          name: 'Test',
+          description: 'A test form',
+          anonymousApply: true,
+          applicantRoles: ['custom-role'],
+          assessorRoles: ['assessor'],
+          formDraftUrlTemplate: 'https://example.com/form/{{id}}',
+          dataSchema: { type: 'object' },
+        },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          operation: 'REPLACE',
+          configuration: {
+            id: 'test',
+            name: 'Test',
+            description: 'A test form',
+            anonymousApply: false,
+            applicantRoles: [],
+            assessorRoles: [],
+            clerkRoles: [],
+            dataSchema: {},
+          },
+        },
+        expect.any(Object),
+      );
+    });
+
+    it('defaults description to empty string when not provided', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+      axiosMock.patch.mockResolvedValue({
+        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
+      });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: 'Test' },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ configuration: expect.objectContaining({ description: '' }) }),
+        expect.any(Object),
+      );
+    });
+
+    it('proceeds to create when the existence check throws', async () => {
+      const configurationServiceUrl = new URL('http://configuration-service');
+      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
+      axiosMock.patch.mockResolvedValue({
+        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
+      });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: 'Test' },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockRejectedValue(new Error('config service unavailable')),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(loggerMock.warn).toHaveBeenCalledWith(expect.stringContaining('test'));
+      expect(axiosMock.patch).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(next).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -75,8 +75,13 @@ describe('definition router', () => {
     axiosMock.delete.mockReset();
     jest.mocked(axiosMock.isAxiosError).mockReturnValue(false);
     directoryMock.getServiceUrl.mockReset();
+    directoryMock.getServiceUrl.mockResolvedValue(new URL('http://configuration-service'));
     tokenProviderMock.getAccessToken.mockReturnValue(Promise.resolve('token'));
   });
+
+  function mockPatchSuccess(configuration: Record<string, unknown>, revision = 1): void {
+    axiosMock.patch.mockResolvedValue({ data: { latest: { revision, configuration } } });
+  }
 
   it('can create router', () => {
     const router = createFormDefinitionRouter({
@@ -112,8 +117,6 @@ describe('definition router', () => {
     });
 
     it('can get definitions', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
       axiosMock.get.mockResolvedValue({
         data: {
           results: [{ latest: { revision: 1, configuration: definition }, active: null }],
@@ -139,8 +142,6 @@ describe('definition router', () => {
     });
 
     it('can get definitions with name search', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
       axiosMock.get.mockResolvedValue({
         data: {
           results: [{ latest: { revision: 1, configuration: definition }, active: null }],
@@ -212,8 +213,6 @@ describe('definition router', () => {
     });
 
     it('can create a definition', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
       const createdDefinition = {
         id: 'new-definition',
         name: 'New Definition',
@@ -224,9 +223,7 @@ describe('definition router', () => {
         clerkRoles: [],
         dataSchema: {},
       };
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: createdDefinition } },
-      });
+      mockPatchSuccess(createdDefinition);
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -251,8 +248,6 @@ describe('definition router', () => {
     });
 
     it('calls next with 400 when configuration service rejects the patch', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
       const axiosError = Object.assign(new Error('Bad Request'), {
         isAxiosError: true,
         response: { data: { errorMessage: 'Schema validation failed.' } },
@@ -320,11 +315,7 @@ describe('definition router', () => {
     });
 
     it('always sets anonymousApply=false, applicantRoles=[], assessorRoles=[] regardless of body', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
-      });
+      mockPatchSuccess({ id: 'test', name: 'Test' });
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -352,11 +343,7 @@ describe('definition router', () => {
     });
 
     it('derives kebab-case id from multi-word name', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: { id: 'my-application-form', name: 'My Application Form' } } },
-      });
+      mockPatchSuccess({ id: 'my-application-form', name: 'My Application Form' });
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -394,18 +381,35 @@ describe('definition router', () => {
       expect(axiosMock.patch).not.toHaveBeenCalled();
     });
 
-    it('accepts description from body and ignores all other extra fields', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
-      });
+    it('passes description from body to the configuration service', async () => {
+      mockPatchSuccess({ id: 'test', name: 'Test' });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        body: { name: 'Test', description: 'A test form' },
+        tenant: { id: tenantId },
+        getServiceConfiguration: jest.fn().mockResolvedValue([null]),
+      };
+      const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      const next = jest.fn();
+
+      const handler = createFormDefinition(directoryMock, tokenProviderMock, loggerMock as unknown as Logger);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ configuration: expect.objectContaining({ description: 'A test form' }) }),
+        expect.any(Object),
+      );
+    });
+
+    it('ignores extra body fields and sends only the permitted fields', async () => {
+      mockPatchSuccess({ id: 'test', name: 'Test' });
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
         body: {
           name: 'Test',
-          description: 'A test form',
           anonymousApply: true,
           applicantRoles: ['custom-role'],
           assessorRoles: ['assessor'],
@@ -428,7 +432,7 @@ describe('definition router', () => {
           configuration: {
             id: 'test',
             name: 'Test',
-            description: 'A test form',
+            description: '',
             anonymousApply: false,
             applicantRoles: [],
             assessorRoles: [],
@@ -441,11 +445,7 @@ describe('definition router', () => {
     });
 
     it('defaults description to empty string when not provided', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
-      });
+      mockPatchSuccess({ id: 'test', name: 'Test' });
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -467,11 +467,7 @@ describe('definition router', () => {
     });
 
     it('proceeds to create when the existence check throws', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 1, configuration: { id: 'test', name: 'Test' } } },
-      });
+      mockPatchSuccess({ id: 'test', name: 'Test' });
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -517,9 +513,6 @@ describe('definition router', () => {
     });
 
     it('can call next with not found when definition does not exist', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-
       axiosMock.get.mockResolvedValue({
         status: 404,
         data: {},
@@ -554,9 +547,6 @@ describe('definition router', () => {
     });
 
     it('can patch only provided fields and preserve existing definition values', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-
       const existingDefinition = {
         id: 'test',
         name: 'Original Name',
@@ -588,19 +578,8 @@ describe('definition router', () => {
         description: 'Patched description',
       };
 
-      axiosMock.get.mockResolvedValue({
-        status: HttpStatusCodes.OK,
-        data: existingDefinition,
-      });
-
-      axiosMock.patch.mockResolvedValue({
-        data: {
-          latest: {
-            revision: 2,
-            configuration: expectedPatchedDefinition,
-          },
-        },
-      });
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+      mockPatchSuccess(expectedPatchedDefinition, 2);
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -650,9 +629,6 @@ describe('definition router', () => {
     });
 
     it('can patch dataSchema and uiSchema', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-
       const existingDefinition = {
         id: 'test',
         name: 'Original Name',
@@ -687,19 +663,8 @@ describe('definition router', () => {
         uiSchema: patchedUiSchema,
       };
 
-      axiosMock.get.mockResolvedValue({
-        status: HttpStatusCodes.OK,
-        data: existingDefinition,
-      });
-
-      axiosMock.patch.mockResolvedValue({
-        data: {
-          latest: {
-            revision: 2,
-            configuration: expectedPatchedDefinition,
-          },
-        },
-      });
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+      mockPatchSuccess(expectedPatchedDefinition, 2);
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -750,9 +715,6 @@ describe('definition router', () => {
     });
 
     it('calls next with 400 when configuration service rejects the patch', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
-
       axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: { id: 'test', name: 'Test' } });
 
       const axiosError = Object.assign(new Error('Bad Request'), {
@@ -804,8 +766,6 @@ describe('definition router', () => {
     });
 
     it('can update a definition', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
       const updated = {
         id: 'test',
         name: 'Updated Name',
@@ -813,9 +773,7 @@ describe('definition router', () => {
         applicantRoles: [],
         assessorRoles: [],
       };
-      axiosMock.patch.mockResolvedValue({
-        data: { latest: { revision: 2, configuration: updated } },
-      });
+      mockPatchSuccess(updated, 2);
 
       const req = {
         user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
@@ -861,8 +819,6 @@ describe('definition router', () => {
     });
 
     it('can delete a definition', async () => {
-      const configurationServiceUrl = new URL('http://configuration-service');
-      directoryMock.getServiceUrl.mockResolvedValue(configurationServiceUrl);
       axiosMock.delete.mockResolvedValue({});
 
       const req = {

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -151,15 +151,21 @@ export function createFormDefinition(
         throw new UnauthorizedUserError('create form definition', user);
       }
 
-      const generatedId = req.body.id || toKebabCase(req.body.name);
+      const generatedId = toKebabCase(req.body.name);
 
       if (!generatedId) {
         throw new InvalidOperationError('Form definition ID could not be generated from the provided name.');
       }
 
       const definition: FormDefinition = {
-        ...req.body,
         id: generatedId,
+        name: req.body.name,
+        description: req.body.description ?? '',
+        anonymousApply: false,
+        applicantRoles: [],
+        assessorRoles: [],
+        clerkRoles: [],
+        dataSchema: {},
       };
 
       const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
@@ -352,23 +358,8 @@ export function createFormDefinitionRouter({
     '/definitions',
     assertAuthenticatedHandler,
     createValidationHandler(
-      body('id')
-        .optional()
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
       body('name').isString().isLength({ min: 1 }),
-      body('anonymousApply').optional().default(false).isBoolean(),
       body('description').optional().isString(),
-      body('dataSchema').optional().isObject(),
-      body('uiSchema').optional().isObject(),
-      body('applicantRoles').optional().default(['urn:ads:platform:form-service:form-applicant']).isArray(),
-      body('assessorRoles').optional().default([]).isArray(),
-      body('formDraftUrlTemplate')
-        .optional()
-        .isString()
-        .isLength({ min: 6, max: 500 })
-        .isURL({ protocols: ['http', 'https'], require_protocol: true }),
     ),
     createFormDefinition(directory, tokenProvider, logger),
   );

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -10,8 +10,8 @@ components:
       properties:
         id:
           type: string
-          maxLength: 50
-          description: Unique identifier for the form definition. If not provided, will be auto-generated from the name in kebab-case format.
+          readOnly: true
+          description: Unique identifier for the form definition. Always auto-generated from the name in kebab-case format. Cannot be set by the client.
         name:
           type: string
         description:
@@ -24,12 +24,12 @@ components:
           type: boolean
         applicantRoles:
           type: array
-          description: Roles allowed to submit the form. Defaults to ['urn:ads:platform:form-service:form-applicant'] when not provided.
+          description: Roles allowed to submit the form.
           items:
             type: string
         assessorRoles:
           type: array
-          description: Roles allowed to assess submitted forms. Defaults to [] when not provided.
+          description: Roles allowed to assess submitted forms.
           items:
             type: string
         clerkRoles:
@@ -84,6 +84,18 @@ components:
               type: string
         dryRun:
           type: boolean
+    FormDefinitionCreate:
+      type: object
+      description: Payload for creating a new form definition. Only name and description are accepted; all other fields are set to defaults.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+      additionalProperties: false
     FormDefinitionPatch:
       type: object
       description: Partial update payload for a form definition. Only provided fields will be updated; omitted fields will not be changed.
@@ -309,35 +321,19 @@ components:
     description: |
       Creates a new form definition. Requires the form-service admin role.
 
-      **Defaults applied when fields are omitted:**
-      - `id`: auto-generated from `name` in kebab-case if not provided
+      Only `name` and `description` are accepted in the request body. All other fields are set automatically:
+      - `id`: auto-generated from `name` in kebab-case
       - `anonymousApply`: `false`
-      - `applicantRoles`: `["urn:ads:platform:form-service:form-applicant"]`
+      - `applicantRoles`: `[]`
       - `assessorRoles`: `[]`
     requestBody:
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/FormDefinition'
+            $ref: '#/components/schemas/FormDefinitionCreate'
           example:
             name: My Application Form
-            description: A form for submitting applications.
-            anonymousApply: false
-            applicantRoles:
-              - urn:ads:platform:form-service:form-applicant
-            assessorRoles: []
-            formDraftUrlTemplate: 'https://example.com/form/{{id}}'
-            oneFormPerApplicant: true
-            dataSchema:
-              type: object
-              properties:
-                firstName:
-                  type: string
-                lastName:
-                  type: string
-              required:
-                - firstName
     responses:
       201:
         description: Successfully created the form definition.
@@ -346,11 +342,11 @@ components:
             schema:
               $ref: '#/components/schemas/FormDefinition'
       400:
-        description: Validation failed (e.g. invalid formDraftUrlTemplate format).
+        description: Validation failed or ID could not be generated from the provided name.
       401:
         description: User is not authorized to create form definitions.
       409:
-        description: Form definition with the specified ID already exists.
+        description: Form definition with the generated ID already exists.
 
 /form/v1/definitions/{definitionId}:
   get:


### PR DESCRIPTION
* POST body accepts only name and description
* id always derived from name via toKebabCase
* anonymousApply, applicantRoles, assessorRoles, clerkRoles, dataSchema hardcoded as server defaults
* FormDefinitionCreate schema added to swagger
* FormDefinition.id marked readOnly in swagger
* Stale default-role descriptions removed from swagger
* Obsolete tests removed, new edge-case tests added