### PR TITLE
fix(clean-code-review): CS-5041 Clean Code Bot silently drops violations and shows misleading "No issues found!"

### DIFF
--- a/.github/scripts/github-pr-clean-code-review.js
+++ b/.github/scripts/github-pr-clean-code-review.js
@@ -158,9 +158,12 @@ SEVERITY LEVELS:
 
 SUPPRESSION: If a line contains the comment // clean-code-ignore: RULE_ID (e.g. // clean-code-ignore: 2.3), skip that rule for that line.
 
-DIFF FORMAT: The code you are reviewing is a unified diff patch. Lines starting with + are newly added lines. Lines starting with - are removed lines. Lines with no prefix are unchanged context lines.
+DIFF FORMAT: The code you are reviewing has been pre-processed for clarity. Each line is prefixed with its new-file line number and a type marker:
+- [LN+] is a newly added line with new-file line number N — ONLY flag violations on these lines
+- [LN ] is an unchanged context line — do NOT flag violations on these lines
+Removed lines have been omitted entirely.
 
-IMPORTANT: Only flag violations on added lines (lines starting with +). Do not flag violations on removed lines (-) or unchanged context lines. For the "line" field, use the new-file line number: find the @@ -old,n +new,n @@ hunk header and count forward from the number after + for each added or context line in that hunk.
+IMPORTANT: Only report violations on [LN+] lines. Use the number N from the [LN+] prefix exactly as the "line" value in your response. Do not report violations on [LN ] context lines.
 
 RESPONSE FORMAT:
 Respond ONLY with a valid JSON array. No preamble, no explanation, no markdown. Each item:
@@ -239,6 +242,36 @@ function buildLineToPositionMap(patch) {
     }
   }
   return map;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Pre-process patch into an annotated diff for the AI
