### PR TITLE
test(jsonforms-components): add missing branch coverage for autoPopulate utils

### DIFF
--- a/libs/jsonforms-components/src/lib/util/autoPopulate.spec.tsx
+++ b/libs/jsonforms-components/src/lib/util/autoPopulate.spec.tsx
@@ -3,6 +3,8 @@ import {
   autoPopulatePropertiesMonaco,
   autoPopulateValue,
   createAutoPopulateMiddleware,
+  getAutoPopulateControls,
+  getAutoPopulatedData,
   mergeAutoPopulatedData,
 } from './autoPopulate';
 import { User } from '../Context/register';
@@ -66,6 +68,26 @@ describe('autoPopulateValue', () => {
   });
 });
 
+describe('getAutoPopulateControls', () => {
+  it('returns empty array when element is undefined', () => {
+    expect(getAutoPopulateControls(undefined)).toEqual([]);
+  });
+});
+
+describe('getAutoPopulatedData', () => {
+  it('returns empty array when user is undefined', () => {
+    const uiSchema = { type: 'VerticalLayout', elements: [] };
+    expect(getAutoPopulatedData(uiSchema, undefined)).toEqual([]);
+  });
+});
+
+describe('mergeAutoPopulatedData', () => {
+  it('returns original data unchanged when autoPopulatedData is empty', () => {
+    const data = { foo: 'bar' };
+    expect(mergeAutoPopulatedData(data, [])).toBe(data);
+  });
+});
+
 describe('auto-populate middleware', () => {
   const mockUser: User = {
     name: 'John Doe',
@@ -107,6 +129,15 @@ describe('auto-populate middleware', () => {
         email: 'john@example.com',
       },
     });
+  });
+
+  it('does not modify state for unrelated action types', () => {
+    const middleware = createAutoPopulateMiddleware(uiSchema, mockUser);
+    const existingState = { data: { applicantFirstName: 'Existing' } };
+
+    const state = middleware(existingState, { type: 'SOME_OTHER_ACTION' }, () => existingState);
+
+    expect(state).toBe(existingState);
   });
 
   it('does not overwrite existing values', () => {


### PR DESCRIPTION
## Summary

Fixes the `jsonforms-components` test suite failing due to the global branch coverage threshold (80%) not being met after the auto-population feature was added.

All 1246 tests pass; coverage was at **79.93%** and is now above **80%**.

## Root cause

The `autoPopulate.ts` utility added in the auto-population feature had four untested branches:

| Branch | Location |
|--------|----------|
| `getAutoPopulateControls(undefined)` early return | `autoPopulate.ts:82` |
| `getAutoPopulatedData` when `user` is `undefined` | `autoPopulate.ts:93` |
| `mergeAutoPopulatedData` with empty array (returns data unchanged) | `autoPopulate.ts:106` |
| Middleware early return for non-`INIT`/`UPDATE_CORE` action types | `autoPopulate.ts:130` |

## Changes

- `autoPopulate.spec.tsx`: added imports for `getAutoPopulateControls` and `getAutoPopulatedData`, plus 4 targeted tests covering the missing branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)