### PR TITLE
docs(adsp-sdk-mcp-server): default content to initializeService, not initializePlatform

### DIFF
--- a/libs/adsp-sdk-mcp-server/README.md
+++ b/libs/adsp-sdk-mcp-server/README.md
@@ -12,10 +12,16 @@ and exposes them over stdio via four tools:
 - `read_adsp_doc` — read the full content of a doc page found via search.
 - `search_sdk_reference` — search `@abgov/adsp-service-sdk` by symbol name, module, or keyword; returns full symbol
   details (kind, description, option/return shape, example, deprecated flag).
-- `get_platform_quickstart` — the canonical `initializePlatform` usage pattern and a capabilities summary, for the
-  most common question: how to start using ADSP from a Node service.
+- `get_platform_quickstart` — the canonical `initializeService` usage pattern (the common case for a tenant service
+  built on top of ADSP) and a capabilities summary, for the most common question: how to start using ADSP from a
+  Node service.
 
 This package covers the Node SDK only. Other language SDKs (`.NET`, Django, Flask, Spring) are out of scope for now.
+
+The SDK has two entry points for two different kinds of service: `initializeService` for tenant services (the
+primary audience for this package — product teams building on top of ADSP) and `initializePlatform` for cross-tenant
+platform services (the ones that live in this monorepo, e.g. `directory-service`, `configuration-service`). Content
+here is weighted toward `initializeService` accordingly.
 
 ## Usage
 