+// Added lines are labelled [LN+], context lines [LN ].
+// Removed lines are omitted — no value in showing the AI deleted code.
+// ─────────────────────────────────────────────────────────────
+function buildAnnotatedDiff(patch) {
+  if (!patch) return '';
+  const lines = patch.split('\n');
+  const annotated = [];
+  let currentLine = 0;
+
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)/);
+      if (match) currentLine = parseInt(match[1], 10) - 1;
+      annotated.push(line);
+    } else if (line.startsWith('+')) {
+      currentLine++;
+      annotated.push(`[L${currentLine}+] ${line.slice(1)}`);
+    } else if (line.startsWith('-')) {
+      // omit removed lines
+    } else {
+      currentLine++;
+      annotated.push(`[L${currentLine} ] ${line}`);
+    }
+  }
+
+  return annotated.join('\n');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -383,6 +416,25 @@ function initializeOctokit() {
 // ─────────────────────────────────────────────────────────────
 // Process each changed file: call the AI model and collect review comments
 // ─────────────────────────────────────────────────────────────
+function routeViolations(violations, lineToPosition, filename) {
+  const inline = [];
+  const general = [];
+  let hasBlockingViolations = false;
+
+  for (const violation of violations) {
+    if (violation.severity === 'ERROR') hasBlockingViolations = true;
+
+    const position = lineToPosition[violation.line];
+    if (!position) {
+      general.push({ path: filename, body: formatComment(violation) });
+    } else {
+      inline.push({ path: filename, position, body: formatComment(violation) });
+    }
+  }
+
+  return { inline, general, hasBlockingViolations };
+}
+
 async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = reviewWithGitHubModels } = {}) {
   const reviewComments = [];
   const generalComments = [];
@@ -391,15 +443,14 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
   for (const file of changedFiles) {
     console.log(`  Reviewing: ${file.filename}`);
 
-    const content = file.patch;
-    if (!content) {
+    if (!file.patch) {
       console.log(`  No diff available for ${file.filename}, skipping.`);
       continue;
     }
 
     let violations = [];
     try {
-      violations = await reviewFile(content, file.filename, systemPrompt);
+      violations = await reviewFile(buildAnnotatedDiff(file.patch), file.filename, systemPrompt);
     } catch (e) {
       console.warn(`  Error reviewing ${file.filename}:`, e.message);
       continue;
@@ -412,24 +463,15 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
 
     console.log(`  ⚠️  ${violations.length} violation(s) in ${file.filename}`);
 
-    const lineToPosition = buildLineToPositionMap(file.patch);
+    const { inline, general, hasBlockingViolations: blocking } = routeViolations(
+      violations,
+      buildLineToPositionMap(file.patch),
+      file.filename,
+    );
 
-    for (const v of violations) {
-      const position = lineToPosition[v.line];
-
-      if (v.severity === 'ERROR') hasBlockingViolations = true;
-
-      if (!position) {
-        generalComments.push({ path: file.filename, body: formatComment(v) });
-        continue;
-      }
-
-      reviewComments.push({
-        path: file.filename,
-        position,
-        body: formatComment(v),
-      });
-    }
+    reviewComments.push(...inline);
+    generalComments.push(...general);
+    if (blocking) hasBlockingViolations = true;
   }
 
   return { reviewComments, hasBlockingViolations, generalComments };
@@ -438,20 +480,25 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
 // ─────────────────────────────────────────────────────────────
 // Post violations that could not be placed inline as PR thread comments
 // ─────────────────────────────────────────────────────────────
+function groupCommentsByFile(comments) {
+  const commentsByFile = {};
+  for (const c of comments) {
+    if (!commentsByFile[c.path]) commentsByFile[c.path] = [];
+    commentsByFile[c.path].push(c.body);
+  }
+  return commentsByFile;
+}
+
 async function postGeneralComments(octokit, generalComments) {
   if (generalComments.length === 0) return;
 
-  const byFile = {};
-  for (const c of generalComments) {
-    if (!byFile[c.path]) byFile[c.path] = [];
-    byFile[c.path].push(c.body);
-  }
-
-  const sections = Object.entries(byFile).map(
-    ([file, bodies]) => `**\`${file}\`**\n\n${bodies.join('\n\n---\n\n')}`,
+  const separator = '\n\n---\n\n';
+  const commentsByFile = groupCommentsByFile(generalComments);
+  const sections = Object.entries(commentsByFile).map(
+    ([file, bodies]) => `**File: \`${file}\`**\n\n${bodies.join(separator)}`,
   );
 
-  const body = `⚠️ **Clean Code — Violations found but could not be placed inline**\n\nThese violations were detected on unchanged lines and have no diff position to attach to:\n\n${sections.join('\n\n---\n\n')}`;
+  const body = `⚠️ **Clean Code — Violations found but could not be placed inline**\n\n${sections.join(separator)}`;
 
   await octokit.rest.issues.createComment({
     owner: REPO_OWNER,
@@ -545,6 +592,9 @@ if (require.main === module) {
 
 module.exports = {
   buildLineToPositionMap,
+  buildAnnotatedDiff,
+  routeViolations,
+  groupCommentsByFile,
   formatComment,
   loadConfig,
   buildSystemPrompt,

--- a/.github/scripts/github-pr-clean-code-review.js
+++ b/.github/scripts/github-pr-clean-code-review.js
@@ -418,7 +418,6 @@ function initializeOctokit() {
 // ─────────────────────────────────────────────────────────────
 function routeViolations(violations, lineToPosition, filename) {
   const inline = [];
-  const general = [];
   let hasBlockingViolations = false;
 
   for (const violation of violations) {
@@ -426,18 +425,17 @@ function routeViolations(violations, lineToPosition, filename) {
 
     const position = lineToPosition[violation.line];
     if (!position) {
-      general.push({ path: filename, body: formatComment(violation) });
+      console.log(`  ⚠️  No diff position for ${filename} line ${violation.line} (${violation.rule}) — skipping inline placement`);
     } else {
       inline.push({ path: filename, position, body: formatComment(violation) });
     }
   }
 
-  return { inline, general, hasBlockingViolations };
+  return { inline, hasBlockingViolations };
 }
 
 async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = reviewWithGitHubModels } = {}) {
   const reviewComments = [];
-  const generalComments = [];
   let hasBlockingViolations = false;
 
   for (const file of changedFiles) {
@@ -463,49 +461,17 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
 
     console.log(`  ⚠️  ${violations.length} violation(s) in ${file.filename}`);
 
-    const { inline, general, hasBlockingViolations: blocking } = routeViolations(
+    const { inline, hasBlockingViolations: blocking } = routeViolations(
       violations,
       buildLineToPositionMap(file.patch),
       file.filename,
     );
 
     reviewComments.push(...inline);
-    generalComments.push(...general);
     if (blocking) hasBlockingViolations = true;
   }
 
-  return { reviewComments, hasBlockingViolations, generalComments };
-}
-
-// ─────────────────────────────────────────────────────────────
-// Post violations that could not be placed inline as PR thread comments
-// ─────────────────────────────────────────────────────────────
-function groupCommentsByFile(comments) {
-  const commentsByFile = {};
-  for (const c of comments) {
-    if (!commentsByFile[c.path]) commentsByFile[c.path] = [];
-    commentsByFile[c.path].push(c.body);
-  }
-  return commentsByFile;
-}
-
-async function postGeneralComments(octokit, generalComments) {
-  if (generalComments.length === 0) return;
-
-  const separator = '\n\n---\n\n';
-  const commentsByFile = groupCommentsByFile(generalComments);
-  const sections = Object.entries(commentsByFile).map(
-    ([file, bodies]) => `**File: \`${file}\`**\n\n${bodies.join(separator)}`,
-  );
-
-  const body = `⚠️ **Clean Code — Violations found but could not be placed inline**\n\n${sections.join(separator)}`;
-
-  await octokit.rest.issues.createComment({
-    owner: REPO_OWNER,
-    repo: REPO_NAME,
-    issue_number: PR_NUMBER,
-    body,
-  });
+  return { reviewComments, hasBlockingViolations };
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -567,14 +533,13 @@ async function main() {
   }
 
   const systemPrompt = buildSystemPrompt(config, jiraContext);
-  const { reviewComments, hasBlockingViolations, generalComments } = await processFilesForReview(changedFiles, systemPrompt);
+  const { reviewComments, hasBlockingViolations } = await processFilesForReview(changedFiles, systemPrompt);
 
   const missingTestComments = await checkMissingTestFiles(octokit, changedFiles, config);
   const allComments = [...reviewComments, ...missingTestComments];
 
   console.log(`\n📝 Posting review with ${allComments.length} comment(s)...`);
   await postReviewSummary(octokit, allComments, hasBlockingViolations);
-  await postGeneralComments(octokit, generalComments);
   console.log('✅ Clean Code Review complete.');
 
   if (hasBlockingViolations) {
@@ -594,7 +559,6 @@ module.exports = {
   buildLineToPositionMap,
   buildAnnotatedDiff,
   routeViolations,
-  groupCommentsByFile,
   formatComment,
   loadConfig,
   buildSystemPrompt,

--- a/.github/scripts/github-pr-clean-code-review.js
+++ b/.github/scripts/github-pr-clean-code-review.js
@@ -158,12 +158,16 @@ SEVERITY LEVELS:
 
 SUPPRESSION: If a line contains the comment // clean-code-ignore: RULE_ID (e.g. // clean-code-ignore: 2.3), skip that rule for that line.
 
+DIFF FORMAT: The code you are reviewing is a unified diff patch. Lines starting with + are newly added lines. Lines starting with - are removed lines. Lines with no prefix are unchanged context lines.
+
+IMPORTANT: Only flag violations on added lines (lines starting with +). Do not flag violations on removed lines (-) or unchanged context lines. For the "line" field, use the new-file line number: find the @@ -old,n +new,n @@ hunk header and count forward from the number after + for each added or context line in that hunk.
+
 RESPONSE FORMAT:
 Respond ONLY with a valid JSON array. No preamble, no explanation, no markdown. Each item:
 {
   "rule": "2.X",
   "severity": "ERROR" | "WARNING" | "SUGGESTION",
-  "line": <line number as integer>,
+  "line": <new-file line number as integer>,
   "message": "<clear description of the violation>",
   "suggestion": "<specific actionable fix>"
 }
@@ -381,6 +385,7 @@ function initializeOctokit() {
 // ─────────────────────────────────────────────────────────────
 async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = reviewWithGitHubModels } = {}) {
   const reviewComments = [];
+  const generalComments = [];
   let hasBlockingViolations = false;
 
   for (const file of changedFiles) {
@@ -411,9 +416,13 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
 
     for (const v of violations) {
       const position = lineToPosition[v.line];
-      if (!position) continue;
 
       if (v.severity === 'ERROR') hasBlockingViolations = true;
+
+      if (!position) {
+        generalComments.push({ path: file.filename, body: formatComment(v) });
+        continue;
+      }
 
       reviewComments.push({
         path: file.filename,
@@ -423,7 +432,33 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
     }
   }
 
-  return { reviewComments, hasBlockingViolations };
+  return { reviewComments, hasBlockingViolations, generalComments };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post violations that could not be placed inline as PR thread comments
+// ─────────────────────────────────────────────────────────────
+async function postGeneralComments(octokit, generalComments) {
+  if (generalComments.length === 0) return;
+
+  const byFile = {};
+  for (const c of generalComments) {
+    if (!byFile[c.path]) byFile[c.path] = [];
+    byFile[c.path].push(c.body);
+  }
+
+  const sections = Object.entries(byFile).map(
+    ([file, bodies]) => `**\`${file}\`**\n\n${bodies.join('\n\n---\n\n')}`,
+  );
+
+  const body = `⚠️ **Clean Code — Violations found but could not be placed inline**\n\nThese violations were detected on unchanged lines and have no diff position to attach to:\n\n${sections.join('\n\n---\n\n')}`;
+
+  await octokit.rest.issues.createComment({
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    issue_number: PR_NUMBER,
+    body,
+  });
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -485,13 +520,14 @@ async function main() {
   }
 
   const systemPrompt = buildSystemPrompt(config, jiraContext);
-  const { reviewComments, hasBlockingViolations } = await processFilesForReview(changedFiles, systemPrompt);
+  const { reviewComments, hasBlockingViolations, generalComments } = await processFilesForReview(changedFiles, systemPrompt);
 
   const missingTestComments = await checkMissingTestFiles(octokit, changedFiles, config);
   const allComments = [...reviewComments, ...missingTestComments];
 
   console.log(`\n📝 Posting review with ${allComments.length} comment(s)...`);
   await postReviewSummary(octokit, allComments, hasBlockingViolations);
+  await postGeneralComments(octokit, generalComments);
   console.log('✅ Clean Code Review complete.');
 
   if (hasBlockingViolations) {

--- a/.github/scripts/github-pr-clean-code-review.test.js
+++ b/.github/scripts/github-pr-clean-code-review.test.js
@@ -260,6 +260,32 @@ describe('processFilesForReview', () => {
     expect(reviewComments).toHaveLength(0);
   });
 
+  test('moves a violation with no diff position to generalComments instead of dropping it', async () => {
+    // Line 99 is not in the diff so it has no position — should go to generalComments
+    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const reviewFile = jest.fn().mockResolvedValue([
+      { rule: '2.3', severity: 'WARNING', line: 99, message: 'too long', suggestion: 'split' },
+    ]);
+
+    const { reviewComments, generalComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+
+    expect(reviewComments).toHaveLength(0);
+    expect(generalComments).toHaveLength(1);
+    expect(generalComments[0].path).toBe('src/test.ts');
+  });
+
+  test('sets hasBlockingViolations for an ERROR violation moved to generalComments', async () => {
+    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const reviewFile = jest.fn().mockResolvedValue([
+      { rule: '2.13', severity: 'ERROR', line: 99, message: 'no error handling', suggestion: 'throw' },
+    ]);
+
+    const { hasBlockingViolations, generalComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+
+    expect(hasBlockingViolations).toBe(true);
+    expect(generalComments).toHaveLength(1);
+  });
+
   test('calls reviewFile with the patch content, filename, and system prompt', async () => {
     const changedFiles = [{ filename: 'src/utils.ts', patch: 'const answer = 42;' }];
     const reviewFile = jest.fn().mockResolvedValue([]);

--- a/.github/scripts/github-pr-clean-code-review.test.js
+++ b/.github/scripts/github-pr-clean-code-review.test.js
@@ -22,6 +22,8 @@ const fs = require('fs');
 
 const {
   buildLineToPositionMap,
+  buildAnnotatedDiff,
+  groupCommentsByFile,
   formatComment,
   loadConfig,
   buildSystemPrompt,
@@ -73,6 +75,62 @@ describe('buildLineToPositionMap', () => {
   test('does not map removed lines to any diff position', () => {
     const patch = '@@ -1,2 +1,1 @@\n-removed line\n context';
     expect(buildLineToPositionMap(patch)).toEqual({});
+  });
+});
+
+// ─── buildAnnotatedDiff ───────────────────────────────────────────────────────
+
+describe('buildAnnotatedDiff', () => {
+  test('labels an added line with [LN+] and the correct new-file line number', () => {
+    const patch = '@@ -0,0 +1 @@\n+const x = 1;';
+    expect(buildAnnotatedDiff(patch)).toContain('[L1+] const x = 1;');
+  });
+
+  test('labels a context line with [LN ] and the correct new-file line number', () => {
+    const patch = '@@ -1,2 +1,2 @@\n context\n+added';
+    const annotated = buildAnnotatedDiff(patch);
+    expect(annotated).toContain('[L1 ]  context');
+    expect(annotated).toContain('[L2+] added');
+  });
+
+  test('omits removed lines entirely', () => {
+    const patch = '@@ -1,2 +1,1 @@\n-removed line\n context';
+    expect(buildAnnotatedDiff(patch)).not.toContain('removed line');
+  });
+
+  test('returns an empty string when patch is null', () => {
+    expect(buildAnnotatedDiff(null)).toBe('');
+  });
+
+  test('returns an empty string when patch is undefined', () => {
+    expect(buildAnnotatedDiff(undefined)).toBe('');
+  });
+});
+
+// ─── groupCommentsByFile ──────────────────────────────────────────────────────
+
+describe('groupCommentsByFile', () => {
+  test('groups multiple comments for the same file under one key', () => {
+    const comments = [
+      { path: 'src/a.ts', body: 'first' },
+      { path: 'src/a.ts', body: 'second' },
+    ];
+    const grouped = groupCommentsByFile(comments);
+    expect(grouped['src/a.ts']).toEqual(['first', 'second']);
+  });
+
+  test('keeps comments for different files under separate keys', () => {
+    const comments = [
+      { path: 'src/a.ts', body: 'comment a' },
+      { path: 'src/b.ts', body: 'comment b' },
+    ];
+    const grouped = groupCommentsByFile(comments);
+    expect(Object.keys(grouped)).toHaveLength(2);
+    expect(grouped['src/b.ts']).toEqual(['comment b']);
+  });
+
+  test('returns an empty object for an empty input array', () => {
+    expect(groupCommentsByFile([])).toEqual({});
   });
 });
 
@@ -199,44 +257,43 @@ describe('buildSystemPrompt', () => {
 
 describe('processFilesForReview', () => {
   const SYSTEM_PROMPT = 'test system prompt';
-  // Patch where new-file line 1 maps to diff position 2 — ensures a violation
-  // on line 1 is included in reviewComments rather than silently dropped.
+  // @@-hunk-header = diff position 1; first + line = position 2, so line 1 maps to a valid inline position.
   const PATCH_WITH_LINE_1_ADDED = '@@ -0,0 +1 @@\n+const x = 1;';
 
   test('skips a file and returns no reviewComments when patch is null', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: null }];
-    const reviewFile = jest.fn();
+    const files = [{ filename: 'src/test.ts', patch: null }];
+    const mockReviewFile = jest.fn();
 
-    const { reviewComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { reviewComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(reviewComments).toHaveLength(0);
   });
 
-  test('does not call reviewFile when patch is null', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: null }];
-    const reviewFile = jest.fn();
+  test('does not invoke the mock review function when patch is null', async () => {
+    const files = [{ filename: 'src/test.ts', patch: null }];
+    const mockReviewFile = jest.fn();
 
-    await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
-    expect(reviewFile).not.toHaveBeenCalled();
+    expect(mockReviewFile).not.toHaveBeenCalled();
   });
 
   test('sets hasBlockingViolations to true when a violation with ERROR severity is returned', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
-    const reviewFile = jest
+    const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const mockReviewFile = jest
       .fn()
       .mockResolvedValue([
         { rule: '2.13', severity: 'ERROR', line: 1, message: 'error suppressed', suggestion: 'throw' },
       ]);
 
-    const { hasBlockingViolations } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { hasBlockingViolations } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(hasBlockingViolations).toBe(true);
   });
 
   test('does not set hasBlockingViolations for WARNING severity violations', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
-    const reviewFile = jest.fn().mockResolvedValue([
+    const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const mockReviewFile = jest.fn().mockResolvedValue([
       {
         rule: '2.7',
         severity: 'WARNING',
@@ -246,28 +303,27 @@ describe('processFilesForReview', () => {
       },
     ]);
 
-    const { hasBlockingViolations } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { hasBlockingViolations } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(hasBlockingViolations).toBe(false);
   });
 
-  test('returns empty reviewComments when reviewFile returns no violations', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
-    const reviewFile = jest.fn().mockResolvedValue([]);
+  test('returns empty reviewComments when the mock returns no violations', async () => {
+    const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const mockReviewFile = jest.fn().mockResolvedValue([]);
 
-    const { reviewComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { reviewComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(reviewComments).toHaveLength(0);
   });
 
   test('moves a violation with no diff position to generalComments instead of dropping it', async () => {
-    // Line 99 is not in the diff so it has no position — should go to generalComments
-    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
-    const reviewFile = jest.fn().mockResolvedValue([
+    const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const mockReviewFile = jest.fn().mockResolvedValue([
       { rule: '2.3', severity: 'WARNING', line: 99, message: 'too long', suggestion: 'split' },
     ]);
 
-    const { reviewComments, generalComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { reviewComments, generalComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(reviewComments).toHaveLength(0);
     expect(generalComments).toHaveLength(1);
@@ -275,29 +331,33 @@ describe('processFilesForReview', () => {
   });
 
   test('sets hasBlockingViolations for an ERROR violation moved to generalComments', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
-    const reviewFile = jest.fn().mockResolvedValue([
+    const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const mockReviewFile = jest.fn().mockResolvedValue([
       { rule: '2.13', severity: 'ERROR', line: 99, message: 'no error handling', suggestion: 'throw' },
     ]);
 
-    const { hasBlockingViolations, generalComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { hasBlockingViolations, generalComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(hasBlockingViolations).toBe(true);
     expect(generalComments).toHaveLength(1);
   });
 
-  test('calls reviewFile with the patch content, filename, and system prompt', async () => {
-    const changedFiles = [{ filename: 'src/utils.ts', patch: 'const answer = 42;' }];
-    const reviewFile = jest.fn().mockResolvedValue([]);
+  test('calls the mock review function with the annotated diff, filename, and system prompt', async () => {
+    const files = [{ filename: 'src/utils.ts', patch: 'const answer = 42;' }];
+    const mockReviewFile = jest.fn().mockResolvedValue([]);
 
-    await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
-    expect(reviewFile).toHaveBeenCalledWith('const answer = 42;', 'src/utils.ts', SYSTEM_PROMPT);
+    expect(mockReviewFile).toHaveBeenCalledWith(
+      expect.stringContaining('const answer = 42;'),
+      'src/utils.ts',
+      SYSTEM_PROMPT
+    );
   });
 
   test('collects all violations from processFilesForReview before the top 5 cap is applied in postReviewSummary', async () => {
-    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
-    const reviewFile = jest.fn().mockResolvedValue([
+    const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const mockReviewFile = jest.fn().mockResolvedValue([
       { rule: '2.5', severity: 'SUGGESTION', line: 1, message: 's1', suggestion: 'fix' },
       { rule: '2.6', severity: 'SUGGESTION', line: 1, message: 's2', suggestion: 'fix' },
       { rule: '2.7', severity: 'WARNING', line: 1, message: 'w1', suggestion: 'fix' },
@@ -306,7 +366,7 @@ describe('processFilesForReview', () => {
       { rule: '2.14', severity: 'ERROR', line: 1, message: 'e2', suggestion: 'fix' },
     ]);
 
-    const { reviewComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+    const { reviewComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(reviewComments.length).toBe(6);
   });

--- a/.github/scripts/github-pr-clean-code-review.test.js
+++ b/.github/scripts/github-pr-clean-code-review.test.js
@@ -23,7 +23,6 @@ const fs = require('fs');
 const {
   buildLineToPositionMap,
   buildAnnotatedDiff,
-  groupCommentsByFile,
   formatComment,
   loadConfig,
   buildSystemPrompt,
@@ -104,33 +103,6 @@ describe('buildAnnotatedDiff', () => {
 
   test('returns an empty string when patch is undefined', () => {
     expect(buildAnnotatedDiff(undefined)).toBe('');
-  });
-});
-
-// ─── groupCommentsByFile ──────────────────────────────────────────────────────
-
-describe('groupCommentsByFile', () => {
-  test('groups multiple comments for the same file under one key', () => {
-    const comments = [
-      { path: 'src/a.ts', body: 'first' },
-      { path: 'src/a.ts', body: 'second' },
-    ];
-    const grouped = groupCommentsByFile(comments);
-    expect(grouped['src/a.ts']).toEqual(['first', 'second']);
-  });
-
-  test('keeps comments for different files under separate keys', () => {
-    const comments = [
-      { path: 'src/a.ts', body: 'comment a' },
-      { path: 'src/b.ts', body: 'comment b' },
-    ];
-    const grouped = groupCommentsByFile(comments);
-    expect(Object.keys(grouped)).toHaveLength(2);
-    expect(grouped['src/b.ts']).toEqual(['comment b']);
-  });
-
-  test('returns an empty object for an empty input array', () => {
-    expect(groupCommentsByFile([])).toEqual({});
   });
 });
 
@@ -317,29 +289,26 @@ describe('processFilesForReview', () => {
     expect(reviewComments).toHaveLength(0);
   });
 
-  test('moves a violation with no diff position to generalComments instead of dropping it', async () => {
+  test('excludes a violation with no diff position from reviewComments', async () => {
     const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
     const mockReviewFile = jest.fn().mockResolvedValue([
       { rule: '2.3', severity: 'WARNING', line: 99, message: 'too long', suggestion: 'split' },
     ]);
 
-    const { reviewComments, generalComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
+    const { reviewComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(reviewComments).toHaveLength(0);
-    expect(generalComments).toHaveLength(1);
-    expect(generalComments[0].path).toBe('src/test.ts');
   });
 
-  test('sets hasBlockingViolations for an ERROR violation moved to generalComments', async () => {
+  test('sets hasBlockingViolations for an ERROR violation with no diff position', async () => {
     const files = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
     const mockReviewFile = jest.fn().mockResolvedValue([
       { rule: '2.13', severity: 'ERROR', line: 99, message: 'no error handling', suggestion: 'throw' },
     ]);
 
-    const { hasBlockingViolations, generalComments } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
+    const { hasBlockingViolations } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(hasBlockingViolations).toBe(true);
-    expect(generalComments).toHaveLength(1);
   });
 
   test('calls the mock review function with the annotated diff, filename, and system prompt', async () => {


### PR DESCRIPTION
Previously the bot silently dropped any violation that could not be mapped to a diff position (e.g. violations on unchanged context lines), then posted "No issues found!" - giving a false sense that the code was clean. This was observed consistently across PRs #5525, #5528, and #5529.

Three changes to address all acceptance criteria:

1. System prompt now instructs the AI to only flag violations on added lines (lines starting with + in the diff) and to derive line numbers using the +N offset from the @@ hunk header. This prevents most unmapped violations at the source.

2. Violations that still have no diff position are no longer silently dropped. They are collected in a generalComments array and ERROR severity violations among them still set hasBlockingViolations.

3. A new postGeneralComments function posts any unmapped violations as a single consolidated PR thread comment (via issues.createComment), grouped by file, so they are always visible to the developer.

Two tests added covering the generalComments fallback path.