### PR TITLE
feat(tenant-management-api): make tenant creation async to prevent timeouts

### DIFF
--- a/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
@@ -105,8 +105,8 @@ describe('KeycloakRealmService', () => {
       );
     });
 
-    it('can throw for no realm', async () => {
-      await expect(service.deleteRealm({ ...tenant, realm: null })).rejects.toThrow(InvalidOperationError);
+    it('can succeed for no realm', async () => {
+      await expect(service.deleteRealm({ ...tenant, realm: null })).resolves.toBe(true);
     });
 
     it('can return false for delete realm error', async () => {

--- a/apps/tenant-management-api/src/keycloak/keycloak.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.ts
@@ -430,7 +430,7 @@ export class KeycloakRealmServiceImpl implements RealmService {
 
   async deleteRealm({ realm }: Tenant): Promise<boolean> {
     if (!realm) {
-      throw new InvalidOperationError('Tenant realm not specified.');
+      return true;
     }
 
     const client = await this.createAdminClient();

--- a/apps/tenant-management-api/src/mongo/schema/tenant.ts
+++ b/apps/tenant-management-api/src/mongo/schema/tenant.ts
@@ -19,6 +19,11 @@ export const tenantSchema: Schema = new Schema(
       type: String,
       required: true,
     },
+    status: {
+      type: String,
+      enum: ['provisioning', 'active'],
+      default: 'active',
+    },
   },
   { timestamps: true }
 );

--- a/apps/tenant-management-api/src/mongo/tenant.ts
+++ b/apps/tenant-management-api/src/mongo/tenant.ts
@@ -64,6 +64,10 @@ export class MongoTenantRepository implements TenantRepository {
       if (criteria.nameEquals) {
         query.name = { $regex: `^${criteria.nameEquals}$`, $options: 'i' };
       }
+
+      if (criteria.activeOnly) {
+        query.status = { $ne: 'provisioning' };
+      }
     }
 
     const docs = (await this.tenantModel.find(query)) || [];
@@ -80,6 +84,7 @@ export class MongoTenantRepository implements TenantRepository {
       name: doc.name,
       realm: doc.realm,
       adminEmail: doc.adminEmail,
+      status: doc.status || 'active',
     });
   }
 
@@ -88,6 +93,7 @@ export class MongoTenantRepository implements TenantRepository {
       name: entity.name,
       realm: entity.realm,
       adminEmail: entity.adminEmail,
+      status: entity.status,
     };
   }
 }

--- a/apps/tenant-management-api/src/tenant/models/tenant.ts
+++ b/apps/tenant-management-api/src/tenant/models/tenant.ts
@@ -1,6 +1,6 @@
 import { New } from '@core-services/core-common';
 import { TenantRepository } from '../repository';
