### PR TITLE
feat(adsp-service-sdk): add authorize middleware and createErrorHandler

### DIFF
--- a/docs/platform/platform-node-sdk.md
+++ b/docs/platform/platform-node-sdk.md
@@ -350,6 +350,64 @@ Parse and convert urns:
 ```
 
 ### Role-based authorization
+The SDK provides an `authorize` middleware factory for enforcing role-based access control on Express routes. It uses the roles resolved from the JWT bearer token by the Passport strategies, so role names match what is configured in the Keycloak client.
+
+Protecting a route with a required role:
+```typescript
+  import { authorize } from '@abgov/adsp-service-sdk';
+
+  app.post(
+    '/my-resource',
+    authenticateHandler,
+    tenantHandler,
+    authorize('my-service-admin'),
+    (req, res) => { res.send('OK') }
+  );
+```
+
+When the authenticated user lacks the required role, `authorize` passes an `UnauthorizedUserError` to Express's `next()`, which `createErrorHandler` maps to a 403 response automatically.
+
+Multiple roles can be specified; the user must have at least one:
+```typescript
+  app.delete(
+    '/my-resource/:id',
+    authenticateHandler,
+    authorize('my-service-admin', 'my-service-editor'),
+    deleteHandler,
+  );
+```
+
+### Error handling
+The SDK provides a `createErrorHandler` factory that normalizes error responses across GoA services. It recognizes `GoAError` subclasses (including `UnauthorizedUserError`) and maps their `statusCode` to the HTTP response status. Internal server errors (5xx) have their message masked in production to prevent information disclosure.
+
+Mount `createErrorHandler` last in the Express middleware chain:
+```typescript
+  import { createErrorHandler } from '@abgov/adsp-service-sdk';
+
+  const {
+    logger,
+    ...sdkCapabilities,
+  } = await initializePlatform(parameters);
+
+  // ... routes and other middleware ...
+
+  app.use(createErrorHandler(logger));
+```
+
+When a logger is provided, errors are logged with the HTTP status code, request path and method, and correlation ID from the `x-correlation-id` request header.
+
+Throwing a typed error from a route handler:
+```typescript
+  import { GoAError } from '@abgov/adsp-service-sdk';
+
+  app.get('/my-resource/:id', authenticateHandler, authorize('my-service-user'), async (req, res) => {
+    const resource = await findResource(req.params.id);
+    if (!resource) {
+      throw new GoAError('Resource not found', { statusCode: 404 });
+    }
+    res.json(resource);
+  });
+```
 
 ### Platform health check
 Include platform service checks in the service health check endpoint:

--- a/libs/adsp-service-sdk/src/access/index.ts
+++ b/libs/adsp-service-sdk/src/access/index.ts
@@ -18,6 +18,7 @@ declare global {
 export type { User } from './user';
 
 export { isAllowedUser, AssertRole, AssertCoreRole, UnauthorizedUserError, hasRequiredRole } from './assert';
+export { authorize } from './middleware';
 export { createRealmStrategy } from './createRealmStrategy';
 export { createTenantStrategy } from './createTenantStrategy';
 export type { TokenProvider } from './tokenProvider';

--- a/libs/adsp-service-sdk/src/access/middleware.spec.ts
+++ b/libs/adsp-service-sdk/src/access/middleware.spec.ts
@@ -1,0 +1,76 @@
+import { Request, Response } from 'express';
+import { authorize } from './middleware';
+import { UnauthorizedUserError } from './assert';
+import { User } from './user';
+import { adspId } from '../utils';
+
+const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+
+function makeUser(roles: string[]): User {
+  return {
+    id: 'test-user',
+    name: 'Test User',
+    email: 'test@example.com',
+    roles,
+    tenantId,
+    isCore: false,
+    token: null,
+  };
+}
+
+function makeReq(user?: User): Partial<Request> {
+  return { user } as Partial<Request>;
+}
+
+describe('authorize', () => {
+  it('calls next() when user has a required role', () => {
+    const middleware = authorize('admin');
+    const req = makeReq(makeUser(['admin', 'user']));
+    const next = jest.fn();
+
+    middleware(req as Request, {} as Response, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('calls next() when user has one of multiple required roles', () => {
+    const middleware = authorize('editor', 'admin');
+    const req = makeReq(makeUser(['editor']));
+    const next = jest.fn();
+
+    middleware(req as Request, {} as Response, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('calls next(UnauthorizedUserError) when user lacks required role', () => {
+    const middleware = authorize('admin');
+    const req = makeReq(makeUser(['user']));
+    const next = jest.fn();
+
+    middleware(req as Request, {} as Response, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+  });
+
+  it('calls next(UnauthorizedUserError) when req.user is not set', () => {
+    const middleware = authorize('admin');
+    const req = makeReq(undefined);
+    const next = jest.fn();
+
+    middleware(req as Request, {} as Response, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+  });
+
+  it('passes UnauthorizedUserError with 403 status code', () => {
+    const middleware = authorize('admin');
+    const req = makeReq(makeUser([]));
+    const next = jest.fn();
+
+    middleware(req as Request, {} as Response, next);
+
+    const err = next.mock.calls[0][0] as UnauthorizedUserError;
+    expect(err.extra.statusCode).toBe(403);
+  });
+});

--- a/libs/adsp-service-sdk/src/access/middleware.ts
+++ b/libs/adsp-service-sdk/src/access/middleware.ts
@@ -1,0 +1,28 @@
+import { RequestHandler } from 'express';
+import { hasRequiredRole, UnauthorizedUserError } from './assert';
+import { User } from './user';
+
+/**
+ * authorize
+ * Returns Express middleware that enforces role-based access control using the
+ * roles resolved by the SDK's Passport strategies. Passes an UnauthorizedUserError
+ * to next() when the authenticated user lacks at least one of the required roles,
+ * which the createErrorHandler middleware maps to a 403 response.
+ *
+ * @param roles One or more role strings; user must have at least one.
+ */
+export function authorize(...roles: string[]): RequestHandler {
+  return (req, _res, next) => {
+    const user = req.user as User;
+
+    if (!user) {
+      return next(new UnauthorizedUserError('access resource', { id: 'anonymous', name: 'anonymous' } as User));
+    }
+
+    if (!hasRequiredRole(user, roles)) {
+      return next(new UnauthorizedUserError('access resource', user));
+    }
+
+    next();
+  };
+}

--- a/libs/adsp-service-sdk/src/index.ts
+++ b/libs/adsp-service-sdk/src/index.ts
@@ -9,8 +9,9 @@ export {
   retry,
   toKebabName,
   toKebabCase,
+  createErrorHandler,
 } from './utils';
-export { AssertCoreRole, AssertRole, isAllowedUser, UnauthorizedUserError, hasRequiredRole } from './access';
+export { AssertCoreRole, AssertRole, isAllowedUser, UnauthorizedUserError, hasRequiredRole, authorize } from './access';
 export type { TokenProvider, User } from './access';
 export type { GoAErrorExtra } from './utils';
 export type { ServiceDirectory } from './directory';

--- a/libs/adsp-service-sdk/src/utils/errorHandler.spec.ts
+++ b/libs/adsp-service-sdk/src/utils/errorHandler.spec.ts
@@ -1,0 +1,112 @@
+import { Request, Response } from 'express';
+import { Logger } from 'winston';
+import { createErrorHandler } from './errorHandler';
+import { GoAError } from './errors';
+
+function makeRes(): Partial<Response> {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function makeReq(headers: Record<string, string> = {}): Partial<Request> {
+  return { path: '/test', method: 'GET', headers } as Partial<Request>;
+}
+
+describe('createErrorHandler', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('responds with statusCode from GoAError.extra', () => {
+    const handler = createErrorHandler();
+    const err = new GoAError('Not found', { statusCode: 404 });
+    const res = makeRes();
+
+    handler(err, makeReq() as Request, res as Response, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+
+  it('responds with statusCode from err.statusCode for non-GoAError errors', () => {
+    const handler = createErrorHandler();
+    const err = Object.assign(new Error('Bad request'), { statusCode: 400 });
+    const res = makeRes();
+
+    handler(err, makeReq() as Request, res as Response, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('defaults to 500 when no statusCode is present', () => {
+    const handler = createErrorHandler();
+    const err = new Error('Unexpected failure');
+    const res = makeRes();
+
+    handler(err, makeReq() as Request, res as Response, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('masks 5xx error messages in production', () => {
+    process.env.NODE_ENV = 'production';
+    const handler = createErrorHandler();
+    const err = new Error('Database connection lost');
+    const res = makeRes();
+
+    handler(err, makeReq() as Request, res as Response, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+  });
+
+  it('exposes error message for 5xx outside production', () => {
+    process.env.NODE_ENV = 'development';
+    const handler = createErrorHandler();
+    const err = new Error('Database connection lost');
+    const res = makeRes();
+
+    handler(err, makeReq() as Request, res as Response, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({ error: 'Database connection lost' });
+  });
+
+  it('does not mask 4xx error messages in production', () => {
+    process.env.NODE_ENV = 'production';
+    const handler = createErrorHandler();
+    const err = new GoAError('Validation failed', { statusCode: 422 });
+    const res = makeRes();
+
+    handler(err, makeReq() as Request, res as Response, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({ error: 'Validation failed' });
+  });
+
+  it('logs error with request context when logger is provided', () => {
+    const logger = { error: jest.fn() } as unknown as Logger;
+    const handler = createErrorHandler(logger);
+    const err = new GoAError('Forbidden', { statusCode: 403 });
+    const req = makeReq({ 'x-correlation-id': 'abc-123' });
+    const res = makeRes();
+
+    handler(err, req as Request, res as Response, jest.fn());
+
+    expect(logger.error).toHaveBeenCalledWith('Forbidden', {
+      statusCode: 403,
+      path: '/test',
+      method: 'GET',
+      correlationId: 'abc-123',
+    });
+  });
+
+  it('does not throw when no logger is provided', () => {
+    const handler = createErrorHandler();
+    const err = new Error('Something went wrong');
+    const res = makeRes();
+
+    expect(() => handler(err, makeReq() as Request, res as Response, jest.fn())).not.toThrow();
+  });
+});

--- a/libs/adsp-service-sdk/src/utils/errorHandler.ts
+++ b/libs/adsp-service-sdk/src/utils/errorHandler.ts
@@ -1,0 +1,43 @@
+import { ErrorRequestHandler, Request } from 'express';
+import { Logger } from 'winston';
+import { GoAError } from './errors';
+
+function getCorrelationId(req: Request): string | undefined {
+  const value = req.headers['x-correlation-id'];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * createErrorHandler
+ * Returns an Express error-handling middleware that normalizes error responses
+ * across GoA services. Recognizes GoAError.extra.statusCode for HTTP status
+ * mapping, sanitizes internal error details in production, and logs errors with
+ * request context when a Winston logger is provided.
+ *
+ * Mount last in the Express middleware chain:
+ *   app.use(createErrorHandler(logger));
+ *
+ * @param logger Optional Winston logger. When provided, errors are logged with
+ *               statusCode, path, method, and correlation ID.
+ */
+export function createErrorHandler(logger?: Logger): ErrorRequestHandler {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return (err, req, res, _next) => {
+    const statusCode: number =
+      (err instanceof GoAError ? err.extra?.statusCode : undefined) ?? err?.statusCode ?? 500;
+
+    const isProd = process.env.NODE_ENV === 'production';
+    const message = isProd && statusCode >= 500 ? 'Internal server error' : err?.message ?? 'An error occurred';
+
+    if (logger) {
+      logger.error(err?.message ?? 'Request error', {
+        statusCode,
+        path: req.path,
+        method: req.method,
+        correlationId: getCorrelationId(req),
+      });
+    }
+
+    res.status(statusCode).json({ error: message });
+  };
+}

--- a/libs/adsp-service-sdk/src/utils/index.ts
+++ b/libs/adsp-service-sdk/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './adspId';
 export * from './logger';
 export * from './errors';
+export * from './errorHandler';
 export * from './naming';
 export * from './limitToOne';
 export * from './retry';


### PR DESCRIPTION
## Summary

- **`authorize(...roles)`** — Express middleware factory that enforces role-based access using the SDK's existing `hasRequiredRole`. Passes `UnauthorizedUserError` to `next()` on failure, which `createErrorHandler` automatically maps to a 403 response. Eliminates the need for manual `req.user.roles.includes(...)` checks in route handlers.

- **`createErrorHandler(logger?)`** — Express error-handling middleware factory that normalizes error responses across GoA services. Reads `statusCode` from `GoAError.extra` for correct HTTP status mapping, masks 5xx message content in production to prevent information disclosure, and logs errors with correlation ID and request context when a Winston logger is provided. Mount last in the Express chain.

Both are exported from `@abgov/adsp-service-sdk` and work with the roles and error types the SDK already defines — ensuring consistent behavior without teams needing to coordinate independently.

## Motivation

Every Express service using the SDK reimplements these two middleware concerns independently. Because correctness depends on SDK internals (how `hasRequiredRole` resolves roles from the JWT, how `GoAError.extra.statusCode` maps to HTTP status), independent reimplementations frequently diverge. Promoting these to the SDK closes the gap between what internal ADSP services receive via `core-common` and what external teams building on the SDK get.

## Test plan

- [ ] `nx test adsp-service-sdk` passes with no regressions (186 tests)
- [ ] `authorize` — verify role match calls `next()`, role mismatch and missing user call `next(UnauthorizedUserError)` with statusCode 403
- [ ] `createErrorHandler` — verify GoAError status mapping, 5xx masking in production, 4xx passthrough, logger call with correlation ID, graceful no-logger path

🤖 Generated with [Claude Code](https://claude.ai/claude-code)