### PR TITLE
fix(jsonforms-components): ListWithDetail errors to be consistent on new layout

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -799,7 +799,7 @@ const MainTab = ({
   const rowData = getDataAtPath(core?.data, childPath);
 
   function resolveField(e: any): string {
-    if (e.keyword === 'required') {
+    if (e.keyword === VALIDATION_KEYWORDS.REQUIRED) {
       return e.params.missingProperty;
     } else if (e.keyword === VALIDATION_KEYWORDS.ERROR_MESSAGE && e.params?.errors[0].params.missingProperty) {
       return e.params.errors[0].params.missingProperty;

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -1,18 +1,14 @@
+import merge from 'lodash/merge';
 import isEmpty from 'lodash/isEmpty';
-import { JsonFormsStateContext, useJsonForms } from '@jsonforms/react';
-import { toDataPath } from '@jsonforms/core';
-
 import range from 'lodash/range';
-import React, { useRef, useLayoutEffect } from 'react';
-import { Resolve } from '@jsonforms/core';
-import type { ErrorObject } from 'ajv';
-
+import { JsonFormsStateContext, useJsonForms, JsonFormsDispatch } from '@jsonforms/react';
 import {
+  toDataPath,
+  Resolve,
   ArrayLayoutProps,
   ControlElement,
   JsonSchema,
   Paths,
-  JsonFormsRendererRegistryEntry,
   JsonFormsCellRendererRegistryEntry,
   ArrayTranslations,
   UISchemaElement,
@@ -20,10 +16,11 @@ import {
   LabelDescription,
 } from '@jsonforms/core';
 
+import React, { useRef, useLayoutEffect } from 'react';
+import type { ErrorObject } from 'ajv';
 import { WithDeleteDialogSupport } from './DeleteDialog';
 import ObjectArrayToolBar from './ObjectArrayToolBar';
-import merge from 'lodash/merge';
-import { JsonFormsDispatch } from '@jsonforms/react';
+
 import { GoabButton, GoabGrid, GoabIconButton, GoabFormItem, GoabTable } from '@abgov/react-components';
 import {
   ToolBarHeader,
@@ -46,7 +43,15 @@ import {
   TableContentContainer,
 } from './styled-components';
 import { Visible } from '../../util';
-import { DEFAULT_MAX_ITEMS, REQUIRED_PROPERTY_ERROR } from '../../common/Constants';
+import { DEFAULT_MAX_ITEMS, REQUIRED_PROPERTY_ERROR, VALIDATION_KEYWORDS } from '../../common/Constants';
+import {
+  EmptyListProps,
+  NonEmptyCellProps,
+  NonEmptyRowComponentProps,
+  OwnPropsOfNonEmptyCell,
+  TableRowsProp,
+} from './ListWithDetailTypes';
+import { prettify } from './ObjectListControlUtils';
 
 const getItemsTitle = (schema?: JsonSchema): string | undefined => {
   const items = schema?.items;
@@ -165,12 +170,6 @@ const getValidColumnProps = (scopedSchema: JsonSchema) => {
   return [''];
 };
 
-export interface EmptyListProps {
-  numColumns: number;
-  noDataMessage: string;
-  translations: ArrayTranslations;
-}
-
 const EmptyList = ({ numColumns, noDataMessage }: EmptyListProps) => (
   <GoabGrid minChildWidth="60ch" mt="l" mb="l">
     <TextCenter>
@@ -179,20 +178,6 @@ const EmptyList = ({ numColumns, noDataMessage }: EmptyListProps) => (
   </GoabGrid>
 );
 
-interface NonEmptyCellProps extends OwnPropsOfNonEmptyCell {
-  rootSchema?: JsonSchema;
-  errors: string;
-  enabled: boolean;
-}
-interface OwnPropsOfNonEmptyCell {
-  rowPath: string;
-  propName?: string;
-  schema: JsonSchema;
-  enabled: boolean;
-  renderers?: JsonFormsRendererRegistryEntry[];
-  cells?: JsonFormsCellRendererRegistryEntry[];
-  uischema?: ControlElement;
-}
 const ctxToNonEmptyCellProps = (ctx: JsonFormsStateContext, ownProps: OwnPropsOfNonEmptyCell): NonEmptyCellProps => {
   const path = ownProps.rowPath + (ownProps.schema?.type === 'object' ? '.' + ownProps.propName : '');
   const errors = '';
@@ -208,21 +193,8 @@ const ctxToNonEmptyCellProps = (ctx: JsonFormsStateContext, ownProps: OwnPropsOf
   };
 };
 
-interface NonEmptyRowComponentProps {
-  propName?: string;
-  schema: JsonSchema;
-  rootSchema?: JsonSchema;
-  rowPath: string;
-  errors: string;
-  enabled: boolean;
-  renderers?: JsonFormsRendererRegistryEntry[];
-  cells?: JsonFormsCellRendererRegistryEntry[];
-  isValid: boolean;
-  uischema?: ControlElement | Layout;
-}
-
 export const NonEmptyCellComponent = React.memo(function NonEmptyCellComponent(props: NonEmptyRowComponentProps) {
-  const { schema, errors, enabled, renderers, cells, rowPath, isValid, uischema } = props;
+  const { schema, enabled, renderers, cells, rowPath, uischema } = props;
   const propNames = getValidColumnProps(schema);
   const propScopes = (uischema as ControlElement)?.scope
     ? propNames.map((name) => {
@@ -426,13 +398,6 @@ function getValue(obj: unknown, path: string): unknown {
       }
       return undefined;
     }, obj);
-}
-
-function prettify(prop: string) {
-  return prop
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/[_-]/g, ' ')
-    .replace(/^./, (c) => c.toUpperCase());
 }
 
 function findLabelForPath(path: string, uiSchema?: UISchemaElement, schema?: JsonSchema): string {
@@ -702,16 +667,6 @@ export function findControlLabel(uischema: UISchemaElement, scope: string): stri
   return;
 }
 
-const VALIDATION_KEYWORDS = {
-  REQUIRED: 'required',
-  MIN_LENGTH: 'minLength',
-  MAX_LENGTH: 'maxLength',
-  FORMAT: 'format',
-  MINIMUM: 'minimum',
-  MAXIMUM: 'maximum',
-  TYPE: 'type',
-};
-
 export function humanizeAjvError(error: ErrorObject, schema: JsonSchema, uischema?: UISchemaElement): string {
   const path = getEffectiveInstancePath(error);
   const label = resolveLabel(path, schema, uischema);
@@ -743,7 +698,7 @@ export function humanizeAjvError(error: ErrorObject, schema: JsonSchema, uischem
 
     case VALIDATION_KEYWORDS.TYPE:
       return `${label} must be a ${error.params.type}`;
-
+      0;
     default:
       return error.message ?? `${label} is invalid`;
   }
@@ -847,7 +802,7 @@ const MainTab = ({
   function resolveField(e: any): string {
     if (e.keyword === 'required') {
       return e.params.missingProperty;
-    } else if (e.keyword === 'errorMessage' && e.params?.errors[0].params.missingProperty) {
+    } else if (e.keyword === VALIDATION_KEYWORDS.ERROR_MESSAGE && e.params?.errors[0].params.missingProperty) {
       return e.params.errors[0].params.missingProperty;
     }
 
@@ -861,17 +816,20 @@ const MainTab = ({
     fields: Record<string, string>;
     row?: string;
   };
+
   const fieldErrors = core?.errors
     ?.filter((e) => e.instancePath === rowBase || e.instancePath.startsWith(rowBase + '/'))
     .reduce<FieldErrors>(
       (acc, e) => {
         const field = resolveField(e);
 
-        if (e.keyword === 'errorMessage' && e.params?.errors) {
+        if (e.keyword === VALIDATION_KEYWORDS.ERROR_MESSAGE && e.params?.errors) {
           const nestedErrors = e.params.errors as ErrorObject[];
           if (field) {
             try {
-              acc.fields[field] = nestedErrors.map((ne) => humanizeAjvError(ne, core.schema, core.uischema)).join(', ');
+              acc.fields[field] = e.message
+                ? e.message
+                : nestedErrors.map((ne) => humanizeAjvError(ne, core.schema, core.uischema)).join(', ');
             } catch (err) {
               // Fallback: if nestedErrors contain a missingProperty, use it
               const missingFromNested = nestedErrors?.[0]?.params?.missingProperty;
@@ -970,23 +928,7 @@ const MainTab = ({
 };
 
 export const NonEmptyList = React.memo(NonEmptyRowComponent);
-interface TableRowsProp {
-  data: number;
-  path: string;
-  schema: JsonSchema;
-  uischema: ControlElement;
-  //eslint-disable-next-line
-  config?: any;
-  enabled: boolean;
-  cells?: JsonFormsCellRendererRegistryEntry[];
-  translations: ArrayTranslations;
-  currentIndex: number;
-  setCurrentIndex: (index: number) => void;
-  setCurrentListPage: (index: number) => void;
-  currentListPage: number;
-  listTitle?: string;
-  errors: string;
-}
+
 const ObjectArrayList = ({
   data,
   path,

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -698,7 +698,6 @@ export function humanizeAjvError(error: ErrorObject, schema: JsonSchema, uischem
 
     case VALIDATION_KEYWORDS.TYPE:
       return `${label} must be a ${error.params.type}`;
-      0;
     default:
       return error.message ?? `${label} is invalid`;
   }

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailTypes.ts
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailTypes.ts
@@ -1,0 +1,128 @@
+import {
+  ArrayLayoutProps,
+  ArrayTranslations,
+  ControlElement,
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  Layout,
+  UISchemaElement,
+} from '@jsonforms/core';
+import { WithDeleteDialogSupport } from './DeleteDialog';
+
+export type ListWithDetailArrayControlProps = ArrayLayoutProps & WithDeleteDialogSupport;
+
+export interface EmptyListProps {
+  numColumns: number;
+  noDataMessage: string;
+  translations: ArrayTranslations;
+}
+export interface NonEmptyCellProps extends OwnPropsOfNonEmptyCell {
+  rootSchema?: JsonSchema;
+  errors: string;
+  enabled: boolean;
+}
+export interface OwnPropsOfNonEmptyCell {
+  rowPath: string;
+  propName?: string;
+  schema: JsonSchema;
+  enabled: boolean;
+  renderers?: JsonFormsRendererRegistryEntry[];
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  uischema?: ControlElement;
+}
+
+export interface NonEmptyRowComponentProps {
+  propName?: string;
+  schema: JsonSchema;
+  rootSchema?: JsonSchema;
+  rowPath: string;
+  errors: string;
+  enabled: boolean;
+  renderers?: JsonFormsRendererRegistryEntry[];
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  isValid: boolean;
+  uischema?: ControlElement | Layout;
+}
+
+export interface NonEmptyRowProps {
+  childPath: string;
+  schema: JsonSchema;
+  rowIndex: number;
+  showSortButtons: boolean;
+  enabled: boolean;
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  path: string;
+  translations: ArrayTranslations;
+  uischema: ControlElement;
+  listTitle?: string;
+}
+
+export interface MainRowProps {
+  childPath: string;
+  rowIndex: number;
+  enabled: boolean;
+  currentTab: number;
+  current: HTMLElement | null;
+  selectCurrentTab: (index: number) => void;
+  setCurrentListPage: (index: number) => void;
+  // eslint-disable-next-line
+  rowData?: Record<string, any>;
+  uischema?: ControlElement;
+  schema?: JsonSchema;
+}
+export interface LeftRowProps {
+  childPath: string;
+  rowIndex: number;
+  enabled: boolean;
+  currentTab: number;
+  current: HTMLElement | null;
+  selectCurrentTab: (index: number) => void;
+  // eslint-disable-next-line
+  rowData?: Record<string, any>;
+  uischema?: ControlElement;
+  schema?: JsonSchema;
+  name: string;
+  translations: ArrayTranslations;
+}
+
+export interface TableRowsProp {
+  data: number;
+  path: string;
+  schema: JsonSchema;
+  uischema: ControlElement;
+  //eslint-disable-next-line
+  config?: any;
+  enabled: boolean;
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  translations: ArrayTranslations;
+  currentIndex: number;
+  setCurrentIndex: (index: number) => void;
+  setCurrentListPage: (index: number) => void;
+  currentListPage: number;
+  listTitle?: string;
+  errors: string;
+}
+export interface SummaryDisplayProps {
+  rowData: Record<string, unknown> | undefined;
+  uischema?: UISchemaElement;
+  schema?: JsonSchema;
+}
+
+export interface TableRowsProp {
+  data: number;
+  path: string;
+  schema: JsonSchema;
+  uischema: ControlElement;
+  //eslint-disable-next-line
+  config?: any;
+  enabled: boolean;
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  translations: ArrayTranslations;
+  currentIndex: number;
+  setCurrentIndex: (index: number) => void;
+  setCurrentListPage: (index: number) => void;
+  currentListPage: number;
+  listTitle?: string;
+  errors: string;
+}

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailTypes.ts
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailTypes.ts
@@ -103,26 +103,9 @@ export interface TableRowsProp {
   listTitle?: string;
   errors: string;
 }
+
 export interface SummaryDisplayProps {
   rowData: Record<string, unknown> | undefined;
   uischema?: UISchemaElement;
   schema?: JsonSchema;
-}
-
-export interface TableRowsProp {
-  data: number;
-  path: string;
-  schema: JsonSchema;
-  uischema: ControlElement;
-  //eslint-disable-next-line
-  config?: any;
-  enabled: boolean;
-  cells?: JsonFormsCellRendererRegistryEntry[];
-  translations: ArrayTranslations;
-  currentIndex: number;
-  setCurrentIndex: (index: number) => void;
-  setCurrentListPage: (index: number) => void;
-  currentListPage: number;
-  listTitle?: string;
-  errors: string;
 }

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -5,7 +5,6 @@ import {
   GoabDropdown,
   GoabDropdownItem,
   GoabFormItem,
-  GoabGrid,
   GoabIcon,
   GoabIconButton,
   GoabInput,
@@ -26,7 +25,6 @@ import range from 'lodash/range';
 import React, { useCallback, useContext, useEffect, useReducer, useState } from 'react';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { capitalizeFirstLetter, isEmptyBoolean, isEmptyNumber, Visible } from '../../util';
-import { humanizeAjvError } from './ListWithDetailControl';
 import {
   ADD_DATA_ACTION,
   Categories,
@@ -56,7 +54,6 @@ import {
   NonEmptyCellStyle,
   ObjectArrayTitle,
   RequiredSpan,
-  TableTHHeader,
   TextCenter,
   ToolBarHeader,
   ListWithDetailsReviewCellDiv,

--- a/libs/jsonforms-components/src/lib/common/Constants.ts
+++ b/libs/jsonforms-components/src/lib/common/Constants.ts
@@ -11,6 +11,17 @@ export const ADDRESS_LOOKUP_LABELS = {
   country: 'Country',
 } as const;
 
+export const VALIDATION_KEYWORDS = {
+  REQUIRED: 'required',
+  MIN_LENGTH: 'minLength',
+  MAX_LENGTH: 'maxLength',
+  FORMAT: 'format',
+  MINIMUM: 'minimum',
+  MAXIMUM: 'maximum',
+  TYPE: 'type',
+  ERROR_MESSAGE: 'errorMessage',
+};
+
 export const getAddressLookupFieldLabel = (fieldName: string): string => {
   return ADDRESS_LOOKUP_LABELS[fieldName as keyof typeof ADDRESS_LOOKUP_LABELS] || fieldName;
 };


### PR DESCRIPTION
- fix missing custom error on List With Detail
- reorganize interfaces that is used by ListWithDetail to its own file
- Move `VALIDATION_KEYWORDS` to the constant file

<img width="869" height="333" alt="image" src="https://github.com/user-attachments/assets/31d4a3ca-f32a-486c-a4ed-4dc7b593014e" />
