### PR TITLE
fix(jsonforms-components): update  checkbox to accept react node instead of just a string

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanControl.spec.tsx
@@ -42,7 +42,7 @@ describe('Input Boolean Control', () => {
     const { baseElement } = render(getForm(dataSchema, uiSchema));
     const checkbox = baseElement.querySelector("goa-checkbox[testId='isAlive-checkbox-test-id']");
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox!.getAttribute('text')).toBe('Check Me');
+    expect(checkbox!.innerHTML).toBe('Check Me');
   });
 
   it('can render a required checkbox', () => {
@@ -51,7 +51,8 @@ describe('Input Boolean Control', () => {
     const { baseElement } = render(getForm(dataSchema, uiSchema));
     const checkbox = baseElement.querySelector("goa-checkbox[testId='isAlive-checkbox-test-id']");
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox!.getAttribute('text')).toBe('Check Me (required)');
+    expect(checkbox).toHaveTextContent('Check Me');
+    expect(checkbox).toHaveTextContent('(required)');
   });
 
   it('will use a title if no label', () => {
@@ -60,7 +61,7 @@ describe('Input Boolean Control', () => {
     const { baseElement } = render(getForm(dataSchema, uiSchema));
     const checkbox = baseElement.querySelector("goa-checkbox[testId='isAlive-checkbox-test-id']");
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox!.getAttribute('text')).toBe('Bob');
+    expect(checkbox!.innerHTML).toBe('Bob');
   });
 
   it('will use a description if no label', () => {
@@ -69,7 +70,7 @@ describe('Input Boolean Control', () => {
     const { baseElement } = render(getForm(dataSchema, uiSchema));
     const checkbox = baseElement.querySelector("goa-checkbox[testId='isAlive-checkbox-test-id']");
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox!.getAttribute('text')).toBe('Bob');
+    expect(checkbox!.innerHTML).toBe('Bob');
   });
   it('will use a uischema label', () => {
     const dataSchema = { type: 'object', properties: { isAlive: { type: 'boolean' } } };
@@ -77,7 +78,7 @@ describe('Input Boolean Control', () => {
     const { baseElement } = render(getForm(dataSchema, uiSchema));
     const checkbox = baseElement.querySelector("goa-checkbox[testId='isAlive-checkbox-test-id']");
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox!.getAttribute('text')).toBe('checkbox');
+    expect(checkbox!.innerHTML).toBe('checkbox');
   });
 
   it('will use a uischema label', () => {
@@ -86,6 +87,6 @@ describe('Input Boolean Control', () => {
     const { baseElement } = render(getForm(dataSchema, uiSchema));
     const checkbox = baseElement.querySelector("goa-checkbox[testId='isAlive-checkbox-test-id']");
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox!.getAttribute('text')).toBe('Bob');
+    expect(checkbox!.innerHTML).toBe('Bob');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanControl.tsx
@@ -4,8 +4,9 @@ import { GoabCheckbox } from '@abgov/react-components';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { getLastSegmentFromPointer, convertToReadableFormat } from '../../util/stringUtils';
 import { WithInputProps } from './type';
-import { CheckboxWrapper } from './style-component';
+import { CheckboxWrapper, RequiredTextLabel } from './style-component';
 import { GoabCheckboxOnChangeDetail } from '@abgov/ui-components-common';
+import React from 'react';
 export const BooleanComponent = ({
   data,
   enabled,
@@ -18,7 +19,7 @@ export const BooleanComponent = ({
   schema,
   isVisited,
 }: ControlProps & WithInputProps) => {
-  const getRequiredLabelText = () => {
+  const getRequiredLabelText = (): React.ReactNode => {
     let label = '';
     if (uischema?.options?.text) {
       label = uischema?.options?.text;
@@ -29,18 +30,22 @@ export const BooleanComponent = ({
     } else if (uischema?.label) {
       label = uischema?.label as string;
     }
-    return `${label}${required ? ' (required)' : ''}`;
+
+    return (
+      <>
+        {label}
+        {required ? <RequiredTextLabel> (required) </RequiredTextLabel> : ''}
+      </>
+    );
   };
 
   const text = getRequiredLabelText();
-
   return (
     <CheckboxWrapper>
       <GoabCheckbox
         error={isVisited && errors.length > 0}
         testId={`${path}-checkbox-test-id`}
         disabled={!enabled}
-        text={text && text !== 'undefined' ? text : convertToReadableFormat(getLastSegmentFromPointer(uischema.scope))}
         name={`${path}`}
         checked={data}
         onChange={(detail: GoabCheckboxOnChangeDetail) => {
@@ -48,7 +53,9 @@ export const BooleanComponent = ({
         }}
         {...uischema?.options?.componentProps}
         mb="none"
-      />
+      >
+        {text && text !== undefined ? text : convertToReadableFormat(getLastSegmentFromPointer(uischema.scope))}
+      </GoabCheckbox>
     </CheckboxWrapper>
   );
 };


### PR DESCRIPTION

- modify checkbox when `required` to display like the GoabFormItem `required` grey text

<img width="958" height="270" alt="image" src="https://github.com/user-attachments/assets/af25a42a-3ff2-41a4-a9f2-fedeaa334557" />