--- a/libs/adsp-sdk-mcp-server/src/sdk-reference/reference.ts
+++ b/libs/adsp-sdk-mcp-server/src/sdk-reference/reference.ts
@@ -19,10 +19,49 @@ export interface SdkSymbolDoc {
 export const SDK_REFERENCE: SdkSymbolDoc[] = [
   // initialize
   {
+    name: 'initializeService',
+    kind: 'function',
+    module: 'initialize',
+    summary:
+      "SDK's main entry point for a tenant service — the typical way a product team consumes this SDK, since " +
+      'platform services already live in the ADSP core-services monorepo and use initializePlatform instead.',
+    details:
+      'async initializeService(options: Omit<PlatformOptions, "ignoreServiceAud">, logOptions: Logger | LogOptions): ' +
+      'Promise<Capabilities>\n\n' +
+      'Unlike the root initializePlatform (which fixes realm to "core"), options.realm here is your tenant\'s realm ' +
+      '(visible in Tenant Admin, or the realm name you set up your service client under in Keycloak). Resolves the ' +
+      "service's single tenant via tenantService.getTenants()[0] and returns a reshaped capability set: same as " +
+      'PlatformCapabilities but without tenantService/tenantHandler, and clearCached is reshaped to ' +
+      '(serviceId: AdspId) => void (tenant is implicit).',
+    example:
+      "import { AdspId, initializeService } from '@abgov/adsp-service-sdk';\n\n" +
+      "const serviceId = AdspId.parse(environment.CLIENT_ID);\n" +
+      "const { coreStrategy, tenantStrategy, ...sdkCapabilities } = await initializeService(\n" +
+      "  {\n" +
+      "    displayName: 'My tenant service',\n" +
+      "    description: 'Example of a service built on top of ADSP.',\n" +
+      "    serviceId,\n" +
+      "    realm: environment.TENANT_REALM,\n" +
+      "    accessServiceUrl: new URL(environment.KEYCLOAK_ROOT_URL),\n" +
+      "    clientSecret: environment.CLIENT_SECRET,\n" +
+      "    directoryUrl: new URL(environment.DIRECTORY_URL),\n" +
+      "    configurationSchema,\n" +
+      "    events: [],\n" +
+      "    roles: [],\n" +
+      "    notifications: [],\n" +
+      "  },\n" +
+      "  { logger }\n" +
+      ");",
+    seeAlso: ['initializePlatform', 'ServiceRegistration'],
+  },
+  {
     name: 'initializePlatform',
     kind: 'function',
     module: 'initialize',
-    summary: "SDK's main entry point for a multi-tenant platform service; sets up all core capabilities.",
+    summary:
+      'Entry point for a multi-tenant platform service (the kind that lives in the ADSP core-services monorepo ' +
+      'alongside directory-service, configuration-service, etc). Most product teams building on ADSP want ' +
+      'initializeService instead — use this only if you are building a new cross-tenant platform capability.',
     details:
       'async initializePlatform(options: PlatformOptions, logOptions: Logger | LogOptions, services?: Partial<PlatformServices>): Promise<PlatformCapabilities>\n\n' +
       'Fixes realm to "core". options extends ServiceRegistration with: clientSecret, directoryUrl, accessServiceUrl, ' +
@@ -34,38 +73,7 @@ export const SDK_REFERENCE: SdkSymbolDoc[] = [
       'metricsHandler, traceHandler, tracerProvider? (only if tracing enabled), meterProvider? (only if metrics enabled), logger.\n\n' +
       'Also triggers a fire-and-forget registration of roles/events/configuration schema/notifications/etc with the ' +
       'relevant platform services (see ServiceRegistration).',
-    example:
-      "import { AdspId, initializePlatform } from '@abgov/adsp-service-sdk';\n\n" +
-      "const serviceId = AdspId.parse(environment.CLIENT_ID);\n" +
-      "const { coreStrategy, tenantStrategy, ...sdkCapabilities } = await initializePlatform(\n" +
-      "  {\n" +
-      "    displayName: 'My platform service',\n" +
-      "    description: 'Example of a platform service.',\n" +
-      "    serviceId,\n" +
-      "    accessServiceUrl: new URL(environment.KEYCLOAK_ROOT_URL),\n" +
-      "    clientSecret: environment.CLIENT_SECRET,\n" +
-      "    directoryUrl: new URL(environment.DIRECTORY_URL),\n" +
-      "    configurationSchema,\n" +
-      "    events: [],\n" +
-      "    roles: [],\n" +
-      "    notifications: [],\n" +
-      "  },\n" +
-      "  { logger }\n" +
-      ");",
     seeAlso: ['initializeService', 'ServiceRegistration'],
-  },
-  {
-    name: 'initializeService',
-    kind: 'function',
-    module: 'initialize',
-    summary: 'Entry point for a single-tenant (tenant-scoped) service; thin wrapper over initializePlatform.',
-    details:
-      'async initializeService(options: Omit<PlatformOptions, "ignoreServiceAud">, logOptions: Logger | LogOptions): ' +
-      'Promise<Capabilities>\n\n' +
-      'Resolves the service\'s single tenant via tenantService.getTenants()[0] and returns a reshaped capability set: ' +
-      'same as PlatformCapabilities but without tenantService/tenantHandler, and clearCached is reshaped to ' +
-      '(serviceId: AdspId) => void (tenant is implicit).',
-    seeAlso: ['initializePlatform'],
   },
 
   // access

--- a/libs/adsp-sdk-mcp-server/src/server.spec.ts
+++ b/libs/adsp-sdk-mcp-server/src/server.spec.ts
@@ -79,10 +79,11 @@ describe('adsp-sdk-mcp-server', () => {
     expect(results[0].name).toBe('initializePlatform');
   });
 
-  it('get_platform_quickstart returns the initializePlatform usage snippet', async () => {
+  it('get_platform_quickstart returns the initializeService usage snippet, with initializePlatform noted as the platform-service variant', async () => {
     const result = await client.callTool({ name: 'get_platform_quickstart', arguments: {} });
     const [content] = result.content as { type: 'text'; text: string }[];
 
+    expect(content.text).toContain('initializeService');
     expect(content.text).toContain('initializePlatform');
     expect(content.text).toContain('@abgov/adsp-service-sdk');
   });

--- a/libs/adsp-sdk-mcp-server/src/tools/registerQuickstartTool.ts
+++ b/libs/adsp-sdk-mcp-server/src/tools/registerQuickstartTool.ts
@@ -2,23 +2,28 @@ import { ToolDefinition } from './types';
 
 const QUICKSTART = `# Getting started with @abgov/adsp-service-sdk (Node)
 
-## 1. Initialize the SDK
+The SDK has two entry points for two different kinds of service. Most product teams building on ADSP want
+**\`initializeService\`** — use that unless you are specifically building a new cross-tenant platform capability
+(the kind that lives in the ADSP core-services monorepo itself, e.g. directory-service, configuration-service).
 
-For a multi-tenant platform service, call \`initializePlatform\` once at startup:
+## 1. Initialize the SDK (tenant service)
+
+Call \`initializeService\` once at startup, with your tenant's realm:
 
 \`\`\`typescript
-import { AdspId, initializePlatform } from '@abgov/adsp-service-sdk';
+import { AdspId, initializeService } from '@abgov/adsp-service-sdk';
 
 const serviceId = AdspId.parse(environment.CLIENT_ID);
 const {
   coreStrategy,
   tenantStrategy,
   ...sdkCapabilities
-} = await initializePlatform(
+} = await initializeService(
   {
-    displayName: 'My platform service',
-    description: 'Example of a platform service.',
+    displayName: 'My tenant service',
+    description: 'Example of a service built on top of ADSP.',
     serviceId,
+    realm: environment.TENANT_REALM,
     accessServiceUrl: new URL(environment.KEYCLOAK_ROOT_URL),
     clientSecret: environment.CLIENT_SECRET,
     directoryUrl: new URL(environment.DIRECTORY_URL),
@@ -31,24 +36,28 @@ const {
 );
 \`\`\`
 
-For a single-tenant service, use \`initializeService\` instead (same options, minus \`ignoreServiceAud\`; it resolves the
-service's own tenant automatically and omits \`tenantService\`/\`tenantHandler\` from what it returns).
+\`realm\` is your tenant's Keycloak realm — visible in Tenant Admin, or the realm you created your service client
+under. (If you're instead building a cross-tenant platform service, use \`initializePlatform\` — same options minus
+\`realm\`, which is fixed to \`"core"\`; it additionally returns \`tenantService\`/\`tenantHandler\` since it serves many
+tenants.)
 
 ## 2. What you get back
 
-\`initializePlatform\` returns capabilities you wire into your Express app:
+Both entry points return capabilities you wire into your Express app:
 
 | Capability | Purpose |
 |---|---|
 | \`directory\` | Look up other service/API URLs by ADSP URN |
-| \`tenantService\` | Look up tenant records |
 | \`configurationService\` | Retrieve tenant/core configuration |
 | \`eventService\` | Send domain events |
 | \`tokenProvider\` | Get this service's own access token |
 | \`coreStrategy\` / \`tenantStrategy\` | Passport strategies to validate incoming tokens |
-| \`tenantHandler\` / \`configurationHandler\` | Express middleware setting \`req.tenant\` / \`req.getConfiguration()\` |
+| \`configurationHandler\` | Express middleware setting \`req.getConfiguration()\` |
 | \`healthCheck\` | Function to check platform dependency health |
 | \`metricsHandler\` / \`traceHandler\` | Request instrumentation middleware |
+
+(\`initializePlatform\` additionally returns \`tenantService\` and \`tenantHandler\`, since a platform service serves
+many tenants and needs to resolve which one a request belongs to.)
 
 ## 3. Registering what your service needs
 
@@ -72,9 +81,10 @@ export function createQuickstartTool(): ToolDefinition[] {
     {
       name: 'get_platform_quickstart',
       description:
-        'Returns the canonical initializePlatform usage pattern for a new Node ADSP service, a summary of the ' +
-        'capabilities it returns, and pointers to further docs. Use this first for the most common question: how to ' +
-        'start using ADSP from a Node service.',
+        'Returns the canonical initializeService usage pattern for a new Node service built on top of ADSP (the ' +
+        'common case for product teams), notes the initializePlatform variant for cross-tenant platform services, ' +
+        'and summarizes the capabilities returned. Use this first for the most common question: how to start using ' +
+        'ADSP from a Node service.',
       inputSchema: { type: 'object', properties: {} },
       handler: () => ({ content: [{ type: 'text', text: QUICKSTART }] }),
     },


### PR DESCRIPTION
## Summary
- `@abgov/adsp-service-sdk` has two entry points for two different consumers: `initializePlatform` for cross-tenant platform services (which already live in this monorepo, e.g. `directory-service`, `configuration-service`) and `initializeService` for tenant services built on top of ADSP by external product teams.
- Since platform services are already in-repo, the primary audience for `libs/adsp-sdk-mcp-server` is tenant service developers — but the SDK reference and `get_platform_quickstart` tool previously led with `initializePlatform` and treated `initializeService` as the secondary variant. This flips that: `initializeService` now leads with a full example (including the required tenant `realm` option), `initializePlatform` is noted as the monorepo-internal variant.
- Updated `README.md` and the `server.spec.ts` assertion on `get_platform_quickstart`'s output to match.

## Test plan
- [x] `nx build/lint/test adsp-sdk-mcp-server` — all pass, 31 tests
- [x] Manual smoke test: spawned the built server over stdio and printed `get_platform_quickstart`'s actual output to confirm it leads with `initializeService` and correctly notes `initializePlatform` as the variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)