### PR TITLE
fix(jsonforms-components): add the global event for the change event

### DIFF
--- a/libs/jsonforms-components/src/lib/Context/ReviewRenderContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ReviewRenderContext.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  ReviewRenderProvider,
+  useReviewContext,
+  REVIEW_CHANGE_ACTION,
+  ReviewChangeState,
+} from './ReviewRenderContext';
+
+function Consumer({ onContext }: { onContext: (ctx: ReturnType<typeof useReviewContext>) => void }): JSX.Element {
+  const ctx = useReviewContext();
+  onContext(ctx);
+  return <button data-testid="trigger" onClick={() => ctx?.onChangeDispatch(1, '#/properties/firstName')} />;
+}
+
+describe('ReviewRenderProvider', () => {
+  it('provides isProvided=true to consumers', () => {
+    let captured: ReturnType<typeof useReviewContext>;
+    render(
+      <ReviewRenderProvider>
+        <Consumer onContext={(ctx) => (captured = ctx)} />
+      </ReviewRenderProvider>,
+    );
+    expect(captured!.isProvided).toBe(true);
+  });
+
+  it('reviewChange is null before any dispatch', () => {
+    let captured: ReturnType<typeof useReviewContext>;
+    render(
+      <ReviewRenderProvider>
+        <Consumer onContext={(ctx) => (captured = ctx)} />
+      </ReviewRenderProvider>,
+    );
+    expect(captured!.reviewChange).toBeNull();
+  });
+
+  it('updates reviewChange state after onChangeDispatch', () => {
+    let captured: ReturnType<typeof useReviewContext>;
+    const { getByTestId } = render(
+      <ReviewRenderProvider>
+        <Consumer onContext={(ctx) => (captured = ctx)} />
+      </ReviewRenderProvider>,
+    );
+
+    act(() => {
+      getByTestId('trigger').click();
+    });
+
+    expect(captured!.reviewChange).toEqual<ReviewChangeState>({ stepId: 1, scope: '#/properties/firstName' });
+  });
+
+  it('calls onReviewChange prop with stepId and scope', () => {
+    const onReviewChange = jest.fn();
+    const { getByTestId } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <Consumer onContext={() => {}} />
+      </ReviewRenderProvider>,
+    );
+
+    act(() => {
+      getByTestId('trigger').click();
+    });
+
+    expect(onReviewChange).toHaveBeenCalledWith(1, '#/properties/firstName');
+  });
+
+  it('does not throw when onReviewChange prop is not provided', () => {
+    const { getByTestId } = render(
+      <ReviewRenderProvider>
+        <Consumer onContext={() => {}} />
+      </ReviewRenderProvider>,
+    );
+
+    expect(() => act(() => getByTestId('trigger').click())).not.toThrow();
+  });
+});
+
+describe('useReviewContext', () => {
+  it('returns undefined when used outside ReviewRenderProvider', () => {
+    let captured: ReturnType<typeof useReviewContext>;
+    render(<Consumer onContext={(ctx) => (captured = ctx)} />);
+    expect(captured!).toBeUndefined();
+  });
+});
+
+describe('REVIEW_CHANGE_ACTION', () => {
+  it('has the correct namespaced value', () => {
+    expect(REVIEW_CHANGE_ACTION).toBe('jsonforms/review/change');
+  });
+});

--- a/libs/jsonforms-components/src/lib/Context/ReviewRenderContext.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ReviewRenderContext.tsx
@@ -1,0 +1,51 @@
+import { createContext, ReactNode, useCallback, useContext, useMemo, useReducer } from 'react';
+
+export interface ReviewChangeState {
+  stepId: number | undefined;
+  scope: string;
+}
+
+type ReviewChangeAction = { type: 'REVIEW_CHANGE'; payload: ReviewChangeState };
+
+function reviewReducer(_state: ReviewChangeState | null, action: ReviewChangeAction): ReviewChangeState | null {
+  if (action.type === 'REVIEW_CHANGE') {
+    return action.payload;
+  }
+  return null;
+}
+
+interface ReviewContext {
+  isProvided: boolean;
+  onChangeDispatch: (stepId: number | undefined, scope: string) => void;
+  reviewChange: ReviewChangeState | null;
+}
+
+export const ReviewRenderContext = createContext<ReviewContext | undefined>(undefined);
+
+interface ReviewRenderProviderProps {
+  children: ReactNode;
+  onReviewChange?: (stepId: number | undefined, scope: string) => void;
+}
+
+export const ReviewRenderProvider = ({ children, onReviewChange }: ReviewRenderProviderProps): JSX.Element => {
+  const [reviewChange, dispatch] = useReducer(reviewReducer, null);
+
+  const onChangeDispatch = useCallback(
+    (stepId: number | undefined, scope: string): void => {
+      dispatch({ type: 'REVIEW_CHANGE', payload: { stepId, scope } });
+      onReviewChange?.(stepId, scope);
+    },
+    [onReviewChange],
+  );
+
+  const context = useMemo(
+    () => ({ isProvided: true, onChangeDispatch, reviewChange }),
+    [onChangeDispatch, reviewChange],
+  );
+
+  return <ReviewRenderContext.Provider value={context}>{children}</ReviewRenderContext.Provider>;
+};
+
+export const useReviewContext = (): ReviewContext | undefined => {
+  return useContext(ReviewRenderContext);
+};

