### PR TITLE
fix(clean-code-review): fix 422 "Position could not be resolved" on short diffs

### DIFF
--- a/.github/scripts/github-pr-clean-code-review.js
+++ b/.github/scripts/github-pr-clean-code-review.js
@@ -220,7 +220,10 @@ async function reviewWithGitHubModels(fileContent, fileName, systemPrompt) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Map violations to PR diff positions
+// Map violations to PR diff positions (kept for backwards compat / tests)
+// NOTE: This function counts @@ hunk headers as position 1, which is
+// incorrect per GitHub's API ("line just below hunk header is position 1").
+// Use buildChangedLineSet + line/side params instead.
 // ─────────────────────────────────────────────────────────────
 function buildLineToPositionMap(patch) {
   if (!patch) return {};
@@ -245,7 +248,7 @@ function buildLineToPositionMap(patch) {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Pre-process patch into an annotated diff for the AI
+// Pre-process patch into an annotated diff for the AI.
 // Added lines are labelled [LN+], context lines [LN ].
 // Removed lines are omitted — no value in showing the AI deleted code.
 // ─────────────────────────────────────────────────────────────
@@ -272,6 +275,30 @@ function buildAnnotatedDiff(patch) {
   }
 
   return annotated.join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────
+// Return the set of file line numbers that were added (+) in this diff.
+// Used with the line/side GitHub review comment API to avoid position
+// arithmetic entirely (GitHub counts @@ headers inconsistently).
+// ─────────────────────────────────────────────────────────────
+function buildChangedLineSet(patch) {
+  if (!patch) return new Set();
+  const set = new Set();
+  let currentLine = 0;
+
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('@@')) {
+      const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)/);
+      if (match) currentLine = parseInt(match[1], 10) - 1;
+    } else if (line.startsWith('+')) {
+      currentLine++;
+      set.add(currentLine);
+    } else if (!line.startsWith('-')) {
+      currentLine++;
+    }
+  }
+  return set;
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -336,13 +363,13 @@ async function checkMissingTestFiles(octokit, changedFiles, config, { checkRepoF
     const repoChecks = await Promise.all(expectedTestPaths.map((p) => checkRepoFile(octokit, p)));
     if (repoChecks.some(Boolean)) continue;
 
-    const lineToPosition = buildLineToPositionMap(file.patch);
-    const positions = Object.values(lineToPosition);
-    if (positions.length === 0) continue;
+    const changedLines = buildChangedLineSet(file.patch);
+    if (changedLines.size === 0) continue;
 
     missingTestComments.push({
       path: file.filename,
-      position: Math.min(...positions),
+      line: Math.min(...changedLines),
+      side: 'RIGHT',
       body: formatComment({
         rule: 'RULE-19',
         severity: 'WARNING',
@@ -416,18 +443,17 @@ function initializeOctokit() {
 // ─────────────────────────────────────────────────────────────
 // Process each changed file: call the AI model and collect review comments
 // ─────────────────────────────────────────────────────────────
-function routeViolations(violations, lineToPosition, filename) {
+function routeViolations(violations, changedLines, filename) {
   const inline = [];
   let hasBlockingViolations = false;
 
   for (const violation of violations) {
     if (violation.severity === 'ERROR') hasBlockingViolations = true;
 
-    const position = lineToPosition[violation.line];
-    if (!position) {
-      console.log(`  ⚠️  No diff position for ${filename} line ${violation.line} (${violation.rule}) — skipping inline placement`);
+    if (!changedLines.has(violation.line)) {
+      console.log(`  ⚠️  Line ${violation.line} not in diff for ${filename} (${violation.rule}) — skipping`);
     } else {
-      inline.push({ path: filename, position, body: formatComment(violation) });
+      inline.push({ path: filename, line: violation.line, side: 'RIGHT', body: formatComment(violation) });
     }
   }
 
@@ -463,7 +489,7 @@ async function processFilesForReview(changedFiles, systemPrompt, { reviewFile = 
 
     const { inline, hasBlockingViolations: blocking } = routeViolations(
       violations,
-      buildLineToPositionMap(file.patch),
+      buildChangedLineSet(file.patch),
       file.filename,
     );
 
@@ -558,6 +584,7 @@ if (require.main === module) {
 module.exports = {
   buildLineToPositionMap,
   buildAnnotatedDiff,
+  buildChangedLineSet,
   routeViolations,
   formatComment,
   loadConfig,

--- a/.github/scripts/github-pr-clean-code-review.test.js
+++ b/.github/scripts/github-pr-clean-code-review.test.js
@@ -23,6 +23,7 @@ const fs = require('fs');
 const {
   buildLineToPositionMap,
   buildAnnotatedDiff,
+  buildChangedLineSet,
   formatComment,
   loadConfig,
   buildSystemPrompt,
@@ -103,6 +104,54 @@ describe('buildAnnotatedDiff', () => {
 
   test('returns an empty string when patch is undefined', () => {
     expect(buildAnnotatedDiff(undefined)).toBe('');
+  });
+});
+
+// ─── buildChangedLineSet ──────────────────────────────────────────────────────
+
+describe('buildChangedLineSet', () => {
+  test('returns the file line number of an added line', () => {
+    // @@ says new file starts at line 1; after 1 context line the + line is at file line 2.
+    const patch = '@@ -1,3 +1,4 @@\n context\n+added line\n context';
+    expect(buildChangedLineSet(patch).has(2)).toBe(true);
+  });
+
+  test('returns an empty set when patch is null', () => {
+    expect(buildChangedLineSet(null).size).toBe(0);
+  });
+
+  test('returns an empty set when patch is undefined', () => {
+    expect(buildChangedLineSet(undefined).size).toBe(0);
+  });
+
+  test('does not include removed lines', () => {
+    const patch = '@@ -1,2 +1,1 @@\n-removed line\n context';
+    expect(buildChangedLineSet(patch).size).toBe(0);
+  });
+
+  test('does not include context lines', () => {
+    const patch = '@@ -1,2 +1,3 @@\n context\n+added\n context';
+    const set = buildChangedLineSet(patch);
+    expect(set.has(1)).toBe(false); // context
+    expect(set.has(3)).toBe(false); // context
+    expect(set.has(2)).toBe(true);  // only the + line
+  });
+
+  test('handles a new-file patch starting at line 1 with no context', () => {
+    // Typical new-file diff: @@ -0,0 +1 @@\n+line
+    const patch = '@@ -0,0 +1 @@\n+const x = 1;';
+    expect(buildChangedLineSet(patch).has(1)).toBe(true);
+  });
+
+  test('handles multi-hunk patches and tracks line numbers across hunks', () => {
+    // First hunk: + line at file line 2. Second hunk: + line at file line 88.
+    const patch =
+      '@@ -1,3 +1,4 @@\n context\n+hunk1\n context\n context\n' +
+      '@@ -85,3 +86,4 @@\n context\n context\n+hunk2\n context';
+    const set = buildChangedLineSet(patch);
+    expect(set.has(2)).toBe(true);
+    expect(set.has(88)).toBe(true);
+    expect(set.size).toBe(2);
   });
 });
 
@@ -261,6 +310,19 @@ describe('processFilesForReview', () => {
     const { hasBlockingViolations } = await processFilesForReview(files, SYSTEM_PROMPT, { reviewFile: mockReviewFile });
 
     expect(hasBlockingViolations).toBe(true);
+  });
+
+  test('review comment uses line and side instead of position', async () => {
+    const changedFiles = [{ filename: 'src/test.ts', patch: PATCH_WITH_LINE_1_ADDED }];
+    const reviewFile = jest
+      .fn()
+      .mockResolvedValue([{ rule: '2.13', severity: 'ERROR', line: 1, message: 'msg', suggestion: 'fix' }]);
+
+    const { reviewComments } = await processFilesForReview(changedFiles, SYSTEM_PROMPT, { reviewFile });
+
+    expect(reviewComments[0].line).toBe(1);
+    expect(reviewComments[0].side).toBe('RIGHT');
+    expect(reviewComments[0]).not.toHaveProperty('position');
   });
 
   test('does not set hasBlockingViolations for WARNING severity violations', async () => {
@@ -456,6 +518,9 @@ describe('checkMissingTestFiles', () => {
     expect(comments).toHaveLength(1);
     expect(comments[0].body).toContain('RULE-19');
     expect(comments[0].path).toBe('src/auth.service.ts');
+    expect(comments[0].line).toBe(1);
+    expect(comments[0].side).toBe('RIGHT');
+    expect(comments[0]).not.toHaveProperty('position');
   });
 
   test('returns no comments when a matching test file is in the PR diff', async () => {


### PR DESCRIPTION
Root cause: buildLineToPositionMap counted @@ hunk header lines as diff position 1. GitHub's API spec states "the line just below the hunk header is position 1" — @@ itself is not counted. This made every submitted position off by +1 per hunk. On short diffs (e.g. the 3-line router/index.ts change in PR #5535) the inflated position exceeded the diff bounds, causing GitHub to reject the entire review batch with 422 "Position could not be resolved".

Fix 1 (upstream - buildAnnotatedDiff): Pre-processes the patch into an annotated format ([LN+], [LN ]) before sending to the AI, so the model receives explicit file line numbers and is instructed to return only [LN+] violations. This makes the AI's line numbers reliable.
