### PR TITLE
fix: update document extraction logic to handle images correctly

### DIFF
--- a/apps/agent-service/src/agent/agents/form.ts
+++ b/apps/agent-service/src/agent/agents/form.ts
@@ -56,6 +56,11 @@ Source document fidelity (PDF / DOCX uploads)
 - Use EXACT wording from the document for field labels, questions, help text, options, section titles, and field order.
 - If you believe a label or text should be changed, ask the user first and explain why. Only proceed if they agree.
 
+Uploaded images (JPG, PNG, screenshots, scanned forms)
+- Images are provided to you directly as visual content. READ THEM DIRECTLY to extract data or build a form.
+- NEVER call documentExtractTool for an image — it only handles PDF/DOCX and will corrupt image data.
+- Only use documentExtractTool for PDF or DOCX uploads.
+
 Data registers
 - NEVER call dataRegisterUpdateTool without first retrieving current values via dataRegisterGetTool and getting user confirmation.
 - NEVER call dataRegisterCreateTool without completing the full collection flow (Steps 1–4 in the Data Registers section).

--- a/apps/agent-service/src/agent/tools/document.ts
+++ b/apps/agent-service/src/agent/tools/document.ts
@@ -20,8 +20,10 @@ export async function createDocumentTools({ directory, tokenProvider, logger }: 
     id: 'extract-document',
     description:
       'Extracts text content from a PDF or DOCX file uploaded to the file service. ' +
-      'Use this when you need to read the textual content of a document. ' +
-      'For non-PDF/DOCX files, falls back to UTF-8 text decoding.',
+      'Use this ONLY to read the textual content of a PDF or DOCX document. ' +
+      'Do NOT use this for images (JPG, PNG, etc.) — uploaded images are already provided ' +
+      'to you as visual content, so read them directly instead of calling this tool. ' +
+      'For other non-PDF/DOCX text-based files, falls back to UTF-8 text decoding.',
     inputSchema: z.object({
       fileId: z
         .string()
@@ -49,6 +51,18 @@ export async function createDocumentTools({ directory, tokenProvider, logger }: 
         context: 'documentExtractTool',
         tenant: tenantId?.toString(),
       });
+
+      // Images are provided to the model directly as visual content. UTF-8 decoding
+      // raw image bytes produces binary garbage, so refuse and redirect to vision.
+      if (metadata.mimeType?.startsWith('image/')) {
+        return {
+          text:
+            `'${metadata.filename}' is an image (${metadata.mimeType}). It has already been provided to you ` +
+            `as visual content — read it directly to extract its data or build the form. Do not call this tool for images.`,
+          filename: metadata.filename,
+          mimeType: metadata.mimeType,
+        };
+      }
 
       if (isExtractableDocument(metadata.mimeType, metadata.filename)) {
         const result = await extractDocumentText(data, metadata.mimeType, metadata.filename, logger);


### PR DESCRIPTION
FOrm AI agent no longer calls document extract tool on images

https://github.com/user-attachments/assets/9be27459-5060-49cf-9c8c-5f65e8fc7bca