--- a/libs/jsonforms-components/src/lib/Context/ReviewRenderContext.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ReviewRenderContext.tsx
@@ -1,14 +1,16 @@
 import { createContext, ReactNode, useCallback, useContext, useMemo, useReducer } from 'react';
 
+export const REVIEW_CHANGE_ACTION = 'jsonforms/review/change';
+
 export interface ReviewChangeState {
   stepId: number | undefined;
   scope: string;
 }
 
-type ReviewChangeAction = { type: 'REVIEW_CHANGE'; payload: ReviewChangeState };
+export type ReviewChangeAction = { type: typeof REVIEW_CHANGE_ACTION; payload: ReviewChangeState };
 
 function reviewReducer(_state: ReviewChangeState | null, action: ReviewChangeAction): ReviewChangeState | null {
-  if (action.type === 'REVIEW_CHANGE') {
+  if (action.type === REVIEW_CHANGE_ACTION) {
     return action.payload;
   }
   return null;
@@ -32,7 +34,7 @@ export const ReviewRenderProvider = ({ children, onReviewChange }: ReviewRenderP
 
   const onChangeDispatch = useCallback(
     (stepId: number | undefined, scope: string): void => {
-      dispatch({ type: 'REVIEW_CHANGE', payload: { stepId, scope } });
+      dispatch({ type: REVIEW_CHANGE_ACTION, payload: { stepId, scope } });
       onReviewChange?.(stepId, scope);
     },
     [onReviewChange],

--- a/libs/jsonforms-components/src/lib/Context/index.tsx
+++ b/libs/jsonforms-components/src/lib/Context/index.tsx
@@ -1,1 +1,2 @@
 export * from './ContextProvider';
+export * from './ReviewRenderContext';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -8,6 +8,7 @@ import { JsonForms } from '@jsonforms/react';
 import { GoAInputBaseTableReview } from './InputBaseTableReviewControl';
 import { JsonFormsStepperContext, JsonFormsStepperContextProps } from '../FormStepper/context/StepperContext';
 import { invalidSin } from '../../common/Constants';
+import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
 
 import { CategorizationStepperLayoutRendererProps } from '../FormStepper/types';
 import { JsonFormsStepperContextProvider } from '../FormStepper/context';
@@ -754,5 +755,46 @@ describe('InputBaseTableReviewControl', () => {
     );
 
     expect(getByTestId('review-value-').textContent).toBe('');
+  });
+
+  it('calls onReviewChange with stepId and scope when Change button is clicked', () => {
+    const onReviewChange = jest.fn();
+    const mockGoToPage = jest.fn();
+    const contextValue = { goToPage: mockGoToPage } as unknown as JsonFormsStepperContextProps;
+    const scope = '#/properties/firstName';
+
+    const { baseElement } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <JsonFormsStepperContext.Provider value={contextValue}>
+          <table>
+            <tbody>
+              <GoAInputBaseTableReview
+                data="Jane"
+                visible={true}
+                label="First name"
+                path="firstName"
+                schema={{ type: 'string' }}
+                uischema={{ type: 'Control', scope, options: { stepId: 2 } }}
+                enabled={true}
+                errors=""
+                cells={[]}
+                required={false}
+                id="firstName"
+                rootSchema={{ type: 'object', properties: {} }}
+                config={{}}
+                renderers={[]}
+                handleChange={jest.fn()}
+              />
+            </tbody>
+          </table>
+        </JsonFormsStepperContext.Provider>
+      </ReviewRenderProvider>,
+    );
+
+    const changeButton = baseElement.querySelector('goa-button');
+    fireEvent(changeButton!, new CustomEvent('_click'));
+
+    expect(mockGoToPage).toHaveBeenCalledWith(2, scope);
+    expect(onReviewChange).toHaveBeenCalledWith(2, scope);
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -22,11 +22,13 @@ import { humanizeAjvError } from '../ObjectArray/ListWithDetailControl';
 import { GoabButton, GoabFormItem } from '@abgov/react-components';
 
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useReviewContext } from '../../Context/ReviewRenderContext';
 import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
 
 export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null => {
   const { data, uischema, label, schema, rootSchema, path, errors, enabled, cells, required, visible } = props;
   const context = useContext(JsonFormsStepperContext);
+  const reviewCtx = useReviewContext();
   const jsonForms = useJsonForms();
   const reviewLabel = typeof uischema.options?.reviewLabel === 'string' ? (uischema.options.reviewLabel as string) : '';
   const propLabel = typeof label === 'string' ? label : '';
@@ -212,6 +214,11 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
 
   // eslint-disable-next-line
   const stepId = uischema.options?.stepId;
+
+  function handleChangeClick(): void {
+    context?.goToPage(stepId, uischema.scope);
+    reviewCtx?.onChangeDispatch(stepId, uischema.scope);
+  }
   const showInlineValue =
     reviewText === null ||
     reviewText === undefined ||
@@ -236,7 +243,7 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
             {required && <RequiredTextLabel> (required)</RequiredTextLabel>}
           </ReviewLabel>
           {stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
-            <GoabButton type="tertiary" size="compact" onClick={() => context?.goToPage(stepId, uischema.scope)}>
+            <GoabButton type="tertiary" size="compact" onClick={handleChangeClick}>
               Change
             </GoabButton>
           )}


### PR DESCRIPTION
* InputBaseTableReviewControl.tsx — Change button calls onChangeDispatch(stepId, scope) via useReviewContext; logic extracted to named handleChangeClick
* InputBaseTableReviewControl.spec.tsx — Added test verifying onReviewChange fires with correct stepId and scope