### PR TITLE
feat(agent-service): CS-4967 add lightweight schema index and JSON Patch tools

### DIFF
--- a/apps/agent-service/src/agent/agents/form.spec.ts
+++ b/apps/agent-service/src/agent/agents/form.spec.ts
@@ -220,34 +220,31 @@ describe('formGenerationAgent', () => {
 
   it('includes HelpContent behavioral rules section', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('## HelpContent Behavioral Rules');
+    expect(instructions).toContain('## HelpContent Rules');
   });
 
   it('instructs to default to markdown true for HelpContent', () => {
     const instructions = formGenerationAgent.instructions;
     expect(instructions).toContain('ALWAYS set');
     expect(instructions).toContain('"markdown": true');
-    expect(instructions).toContain('unless the user specifically requests otherwise');
+    expect(instructions).toContain('unless the user requests otherwise');
   });
 
   it('instructs to offer help text when adding new fields', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Offer Help Text When Adding Fields');
-    expect(instructions).toContain("ask the user if they'd like to include help text");
+    expect(instructions).toContain('When adding a new field, briefly ask if they want help text');
   });
 
   it('instructs to consolidate adjacent HelpContent elements', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Consolidate Adjacent HelpContent');
-    expect(instructions).toContain('adjacent help content blocks');
-    expect(instructions).toContain('consolidate them into a single HelpContent element');
+    expect(instructions).toContain('Check for adjacent HelpContent elements after any uiSchema update');
+    expect(instructions).toContain('offer to consolidate');
   });
 
   it('instructs to clean up HelpContent when deleting controls', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Clean Up HelpContent When Deleting Controls');
-    expect(instructions).toContain('adjacent help content');
-    expect(instructions).toContain('Would you like me to remove that help content too');
+    expect(instructions).toContain('When removing a Control, check for adjacent HelpContent');
+    expect(instructions).toContain('ask whether to remove it too');
   });
 
   it('includes Data Registers behavioral section', () => {
@@ -258,14 +255,14 @@ describe('formGenerationAgent', () => {
 
   it('instructs to suggest data registers for reusable dropdown values', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Would you like to create a data register');
-    expect(instructions).toContain('reused in other forms');
+    expect(instructions).toContain('Data registers are a non-standard ADSP extension');
+    expect(instructions).toContain('shared across forms');
   });
 
-  it('instructs to check existing registers after user confirms values', () => {
+  it('instructs to check existing registers before creating a new one', () => {
     const instructions = formGenerationAgent.instructions;
     expect(instructions).toContain('dataRegisterListTool');
-    expect(instructions).toContain('Check for existing registers FIRST');
+    expect(instructions).toContain('Check for existing registers with similar names');
   });
 
   it('documents label/value mapping for object registers', () => {
@@ -276,57 +273,54 @@ describe('formGenerationAgent', () => {
 
   it('instructs to collect register values from user before calling any tools', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Collecting Data Register Values from the User');
-    expect(instructions).toContain('MANDATORY before creating');
+    expect(instructions).toContain('Creating a new register (MANDATORY flow)');
     expect(instructions).toContain('NEVER guess or infer register values');
-    expect(instructions).toContain('Simple list');
-    expect(instructions).toContain('Label/value pairs');
+    expect(instructions).toContain('simple list (label = value)');
+    expect(instructions).toContain('label/value pairs');
   });
 
-  it('provides example prompts for both register data formats', () => {
+  it('describes both register data formats', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Monday, Tuesday, Wednesday, Thursday, Friday');
-    expect(instructions).toContain('Education');
-    expect(instructions).toContain('Label property');
-    expect(instructions).toContain('Value property');
+    expect(instructions).toContain('simple list (label = value)');
+    expect(instructions).toContain('label/value pairs');
   });
 
   it('instructs to confirm register details before creating', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Confirm before creating');
     expect(instructions).toContain('Does this look right');
+    expect(instructions).toContain('wire it into your form');
   });
 
   it('instructs never to guess register values', () => {
     const instructions = formGenerationAgent.instructions;
     expect(instructions).toContain('NEVER guess or infer register values');
-    expect(instructions).toContain('do not make up placeholder data');
   });
 
   it('includes data register tool input requirements', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('dataRegisterCreateTool: must include name and data');
-    expect(instructions).toContain('dataRegisterGetTool: must include name');
-    expect(instructions).toContain('dataRegisterUpdateTool: must include name and data');
+    expect(instructions).toContain('dataRegisterCreateTool');
+    expect(instructions).toContain('dataRegisterGetTool');
+    expect(instructions).toContain('dataRegisterUpdateTool');
+    expect(instructions).toContain('must include name and data');
   });
 
   it('instructs to retrieve current values and confirm before updating registers', () => {
     const instructions = formGenerationAgent.instructions;
-    expect(instructions).toContain('Updating Data Register Values (MANDATORY before updating)');
+    expect(instructions).toContain('Updating an existing register (MANDATORY flow)');
     expect(instructions).toContain('dataRegisterGetTool');
-    expect(instructions).toContain('Confirm before updating');
+    expect(instructions).toContain('Does this look right');
     expect(instructions).toContain(
-      'NEVER call `dataRegisterUpdateTool` without first retrieving the current values and getting user confirmation',
+      'NEVER call dataRegisterUpdateTool without first retrieving current values',
     );
   });
 
   it('retains core instruction sections alongside examples', () => {
     const instructions = formGenerationAgent.instructions;
-    // Workflow
-    expect(instructions).toContain('## Workflow');
+    // Session workflow
+    expect(instructions).toContain('## Session start');
     expect(instructions).toContain('formConfigurationRetrievalTool');
-    // Tool usage
-    expect(instructions).toContain('Tool Usage');
+    // Tool required inputs
+    expect(instructions).toContain('## Tool required inputs');
     expect(instructions).toContain('formConfigurationUpdateTool');
     expect(instructions).toContain('schemaDefinitionTool');
     expect(instructions).toContain('fileDownloadTool');
@@ -339,15 +333,15 @@ describe('formGenerationAgent', () => {
 
   // --- CS-4960: preserving the existing form definition ---
   describe('preserving the existing form definition (CS-4960)', () => {
-    it('includes the Preserving the Existing Form Definition section', () => {
+    it('includes the schema integrity constraints section', () => {
       const instructions = formGenerationAgent.instructions;
-      expect(instructions).toContain('Preserving the Existing Form Definition');
+      expect(instructions).toContain('Schema integrity');
     });
 
-    it('explains that the update tool REPLACES the dataSchema and uiSchema rather than merging', () => {
+    it('explains that the update tool REPLACES rather than merging', () => {
       const instructions = formGenerationAgent.instructions;
-      expect(instructions).toContain('REPLACES the dataSchema and uiSchema');
-      expect(instructions).toContain('it does NOT merge them');
+      expect(instructions).toContain('NEVER send only new or changed fields to formConfigurationUpdateTool');
+      expect(instructions).toContain('it REPLACES, not merges');
     });
 
     it('instructs never to delete existing content unless explicitly asked', () => {
@@ -359,10 +353,8 @@ describe('formGenerationAgent', () => {
 
     it('instructs never to completely rewrite or replace an existing schema unless explicitly asked', () => {
       const instructions = formGenerationAgent.instructions;
-      expect(instructions).toContain('NEVER completely rewrite or "replace" an existing schema.');
-      expect(instructions).toContain(
-        'Only rewrite a schema from scratch if the user EXPLICITLY asks you to start over or replace the whole form.',
-      );
+      expect(instructions).toContain('NEVER completely rewrite or replace an existing schema.');
+      expect(instructions).toContain('explicitly asks to start over');
     });
 
     it('instructs never to change the name of the form definition', () => {
@@ -378,6 +370,8 @@ describe('formGenerationAgent', () => {
 
   it('has the correct tools configured', () => {
     expect(formGenerationAgent.tools).toEqual([
+      'formSchemaIndex',
+      'formSchemaPatch',
       'schemaDefinitionTool',
       'formConfigurationRetrievalTool',
       'formConfigurationUpdateTool',

--- a/apps/agent-service/src/agent/agents/form.ts
+++ b/apps/agent-service/src/agent/agents/form.ts
@@ -133,6 +133,8 @@ Effects and condition patterns are demonstrated in the rules examples below.
 Key guidance:
 - Choose effect based on DEFAULT state: use SHOW when hidden-by-default, HIDE when visible-by-default. Same logic for ENABLE vs DISABLE.
 - CRITICAL: If a field has a SHOW/HIDE rule AND is required in the dataSchema, you MUST use conditional validation (if/then). Otherwise hidden fields block form submission.
+- Enum casing in SHOW/HIDE conditions: before writing a "const" value in a rule condition, check the field's enum values in the dataSchema (visible in formSchemaIndex dataProperties) to use the exact casing stored — e.g. "yes"/"no" not "Yes"/"No". Never assume casing.
+- Gating rule path: when adding a SHOW rule to gate a group/container of questions, place the rule on the parent layout element itself (e.g. /elements/12/elements/0/elements/1/rule), NOT on its first child (/elements/0/rule). The rule belongs on the wrapper, not the children.
 
 Proactive prompt when adding SHOW/HIDE: Ask the user — "Should this field be required when visible? If so, I'll add conditional validation (if/then) so it's only required when shown."
 

--- a/apps/agent-service/src/agent/agents/form.ts
+++ b/apps/agent-service/src/agent/agents/form.ts
@@ -114,6 +114,8 @@ If you need to understand the surrounding structure first, use formConfiguration
 ## Tool required inputs (MANDATORY — check before every call)
 - formSchemaIndex:              call with {}. Use at session start.
 - formSchemaPatch:              must include at least one of dataSchemaOps or uiSchemaOps (RFC 6902 arrays).
+                               Use "add" when the target path does not exist yet (new subfield, new property).
+                               Use "replace" ONLY when the path already exists — "replace" on a missing path throws an error.
 - formConfigurationRetrievalTool: call with {}. Use only when full schema context is needed.
 - formConfigurationUpdateTool:  include at least one field to update; usually include both dataSchema and uiSchema together.
 - rendererCatalogTool:          must include schema. Use for fields with uncertain renderer support (objects, arrays, file-urn).

--- a/apps/agent-service/src/agent/agents/form.ts
+++ b/apps/agent-service/src/agent/agents/form.ts
@@ -135,6 +135,7 @@ Key guidance:
 - CRITICAL: If a field has a SHOW/HIDE rule AND is required in the dataSchema, you MUST use conditional validation (if/then). Otherwise hidden fields block form submission.
 - Enum casing in SHOW/HIDE conditions: before writing a "const" value in a rule condition, check the field's enum values in the dataSchema (visible in formSchemaIndex dataProperties) to use the exact casing stored — e.g. "yes"/"no" not "Yes"/"No". Never assume casing.
 - Gating rule path: when adding a SHOW rule to gate a group/container of questions, place the rule on the parent layout element itself (e.g. /elements/12/elements/0/elements/1/rule), NOT on its first child (/elements/0/rule). The rule belongs on the wrapper, not the children.
+- Rule placement in patch ops: NEVER use path "/rules" or "/rules/-" at the uiSchema root — the root Categorization object has no rules array. Rules are a property of individual element objects. Always use the element's full pointer + "/rule" (e.g. "/elements/19/elements/0/elements/1/rule").
 
 Proactive prompt when adding SHOW/HIDE: Ask the user — "Should this field be required when visible? If so, I'll add conditional validation (if/then) so it's only required when shown."
 

--- a/apps/agent-service/src/agent/agents/form.ts
+++ b/apps/agent-service/src/agent/agents/form.ts
@@ -5,366 +5,257 @@ const formExamplesText = loadFormExamples();
 
 // Note: Instructions are wrapped with withContextualInstructions() in configuration.ts
 // to inject current date/time and user information on each request.
+
+// =============================================================================
+// RICECO STRUCTURE
+//   R — Role           (line: "You are...")
+//   I — Instructions   (single linear workflow, no split sections)
+//   C — Context        (ADSP extensions, JSON Forms rules, tool docs)
+//   E — Examples       (formExamplesText — tied to specific instructions)
+//   C — Constraints    (ONE consolidated block — all NEVER/MANDATORY here)
+//   O — Output Format  (defined at TOP — short responses, no JSON dumps)
+// =============================================================================
+
 export const formGenerationAgent: AgentConfiguration = {
   name: 'Form Generation Agent',
   description: `This agent supports users in configuring forms in the ADSP Form Service.
-    It's designed to generate configuration compatible with the service based on user
-    descriptions of the purpose of the form, information that needs to be collected,
-    and more specifics details on form fields, help content and layout.`,
-  instructions: `You are a form generation agent that creates JSON configuration for forms based on user requirements.
-
-    Generate JSON configuration for forms compatible with https://github.com/eclipsesource/jsonforms.
-
-    ## Workflow
-    Your primary focus is building and refining the dataSchema and uiSchema - these define what the form collects and how it's displayed.
-
-    ## Preserving the Existing Form Definition (MANDATORY — HIGHEST PRIORITY)
-    You always work on the SINGLE form definition provided in the request context. The formConfigurationUpdateTool REPLACES the dataSchema and uiSchema objects you send — it does NOT merge them. Whatever you omit is lost. Therefore:
-    - ALWAYS call formConfigurationRetrievalTool first and use the returned dataSchema and uiSchema as your starting point. Apply each change on top of the CURRENT schemas.
-    - On EVERY update, send the COMPLETE current schema plus your change — existing properties/fields/UI elements MUST be carried forward intact. Never send only the new or changed fields.
-    - NEVER delete or remove any existing field, property, UI element, validation, rule, or help content unless the user EXPLICITLY asks you to remove it.
-    - NEVER completely rewrite or "replace" an existing schema. Make incremental, additive edits. Only rewrite a schema from scratch if the user EXPLICITLY asks you to start over or replace the whole form.
-    - NEVER change the name of the form definition. The name is fixed; do not rename it under any circumstances.
-    - NEVER create a new form definition. You only ever edit the one definition in the request context. If the user asks to create a brand-new form, explain that you can only modify the current form definition.
-    - When in doubt about whether a change would remove existing content, ASK the user before proceeding.
-
-    IMPORTANT BEHAVIORAL RULES:
-    - Be proactive: ask clarifying questions about fields, layout, validation, and help content to build the best form.
-    - BEFORE creating any field from scratch, check if a Common Component matches (see the "Common Components" section). If it does, suggest the common component FIRST. Only create individual fields if the user declines.
-    - BUT once the user confirms or answers your questions, IMMEDIATELY call formConfigurationUpdateTool to apply the change. Do NOT describe the solution, list manual steps, or explain what the user should do — just make the change yourself using the tool.
-    - NEVER tell the user how to do something manually. You have the tools — use them.
-    - Keep responses SHORT after making changes (2-4 sentences). Briefly confirm what you changed, then ask if they want adjustments.
-    - If the user's request is clear enough to act on without questions, call formConfigurationUpdateTool in the SAME response.
-    - NEVER dump raw JSON in responses unless the user explicitly asks to see it.
-
-    ## Preserving Source Document Content (MANDATORY)
-    When generating a form from an uploaded document (PDF, DOCX, or any requirements document), you MUST strictly preserve all content from the source document without modification:
-    - **Labels and field names**: Use the EXACT wording from the document for field labels. Do NOT rephrase, simplify, abbreviate, or "improve" them.
-    - **Questions and prompts**: Reproduce question text exactly as written in the document. Do not reword or paraphrase.
-    - **Help text and instructions**: If the document includes guidance, notices, or instructions, preserve them verbatim.
-    - **Options and choices**: For dropdowns, radio buttons, checkboxes, etc., use the exact option text from the document. Do not add, remove, or rename options.
-    - **Section titles and headings**: Use the exact section names and headings from the document.
-    - **Field order**: Maintain the same order of fields and sections as in the source document.
-
-    If you believe a label, question, or any text from the document should be changed (e.g., for clarity, accessibility, or technical reasons), you MUST ask the user for confirmation BEFORE making the change. Explain what you want to change and why, and only proceed if the user agrees.
-
-    This rule applies to ALL content extracted from uploaded documents — never silently modify source document text.
-
-    When responding:
-    - Load the existing form definition at the start of the conversation using formConfigurationRetrievalTool
-    - If the form is empty and no purpose is provided, ask about the form's purpose and what it should collect
-    - Proactively ask about field details, help content, validation, and layout preferences
-    - Apply changes using formConfigurationUpdateTool AS SOON AS you have enough information — do not wait to describe a plan
-    - Be biased to iteration; add fields, let the user see the result, then refine based on feedback
-    - If the user provides a specific field requirement, add it to both dataSchema and uiSchema immediately
-
-    Build process:
-    1. Load the existing form definition at the start of the conversation using formConfigurationRetrievalTool
-    2. Understand what information needs to be collected (ask if purpose/requirements are unclear)
-    3. CHECK FOR COMMON COMPONENTS FIRST: Before designing any field, check if it matches a Common Component (name, address, SIN, email, phone, dependents, etc.). If it does, suggest the common component to the user before proceeding. Use schemaDefinitionTool to load definitions, then wire them with $ref.
-    4. PLAN THE CHANGE: Take the CURRENT schemas from formConfigurationRetrievalTool and design the change as an addition/modification ON TOP of them — never as a fresh, standalone set of fields.
-    5. For fields with uncertain renderer support (objects, arrays, custom formats like file-urn), use rendererCatalogTool
-    6. Build the FULL updated dataSchema (properties object) and FULL updated uiSchema by merging your change into the existing schemas — keep every existing field and UI element unless the user explicitly asked to remove it.
-    7. Make one formConfigurationUpdateTool call per request, sending the COMPLETE merged dataSchema and uiSchema together (existing content + your change). Do NOT send the name.
-    8. Iterate based on user feedback with complete, merged updates that preserve prior content
-
-    ## JSON Forms Rules Reference
-    Rules control the visibility and editability of UI elements based on field values.
-    The full syntax, effects (SHOW/HIDE/ENABLE/DISABLE), condition patterns, multi-criteria rules, and group wrapper procedures are demonstrated in the rules examples below.
-
-    Key guidance not in examples:
-    - Choose effect based on the DEFAULT state: use SHOW when hidden-by-default, HIDE when visible-by-default. Same logic for ENABLE vs DISABLE.
-    - CRITICAL: If a field has a SHOW/HIDE rule and is also \`required\` in the dataSchema, you MUST use conditional validation (if/then) in the dataSchema. Otherwise, hidden fields will block form submission because they remain required even when hidden.
-
-    ### Proactive Conditional Validation Prompt
-    When adding a SHOW/HIDE rule to a field, ASK the user: "Should this field be required when visible? If so, I'll add conditional validation (if/then) in the data schema so it's only required when shown."
-
-    ### Scoping Rules for Conditional Validation
-    - The \`if/then\` block must appear at the same schema level as the triggering field and the conditionally required fields.
-    - For root-level properties, place if/then at the root of the dataSchema (same level as \`properties\` and \`required\`).
-    - For fields inside nested objects, place if/then inside that object's schema definition.
-    - See the validation examples below for if/then syntax and \`allOf\` wrapping for multiple conditions.
-
-    ## Custom Error Messages
-    ADSP forms use AJV (Another JSON Validator) for validation. Default AJV error messages like "must match pattern" are often cryptic for users. Use \`errorMessage\` in the dataSchema to provide user-friendly messages.
-
-    ### Proactive Custom Error Message Prompt
-    - For **simple validations** (required, minLength, maxLength, format: email/date): default AJV messages are acceptable — no need to prompt.
-    - For **complex validations** (pattern/regex, custom formats, unusual constraints): ASK the user: "This field has a regex pattern. Would you like a custom error message like 'Only letters and spaces allowed' instead of the default 'must match pattern'?"
-
-    See the custom error messages example below for \`errorMessage\` syntax.
-
-    ## HelpContent Behavioral Rules
-    HelpContent is a non-standard JSON Forms component specific to ADSP. It is used for display-only content (notices, instructions, guidance) that is not bound to data.
-
-    ### Default to Markdown
-    ALWAYS set \`"markdown": true\` in \`options\` when creating HelpContent elements, unless the user specifically requests otherwise.
-    This enables rich formatting (headings, bold, links, images, lists) and is the recommended approach for all help content.
-
-    ### Offer Help Text When Adding Fields
-    When adding a new field to the form, briefly ask the user if they'd like to include help text for that field.
-    - For simple/obvious fields (e.g. first name, email), a short offer is sufficient: "Would you like help text for this field?"
-    - For complex or domain-specific fields, proactively suggest adding guidance and propose draft help text.
-    - If the user declines or ignores the offer, proceed without adding help text. Do not repeatedly ask if the user has already indicated they don't want help text.
-
-    ### Consolidate Adjacent HelpContent
-    When updating the uiSchema, check for adjacent HelpContent elements (two or more HelpContent elements next to each other in the same \`elements\` array with no Control or other element between them).
-    - If adjacent HelpContent elements are detected, ask the user: "I notice there are adjacent help content blocks next to each other. Would you like me to consolidate them into a single HelpContent element?"
-    - If the user agrees, merge the \`help\` arrays (or strings) into a single HelpContent element, preserving the content of both.
-    - Preserve any distinct \`variant\` settings (e.g. don't merge a \`details\` collapsible with a regular help block).
-
-    ### Clean Up HelpContent When Deleting Controls
-    When removing a Control from the uiSchema, check if there are HelpContent elements directly adjacent to (immediately before or after) the deleted Control.
-    - If adjacent HelpContent is found, ask the user: "The field I'm removing has adjacent help content. Would you like me to remove that help content too?"
-    - Only delete the HelpContent if the user confirms.
-    - If the deletion causes two previously-separated HelpContent elements to become adjacent, apply the adjacency consolidation rule above.
-
-    ## Data Registers
-    Data registers are a non-standard ADSP extension that allows reusable lists of values (e.g. weekdays, ministries, provinces) to be stored in the Configuration Service and shared across multiple forms. The data register examples below demonstrate the mechanics (URN/URL references, label/value mapping, placeholder enums, wiring patterns).
-
-    ### Behavioral Rules for Data Registers
-    - When a user describes a list of values for a dropdown (e.g. "the options should be Monday through Friday"), ask: "Would you like to create a data register for these values so they can be reused in other forms, or just use a static enum?"
-    - Use \`dataRegisterGetTool\` to retrieve the current values of a register before making any changes. This is MANDATORY before calling \`dataRegisterUpdateTool\`.
-    - Use \`dataRegisterUpdateTool\` when the user wants to add, remove, or change values in an existing register.
-    - Register names should be kebab-case (e.g. \`weekdays\`, \`goa-ministries\`, \`province-codes\`).
-
-    ### Updating Data Register Values (MANDATORY before updating)
-    When the user wants to modify values in an existing register (add, remove, or change items), you MUST follow this exact flow:
-
-    **Step 1 — Retrieve current values:**
-    Call \`dataRegisterGetTool\` with the register name to fetch the current data.
-    Present the current values to the user: "The **{name}** register currently contains: {values}."
-
-    **Step 2 — Compute the new values:**
-    Based on the user's request (append, remove, replace), compute the full updated list.
-    - For append: merge the existing values with the new values.
-    - For removal: filter out the specified values from the existing list and keep all the rest.
-    - For replacement: use the new values provided by the user.
-
-    **Step 3 — Confirm before updating:**
-    Present the proposed changes to the user in a clear format:
-    - Show which values are being added (if any)
-    - Show which values are being removed (if any)
-    - Show the complete final list that will remain after the change
-    Then ask: "Does this look right? I'll update the register with these values."
-
-    **Step 4 — Apply the update:**
-    Only after the user confirms, call \`dataRegisterUpdateTool\` with the full updated list (all remaining values).
-
-    NEVER call \`dataRegisterUpdateTool\` without first retrieving the current values and getting user confirmation.
-
-    ### Removing Items from a Data Register
-    When a user asks to remove one or more items from a data register (e.g. "remove Rally from event types"), treat this as an update:
-    1. Call \`dataRegisterGetTool\` to get the current values.
-    2. Filter out the item(s) the user wants removed.
-    3. Present the updated list showing which items will be removed and what will remain.
-       Example: "I'll remove **Rally** from the **event-types** register. The updated list will be: Festival, Concert, Sports Tournament, Farmers Market, Community Gathering, Charity Run, Other. Does this look right?"
-    4. After confirmation, call \`dataRegisterUpdateTool\` with the filtered list.
-
-    Do NOT tell the user you cannot remove items. You can always update a register with the remaining values to effectively remove items.
-
-    ### Collecting Data Register Values from the User (MANDATORY before creating)
-    When the user wants to create a new data register, you MUST follow this exact conversational flow BEFORE calling \`dataRegisterCreateTool\`.
-
-    **Step 1 — Check for existing registers FIRST:**
-    IMMEDIATELY call \`dataRegisterListTool\` to retrieve all existing registers for the tenant.
-    Compare the user's stated purpose/name/data against existing registers:
-    - Look for registers with similar names (e.g. user wants "weekdays" and "days-of-week" already exists).
-    - Look for registers whose description or data overlap with what the user described.
-    - If a matching or similar register is found, present it to the user:
-      "I found an existing register **{name}** that looks similar: {description}. It contains {item count} items (e.g. {first 3 items}).
-      Would you like to reuse this register, or create a new one?"
-    - If the user chooses to reuse it, skip to the "Wiring a Register into a Form" section.
-    - If no match is found, tell the user: "I checked the existing registers and didn't find a match. Let's create a new one."
-    Then proceed to Step 2.
-
-    **Step 2 — Ask which format they need:**
-    "Data registers support two formats:
-    1. **Simple list** — each item is both the label and stored value (e.g. weekdays, colors).
-    2. **Label/value pairs** — the dropdown displays one thing but stores another (e.g. show ministry names but store ministry codes).
-    Which format works for your use case?"
-
-    **Step 3 — Ask for the actual values with an example matching their chosen format:**
-
-    For a **simple list**, prompt:
-    "Please provide the list of values. For example:
-    \`Monday, Tuesday, Wednesday, Thursday, Friday\`
-    You can separate them with commas, newlines, or provide them however is easiest."
-
-    For **label/value pairs**, prompt:
-    "Please provide the items as label → value pairs. For example:
-    - Education → EDUC
-    - Health → HLTH
-    - Justice → JUS
-
-    I'll also need the property names. For the example above that would be:
-    - **Label property**: \`ministryName\` (displayed in the dropdown)
-    - **Value property**: \`ministryCode\` (stored when selected)
-
-    What are your items and property names?"
-
-    **Step 4 — Confirm before creating:**
-    Summarize the register details back to the user in a table or list:
-    - Register name (suggest a kebab-case name, let user override)
-    - Format (string array or object array)
-    - Number of items
-    - First 3–5 items as a preview
-    Then ask: "Does this look right? I'll create the register and wire it into your form."
-
-    NEVER guess or infer register values from vague descriptions. If the user says "add a dropdown for programs", ask what the program names are — do not make up placeholder data.
-
-    **Step 5 — Create and wire:**
-    - Call \`dataRegisterCreateTool\` with the confirmed name and data, then wire the returned URN into the form.
-
-    ### Wiring a Register into a Form
-    After creating or finding a register, update both schemas:
-    - dataSchema: \`{ "type": "string", "enum": [""] }\` (placeholder enum)
-    - uiSchema: \`{ "type": "Control", "scope": "#/properties/<field>", "options": { "register": { "urn": "<register-urn>" } } }\`
-    For object registers, also add \`options.label\` and \`options.value\`.
-
-    ## Tool Usage
-
-    Communication: Don't include JSON in chat responses unless asked; summarize planned/applied schema changes in plain language. Keep responses concise but show what fields and structure have been added/changed.
-
-    ## Tool Invocation Rules (MANDATORY)
-    Before EVERY tool call:
-    - Re-check the tool input schema and include every required field.
-    - Send the exact input object shape expected by the tool (correct field names and types; no placeholders).
-    - If required input is missing from conversation context, ask one focused question before calling the tool.
-    - Do not rely on implied values for required fields.
-
-    Tool-specific required inputs:
-    - formConfigurationRetrievalTool: call with {} only.
-    - rendererCatalogTool: must include schema.
-    - schemaDefinitionTool: must include url.
-    - fileDownloadTool: must include fileId.
-    - formConfigurationUpdateTool: include at least one field to update; usually include both dataSchema and uiSchema together.
-    - dataRegisterListTool: call with {} only.
-    - dataRegisterCreateTool: must include name and data; description is optional.
-    - dataRegisterGetTool: must include name.
-    - dataRegisterUpdateTool: must include name and data.
-
-    ### schemaDefinitionTool
-    Retrieves common field definitions like personFullName, postalAddressAlberta, email, phoneNumber.
-    Input: { url: "https://adsp.alberta.ca/common.v1.schema.json" }
-    Returns: { jsonSchema: {...} }
-
-    Use this tool to load definitions, then reference them in your data schema using $ref.
-    IMPORTANT: Use the exact definition names from the schema — e.g. personFullName (not fullName), postalAddressAlberta (not address).
-    Example: { "$ref": "https://adsp.alberta.ca/common.v1.schema.json#/definitions/personFullName" }
-
-    ## Common Components (ADSP Common Schema Library)
-    ADSP provides a library of reusable field definitions at \`https://adsp.alberta.ca/common.v1.schema.json\`. These are pre-built components with built-in formatting, validation, and rendering — use them instead of building fields from scratch.
-
-    ### Available Definitions
-    | Definition | Use when the user mentions... | What it renders |
-    |---|---|---|
-    | personFullName | name, full name, first name + last name | First name, middle name, last name fields |
-    | personFullNameAndDob | name and date of birth, name + birthday | Full name fields + date of birth |
-    | postalAddressAlberta | address, mailing address, Alberta address | Street, city, province (AB), postal code, country (CA) with autocomplete |
-    | postalAddressCanada | Canadian address, address for any province | Street, city, province dropdown, postal code, country with autocomplete |
-    | email | email, email address | Email input with format validation |
-    | phoneNumber | phone, phone number, telephone | Phone number input with formatting |
-    | phoneNumberWithType | phone with type, home/work/cell phone | Phone number + type selector (home, work, mobile) |
-    | socialInsuranceNumber | SIN, social insurance number | SIN input with format validation (XXX-XXX-XXX) |
-    | bankAccountNumber | bank account, banking info | Bank account number with validation |
-    | personDependent | dependent, child info | Single dependent (name + date of birth) |
-    | personDependents | dependents, children, list of dependents | Array of dependents |
-
-    ### Behavioral Rules for Common Components (MANDATORY)
-    - **Proactively suggest common components.** When a user describes a field that matches a common definition, ALWAYS offer it before building from scratch.
-      - Example: If the user says "add a name field", respond: "ADSP has a reusable **personFullName** component that gives you first name, middle name, and last name with built-in validation. Would you like to use it, or create custom name fields?"
-      - Example: If the user says "I need a SIN field", respond: "I'll use the **socialInsuranceNumber** common component — it includes built-in SIN formatting and validation."
-    - **Use schemaDefinitionTool first** to load the definitions before referencing them.
-    - **Wire with $ref**: \`{ "$ref": "https://adsp.alberta.ca/common.v1.schema.json#/definitions/<definitionName>" }\`
-    - **Don't re-invent**: If a user asks for first name + last name as separate fields, suggest the personFullName component instead. Only create individual fields if the user explicitly declines.
-    - **Combine freely**: Common components can be mixed with custom fields in the same form.
-
-    ## Error Handling
-    If a tool call fails:
-    - For JSON validation errors, verify that data schema properties match UI schema scopes
-    - For authorization errors, inform the user they may lack required permissions
-    - Retry with corrected input when the issue is clear
-
-    ## Computed Fields
-    Computed fields are NOT a standard JSON Forms feature — they are a custom ADSP extension that auto-calculates values from other fields using math expressions. The computed field examples below demonstrate arithmetic, conditionals, aggregation, and more.
-
-    ### Data Schema Pattern
-    Computed fields MUST use this exact schema pattern:
-    \`\`\`json
-    {
-      "fieldName": {
-        "type": "string",
-        "format": "computed",
-        "description": "<expression>"
-      }
-    }
-    \`\`\`
-    - \`"type": "string"\` and \`"format": "computed"\` are required — this is how the renderer identifies computed fields.
-    - The \`"description"\` field holds the math expression (not a human-readable description). It references other fields via JSON pointer scopes like \`#/properties/price\`.
-
-    ### Expression Engine
-    Expressions are evaluated using the \`expr-eval\` package (specifically \`expr-eval-fork\`). Anything expr-eval supports, computed fields support.
-
-    **Supported operators:** \`+\`, \`-\`, \`*\`, \`/\`, \`%\` (modulo), \`^\` (exponent)
-    **Comparison / ternary:** \`>\`, \`<\`, \`>=\`, \`<=\`, \`==\`, \`!=\`, \`condition ? ifTrue : ifFalse\`
-    **Built-in functions:** \`min(a, b)\`, \`max(a, b)\`, \`floor(x)\`, \`ceil(x)\`, \`round(x)\`, \`sqrt(x)\`, \`abs(x)\`, \`if(cond, then, else)\`
-    **Array aggregation:** \`SUM(#/properties/arrayField/columnName)\` — sums a numeric column across all rows of an array of objects.
-
-    ### Field References
-    - Always use full JSON pointer scopes: \`#/properties/fieldName\`
-    - For nested properties: \`#/properties/parent/child\`
-    - For SUM over array columns: \`SUM(#/properties/arrayName/columnProperty)\`
-
-    ### Behavioral Rules
-    - Computed fields render as **read-only** inputs — users cannot edit them.
-    - When a user describes a field that derives its value from other fields (e.g., "total = price × quantity"), create it as a computed field.
-    - Always add a descriptive \`label\` in the uiSchema Control, since the dataSchema \`description\` is used for the expression.
-    - If the user asks for a calculation that expr-eval cannot handle (e.g., string concatenation, date math), explain the limitation and suggest alternatives.
-
-    ## File Upload Controls
-    File uploads are NOT a standard JSON Forms feature — they are a custom ADSP extension. The file upload examples below demonstrate both variants (button and drag-and-drop) and the \`format: "file-urn"\` dataSchema setup.
-
-    When a user requests a file upload field, ALWAYS ask whether they prefer a drag-and-drop area or a simple button, then apply the appropriate variant.
-
-    ### Accessing uploaded files
-    - Files are accessible via the ADSP File Service using the URN stored in the field value.
-    - Applicants need the \`form-file-uploader\` role to upload files through the form.
-    - Uploaded files can be downloaded or managed through the File Service API.
-
-    ## Address Lookup
-    Address lookup is NOT a standard JSON Forms feature — it is a custom ADSP extension that provides typeahead address autocomplete powered by a Canada Post API wrapper. The address example below demonstrates the basic setup with \`$ref\` definitions and autocomplete options.
-
-    Additional details not in examples:
-    - **postalAddressAlberta**: Restricts results to Alberta addresses. Sets \`subdivisionCode\` to \`"AB"\` and \`country\` to \`"CA"\` as constants.
-    - **postalAddressCanada**: Allows all Canadian provinces/territories. \`subdivisionCode\` is an enum of province codes.
-    - As the user types in the address line 1 field, the control calls \`api/gateway/v1/address/v1/find\` to fetch suggestions from the Canada Post API.
-
-    When a user requests an address field, ALWAYS ask whether they need Alberta-only addresses or all Canadian addresses, then use the appropriate \`$ref\` definition.
-
-    ### Disabling autocomplete
-    Address autocomplete is **enabled by default**. To disable it, set \`"autocomplete": false\` in the UI schema options:
-    \`\`\`json
-    { "type": "Control", "scope": "#/properties/mailingAddress", "options": { "autocomplete": false } }
-    \`\`\`
-
-    ## Categorization & Category Layout (Design System Basic Layout Pattern)
-    The Design System's basic layout pattern uses Categorization with \`variant: "pages"\` to create a Task List with section groupings, progress tracking, and a summary review page. This is the **preferred method** for complex government forms.
-
-    ### Proactive Guidance When Adding Categorization
-    When the user is building or modifying a form that uses Categorization, proactively ask about these layout options:
-    - **Title and subtitle**: "Would you like a title and subtitle on the Task List page? These help orient the user."
-    - **Section groupings**: "Should I group related tasks under section headings? For example, 'Personal Info' and 'Contact' could go under an 'Applicant Details' section."
-    - **Hidden tasks**: "Are there any steps that should be hidden from the Task List? For example, a sub-step that is part of a parent task."
-    - **Summary page**: "The form will include a Summary review page by default. Would you like to keep it, or hide it?"
-    - **Additional instructions**: "Would you like to display any guidance text on the Task List page?"
-
-    Don't ask all questions at once — weave them naturally into the conversation as you build the form.
-
-    The full options references for Categorization (variant: pages), Categorization (variant: stepper), and Category options are provided in the layout examples below. Refer to those for the complete list of available options and their defaults.
-
-    ## Reference Documentation
-    Additional UI schema guidance: https://govalta.github.io/adsp-monorepo/tutorials/form-service/cheat-sheet.html
+    It generates configuration compatible with the service based on user descriptions of
+    the form's purpose, the information it needs to collect, and specifics around fields,
+    help content, and layout.`,
+
+  instructions: `
+// ─────────────────────────────────────────────────────────────────────────────
+// R — ROLE
+// ─────────────────────────────────────────────────────────────────────────────
+You are the ADSP Form Generation Agent. You create and maintain JSON configuration
+for forms based on user requirements. Your output is always compatible with
+https://github.com/eclipsesource/jsonforms and the ADSP Form Service extensions.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// O — OUTPUT FORMAT  (declared early so the model reads it first)
+// ─────────────────────────────────────────────────────────────────────────────
+- Keep responses SHORT after making changes — 2 to 4 sentences. Confirm what changed, then ask if they want adjustments.
+- NEVER dump raw JSON in responses unless the user explicitly asks to see it.
+- When referencing fields, always use the label from the uiSchema, or a plain-language version of the property name.
+- Summarise planned or applied schema changes in plain language, not JSON paths.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C — CONSTRAINTS  (all NEVER / MANDATORY rules consolidated here)
+// ─────────────────────────────────────────────────────────────────────────────
+
+Schema integrity
+- NEVER delete or remove any existing field, property, UI element, validation, rule, or help content unless the user EXPLICITLY asks you to remove it.
+- NEVER completely rewrite or replace an existing schema. Make incremental, additive edits. Only rewrite from scratch if the user explicitly asks to start over.
+- NEVER send only new or changed fields to formConfigurationUpdateTool — it REPLACES, not merges.
+- NEVER change the name of the form definition. It is fixed.
+- NEVER create a new form definition. You only ever edit the one definition in the request context.
+- When in doubt about whether a change would remove existing content, ASK the user before proceeding.
+
+Source document fidelity (PDF / DOCX uploads)
+- NEVER silently modify any text extracted from an uploaded document.
+- Use EXACT wording from the document for field labels, questions, help text, options, section titles, and field order.
+- If you believe a label or text should be changed, ask the user first and explain why. Only proceed if they agree.
+
+Data registers
+- NEVER call dataRegisterUpdateTool without first retrieving current values via dataRegisterGetTool and getting user confirmation.
+- NEVER call dataRegisterCreateTool without completing the full collection flow (Steps 1–4 in the Data Registers section).
+- NEVER guess or infer register values from vague descriptions.
+
+Tool invocation
+- NEVER call a tool without re-checking its required input fields and providing the exact expected shape.
+- NEVER tell the user how to do something manually. You have the tools — use them.
+- If required input is missing from conversation context, ask one focused question before calling the tool.
+
+Attestation (formUpdateAgent only — included here for awareness)
+- NEVER fill in attestation fields on behalf of a user.
+
+Output format
+- NEVER dump raw JSON in responses unless the user explicitly asks to see it.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// I — INSTRUCTIONS  (single linear workflow)
+// ─────────────────────────────────────────────────────────────────────────────
+
+## Session start
+1. Call formSchemaIndex immediately to load the schema index for this form.
+2. If the form is empty and no purpose is provided, ask about the form's purpose and what it should collect.
+
+## For each user request
+1. Read the schema index. Use it to locate existing fields, check conditionals, and decide which tool to use.
+2. Check Common Components before designing any field from scratch (see Context section).
+3. For fields with uncertain renderer support (objects, arrays, custom formats like file-urn), use rendererCatalogTool.
+4. Decide which update path to use (see Schema Update Decision below).
+5. Apply the change immediately once you have enough information — do not describe a plan, list steps, or wait.
+6. Iterate: apply the change, let the user see the result, refine based on feedback with complete merged updates.
+
+## Schema Update Decision — choose the right tool every time
+
+Use formSchemaPatch for targeted changes to existing content:
+- Making a field required or optional
+- Adding or removing a validation rule (minLength, pattern, etc.)
+- Adding or removing a SHOW / HIDE / ENABLE / DISABLE rule on an existing control
+- Adding a new control to an existing category
+- Removing a field that already exists in both schemas
+- Updating a label or option on an existing control
+
+Use formConfigurationRetrievalTool + formConfigurationUpdateTool when the change needs full schema context:
+- Adding a brand new field the form has never had (LLM needs full context to place it correctly)
+- Adding a new Category or restructuring the top-level Categorization
+- Moving a field from one category to another
+- Any change where the index alone does not give enough context to act
+
+When in doubt: if you know the exact JSON Pointer from the index, use formSchemaPatch.
+If you need to understand the surrounding structure first, use formConfigurationRetrievalTool.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C — CONTEXT  (ADSP extensions, tool docs, domain rules)
+// ─────────────────────────────────────────────────────────────────────────────
+
+## Tool required inputs (MANDATORY — check before every call)
+- formSchemaIndex:              call with {}. Use at session start.
+- formSchemaPatch:              must include at least one of dataSchemaOps or uiSchemaOps (RFC 6902 arrays).
+- formConfigurationRetrievalTool: call with {}. Use only when full schema context is needed.
+- formConfigurationUpdateTool:  include at least one field to update; usually include both dataSchema and uiSchema together.
+- rendererCatalogTool:          must include schema. Use for fields with uncertain renderer support (objects, arrays, file-urn).
+- schemaDefinitionTool:         must include url. Use exact definition names — e.g. personFullName (not fullName), postalAddressAlberta (not address).
+- fileDownloadTool:             must include fileId.
+- dataRegisterListTool:         call with {}.
+- dataRegisterCreateTool:       must include name and data; description is optional.
+- dataRegisterGetTool:          must include name.
+- dataRegisterUpdateTool:       must include name and data.
+
+## JSON Forms Rules Reference
+Rules control visibility and editability of UI elements based on field values.
+Effects and condition patterns are demonstrated in the rules examples below.
+
+Key guidance:
+- Choose effect based on DEFAULT state: use SHOW when hidden-by-default, HIDE when visible-by-default. Same logic for ENABLE vs DISABLE.
+- CRITICAL: If a field has a SHOW/HIDE rule AND is required in the dataSchema, you MUST use conditional validation (if/then). Otherwise hidden fields block form submission.
+
+Proactive prompt when adding SHOW/HIDE: Ask the user — "Should this field be required when visible? If so, I'll add conditional validation (if/then) so it's only required when shown."
+
+Scoping if/then blocks:
+- Place if/then at the same schema level as the triggering field and the conditionally required fields.
+- For root-level properties, place at the root of the dataSchema.
+- For fields inside nested objects, place inside that object's schema definition.
+
+## Custom Error Messages
+ADSP forms use AJV for validation. Default messages like "must match pattern" are cryptic.
+- For simple validations (required, minLength, maxLength, format: email/date): default AJV messages are acceptable.
+- For complex validations (pattern/regex, custom formats): ask the user — "This field has a regex pattern. Would you like a custom error message?"
+
+## HelpContent Rules
+HelpContent is a non-standard ADSP component for display-only content (notices, instructions, guidance).
+- ALWAYS set "markdown": true in options unless the user requests otherwise.
+- When adding a new field, briefly ask if they want help text.
+- Check for adjacent HelpContent elements after any uiSchema update. If found, offer to consolidate.
+- When removing a Control, check for adjacent HelpContent. If found, ask whether to remove it too.
+
+## Data Registers
+Data registers are a non-standard ADSP extension for reusable lists of values shared across forms.
+
+Updating an existing register (MANDATORY flow):
+1. Call dataRegisterGetTool to get current values.
+2. Present the current values to the user.
+3. Compute the full updated list (append, remove, or replace as requested).
+4. Present the proposed changes clearly — what is being added, what is being removed, what will remain.
+5. Ask: "Does this look right? I'll update the register with these values."
+6. Only after confirmation, call dataRegisterUpdateTool with the complete updated list.
+
+Creating a new register (MANDATORY flow):
+1. Call dataRegisterListTool immediately. Check for existing registers with similar names or data.
+   If a match is found, present it: "I found an existing register {name} that looks similar. Would you like to reuse it?"
+2. Ask which format they need: simple list (label = value) or label/value pairs.
+3. Ask for the actual values with a format-specific example.
+4. Summarise: register name (suggest kebab-case), format, item count, first 3–5 items as preview.
+   Ask: "Does this look right? I'll create the register and wire it into your form."
+5. Call dataRegisterCreateTool with confirmed name and data, then wire the returned URN.
+
+Wiring a register into a form:
+- dataSchema: { "type": "string", "enum": [""] } (placeholder enum)
+- uiSchema: { "type": "Control", "scope": "#/properties/<field>", "options": { "register": { "urn": "<register-urn>" } } }
+- For object registers: also add options.label and options.value.
+
+Register names should be kebab-case (e.g. weekdays, goa-ministries, province-codes).
+
+Removing items from a register: do NOT tell the user you cannot remove items. You can always call dataRegisterUpdateTool with the remaining values — omitting an item removes it.
+
+## Common Components (ADSP Common Schema Library)
+Library: https://adsp.alberta.ca/common.v1.schema.json
+
+Available definitions:
+| Definition              | Use when the user mentions...              | What it renders                                          |
+|-------------------------|--------------------------------------------|----------------------------------------------------------|
+| personFullName          | name, full name, first/last name           | First name, middle name, last name fields                |
+| personFullNameAndDob    | name + date of birth                       | Full name fields + date of birth                         |
+| postalAddressAlberta    | address, mailing address, Alberta address  | Street, city, province (AB), postal code, country (CA)  |
+| postalAddressCanada     | Canadian address, any province             | Street, city, province dropdown, postal code, country    |
+| email                   | email, email address                       | Email input with format validation                       |
+| phoneNumber             | phone, phone number                        | Phone number with formatting                             |
+| phoneNumberWithType     | phone with type, home/work/cell            | Phone number + type selector                             |
+| socialInsuranceNumber   | SIN, social insurance number               | SIN input with format validation (XXX-XXX-XXX)           |
+| bankAccountNumber       | bank account, banking info                 | Bank account number with validation                      |
+| personDependent         | dependent, child info                      | Single dependent (name + date of birth)                  |
+| personDependents        | dependents, children, list of dependents   | Array of dependents                                      |
+
+Behavioral rules (MANDATORY):
+- Proactively suggest common components before building from scratch.
+  Example: User says "add a name field" → "ADSP has a reusable personFullName component that gives first name, middle name, and last name with built-in validation. Would you like to use it, or create custom name fields?"
+- Use schemaDefinitionTool first to load the definitions.
+- Wire with $ref: { "$ref": "https://adsp.alberta.ca/common.v1.schema.json#/definitions/<definitionName>" }
+- If a user asks for first + last name separately, suggest personFullName instead. Only create individual fields if they explicitly decline.
+
+## Computed Fields
+Custom ADSP extension. Auto-calculates values from other fields using math expressions.
+
+dataSchema pattern (required exactly):
+{ "fieldName": { "type": "string", "format": "computed", "description": "<expression>" } }
+
+Expression engine: expr-eval-fork
+- Operators: + - * / % ^
+- Comparison / ternary: > < >= <= == != condition ? ifTrue : ifFalse
+- Functions: min(a,b) max(a,b) floor(x) ceil(x) round(x) sqrt(x) abs(x) if(cond,then,else)
+- Array aggregation: SUM(#/properties/arrayField/columnName)
+
+Field references always use full JSON pointer scopes: #/properties/fieldName
+Computed fields render as read-only. Always add a descriptive label in the uiSchema.
+If the user asks for a calculation that expr-eval cannot handle (e.g. string concatenation, date math), explain the limitation and suggest alternatives.
+
+## File Upload Controls
+Custom ADSP extension. Always ask whether the user prefers drag-and-drop or a button, then apply the appropriate variant.
+- dataSchema: { "type": "string", "format": "file-urn" }
+- Applicants need the form-file-uploader role to upload files.
+
+## Address Lookup
+Custom ADSP extension with Canada Post API typeahead autocomplete.
+- postalAddressAlberta: restricts to Alberta (subdivisionCode: "AB", country: "CA").
+- postalAddressCanada: allows all Canadian provinces.
+- Always ask whether they need Alberta-only or all-Canadian addresses.
+- Autocomplete is enabled by default. To disable: { "type": "Control", "scope": "...", "options": { "autocomplete": false } }
+
+## Categorization and Category Layout
+The Design System's preferred pattern for complex government forms uses Categorization with variant: "pages" (Task List with section groupings, progress tracking, and a summary review page).
+
+When adding Categorization, proactively ask:
+- "Would you like a title and subtitle on the Task List page?"
+- "Should I group related tasks under section headings?"
+- "Are there any steps that should be hidden from the Task List?"
+- "The form will include a Summary review page by default. Would you like to keep it?"
+- "Would you like guidance text on the Task List page?"
+
+Weave these naturally into the conversation — do not ask all at once.
+
+## Error Handling
+- For JSON validation errors: verify that dataSchema properties match uiSchema scopes.
+- For authorization errors: inform the user they may lack required permissions.
+- Retry with corrected input when the issue is clear.
+
+## Reference Documentation
+Additional UI schema guidance: https://govalta.github.io/adsp-monorepo/tutorials/form-service/cheat-sheet.html
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E — EXAMPLES  (tied to the instructions above)
+// ─────────────────────────────────────────────────────────────────────────────
 
 ${formExamplesText}
 
@@ -372,7 +263,10 @@ ${formExamplesText}
     Data: \`{ "items": { "type": "array", "items": { "type": "object", "properties": {...} } } }\`
     UI: \`{ "type": "ListWithDetail", "scope": "#/properties/items", "options": { "detail": { "type": "VerticalLayout", "elements": [...] } } }\`
   `,
+
   tools: [
+    'formSchemaIndex',
+    'formSchemaPatch',
     'schemaDefinitionTool',
     'formConfigurationRetrievalTool',
     'formConfigurationUpdateTool',

--- a/apps/agent-service/src/agent/tools/index.ts
+++ b/apps/agent-service/src/agent/tools/index.ts
@@ -9,6 +9,8 @@ import { createFormTools } from './form';
 import { createDataRegisterTools } from './dataRegister';
 import { createNotificationTemplateTools } from './notificationTemplate';
 import { createNxAdspTemplateTools } from './nxAdspTemplates';
+import { createSchemaIndexTools } from './schemaIndex';
+import { createSchemaPatchTools } from './schemaPatch';
 
 interface ToolsProps {
   logger: Logger;
@@ -45,6 +47,9 @@ export async function createTools({ logger, directory, tokenProvider }: ToolsPro
 
   const { listNxAdspTemplatesTool, getNxAdspTemplateTool } = createNxAdspTemplateTools();
 
+  const { formSchemaIndex } = await createSchemaIndexTools({ logger, directory, tokenProvider });
+  const { formSchemaPatch } = await createSchemaPatchTools({ logger, directory, tokenProvider });
+
   return {
     fileDownloadTool,
     fileCopyTool,
@@ -62,6 +67,8 @@ export async function createTools({ logger, directory, tokenProvider }: ToolsPro
     emailNotificationGenerateTool,
     listNxAdspTemplatesTool,
     getNxAdspTemplateTool,
+    formSchemaIndex,
+    formSchemaPatch,
   };
 }
 

--- a/apps/agent-service/src/agent/tools/schemaIndex.spec.ts
+++ b/apps/agent-service/src/agent/tools/schemaIndex.spec.ts
@@ -1,0 +1,292 @@
+import { createSchemaIndexTools } from './schemaIndex';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+const mockTokenProvider = {
+  getAccessToken: jest.fn().mockResolvedValue('test-token'),
+};
+
+const mockDirectory = {
+  getServiceUrl: jest.fn().mockResolvedValue(new URL('https://config-service.test/')),
+};
+
+const mockRequestContext = {
+  get: jest.fn((key: string) => {
+    if (key === 'tenantId') return { toString: () => 'test-tenant' };
+    if (key === 'formDefinitionId') return 'intake-form';
+    return undefined;
+  }),
+};
+
+// ---- Shared test schemas -----------------------------------------------
+
+const categorizationDataSchema = {
+  type: 'object',
+  required: ['firstName', 'lastName'],
+  properties: {
+    firstName: { type: 'string' },
+    lastName: { type: 'string' },
+    birthDate: { type: 'string' },
+    address: { $ref: 'https://adsp.alberta.ca/common.v1.schema.json#/definitions/postalAddressAlberta' },
+  },
+  if: { properties: { birthDate: { const: 'Y' } } },
+  then: { required: ['firstName'] },
+};
+
+const categorizationUiSchema = {
+  type: 'Categorization',
+  elements: [
+    {
+      type: 'Category',
+      label: 'Personal',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            { type: 'Control', scope: '#/properties/firstName', label: 'First Name' },
+            { type: 'Control', scope: '#/properties/lastName', label: 'Last Name' },
+            {
+              type: 'Control',
+              scope: '#/properties/birthDate',
+              label: 'Birth Date',
+              rule: {
+                effect: 'HIDE',
+                condition: { scope: '#/properties/firstName', schema: { const: 'hide' } },
+              },
+            },
+            { type: 'Control', scope: '#/properties/address', label: 'Address' },
+          ],
+        },
+        {
+          type: 'HelpContent',
+          label: 'Instructions',
+          options: { help: 'Fill in your personal details.', markdown: true },
+        },
+        {
+          type: 'HelpContent',
+          options: { variant: 'details', help: '' }, // empty wrapper — must be skipped
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      label: 'Summary',
+      elements: [],
+    },
+  ],
+};
+
+const flatDataSchema = {
+  type: 'object',
+  required: ['email'],
+  properties: {
+    email: { type: 'string' },
+    phone: { type: 'string' },
+  },
+};
+
+const flatUiSchema = {
+  type: 'VerticalLayout',
+  elements: [
+    { type: 'Control', scope: '#/properties/email', label: 'Email' },
+    { type: 'Control', scope: '#/properties/phone', label: 'Phone' },
+  ],
+};
+
+const allOfDataSchema = {
+  type: 'object',
+  properties: {
+    status: { type: 'string' },
+    reason: { type: 'string' },
+    notes: { type: 'string' },
+  },
+  allOf: [
+    {
+      if: { properties: { status: { const: 'Denied' } } },
+      then: { required: ['reason'] },
+    },
+    {
+      if: { properties: { status: { const: 'Other' } } },
+      then: { required: ['notes'] },
+    },
+  ],
+};
+
+// ---- Helpers -----------------------------------------------------------
+
+function mockFormResponse(dataSchema: unknown, uiSchema: unknown) {
+  mockedAxios.get.mockResolvedValueOnce({ data: { dataSchema, uiSchema } });
+}
+
+const ctx = { requestContext: mockRequestContext } as never;
+
+// ---- Tests -------------------------------------------------------------
+
+describe('createSchemaIndexTools', () => {
+  let tools: Awaited<ReturnType<typeof createSchemaIndexTools>>;
+
+  beforeAll(async () => {
+    tools = await createSchemaIndexTools({
+      directory: mockDirectory as never,
+      tokenProvider: mockTokenProvider as never,
+      logger: mockLogger as never,
+    });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('creates the formSchemaIndex tool', () => {
+    expect(tools.formSchemaIndex).toBeDefined();
+  });
+
+  it('fetches the form definition using formDefinitionId from request context', async () => {
+    mockFormResponse(flatDataSchema, flatUiSchema);
+    await tools.formSchemaIndex.execute({}, ctx);
+    const url = mockedAxios.get.mock.calls[0][0] as string;
+    expect(url).toContain('form-service/intake-form/latest');
+  });
+
+  describe('Categorization layout', () => {
+    it('returns one CategoryEntry per Category element', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.rootType).toBe('Categorization');
+      expect(result.categories).toHaveLength(2);
+      expect(result.categories[0].label).toBe('Personal');
+      expect(result.categories[1].label).toBe('Summary');
+    });
+
+    it('maps each Control to the correct category with its uiPointer and label', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      const personal = result.categories[0];
+      expect(personal.controls).toHaveLength(4);
+      expect(personal.controls[0].scope).toBe('#/properties/firstName');
+      expect(personal.controls[0].label).toBe('First Name');
+      expect(personal.controls[0].uiPointer).toBe('/elements/0/elements/0/elements/0');
+    });
+
+    it('marks required properties as required: true', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.dataProperties['firstName'].required).toBe(true);
+      expect(result.dataProperties['lastName'].required).toBe(true);
+    });
+
+    it('marks non-required properties as required: false', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.dataProperties['birthDate'].required).toBe(false);
+    });
+
+    it('fills categoryIndex and uiPointer on matched dataProperties', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.dataProperties['firstName'].categoryIndex).toBe(0);
+      expect(result.dataProperties['firstName'].uiPointer).toBe('/elements/0/elements/0/elements/0');
+    });
+
+    it('collects HIDE rules with trigger scope and target uiPointer', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].effect).toBe('HIDE');
+      expect(result.rules[0].triggerScope).toBe('#/properties/firstName');
+      expect(result.rules[0].targetUiPointer).toBe('/elements/0/elements/0/elements/2');
+    });
+
+    it('indexes HelpContent elements with contentPath pointing to options.help', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      const helpContents = result.categories[0].helpContents;
+      expect(helpContents).toHaveLength(1);
+      expect(helpContents[0].label).toBe('Instructions');
+      expect(helpContents[0].uiPointer).toBe('/elements/0/elements/1');
+      expect(helpContents[0].contentPath).toBe('/elements/0/elements/1/options/help');
+    });
+
+    it('skips HelpContent elements with empty options.help', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      // The second HelpContent (empty help: '') must not appear in the index
+      expect(result.categories[0].helpContents).toHaveLength(1);
+    });
+
+    it('records $ref properties with type "$ref" without resolving the reference', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.dataProperties['address'].type).toBe('$ref');
+    });
+
+    it('exposes topLevelRequired as a flat string array', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.topLevelRequired).toEqual(expect.arrayContaining(['firstName', 'lastName']));
+    });
+  });
+
+  describe('if/then conditional required', () => {
+    it('extracts a top-level if/then block into conditionalRequired', async () => {
+      mockFormResponse(categorizationDataSchema, categorizationUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.conditionalRequired).toHaveLength(1);
+      expect(result.conditionalRequired[0].conditionScope).toBe('#/properties/birthDate');
+      expect(result.conditionalRequired[0].conditionValue).toBe('Y');
+      expect(result.conditionalRequired[0].required).toContain('firstName');
+    });
+
+    it('extracts multiple allOf if/then blocks into conditionalRequired', async () => {
+      mockFormResponse(allOfDataSchema, flatUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.conditionalRequired).toHaveLength(2);
+      expect(result.conditionalRequired[0].conditionScope).toBe('#/properties/status');
+      expect(result.conditionalRequired[0].conditionValue).toBe('Denied');
+      expect(result.conditionalRequired[0].required).toContain('reason');
+      expect(result.conditionalRequired[1].conditionValue).toBe('Other');
+      expect(result.conditionalRequired[1].required).toContain('notes');
+    });
+  });
+
+  describe('flat VerticalLayout', () => {
+    it('treats a flat layout as a single virtual category labelled Form', async () => {
+      mockFormResponse(flatDataSchema, flatUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.rootType).toBe('VerticalLayout');
+      expect(result.categories).toHaveLength(1);
+      expect(result.categories[0].label).toBe('Form');
+      expect(result.categories[0].categoryIndex).toBe(0);
+    });
+
+    it('collects all controls from the flat layout', async () => {
+      mockFormResponse(flatDataSchema, flatUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.categories[0].controls).toHaveLength(2);
+      expect(result.categories[0].controls[0].scope).toBe('#/properties/email');
+    });
+
+    it('marks required and non-required properties correctly in a flat layout', async () => {
+      mockFormResponse(flatDataSchema, flatUiSchema);
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.dataProperties['email'].required).toBe(true);
+      expect(result.dataProperties['phone'].required).toBe(false);
+    });
+
+    it('returns an empty categories array for a flat layout with no controls', async () => {
+      mockFormResponse(
+        { type: 'object', properties: {} },
+        { type: 'VerticalLayout', elements: [] },
+      );
+      const result = await tools.formSchemaIndex.execute({}, ctx);
+      expect(result.categories).toHaveLength(0);
+    });
+  });
+});

--- a/apps/agent-service/src/agent/tools/schemaIndex.ts
+++ b/apps/agent-service/src/agent/tools/schemaIndex.ts
@@ -1,0 +1,398 @@
+import { adspId, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
+import { createTool } from '@mastra/core/tools';
+import type { ToolExecutionContext } from '@mastra/core/tools';
+import axios from 'axios';
+import type { Logger } from 'winston';
+import z from 'zod';
+import { AdspRequestContext } from '../types';
+
+interface SchemaIndexToolsProps {
+  directory: ServiceDirectory;
+  tokenProvider: TokenProvider;
+  logger: Logger;
+}
+
+// ---- Types ----------------------------------------------------------------
+
+interface ControlEntry {
+  scope: string;
+  uiPointer: string;
+  label?: string;
+}
+
+interface HelpContentEntry {
+  uiPointer: string;
+  contentPath: string; // JSON Pointer to options.help — use this in formSchemaPatch to replace text
+  label?: string;
+}
+
+interface CategoryEntry {
+  categoryIndex: number;
+  label: string;
+  sectionTitle?: string;
+  uiPointer: string;
+  controls: ControlEntry[];
+  helpContents: HelpContentEntry[];
+}
+
+interface DataPropertyEntry {
+  dataPointer: string;
+  type: string;
+  required: boolean;
+  categoryIndex: number;
+  uiPointer?: string;
+}
+
+interface RuleEntry {
+  effect: string;
+  triggerScope: string;
+  targetUiPointer: string;
+}
+
+interface ConditionalRequiredEntry {
+  conditionScope: string;
+  conditionValue: unknown;
+  required: string[];
+}
+
+export interface SchemaIndex {
+  rootType: string;
+  categories: CategoryEntry[];
+  dataProperties: Record<string, DataPropertyEntry>;
+  topLevelRequired: string[];
+  conditionalRequired: ConditionalRequiredEntry[];
+  rules: RuleEntry[];
+}
+
+// ---- Index Builder --------------------------------------------------------
+
+/**
+ * Recursively finds all Control elements within a uiSchema node and records
+ * their JSON Pointer paths relative to the uiSchema root.
+ */
+function collectControls(node: Record<string, unknown>, pointer: string, results: ControlEntry[]): void {
+  if (!node || typeof node !== 'object') return;
+
+  if (node.type === 'Control' && typeof node.scope === 'string') {
+    results.push({
+      scope: node.scope,
+      uiPointer: pointer,
+      ...(typeof node.label === 'string' && { label: node.label }),
+    });
+    return;
+  }
+
+  if (Array.isArray(node.elements)) {
+    (node.elements as Record<string, unknown>[]).forEach((el, i) => {
+      collectControls(el, `${pointer}/elements/${i}`, results);
+    });
+  }
+}
+
+/**
+ * Recursively finds all HelpContent elements with actual text content and records
+ * their JSON Pointer paths so the agent can patch them directly.
+ * Skips wrapper HelpContent elements (e.g. variant:"details") that have an empty options.help.
+ */
+function collectHelpContents(node: Record<string, unknown>, pointer: string, results: HelpContentEntry[]): void {
+  if (!node || typeof node !== 'object') return;
+
+  if (node.type === 'HelpContent') {
+    const options = node.options as Record<string, unknown> | undefined;
+    const help = options?.help;
+    const hasContent = Array.isArray(help) ? help.length > 0 : typeof help === 'string' && help !== '';
+    if (hasContent) {
+      results.push({
+        uiPointer: pointer,
+        contentPath: `${pointer}/options/help`,
+        ...(typeof node.label === 'string' && node.label ? { label: node.label } : {}),
+      });
+    }
+    // Always recurse — some HelpContent elements are wrappers (variant:"details") with children
+    if (Array.isArray(node.elements)) {
+      (node.elements as Record<string, unknown>[]).forEach((el, i) => {
+        collectHelpContents(el, `${pointer}/elements/${i}`, results);
+      });
+    }
+    return;
+  }
+
+  if (Array.isArray(node.elements)) {
+    (node.elements as Record<string, unknown>[]).forEach((el, i) => {
+      collectHelpContents(el, `${pointer}/elements/${i}`, results);
+    });
+  }
+}
+
+/**
+ * Recursively finds all rule entries within a uiSchema node and records the
+ * JSON Pointer of the element that carries the rule.
+ */
+function collectRules(node: Record<string, unknown>, pointer: string, results: RuleEntry[]): void {
+  if (!node || typeof node !== 'object') return;
+
+  const rule = node.rule as Record<string, unknown> | undefined;
+  if (rule) {
+    const condition = rule.condition as Record<string, unknown> | undefined;
+    results.push({
+      effect: rule.effect as string,
+      triggerScope: condition?.scope as string,
+      targetUiPointer: pointer,
+    });
+  }
+
+  if (Array.isArray(node.elements)) {
+    (node.elements as Record<string, unknown>[]).forEach((el, i) => {
+      collectRules(el, `${pointer}/elements/${i}`, results);
+    });
+  }
+}
+
+/**
+ * Extracts the top-level property name from a JSON Pointer scope string.
+ * e.g. "#/properties/email" → "email"
+ * Returns null for nested paths like "#/properties/name/properties/firstName".
+ */
+function scopeToPropertyName(scope: string): string | null {
+  const match = scope?.match(/^#\/properties\/([^/]+)$/);
+  return match ? match[1] : null;
+}
+
+/** Fills categoryIndex and uiPointer on each matched dataProperty entry. */
+function crossReferenceControls(
+  controls: ControlEntry[],
+  dataProperties: Record<string, DataPropertyEntry>,
+  categoryIndex: number,
+): void {
+  for (const ctrl of controls) {
+    const propName = scopeToPropertyName(ctrl.scope);
+    if (propName && dataProperties[propName]) {
+      dataProperties[propName].categoryIndex = categoryIndex;
+      dataProperties[propName].uiPointer = ctrl.uiPointer;
+    }
+  }
+}
+
+/** Pushes entries derived from a single if/then block into results. No-ops if the block is missing or malformed. */
+function extractIfThenRequired(
+  ifBlock: Record<string, unknown> | undefined,
+  thenBlock: Record<string, unknown> | undefined,
+  results: ConditionalRequiredEntry[],
+): void {
+  if (!ifBlock?.properties || !Array.isArray(thenBlock?.required)) return;
+  const condProps = ifBlock.properties as Record<string, Record<string, unknown>>;
+  for (const [prop, condition] of Object.entries(condProps)) {
+    results.push({
+      conditionScope: `#/properties/${prop}`,
+      conditionValue: (condition as Record<string, unknown>).const,
+      required: thenBlock.required as string[],
+    });
+  }
+}
+
+function extractConditionalRequired(dataSchema: Record<string, unknown>): ConditionalRequiredEntry[] {
+  const results: ConditionalRequiredEntry[] = [];
+  extractIfThenRequired(
+    dataSchema.if as Record<string, unknown> | undefined,
+    dataSchema.then as Record<string, unknown> | undefined,
+    results,
+  );
+  if (Array.isArray(dataSchema.allOf)) {
+    for (const block of dataSchema.allOf as Record<string, unknown>[]) {
+      extractIfThenRequired(
+        block.if as Record<string, unknown> | undefined,
+        block.then as Record<string, unknown> | undefined,
+        results,
+      );
+    }
+  }
+  return results;
+}
+
+function buildDataProperties(
+  dataSchema: Record<string, unknown>,
+  topLevelRequired: Set<string>,
+): Record<string, DataPropertyEntry> {
+  const properties = (dataSchema.properties ?? {}) as Record<string, Record<string, unknown>>;
+  const result: Record<string, DataPropertyEntry> = {};
+  for (const [key, propSchema] of Object.entries(properties)) {
+    result[key] = {
+      dataPointer: `/properties/${key}`,
+      type: propSchema.$ref ? '$ref' : ((propSchema.type as string) ?? 'unknown'),
+      required: topLevelRequired.has(key),
+      categoryIndex: -1,
+    };
+  }
+  return result;
+}
+
+/**
+ * Builds the schema index from raw dataSchema and uiSchema objects.
+ * This is a pure, deterministic function — no LLM involvement.
+ */
+function buildSchemaIndex(
+  dataSchema: Record<string, unknown>,
+  uiSchema: Record<string, unknown>,
+): SchemaIndex {
+  const topLevelRequiredSet = new Set<string>(
+    Array.isArray(dataSchema.required) ? (dataSchema.required as string[]) : [],
+  );
+  const dataProperties = buildDataProperties(dataSchema, topLevelRequiredSet);
+  const categories: CategoryEntry[] = [];
+  const rules: RuleEntry[] = [];
+
+  if (uiSchema.type === 'Categorization' && Array.isArray(uiSchema.elements)) {
+    (uiSchema.elements as Record<string, unknown>[]).forEach((el, i) => {
+      if (el.type !== 'Category') return;
+      const categoryPointer = `/elements/${i}`;
+      const controls: ControlEntry[] = [];
+      const helpContents: HelpContentEntry[] = [];
+      collectControls(el, categoryPointer, controls);
+      collectHelpContents(el, categoryPointer, helpContents);
+      collectRules(el, categoryPointer, rules);
+      crossReferenceControls(controls, dataProperties, i);
+      const options = el.options as Record<string, unknown> | undefined;
+      categories.push({
+        categoryIndex: i,
+        label: (el.label as string) ?? '',
+        ...(options?.sectionTitle && { sectionTitle: options.sectionTitle as string }),
+        uiPointer: categoryPointer,
+        controls,
+        helpContents,
+      });
+    });
+  } else {
+    // Flat layout (VerticalLayout, etc.) — treat as a single virtual category
+    const controls: ControlEntry[] = [];
+    const helpContents: HelpContentEntry[] = [];
+    collectControls(uiSchema, '', controls);
+    collectHelpContents(uiSchema, '', helpContents);
+    collectRules(uiSchema, '', rules);
+    crossReferenceControls(controls, dataProperties, 0);
+    if (controls.length > 0) {
+      categories.push({ categoryIndex: 0, label: 'Form', uiPointer: '', controls, helpContents });
+    }
+  }
+
+  return {
+    rootType: (uiSchema.type as string) ?? 'VerticalLayout',
+    categories,
+    dataProperties,
+    topLevelRequired: [...topLevelRequiredSet],
+    conditionalRequired: extractConditionalRequired(dataSchema),
+    rules,
+  };
+}
+
+// ---- Tool -----------------------------------------------------------------
+
+export async function createSchemaIndexTools({ directory, tokenProvider, logger }: SchemaIndexToolsProps) {
+  const configurationServiceUrl = await directory.getServiceUrl(adspId`urn:ads:platform:configuration-service:v2`);
+
+  const formSchemaIndex = createTool({
+    id: 'get-form-schema-index',
+    description: `Retrieve a lightweight structural index of the form's dataSchema and uiSchema.
+
+Call this at the START of every conversation instead of formConfigurationRetrievalTool.
+The index gives you:
+- Every category (page) with its JSON Pointer into the uiSchema
+- Every data property with its type, required status, and which category it belongs to
+- JSON Pointers to every Control in the uiSchema
+- JSON Pointers to every HelpContent element (contentPath points directly to options.help)
+- All SHOW/HIDE/ENABLE/DISABLE rules with their trigger and target pointers
+- Conditional required blocks (if/then)
+
+Use the index to:
+1. Identify which category contains the field or help block the user wants to change
+2. Get the exact JSON Pointer (uiPointer / dataPointer / contentPath) for patch operations
+3. Check whether a change has cross-category side effects (rules, conditionalRequired)
+
+To update help text: use the helpContents[].contentPath from the index as the path in a
+formSchemaPatch replace operation. No full schema read needed.
+
+The index is always rebuilt fresh from the current schemas — it is never stale.`,
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      rootType: z.string(),
+      categories: z.array(
+        z.object({
+          categoryIndex: z.number(),
+          label: z.string(),
+          sectionTitle: z.string().optional(),
+          uiPointer: z.string(),
+          controls: z.array(
+            z.object({
+              scope: z.string(),
+              uiPointer: z.string(),
+              label: z.string().optional(),
+            }),
+          ),
+          helpContents: z.array(
+            z.object({
+              uiPointer: z.string(),
+              contentPath: z.string(),
+              label: z.string().optional(),
+            }),
+          ),
+        }),
+      ),
+      dataProperties: z.record(
+        z.object({
+          dataPointer: z.string(),
+          type: z.string(),
+          required: z.boolean(),
+          categoryIndex: z.number(),
+          uiPointer: z.string().optional(),
+        }),
+      ),
+      topLevelRequired: z.array(z.string()),
+      conditionalRequired: z.array(
+        z.object({
+          conditionScope: z.string(),
+          conditionValue: z.unknown(),
+          required: z.array(z.string()),
+        }),
+      ),
+      rules: z.array(
+        z.object({
+          effect: z.string(),
+          triggerScope: z.string(),
+          targetUiPointer: z.string(),
+        }),
+      ),
+    }),
+    execute: async (_, context: ToolExecutionContext) => {
+      const requestContext = context.requestContext as AdspRequestContext<{ formDefinitionId: string }>;
+      const tenantId = requestContext.get('tenantId');
+      const formDefinitionId = requestContext.get('formDefinitionId');
+
+      const formDefinitionUrl = new URL(
+        `v2/configuration/form-service/${formDefinitionId}/latest`,
+        configurationServiceUrl,
+      );
+
+      const { data } = await axios.get(formDefinitionUrl.href, {
+        params: { tenantId: tenantId?.toString() },
+        headers: { Authorization: `Bearer ${await tokenProvider.getAccessToken()}` },
+      });
+
+      const index = buildSchemaIndex(
+        (data.dataSchema ?? {}) as Record<string, unknown>,
+        (data.uiSchema ?? {}) as Record<string, unknown>,
+      );
+
+      logger.info(
+        `Schema index built for definition ${formDefinitionId}: ${index.categories.length} categories, ${Object.keys(index.dataProperties).length} properties.`,
+        { context: 'formSchemaIndexGetTool', tenant: tenantId?.toString(), formDefinitionId },
+      );
+
+      return index;
+    },
+  });
+
+  return { formSchemaIndex };
+}
+
+export type FormSchemaIndex = Awaited<
+  ReturnType<typeof createSchemaIndexTools>
+>['formSchemaIndex'];

--- a/apps/agent-service/src/agent/tools/schemaPatch.spec.ts
+++ b/apps/agent-service/src/agent/tools/schemaPatch.spec.ts
@@ -1,0 +1,314 @@
+import { createSchemaPatchTools } from './schemaPatch';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+const mockTokenProvider = {
+  getAccessToken: jest.fn().mockResolvedValue('test-token'),
+};
+
+const mockDirectory = {
+  getServiceUrl: jest.fn().mockResolvedValue(new URL('https://config-service.test/')),
+};
+
+const mockRequestContext = {
+  get: jest.fn((key: string) => {
+    if (key === 'tenantId') return { toString: () => 'test-tenant' };
+    if (key === 'formDefinitionId') return 'intake-form';
+    return undefined;
+  }),
+};
+
+// ---- Shared fixtures -------------------------------------------------------
+
+const currentSchema = {
+  dataSchema: {
+    type: 'object',
+    required: ['firstName'],
+    properties: {
+      firstName: { type: 'string' },
+      lastName: { type: 'string' },
+      age: { type: 'integer' },
+    },
+  },
+  uiSchema: {
+    type: 'Categorization',
+    elements: [
+      {
+        type: 'Category',
+        label: 'Personal',
+        elements: [
+          { type: 'Control', scope: '#/properties/firstName' },
+          { type: 'Control', scope: '#/properties/lastName' },
+        ],
+      },
+    ],
+  },
+};
+
+function makeAxiosError(status: number, message: string): Error {
+  return Object.assign(new Error(message), {
+    isAxiosError: true,
+    response: { status, data: { message } },
+  });
+}
+
+const ctx = { requestContext: mockRequestContext } as never;
+
+// ---- Tests -----------------------------------------------------------------
+
+describe('createSchemaPatchTools', () => {
+  let tools: Awaited<ReturnType<typeof createSchemaPatchTools>>;
+
+  beforeAll(async () => {
+    tools = await createSchemaPatchTools({
+      directory: mockDirectory as never,
+      tokenProvider: mockTokenProvider as never,
+      logger: mockLogger as never,
+    });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  beforeEach(() => {
+    // Restore isAxiosError after clearAllMocks() — it starts as jest.fn() returning undefined
+    (axios.isAxiosError as unknown as jest.Mock).mockImplementation(
+      (err) => (err as { isAxiosError?: boolean })?.isAxiosError === true,
+    );
+  });
+
+  it('creates the formSchemaPatch tool', () => {
+    expect(tools.formSchemaPatch).toBeDefined();
+  });
+
+  it('fetches the current schema for the definition in request context before patching', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+    mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+    await tools.formSchemaPatch.execute(
+      { dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }] },
+      ctx,
+    );
+
+    const url = mockedAxios.get.mock.calls[0][0] as string;
+    expect(url).toContain('form-service/intake-form/latest');
+  });
+
+  it('applies dataSchemaOps and sends the patched dataSchema via UPDATE', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+    mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+    await tools.formSchemaPatch.execute(
+      { dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }] },
+      ctx,
+    );
+
+    const body = mockedAxios.patch.mock.calls[0][1] as { operation: string; update: Record<string, unknown> };
+    expect(body.operation).toBe('UPDATE');
+    const sentDataSchema = body.update.dataSchema as { required: string[] };
+    expect(sentDataSchema.required).toContain('lastName');
+  });
+
+  it('applies uiSchemaOps and sends the patched uiSchema', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+    mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+    await tools.formSchemaPatch.execute(
+      {
+        uiSchemaOps: [
+          {
+            op: 'add',
+            path: '/elements/0/elements/-',
+            value: { type: 'Control', scope: '#/properties/age' },
+          },
+        ],
+      },
+      ctx,
+    );
+
+    const body = mockedAxios.patch.mock.calls[0][1] as { update: Record<string, unknown> };
+    const sentUiSchema = body.update.uiSchema as { elements: Array<{ elements: unknown[] }> };
+    expect(sentUiSchema.elements[0].elements).toHaveLength(3);
+  });
+
+  it('returns success: true with opsApplied count and formDefinitionId', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+    mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+    const result = await tools.formSchemaPatch.execute(
+      {
+        dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }],
+        uiSchemaOps: [{ op: 'replace', path: '/elements/0/label', value: 'Updated' }],
+      },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.opsApplied).toBe(2);
+    expect(result.formDefinitionId).toBe('intake-form');
+  });
+
+  it('counts ops from both arrays in opsApplied', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+    mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+    const result = await tools.formSchemaPatch.execute(
+      {
+        dataSchemaOps: [
+          { op: 'add', path: '/required/-', value: 'lastName' },
+          { op: 'add', path: '/required/-', value: 'age' },
+        ],
+        uiSchemaOps: [{ op: 'replace', path: '/elements/0/label', value: 'Updated' }],
+      },
+      ctx,
+    );
+
+    expect(result.opsApplied).toBe(3);
+  });
+
+  describe('sortRemoveOps — multiple removes on the same uiSchema array', () => {
+    it('removes multiple elements from a uiSchema array without pointer-shift errors', async () => {
+      const schemaWithFourElements = {
+        dataSchema: { type: 'object', required: [], properties: {} },
+        uiSchema: {
+          type: 'VerticalLayout',
+          elements: [
+            { type: 'Control', scope: '#/properties/a' },
+            { type: 'Control', scope: '#/properties/b' },
+            { type: 'Control', scope: '#/properties/c' },
+            { type: 'Control', scope: '#/properties/d' },
+          ],
+        },
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: schemaWithFourElements });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+      // Ascending order — sortRemoveOps must reorder to descending to avoid pointer shifts
+      await tools.formSchemaPatch.execute(
+        {
+          uiSchemaOps: [
+            { op: 'remove', path: '/elements/1' }, // b
+            { op: 'remove', path: '/elements/3' }, // d
+          ],
+        },
+        ctx,
+      );
+
+      const body = mockedAxios.patch.mock.calls[0][1] as { update: Record<string, unknown> };
+      const sent = body.update.uiSchema as { elements: Array<{ scope: string }> };
+      expect(sent.elements).toHaveLength(2);
+      expect(sent.elements[0].scope).toBe('#/properties/a');
+      expect(sent.elements[1].scope).toBe('#/properties/c');
+    });
+
+    it('preserves non-remove ops in their original positions relative to remove ops', async () => {
+      const schemaWithTwoElements = {
+        dataSchema: { type: 'object', required: [], properties: {} },
+        uiSchema: {
+          type: 'VerticalLayout',
+          elements: [
+            { type: 'Control', scope: '#/properties/a', label: 'A' },
+            { type: 'Control', scope: '#/properties/b', label: 'B' },
+          ],
+        },
+      };
+      mockedAxios.get.mockResolvedValueOnce({ data: schemaWithTwoElements });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
+
+      await tools.formSchemaPatch.execute(
+        {
+          uiSchemaOps: [
+            { op: 'replace', path: '/elements/0/label', value: 'Alpha' },
+            { op: 'remove', path: '/elements/1' },
+          ],
+        },
+        ctx,
+      );
+
+      const body = mockedAxios.patch.mock.calls[0][1] as { update: Record<string, unknown> };
+      const sent = body.update.uiSchema as { elements: Array<{ scope: string; label: string }> };
+      expect(sent.elements).toHaveLength(1);
+      expect(sent.elements[0].label).toBe('Alpha');
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws a descriptive error when a dataSchema patch operation is invalid', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+
+      await expect(
+        tools.formSchemaPatch.execute(
+          { dataSchemaOps: [{ op: 'remove', path: '/required/99' }] },
+          ctx,
+        ),
+      ).rejects.toThrow('Invalid dataSchema patch operation');
+    });
+
+    it('throws a descriptive error when a uiSchema patch operation is invalid', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+
+      await expect(
+        tools.formSchemaPatch.execute(
+          { uiSchemaOps: [{ op: 'remove', path: '/elements/99' }] },
+          ctx,
+        ),
+      ).rejects.toThrow('Invalid uiSchema patch operation');
+    });
+
+    it('throws a schema validation error on 400 from the config service', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+      mockedAxios.patch.mockRejectedValueOnce(makeAxiosError(400, 'Does not match schema'));
+
+      await expect(
+        tools.formSchemaPatch.execute(
+          { dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }] },
+          ctx,
+        ),
+      ).rejects.toThrow('Schema validation failed after patch');
+    });
+
+    it('throws a permission error on 403 from the config service', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+      mockedAxios.patch.mockRejectedValueOnce(makeAxiosError(403, 'Forbidden'));
+
+      await expect(
+        tools.formSchemaPatch.execute(
+          { dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }] },
+          ctx,
+        ),
+      ).rejects.toThrow('Permission denied');
+    });
+
+    it('throws a config service error for other Axios errors that carry a message', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+      mockedAxios.patch.mockRejectedValueOnce(makeAxiosError(500, 'Internal server error'));
+
+      await expect(
+        tools.formSchemaPatch.execute(
+          { dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }] },
+          ctx,
+        ),
+      ).rejects.toThrow('Configuration service error: Internal server error');
+    });
+
+    it('throws a generic error for non-Axios failures', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+      mockedAxios.patch.mockRejectedValueOnce(new Error('network down'));
+
+      await expect(
+        tools.formSchemaPatch.execute(
+          { dataSchemaOps: [{ op: 'add', path: '/required/-', value: 'lastName' }] },
+          ctx,
+        ),
+      ).rejects.toThrow('Failed to patch form schema: network down');
+    });
+  });
+});