-import { Tenant } from './types';
+import { Tenant, TenantStatus } from './types';
 
 // TODO: This may be a case of anemic entity anti-pattern; there are no behaviors encapsulated in the entity.
 export class TenantEntity implements Tenant {
@@ -9,9 +9,16 @@ export class TenantEntity implements Tenant {
   adminEmail: string;
   createdBy: string;
   name: string;
+  status: TenantStatus;
 
-  static create(repository: TenantRepository, name: string, realm: string, adminEmail: string): Promise<TenantEntity> {
-    const entity = new TenantEntity(repository, { name, adminEmail, realm });
+  static create(
+    repository: TenantRepository,
+    name: string,
+    realm: string,
+    adminEmail: string,
+    status: TenantStatus = 'active',
+  ): Promise<TenantEntity> {
+    const entity = new TenantEntity(repository, { name, adminEmail, realm, status });
     return repository.save(entity);
   }
 
@@ -24,6 +31,7 @@ export class TenantEntity implements Tenant {
     this.realm = tenant.realm;
     this.adminEmail = tenant.adminEmail;
     this.name = tenant.name;
+    this.status = tenant.status || 'active';
   }
 
   save(): Promise<TenantEntity> {

--- a/apps/tenant-management-api/src/tenant/models/types.ts
+++ b/apps/tenant-management-api/src/tenant/models/types.ts
@@ -1,3 +1,5 @@
+export type TenantStatus = 'provisioning' | 'active';
+
 export interface Tenant {
   id: string;
   /**
@@ -12,4 +14,5 @@ export interface Tenant {
   realm: string;
   adminEmail: string;
   name: string;
+  status?: TenantStatus;
 }

--- a/apps/tenant-management-api/src/tenant/router/mappers.ts
+++ b/apps/tenant-management-api/src/tenant/router/mappers.ts
@@ -1,9 +1,11 @@
 import { TenantEntity } from '../models';
+import { TenantStatus } from '../models/types';
 
 interface TenantResponse {
   id: string;
   realm: string;
   name: string;
+  status: TenantStatus;
   adminEmail?: string;
 }
 
@@ -13,11 +15,13 @@ export function mapTenant(tenant: TenantEntity, anonymous = false): TenantRespon
         id: `urn:ads:platform:tenant-service:v2:/tenants/${tenant.id}`,
         realm: tenant.realm,
         name: tenant.name,
+        status: tenant.status,
       }
     : {
         id: `urn:ads:platform:tenant-service:v2:/tenants/${tenant.id}`,
         realm: tenant.realm,
         name: tenant.name,
+        status: tenant.status,
         adminEmail: tenant.adminEmail,
       };
 }

--- a/apps/tenant-management-api/src/tenant/router/tenantV2.spec.ts
+++ b/apps/tenant-management-api/src/tenant/router/tenantV2.spec.ts
@@ -398,6 +398,7 @@ describe('createTenantV2Router', () => {
       };
       const res = {
         send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
       };
       const next = jest.fn();
       const handler = createTenant(loggerMock, repositoryMock, realmServiceMock, eventServiceMock);
@@ -406,11 +407,80 @@ describe('createTenantV2Router', () => {
       repositoryMock.find.mockResolvedValueOnce([]);
 
       req.getConfiguration.mockResolvedValueOnce([[], []]);
-      repositoryMock.save.mockResolvedValueOnce(new TenantEntity(repositoryMock, tenant));
+      repositoryMock.save.mockResolvedValueOnce(new TenantEntity(repositoryMock, { ...tenant, status: 'provisioning' }));
       await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.status).toHaveBeenCalledWith(202);
       expect(res.send).toHaveBeenCalledWith(
-        expect.objectContaining({ ...tenant, id: `urn:ads:platform:tenant-service:v2:/tenants/${tenant.id}` })
+        expect.objectContaining({ id: `urn:ads:platform:tenant-service:v2:/tenants/${tenant.id}`, status: 'provisioning' })
       );
+    });
+
+    it('can provision tenant realm and mark active', async () => {
+      const req = {
+        body: {
+          name: tenant.name,
+        },
+        user: { isCore: true, roles: [TenantServiceRoles.BetaTester], email: 'beta-tester@test.co' },
+        getConfiguration: jest.fn(),
+      };
+      const res = {
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+      };
+      const next = jest.fn();
+      const handler = createTenant(loggerMock, repositoryMock, realmServiceMock, eventServiceMock);
+
+      repositoryMock.find.mockResolvedValueOnce([]);
+      repositoryMock.find.mockResolvedValueOnce([]);
+      req.getConfiguration.mockResolvedValueOnce([[], []]);
+
+      const provisioningEntity = new TenantEntity(repositoryMock, { ...tenant, status: 'provisioning' });
+      repositoryMock.save.mockResolvedValueOnce(provisioningEntity);
+      realmServiceMock.createRealm.mockResolvedValueOnce(undefined);
+      repositoryMock.save.mockResolvedValueOnce(new TenantEntity(repositoryMock, { ...tenant, status: 'active' }));
+
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      // Flush pending promises so the detached provisionRealm task completes
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(realmServiceMock.createRealm).toHaveBeenCalled();
+      expect(eventServiceMock.send).toHaveBeenCalled();
+    });
+
+    it('can clean up tenant entity on provisioning failure', async () => {
+      const req = {
+        body: {
+          name: tenant.name,
+        },
+        user: { isCore: true, roles: [TenantServiceRoles.BetaTester], email: 'beta-tester@test.co' },
+        getConfiguration: jest.fn(),
+      };
+      const res = {
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+      };
+      const next = jest.fn();
+      const handler = createTenant(loggerMock, repositoryMock, realmServiceMock, eventServiceMock);
+
+      repositoryMock.find.mockResolvedValueOnce([]);
+      repositoryMock.find.mockResolvedValueOnce([]);
+      req.getConfiguration.mockResolvedValueOnce([[], []]);
+
+      const provisioningEntity = new TenantEntity(repositoryMock, { ...tenant, status: 'provisioning' });
+      repositoryMock.save.mockResolvedValueOnce(provisioningEntity);
+      realmServiceMock.createRealm.mockRejectedValueOnce(new Error('Keycloak unavailable'));
+      realmServiceMock.deleteRealm.mockResolvedValueOnce(true);
+      repositoryMock.delete.mockResolvedValueOnce(true);
+
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      // Flush pending promises so the detached provisionRealm task completes
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(realmServiceMock.deleteRealm).toHaveBeenCalled();
+      expect(repositoryMock.delete).toHaveBeenCalled();
+      expect(eventServiceMock.send).not.toHaveBeenCalled();
     });
 
     it('can call next with bad request for duplicate tenant name', async () => {

--- a/apps/tenant-management-api/src/tenant/router/tenantV2.ts
+++ b/apps/tenant-management-api/src/tenant/router/tenantV2.ts
@@ -1,4 +1,4 @@
-import { AdspId, adspId, EventService, UnauthorizedUserError } from '@abgov/adsp-service-sdk';
+import { AdspId, adspId, EventService, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
 import {
   assertAuthenticatedHandler,
   createValidationHandler,
@@ -66,7 +66,7 @@ export function getTenants(logger: Logger, repository: TenantRepository): Reques
       }
 
       // FIXME: accessing a non-injected dependency makes this hard to test
-      const tenants = await repository.find(criteria);
+      const tenants = await repository.find({ ...criteria, activeOnly: true });
 
       res.send({
         results: tenants.map((tenant) => mapTenant(tenant, !user)),
@@ -166,6 +166,32 @@ export function deleteTenant(
   };
 }
 
+async function provisionRealm(
+  entity: TenantEntity,
+  clients: ServiceClient[],
+  realmService: RealmService,
+  eventService: EventService,
+  user: User,
+  logger: Logger,
+): Promise<void> {
+  try {
+    await realmService.createRealm(clients, { realm: entity.realm, adminEmail: entity.adminEmail, name: entity.name });
+    entity.status = 'active';
+    await entity.save();
+    const tenant = mapTenant(entity);
+    eventService.send(tenantCreated(user, { ...tenant, id: AdspId.parse(tenant.id) }));
+    logger.info(`Provisioned tenant '${entity.name}' with realm '${entity.realm}'.`, LOG_CONTEXT);
+  } catch (err) {
+    logger.error(`Failed to provision tenant '${entity.name}': ${err.message}`, LOG_CONTEXT);
+    try {
+      await realmService.deleteRealm(entity);
+    } catch (deleteErr) {
+      logger.error(`Failed to cleanup realm for '${entity.name}': ${deleteErr.message}`, LOG_CONTEXT);
+    }
+    await entity.delete();
+  }
+}
+
 export function createTenant(
   logger: Logger,
   tenantRepository: TenantRepository,
@@ -177,7 +203,6 @@ export function createTenant(
       const user = req.user;
       const { name, realm: existingRealm, adminEmail }: New<Tenant> = req.body;
 
-      let realm = existingRealm;
       const email = adminEmail || user.email;
 
       // Non admins are not permitted to specify realm or admin.
@@ -205,22 +230,27 @@ export function createTenant(
           `Creating tenant '${name}' with existing realm '${existingRealm}' for admin ${email}...`,
           LOG_CONTEXT,
         );
+
+        const entity = await TenantEntity.create(tenantRepository, name, existingRealm, email);
+        const tenant = mapTenant(entity);
+        eventService.send(tenantCreated(user, { ...tenant, id: AdspId.parse(tenant.id) }));
+        logger.info(`Created tenant '${name}' with existing realm '${existingRealm}' for admin ${email}.`, LOG_CONTEXT);
+        res.send(tenant);
       } else {
-        //create new realm
         logger.info(`Creating tenant '${name}' with new realm for admin ${email}...`, LOG_CONTEXT);
 
-        realm = uuidv4();
+        const realm = uuidv4();
         const [_, clients] = await req.getConfiguration<ServiceClient[]>();
-        await realmService.createRealm(clients || [], { realm, adminEmail: email, name });
+
+        const entity = await TenantEntity.create(tenantRepository, name, realm, email, 'provisioning');
+        const tenant = mapTenant(entity);
+
+        res.status(202).send(tenant);
+
+        provisionRealm(entity, clients || [], realmService, eventService, user, logger).catch((err) => {
+          logger.error(`Unhandled error during tenant provisioning: ${err.message}`, LOG_CONTEXT);
+        });
       }
-
-      const entity = await TenantEntity.create(tenantRepository, name, realm, email);
-      const tenant = mapTenant(entity);
-
-      eventService.send(tenantCreated(user, { ...tenant, id: AdspId.parse(tenant.id) }));
-      logger.info(`Created tenant '${name}' with realm '${realm}' for admin ${email}.`, LOG_CONTEXT);
-
-      res.send(tenant);
     } catch (err) {
       logger.error(`Error creating new tenant ${err.message}`, LOG_CONTEXT);
       next(err);

--- a/apps/tenant-management-api/src/tenant/types.ts
+++ b/apps/tenant-management-api/src/tenant/types.ts
@@ -10,4 +10,5 @@ export interface TenantCriteria {
   nameEquals?: string;
   realmEquals?: string;
   adminEmailEquals?: string;
+  activeOnly?: boolean;
 }

--- a/apps/tenant-management-webapp/src/app/store/tenant/api.ts
+++ b/apps/tenant-management-webapp/src/app/store/tenant/api.ts
@@ -41,6 +41,12 @@ export class TenantApi {
     return res.data;
   }
 
+  async getTenantById(id: string): Promise<Tenant> {
+    const url = `/api/tenant/v2/tenants/${id}`;
+    const { data } = await this.http.get<Tenant>(url);
+    return data;
+  }
+
   async fetchTenantByRealm(realm: string): Promise<Tenant> {
     const url = '/api/tenant/v2/tenants';
     const { data } = await this.http.get<TenantsResponse>(url, { params: { realm } });

--- a/apps/tenant-management-webapp/src/app/store/tenant/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/tenant/sagas.ts
@@ -1,4 +1,4 @@
-import { put, select, call, takeEvery, takeLatest } from 'redux-saga/effects';
+import { put, select, call, takeEvery, takeLatest, delay } from 'redux-saga/effects';
 import { RootState } from '@store/index';
 import { ErrorNotification, SuccessNotification } from '@store/notifications/actions';
 import {
@@ -100,6 +100,8 @@ export function* isTenantAdmin(action: CheckIsTenantAdminAction): SagaIterator {
   }
 }
 
+const TENANT_POLL_INTERVAL_MS = 3000;
+
 export function* createTenant(action: CreateTenantAction): SagaIterator {
   const state: RootState = yield select();
   const token = yield call(getAccessToken);
@@ -107,8 +109,18 @@ export function* createTenant(action: CreateTenantAction): SagaIterator {
   const name = action.payload;
 
   try {
-    const result = yield call([api, api.createTenant], name);
-    yield put(CreateTenantSuccess(result.realm));
+    let tenant = yield call([api, api.createTenant], name);
+
+    if (tenant.status === 'provisioning') {
+      // Extract raw MongoDB ID from the URN (urn:ads:platform:tenant-service:v2:/tenants/:id)
+      const rawId = tenant.id.split('/').pop();
+      while (tenant.status === 'provisioning') {
+        yield delay(TENANT_POLL_INTERVAL_MS);
+        tenant = yield call([api, api.getTenantById], rawId);
+      }
+    }
+
+    yield put(CreateTenantSuccess(tenant.realm));
   } catch (err) {
     if (err.message.includes('Invalid value')) {
       yield put(


### PR DESCRIPTION
## Summary

- `POST /api/tenant/v2/tenants` now returns `202 Accepted` immediately after saving the tenant with `status: 'provisioning'`; Keycloak realm creation runs detached. On success, status is set to `'active'` and the `tenant-created` event fires. On failure, any partial Keycloak state is cleaned up and the entity is deleted.
- Added `TenantStatus` type and `status` field throughout the model, schema, repository, and API response.
- `GET /tenants` (list) always filters out `provisioning` tenants via `activeOnly: true` so downstream background jobs (metrics, file-service, status-service, etc.) are unaffected.
- `deleteRealm` returns `true` instead of throwing when realm is null/unset — covers provisioning cleanup and the pre-existing case where a realm was already removed externally.
- Frontend saga polls `GET /tenants/:id` every 3s while `status === 'provisioning'`, then dispatches `CreateTenantSuccess` once active.

## Test plan

- [ ] Create a tenant and verify the POST returns 202 with `status: 'provisioning'`
- [ ] Confirm the frontend shows the in-progress state while provisioning, then transitions to success
- [ ] Verify `GET /api/tenant/v2/tenants` does not return provisioning tenants
- [ ] Verify `GET /api/tenant/v2/tenants/:id` returns the provisioning tenant (for polling)
- [ ] Simulate a Keycloak failure and confirm the entity is cleaned up (no orphaned `provisioning` record)
- [ ] Delete a tenant that has no realm set (or whose realm was already removed) and confirm it returns success

🤖 Generated with [Claude Code](https://claude.com/claude-code)