### PR TITLE
fix(jsonforms-components: correct spacing issues in review summary

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/style-component.ts
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/style-component.ts
@@ -75,7 +75,6 @@ export const NoneGivenText = styled.span`
 
 export const NoneGivenTableText = styled.span`
   padding-top: var(--goa-space-l);
-  padding-left: var(--goa-space-xs);
   color: var(--goa-color-greyscale-700);
   font-style: italic;
 `;

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -275,7 +275,7 @@ export const NonEmptyCellComponent = React.memo(function NonEmptyCellComponent(
                       return (
                         <div
                           key={key}
-                          style={{ display: 'flex', marginBottom: '0.5rem', alignItems: 'center' }}
+                          style={{ display: 'flex', marginBottom: '0.5rem', alignItems: 'flex-start' }}
                           data-testid={`#/properties/${key}-input-${i}-row`}
                         >
                           <strong style={{ width: '50%', flexShrink: 0 }}>

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.tsx
@@ -162,7 +162,7 @@ export const renderCellColumn = ({
         {renderNoneGivenText(data)}
         {error && (
           <ObjectArrayWarningIconDiv>
-            <GoabIcon type="warning" title="warning" size="small" theme="filled" ml="2xs" mt="2xs"></GoabIcon>
+            <GoabIcon type="warning" title="warning" size="small" theme="filled" mt="2xs"></GoabIcon>
             {error ? error : ''}
           </ObjectArrayWarningIconDiv>
         )}


### PR DESCRIPTION
- minor text alignment adjustments on the review summary page for Object lists

<img width="742" height="629" alt="image" src="https://github.com/user-attachments/assets/79e95ff7-5b59-4e8f-8858-1fcf13894fbe" />
