### PR TITLE
feat(agent-service): give the nx-adsp agent live ADSP docs/SDK reference lookup

### DIFF
--- a/apps/agent-service/project.json
+++ b/apps/agent-service/project.json
@@ -18,7 +18,8 @@
       "inputs": [
         "production",
         "^production",
-        "{workspaceRoot}/dist/libs/jsonforms-components/renderer-catalog.json"
+        "{workspaceRoot}/dist/libs/jsonforms-components/renderer-catalog.json",
+        "{workspaceRoot}/docs/**/*.md"
       ],
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
@@ -33,6 +34,11 @@
             "glob": "renderer-catalog.json",
             "input": "dist/libs/jsonforms-components",
             "output": "."
+          },
+          {
+            "input": "docs",
+            "glob": "**/*.md",
+            "output": "assets/docs"
           }
         ],
         "webpackConfig": "apps/agent-service/webpack.config.js",

--- a/apps/agent-service/src/agent/agents/nxAdsp.spec.ts
+++ b/apps/agent-service/src/agent/agents/nxAdsp.spec.ts
@@ -21,6 +21,12 @@ describe('nxAdspAgent', () => {
     expect(nxAdspAgent.tools).toContain('getNxAdspTemplateTool');
   });
 
+  it('references the ADSP SDK reference lookup tools', () => {
+    expect(nxAdspAgent.tools).toContain('searchAdspDocsTool');
+    expect(nxAdspAgent.tools).toContain('readAdspDocTool');
+    expect(nxAdspAgent.tools).toContain('searchAdspSdkReferenceTool');
+  });
+
   it('has userRoles defined', () => {
     expect(nxAdspAgent.userRoles).toBeDefined();
     expect(nxAdspAgent.userRoles?.length).toBeGreaterThan(0);

--- a/apps/agent-service/src/agent/agents/nxAdsp.ts
+++ b/apps/agent-service/src/agent/agents/nxAdsp.ts
@@ -25,6 +25,11 @@ export const nxAdspAgent: AgentConfiguration = {
     - list-nx-adsp-templates: list available templates
     - get-nx-adsp-template: get the full file content and integration patterns for one template
 
+    Reference lookup tools — use to cross-check or supplement template content against the
+    live SDK when a template doesn't cover something, or you're unsure it's current:
+    - search-adsp-sdk-reference: search the actual SDK symbol reference by name/keyword
+    - search-adsp-docs / read-adsp-doc: search/read platform docs for concepts a template doesn't cover
+
     ## Workflow
 
     1. **Read key files** to understand the current workspace:
@@ -63,6 +68,12 @@ export const nxAdspAgent: AgentConfiguration = {
     - Replace ALL {placeholders} with domain values. Never leave them in output.
     - If the developer provides no domain detail, use reasonable defaults from the project name.
   `,
-  tools: ['listNxAdspTemplatesTool', 'getNxAdspTemplateTool'],
+  tools: [
+    'listNxAdspTemplatesTool',
+    'getNxAdspTemplateTool',
+    'searchAdspDocsTool',
+    'readAdspDocTool',
+    'searchAdspSdkReferenceTool',
+  ],
   userRoles: ['urn:ads:platform:agent-service:agent-user'],
 };

--- a/apps/agent-service/src/agent/tools/adspSdkReference.spec.ts
+++ b/apps/agent-service/src/agent/tools/adspSdkReference.spec.ts
@@ -1,0 +1,78 @@
+import * as path from 'path';
+import { createAdspSdkReferenceTools } from './adspSdkReference';
+
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+// Point at the real repo docs/ folder so tests exercise real search behaviour without
+// depending on a prior `nx build agent-service` having populated dist/apps/agent-service/assets/docs.
+const REPO_DOCS_ROOT = path.resolve(__dirname, '../../../../../docs');
+
+describe('createAdspSdkReferenceTools', () => {
+  const tools = createAdspSdkReferenceTools({ logger: mockLogger as never, docsRoot: REPO_DOCS_ROOT });
+
+  describe('searchAdspDocsTool', () => {
+    it('creates a tool with the correct id', () => {
+      expect(tools.searchAdspDocsTool.id).toBe('search-adsp-docs');
+    });
+
+    it('finds a known doc by keyword', async () => {
+      const result = await tools.searchAdspDocsTool.execute({ query: 'send a domain event' } as never, {} as never);
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.results[0].path).toBe('services/event-service.md');
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      const result = await tools.searchAdspDocsTool.execute({ query: 'xyznonexistentterm' } as never, {} as never);
+      expect(result.results).toEqual([]);
+    });
+
+    it('respects the limit parameter', async () => {
+      const result = await tools.searchAdspDocsTool.execute({ query: 'service', limit: 2 } as never, {} as never);
+      expect(result.results.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('readAdspDocTool', () => {
+    it('creates a tool with the correct id', () => {
+      expect(tools.readAdspDocTool.id).toBe('read-adsp-doc');
+    });
+
+    it('returns the full doc for a known path', async () => {
+      const result = await tools.readAdspDocTool.execute({ path: 'services/event-service.md' } as never, {} as never);
+      expect(result.doc?.title).toBe('Event service');
+      expect(result.doc?.content).toContain('domain events');
+    });
+
+    it('returns null for an unknown path', async () => {
+      const result = await tools.readAdspDocTool.execute({ path: 'does/not-exist.md' } as never, {} as never);
+      expect(result.doc).toBeNull();
+    });
+  });
+
+  describe('searchAdspSdkReferenceTool', () => {
+    it('creates a tool with the correct id', () => {
+      expect(tools.searchAdspSdkReferenceTool.id).toBe('search-adsp-sdk-reference');
+    });
+
+    it('finds a known SDK symbol by name', async () => {
+      const result = await tools.searchAdspSdkReferenceTool.execute(
+        { query: 'initializeService' } as never,
+        {} as never
+      );
+      expect(result.results[0].name).toBe('initializeService');
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      const result = await tools.searchAdspSdkReferenceTool.execute(
+        { query: 'xyznonexistentterm' } as never,
+        {} as never
+      );
+      expect(result.results).toEqual([]);
+    });
+  });
+});

--- a/apps/agent-service/src/agent/tools/adspSdkReference.ts
+++ b/apps/agent-service/src/agent/tools/adspSdkReference.ts
@@ -1,0 +1,95 @@
+import * as path from 'path';
+import { createTool } from '@mastra/core/tools';
+import { DocsRepository, searchSdkReference } from '@abgov/adsp-sdk-mcp-server';
+import type { Logger } from 'winston';
+import z from 'zod';
+
+interface AdspSdkReferenceToolsProps {
+  logger: Logger;
+  /** Override for tests; defaults to the docs copied into agent-service's own build output. */
+  docsRoot?: string;
+}
+
+let cachedDocsRepository: DocsRepository | null = null;
+
+function loadDocsRepository(logger: Logger, docsRoot?: string): DocsRepository {
+  if (cachedDocsRepository) {
+    return cachedDocsRepository;
+  }
+
+  // Docs are copied into agent-service output during build (see project.json assets).
+  const resolvedDocsRoot = docsRoot ?? path.resolve(process.cwd(), 'dist/apps/agent-service/assets/docs');
+  cachedDocsRepository = new DocsRepository(resolvedDocsRoot);
+
+  logger.info('ADSP docs repository loaded.', { context: 'adspSdkReferenceTools', docsRoot: resolvedDocsRoot });
+
+  return cachedDocsRepository;
+}
+
+const docsSearchResultSchema = z.object({
+  path: z.string(),
+  title: z.string(),
+  snippet: z.string(),
+  score: z.number(),
+});
+
+const sdkSymbolSchema = z.object({
+  name: z.string(),
+  kind: z.string(),
+  module: z.string(),
+  summary: z.string(),
+  details: z.string().optional(),
+  example: z.string().optional(),
+  deprecated: z.boolean().optional(),
+  seeAlso: z.array(z.string()).optional(),
+});
+
+export function createAdspSdkReferenceTools({ logger, docsRoot }: AdspSdkReferenceToolsProps) {
+  const searchAdspDocsTool = createTool({
+    id: 'search-adsp-docs',
+    description:
+      'Search ADSP platform documentation (getting started, architecture, service concepts, tutorials) by keyword. ' +
+      'Use to cross-check or supplement nx-adsp templates for concepts a template does not cover.',
+    inputSchema: z.object({
+      query: z.string().describe('Keywords to search for, e.g. "send a domain event" or "directory service".'),
+      limit: z.number().int().min(1).max(20).optional().describe('Maximum number of results to return (default 5).'),
+    }),
+    outputSchema: z.object({ results: z.array(docsSearchResultSchema) }),
+    execute: async ({ query, limit }) => ({
+      results: loadDocsRepository(logger, docsRoot).search(query, limit ?? 5),
+    }),
+  });
+
+  const readAdspDocTool = createTool({
+    id: 'read-adsp-doc',
+    description: 'Read the full markdown content of an ADSP doc page by its path, as returned by search-adsp-docs.',
+    inputSchema: z.object({
+      path: z.string().describe('Doc path, e.g. "services/event-service.md".'),
+    }),
+    outputSchema: z.object({
+      doc: z.object({ path: z.string(), title: z.string(), content: z.string() }).nullable(),
+    }),
+    execute: async ({ path: docPath }) => ({
+      doc: loadDocsRepository(logger, docsRoot).read(docPath) ?? null,
+    }),
+  });
+
+  const searchAdspSdkReferenceTool = createTool({
+    id: 'search-adsp-sdk-reference',
+    description:
+      'Search the live @abgov/adsp-service-sdk reference by symbol name, module, or keyword. Use to verify or ' +
+      'supplement SDK constraint details in nx-adsp templates (e.g. exact option/return shapes) against the actual current SDK.',
+    inputSchema: z.object({
+      query: z.string().describe('Symbol name or keyword, e.g. "initializeService", "DomainEventDefinition".'),
+      limit: z.number().int().min(1).max(20).optional().describe('Maximum number of results to return (default 5).'),
+    }),
+    outputSchema: z.object({ results: z.array(sdkSymbolSchema) }),
+    execute: async ({ query, limit }) => ({
+      results: searchSdkReference(query, limit ?? 5),
+    }),
+  });
+
+  return { searchAdspDocsTool, readAdspDocTool, searchAdspSdkReferenceTool };
+}
+
+export type AdspSdkReferenceTools = ReturnType<typeof createAdspSdkReferenceTools>;

--- a/apps/agent-service/src/agent/tools/index.ts
+++ b/apps/agent-service/src/agent/tools/index.ts
@@ -10,6 +10,7 @@ import { createDataRegisterTools } from './dataRegister';
 import { createPdfConfigurationTools } from './pdfConfiguration';
 import { createNotificationTemplateTools } from './notificationTemplate';
 import { createNxAdspTemplateTools } from './nxAdspTemplates';
+import { createAdspSdkReferenceTools } from './adspSdkReference';
 import { createSchemaIndexTools } from './schemaIndex';
 import { createSchemaPatchTools } from './schemaPatch';
 
@@ -53,6 +54,8 @@ export async function createTools({ logger, directory, tokenProvider }: ToolsPro
 
   const { listNxAdspTemplatesTool, getNxAdspTemplateTool } = createNxAdspTemplateTools();
 
+  const { searchAdspDocsTool, readAdspDocTool, searchAdspSdkReferenceTool } = createAdspSdkReferenceTools({ logger });
+
   const { formSchemaIndex } = await createSchemaIndexTools({ logger, directory, tokenProvider });
   const { formSchemaPatch } = await createSchemaPatchTools({ logger, directory, tokenProvider });
 
@@ -75,6 +78,9 @@ export async function createTools({ logger, directory, tokenProvider }: ToolsPro
     emailNotificationGenerateTool,
     listNxAdspTemplatesTool,
     getNxAdspTemplateTool,
+    searchAdspDocsTool,
+    readAdspDocTool,
+    searchAdspSdkReferenceTool,
     formSchemaIndex,
     formSchemaPatch,
   };

--- a/libs/adsp-sdk-mcp-server/project.json
+++ b/libs/adsp-sdk-mcp-server/project.json
@@ -19,6 +19,7 @@
     "build": {
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
+      "inputs": ["production", "^production", "{workspaceRoot}/docs/**/*.md"],
       "options": {
         "outputPath": "dist/libs/adsp-sdk-mcp-server",
         "tsConfig": "libs/adsp-sdk-mcp-server/tsconfig.lib.json",

--- a/libs/adsp-sdk-mcp-server/src/index.ts
+++ b/libs/adsp-sdk-mcp-server/src/index.ts
@@ -1,0 +1,5 @@
+export { DocsRepository, loadDocs } from './docs/docsRepository';
+export type { AdspDoc, AdspDocSearchResult } from './docs/docsRepository';
+export { SDK_REFERENCE } from './sdk-reference/reference';
+export type { SdkSymbolDoc, SdkSymbolKind } from './sdk-reference/reference';
+export { searchSdkReference } from './sdk-reference/search';


### PR DESCRIPTION
## Summary
- The nx-adsp agent (`apps/agent-service/src/agent/agents/nxAdsp.ts`) scaffolds ADSP capability integrations from hardcoded template strings (`nxAdspTemplates.ts`) that can drift from the real SDK over time.
- Gives it three new tools — `search-adsp-docs`, `read-adsp-doc`, `search-adsp-sdk-reference` — backed directly by `@abgov/adsp-sdk-mcp-server`'s `DocsRepository`/`searchSdkReference`, so it can cross-check or supplement templates against the live SDK instead of relying solely on template text.
- **Why not the generic MCP mechanism?** `agent-service`'s per-tenant MCP wiring (`@mastra/mcp`'s `MCPClient`) only supports networked servers (`url: string`, validated as a URI). Our MCP server is stdio-only. Standing up HTTP hosting just to reach one in-repo agent was disproportionate, so this wires the lib in as a plain TS import instead — the same way `agent-service` already imports `@abgov/adsp-service-sdk`.
- Adds `libs/adsp-sdk-mcp-server/src/index.ts` — a library export surface (the lib previously only exposed a CLI/MCP-stdio entry point). `tsconfig.base.json` already had a path alias pointing at this file from the original build.
- Bundles `docs/**/*.md` into `agent-service`'s own build output (mirrors the existing `jsonforms-components` renderer-catalog asset-copy pattern) — confirmed by inspecting the actual build that webpack inlines workspace libs and the deployed container's generated `package.json` has no entry for either `@abgov/adsp-sdk-mcp-server` or `@abgov/adsp-service-sdk`, so there's no `node_modules` copy to read bundled assets from at runtime.
- Also fixes a pre-existing Nx build-cache gap: `adsp-sdk-mcp-server`'s build target had no `inputs` override, so editing a file under `docs/` didn't invalidate its build cache. Fixed on both projects.

## Test plan
- [x] `nx build adsp-sdk-mcp-server` / `nx test adsp-sdk-mcp-server` — pass
- [x] `nx lint agent-service` / `nx test agent-service` (17 suites, 326 tests) — pass, including new `adspSdkReference.spec.ts` (tests against the real repo docs corpus) and an extended `nxAdsp.spec.ts` assertion
- [x] `nx build agent-service` — full webpack build succeeds; confirmed `dist/apps/agent-service/assets/docs/**` contains all 95 docs, `main.js` has the new tool code correctly inlined, and the generated deploy `package.json` has no external entry for either lib (validating the "must bundle docs ourselves" reasoning)
- [x] Caught and fixed a real bug during implementation: `AgentConfiguration.tools` entries must be the camelCase keys returned by `createTools()`, not the kebab-case Mastra tool `id`s — using the wrong name fails silently (tool just doesn't get attached, no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)