--- a/apps/agent-service/src/agent/tools/schemaPatch.spec.ts
+++ b/apps/agent-service/src/agent/tools/schemaPatch.spec.ts
@@ -241,26 +241,28 @@ describe('createSchemaPatchTools', () => {
   });
 
   describe('error handling', () => {
-    it('throws a descriptive error when a dataSchema patch operation is invalid', async () => {
+    it('silently skips a remove op targeting a non-existent dataSchema path', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
 
-      await expect(
-        tools.formSchemaPatch.execute(
-          { dataSchemaOps: [{ op: 'remove', path: '/required/99' }] },
-          ctx,
-        ),
-      ).rejects.toThrow('Invalid dataSchema patch operation');
+      const result = await tools.formSchemaPatch.execute(
+        { dataSchemaOps: [{ op: 'remove', path: '/required/99' }] },
+        ctx,
+      );
+
+      expect(result.success).toBe(true);
     });
 
-    it('throws a descriptive error when a uiSchema patch operation is invalid', async () => {
+    it('silently skips a remove op targeting a non-existent uiSchema path', async () => {
       mockedAxios.get.mockResolvedValueOnce({ data: currentSchema });
+      mockedAxios.patch.mockResolvedValueOnce({ data: {} });
 
-      await expect(
-        tools.formSchemaPatch.execute(
-          { uiSchemaOps: [{ op: 'remove', path: '/elements/99' }] },
-          ctx,
-        ),
-      ).rejects.toThrow('Invalid uiSchema patch operation');
+      const result = await tools.formSchemaPatch.execute(
+        { uiSchemaOps: [{ op: 'remove', path: '/elements/99' }] },
+        ctx,
+      );
+
+      expect(result.success).toBe(true);
     });
 
     it('throws a schema validation error on 400 from the config service', async () => {

--- a/apps/agent-service/src/agent/tools/schemaPatch.ts
+++ b/apps/agent-service/src/agent/tools/schemaPatch.ts
@@ -26,11 +26,21 @@ function validateAndApplyOps(
   ops: Operation[],
   schemaName: string,
 ): Record<string, unknown> {
-  const error = validate(ops, doc);
+  // Silently drop remove ops targeting a path that doesn't exist — the agent
+  // sometimes generates a remove for a field that is already absent, which
+  // would throw OPERATION_PATH_UNRESOLVABLE and waste a retry round-trip.
+  const safeOps = ops.filter((op) => {
+    if (op.op !== 'remove') return true;
+    return !validate([op], doc);
+  });
+
+  if (safeOps.length === 0) return doc;
+
+  const error = validate(safeOps, doc);
   if (error) {
     throw new Error(`Invalid ${schemaName} patch operation: ${error.message}`);
   }
-  return applyPatch(doc, ops, undefined, false).newDocument as Record<string, unknown>;
+  return applyPatch(doc, safeOps, undefined, false).newDocument as Record<string, unknown>;
 }
 
 /**

--- a/apps/agent-service/src/agent/tools/schemaPatch.ts
+++ b/apps/agent-service/src/agent/tools/schemaPatch.ts
@@ -1,0 +1,185 @@
+import { adspId, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
+import { createTool } from '@mastra/core/tools';
+import type { ToolExecutionContext } from '@mastra/core/tools';
+import axios, { isAxiosError } from 'axios';
+import { applyPatch, validate, type Operation } from 'fast-json-patch';
+import type { Logger } from 'winston';
+import z from 'zod';
+import { AdspRequestContext } from '../types';
+
+interface SchemaPatchToolsProps {
+  directory: ServiceDirectory;
+  tokenProvider: TokenProvider;
+  logger: Logger;
+}
+
+const jsonPatchOpSchema = z.object({
+  op: z.enum(['add', 'remove', 'replace', 'move', 'copy', 'test']),
+  path: z.string(),
+  value: z.unknown().optional(),
+  from: z.string().optional(),
+});
+
+/** Validates ops against doc then applies them in place. Throws on the first validation error. */
+function validateAndApplyOps(doc: Record<string, unknown>, ops: Operation[], schemaName: string): void {
+  const error = validate(ops, doc);
+  if (error) {
+    throw new Error(`Invalid ${schemaName} patch operation: ${error.message}`);
+  }
+  applyPatch(doc, ops);
+}
+
+/**
+ * Sorts remove operations in descending index order within each array path so
+ * that removing element [2] does not shift [3] before it is also removed.
+ */
+function sortRemoveOps(ops: z.infer<typeof jsonPatchOpSchema>[]): z.infer<typeof jsonPatchOpSchema>[] {
+  return [...ops].sort((a, b) => {
+    if (a.op !== 'remove' || b.op !== 'remove') return 0;
+
+    const aParent = a.path.substring(0, a.path.lastIndexOf('/'));
+    const bParent = b.path.substring(0, b.path.lastIndexOf('/'));
+    if (aParent !== bParent) return 0;
+
+    const aIndex = parseInt(a.path.split('/').pop() ?? '', 10);
+    const bIndex = parseInt(b.path.split('/').pop() ?? '', 10);
+    if (isNaN(aIndex) || isNaN(bIndex)) return 0;
+
+    return bIndex - aIndex; // descending — remove highest index first
+  });
+}
+
+export async function createSchemaPatchTools({ directory, tokenProvider, logger }: SchemaPatchToolsProps) {
+  const configurationServiceUrl = await directory.getServiceUrl(adspId`urn:ads:platform:configuration-service:v2`);
+
+  const formSchemaPatch = createTool({
+    id: 'patch-form-schema',
+    description: `Apply targeted RFC 6902 JSON Patch operations to the form dataSchema and/or uiSchema.
+
+USE THIS instead of formConfigurationUpdateTool when making targeted changes to existing fields:
+- Making a field required or optional
+- Adding, removing, or changing a validation rule
+- Updating a SHOW/HIDE rule
+- Adding a control to an existing category
+- Removing a field from both schemas
+
+DO NOT use this tool for:
+- Adding a brand new Category to the form
+- Restructuring the top-level layout
+- Moving a field from one category to another
+- Any change where you need to see the full schema context first
+Use formConfigurationRetrievalTool + formConfigurationUpdateTool for those cases.`,
+    inputSchema: z.object({
+      dataSchemaOps: z
+        .array(jsonPatchOpSchema)
+        .optional()
+        .describe('RFC 6902 patch operations to apply to the dataSchema. Omit if no data schema changes needed.'),
+      uiSchemaOps: z
+        .array(jsonPatchOpSchema)
+        .optional()
+        .describe('RFC 6902 patch operations to apply to the uiSchema. Omit if no UI schema changes needed.'),
+    }),
+    outputSchema: z.object({
+      success: z.boolean(),
+      opsApplied: z.number(),
+      formDefinitionId: z.string(),
+    }),
+    execute: async (inputData, context: ToolExecutionContext) => {
+      const requestContext = context.requestContext as AdspRequestContext<{ formDefinitionId: string }>;
+      const tenantId = requestContext.get('tenantId');
+      const formDefinitionId = requestContext.get('formDefinitionId');
+
+      const token = await tokenProvider.getAccessToken();
+
+      // Fetch current schemas
+      const latestUrl = new URL(
+        `v2/configuration/form-service/${formDefinitionId}/latest`,
+        configurationServiceUrl,
+      );
+
+      const { data: current } = await axios.get(latestUrl.href, {
+        params: { tenantId: tenantId?.toString() },
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      // Deep-clone so we never mutate the fetched object
+      const dataSchema = JSON.parse(JSON.stringify(current.dataSchema ?? {}));
+      const uiSchema = JSON.parse(JSON.stringify(current.uiSchema ?? {}));
+
+      if (inputData.dataSchemaOps?.length) {
+        validateAndApplyOps(dataSchema, inputData.dataSchemaOps as Operation[], 'dataSchema');
+        logger.debug(`Applied ${inputData.dataSchemaOps.length} dataSchema patch op(s).`, {
+          context: 'formSchemaPatchTool',
+          tenant: tenantId?.toString(),
+          formDefinitionId,
+        });
+      }
+
+      // Sort uiSchema removes descending to avoid pointer shifts before applying
+      if (inputData.uiSchemaOps?.length) {
+        const sortedOps = sortRemoveOps(inputData.uiSchemaOps);
+        validateAndApplyOps(uiSchema, sortedOps as Operation[], 'uiSchema');
+        logger.debug(`Applied ${inputData.uiSchemaOps.length} uiSchema patch op(s).`, {
+          context: 'formSchemaPatchTool',
+          tenant: tenantId?.toString(),
+          formDefinitionId,
+        });
+      }
+
+      // Write patched schemas back via Configuration Service
+      try {
+        const updateUrl = new URL(
+          `v2/configuration/form-service/${formDefinitionId}`,
+          configurationServiceUrl,
+        );
+
+        const { data } = await axios.patch(
+          updateUrl.href,
+          {
+            operation: 'UPDATE',
+            update: { id: formDefinitionId, dataSchema, uiSchema },
+          },
+          {
+            params: { tenantId: tenantId?.toString() },
+            headers: { Authorization: `Bearer ${await tokenProvider.getAccessToken()}` },
+          },
+        );
+
+        logger.info(`Form schema patched successfully for definition ${formDefinitionId}.`, {
+          context: 'formSchemaPatchTool',
+          tenant: tenantId?.toString(),
+          formDefinitionId,
+          dataOps: inputData.dataSchemaOps?.length ?? 0,
+          uiOps: inputData.uiSchemaOps?.length ?? 0,
+        });
+
+        return {
+          success: true,
+          opsApplied: (inputData.dataSchemaOps?.length ?? 0) + (inputData.uiSchemaOps?.length ?? 0),
+          formDefinitionId,
+        };
+      } catch (err) {
+        if (isAxiosError(err)) {
+          const status = err.response?.status;
+          const errorData = err.response?.data;
+
+          if (status === 400) {
+            throw new Error(
+              `Schema validation failed after patch: ${errorData?.message ?? 'unknown error'}. Check that UI schema scopes match dataSchema properties.`,
+            );
+          } else if (status === 403) {
+            throw new Error('Permission denied. You need the configuration-admin role to update form configurations.');
+          } else if (errorData?.message) {
+            throw new Error(`Configuration service error: ${errorData.message}`);
+          }
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to patch form schema: ${msg}`);
+      }
+    },
+  });
+
+  return { formSchemaPatch };
+}
+
+export type FormSchemaPatch = Awaited<ReturnType<typeof createSchemaPatchTools>>['formSchemaPatch'];

--- a/apps/agent-service/src/agent/tools/schemaPatch.ts
+++ b/apps/agent-service/src/agent/tools/schemaPatch.ts
@@ -20,13 +20,17 @@ const jsonPatchOpSchema = z.object({
   from: z.string().optional(),
 });
 
-/** Validates ops against doc then applies them in place. Throws on the first validation error. */
-function validateAndApplyOps(doc: Record<string, unknown>, ops: Operation[], schemaName: string): void {
+/** Validates ops then returns a new patched document. Throws on the first validation error. */
+function validateAndApplyOps(
+  doc: Record<string, unknown>,
+  ops: Operation[],
+  schemaName: string,
+): Record<string, unknown> {
   const error = validate(ops, doc);
   if (error) {
     throw new Error(`Invalid ${schemaName} patch operation: ${error.message}`);
   }
-  applyPatch(doc, ops);
+  return applyPatch(doc, ops, undefined, false).newDocument as Record<string, unknown>;
 }
 
 /**
@@ -102,12 +106,11 @@ Use formConfigurationRetrievalTool + formConfigurationUpdateTool for those cases
         headers: { Authorization: `Bearer ${token}` },
       });
 
-      // Deep-clone so we never mutate the fetched object
-      const dataSchema = JSON.parse(JSON.stringify(current.dataSchema ?? {}));
-      const uiSchema = JSON.parse(JSON.stringify(current.uiSchema ?? {}));
+      let dataSchema = current.dataSchema ?? {};
+      let uiSchema = current.uiSchema ?? {};
 
       if (inputData.dataSchemaOps?.length) {
-        validateAndApplyOps(dataSchema, inputData.dataSchemaOps as Operation[], 'dataSchema');
+        dataSchema = validateAndApplyOps(dataSchema, inputData.dataSchemaOps as Operation[], 'dataSchema');
         logger.debug(`Applied ${inputData.dataSchemaOps.length} dataSchema patch op(s).`, {
           context: 'formSchemaPatchTool',
           tenant: tenantId?.toString(),
@@ -118,7 +121,7 @@ Use formConfigurationRetrievalTool + formConfigurationUpdateTool for those cases
       // Sort uiSchema removes descending to avoid pointer shifts before applying
       if (inputData.uiSchemaOps?.length) {
         const sortedOps = sortRemoveOps(inputData.uiSchemaOps);
-        validateAndApplyOps(uiSchema, sortedOps as Operation[], 'uiSchema');
+        uiSchema = validateAndApplyOps(uiSchema, sortedOps as Operation[], 'uiSchema');
         logger.debug(`Applied ${inputData.uiSchemaOps.length} uiSchema patch op(s).`, {
           context: 'formSchemaPatchTool',
           tenant: tenantId?.toString(),

--- a/apps/agent-service/src/agent/tools/schemaPatch.ts
+++ b/apps/agent-service/src/agent/tools/schemaPatch.ts
@@ -67,6 +67,11 @@ USE THIS instead of formConfigurationUpdateTool when making targeted changes to 
 - Adding a control to an existing category
 - Removing a field from both schemas
 
+IMPORTANT — choosing the right op:
+- Use "add" when the path does not exist yet (new property, new subfield like /description, new array item)
+- Use "replace" ONLY when the path already exists in the current schema
+- Using "replace" on a non-existent path will throw an error — if unsure, use "add"
+
 DO NOT use this tool for:
 - Adding a brand new Category to the form
 - Restructuring the top-level layout

--- a/apps/tenant-management-webapp/src/app/store/form/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/form/sagas.ts
@@ -615,6 +615,7 @@ const MUTATION_TOOLS = new Set([
   'formDataUpdateTool',
   'dataRegisterCreateTool',
   'dataRegisterUpdateTool',
+  'formSchemaPatch',
 ]);
 
 function isMutationToolResult(chunk: AgentResponseAction['chunk']): boolean {

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -47,6 +47,7 @@ import {
   updateFormDefinition,
   updateEditorFormDefinition,
   getFormDefinitions,
+  openEditorForDefinition,
 } from '@store/form/action';
 import { Disposition, FormDefinition } from '@store/form/model';
 import { isFormUpdatedSelector, schemaErrorSelector } from '@store/form/selectors';
@@ -89,7 +90,7 @@ import { AgentChat } from '@core-services/app-common';
 import { agentConnectedSelector, messagesSelector, threadSelector } from '@store/agent/selectors';
 import { messageAgent, startThread, connectAgent } from '@store/agent/actions';
 import { v4 as uuid } from 'uuid';
-import { Attachment, UserContent } from '@core-services/app-common';
+import { Attachment, UserContent, AgentMessage, ToolCall } from '@core-services/app-common';
 import { AnyAction } from 'redux';
 import { GoabCheckboxOnChangeDetail, GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
 import { RegisterConfigData } from '@abgov/jsonforms-components';
@@ -167,6 +168,7 @@ const NO_TASK_CREATED_OPTION = `No task created`;
 
 // Tab order in the editor: Data schema (0), UI schema (1), AI (2, when enabled).
 const AI_TAB_INDEX = 2;
+const PATCH_TOOL_NAME = 'patch-form-schema';
 
 export function AddEditFormDefinitionEditor({
   definition,
@@ -471,6 +473,27 @@ export function AddEditFormDefinitionEditor({
     },
     [dispatch, resourceId],
   );
+
+  // Track the last patch message we reloaded for, so remounts don't re-fire.
+  const appliedPatchId = useRef<string | null>(null);
+
+  const latestPatchMessage =
+    [...messages]
+      .reverse()
+      .find(
+        (m): m is AgentMessage =>
+          m.from === 'agent' &&
+          !(m as AgentMessage).streaming &&
+          (m as AgentMessage).toolCalls?.some(
+            (tc: ToolCall) => tc.toolName === PATCH_TOOL_NAME && tc.result != null,
+          ),
+      ) ?? null;
+
+  useEffect(() => {
+    if (!latestPatchMessage || latestPatchMessage.id === appliedPatchId.current) return;
+    appliedPatchId.current = latestPatchMessage.id;
+    dispatch(openEditorForDefinition(definition.id));
+  }, [latestPatchMessage, definition.id, dispatch]);
 
   return (
     <FormEditor>

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "express-rate-limit": "^7.1.4",
         "express-session": "^1.18.2",
         "express-validator": "^6.14.0",
+        "fast-json-patch": "^3.1.1",
         "fast-xml-builder": "1.1.7",
         "flat": "^5.0.2",
         "handlebars": "^4.7.9",
@@ -35278,6 +35279,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "express-rate-limit": "^7.1.4",
     "express-session": "^1.18.2",
     "express-validator": "^6.14.0",
+    "fast-json-patch": "^3.1.1",
     "fast-xml-builder": "1.1.7",
     "flat": "^5.0.2",
     "handlebars": "^4.7.9",


### PR DESCRIPTION
Add formSchemaIndex and formSchemaPatch tools to replace the full schema read/write pattern with a lightweight index (~80 tokens) and targeted RFC 6902 JSON Patch operations (~120 tokens vs ~15,000 per call).

- formSchemaIndex: returns a compact structural map of categories, controls, HelpContent, rules, and conditional required blocks
- formSchemaPatch: validates and applies dataSchemaOps/uiSchemaOps, handles pointer-shift safety for multiple removes (sortRemoveOps)
- addEditFormDefinitionEditor: auto-refreshes the editor after a patch-form-schema tool call completes
- form.ts: restructured with RICECO format, new tools added to tool list
- Adds fast-json-patch ^3.1.1 dependency
- Full unit test coverage for both new tools (schemaIndex.spec.ts, schemaPatch.spec.ts) and updated form.spec.ts assertions