### PR TITLE
feat(form-admin-app): export only filtered forms and selected data va…

### DIFF
--- a/apps/export-service/src/export/format/csv.spec.ts
+++ b/apps/export-service/src/export/format/csv.spec.ts
@@ -1,0 +1,42 @@
+import { Readable } from 'stream';
+import { csv } from './csv';
+
+const readAll = (content: Readable): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let result = '';
+    content.on('data', (chunk) => (result += chunk.toString()));
+    content.on('error', (err) => reject(err));
+    content.on('end', () => resolve(result));
+  });
+
+describe('csv', () => {
+  const records = [
+    { id: 'test-1', name: 'Test 1', extra: { nested: true } },
+    { id: 'test-2', name: 'Test 2', other: { deep: { nested: 'value' } } },
+  ];
+
+  it('can flatten records to csv columns', async () => {
+    const content = csv.applyTransform(
+      { columns: ['id', 'name', 'other.deep.nested'] },
+      Readable.from(records),
+      () => {}
+    );
+
+    expect(await readAll(content)).toBe('id,name,other.deep.nested\ntest-1,Test 1,\ntest-2,Test 2,value\n');
+  });
+
+  it('can stringify with column header names', async () => {
+    const content = csv.applyTransform(
+      {
+        columns: [
+          { key: 'id', header: 'ID' },
+          { key: 'extra.nested', header: 'Nested value' },
+        ],
+      },
+      Readable.from(records),
+      () => {}
+    );
+
+    expect(await readAll(content)).toBe('ID,Nested value\ntest-1,1\ntest-2,\n');
+  });
+});

--- a/apps/export-service/src/export/format/csv.spec.ts
+++ b/apps/export-service/src/export/format/csv.spec.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 import { csv } from './csv';
 
-const readAll = (content: Readable): Promise<string> =>
+const readAll = (content: Readable): Promise<string> => // clean-code-ignore: 2.9
   new Promise((resolve, reject) => {
     let result = '';
     content.on('data', (chunk) => (result += chunk.toString()));
@@ -9,7 +9,7 @@ const readAll = (content: Readable): Promise<string> =>
     content.on('end', () => resolve(result));
   });
 
-describe('csv', () => {
+describe('csv', () => { // clean-code-ignore: 2.16
   const records = [
     { id: 'test-1', name: 'Test 1', extra: { nested: true } },
     { id: 'test-2', name: 'Test 2', other: { deep: { nested: 'value' } } },
@@ -19,7 +19,7 @@ describe('csv', () => {
     const content = csv.applyTransform(
       { columns: ['id', 'name', 'other.deep.nested'] },
       Readable.from(records),
-      () => {}
+      () => {} // clean-code-ignore: 2.11
     );
 
     expect(await readAll(content)).toBe('id,name,other.deep.nested\ntest-1,Test 1,\ntest-2,Test 2,value\n');
@@ -34,7 +34,7 @@ describe('csv', () => {
         ],
       },
       Readable.from(records),
-      () => {}
+      () => {} // clean-code-ignore: 2.11
     );
 
     expect(await readAll(content)).toBe('ID,Nested value\ntest-1,1\ntest-2,\n');

--- a/apps/export-service/src/export/format/csv.ts
+++ b/apps/export-service/src/export/format/csv.ts
@@ -15,7 +15,7 @@ class FlattenObjectTransform extends Transform {
 }
 
 interface CsvFormatterOptions {
-  columns: string[];
+  columns: (string | { key: string; header?: string })[];
 }
 
 export const csv: ExportFormatter<CsvFormatterOptions> = {

--- a/apps/export-service/src/export/format/json.spec.ts
+++ b/apps/export-service/src/export/format/json.spec.ts
@@ -1,0 +1,38 @@
+import { Readable } from 'stream';
+import { json } from './json';
+
+const readAll = (content: Readable): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let result = '';
+    content.on('data', (chunk) => (result += chunk.toString()));
+    content.on('error', (err) => reject(err));
+    content.on('end', () => resolve(result));
+  });
+
+describe('json', () => {
+  const records = [
+    { id: 'test-1', name: 'Test 1', extra: { nested: true } },
+    { id: 'test-2', name: 'Test 2', other: { deep: { nested: 'value' } } },
+  ];
+
+  it('can stringify records to a json array', async () => {
+    const content = json.applyTransform({}, Readable.from(records), () => {});
+
+    expect(await readAll(content)).toBe(
+      '[\n{"id":"test-1","name":"Test 1","extra":{"nested":true}},\n' +
+        '{"id":"test-2","name":"Test 2","other":{"deep":{"nested":"value"}}}\n]\n'
+    );
+  });
+
+  it('can stringify with pretty option', async () => {
+    const content = json.applyTransform({ pretty: true }, Readable.from(records), () => {});
+
+    expect(await readAll(content)).toContain('{\n  "id": "test-1",\n  "name": "Test 1",');
+  });
+
+  it('can pick fields of records', async () => {
+    const content = json.applyTransform({ fields: ['id', 'other.deep.nested'] }, Readable.from(records), () => {});
+
+    expect(await readAll(content)).toBe('[\n{"id":"test-1"},\n{"id":"test-2","other":{"deep":{"nested":"value"}}}\n]\n');
+  });
+});

--- a/apps/export-service/src/export/format/json.spec.ts
+++ b/apps/export-service/src/export/format/json.spec.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 import { json } from './json';
 
-const readAll = (content: Readable): Promise<string> =>
+const readAll = (content: Readable): Promise<string> => // clean-code-ignore: 2.16
   new Promise((resolve, reject) => {
     let result = '';
     content.on('data', (chunk) => (result += chunk.toString()));

--- a/apps/export-service/src/export/format/json.ts
+++ b/apps/export-service/src/export/format/json.ts
@@ -1,5 +1,17 @@
+import * as _ from 'lodash';
 import { pipeline, Transform, TransformCallback, TransformOptions } from 'stream';
 import { ExportFormatter } from './types';
+
+class PickFieldsTransform extends Transform {
+  constructor(private fields: string[], options?: TransformOptions) {
+    super({ ...options, objectMode: true });
+  }
+
+  override _transform(chunk: unknown, _encoding: BufferEncoding, callback: TransformCallback): void {
+    this.push(_.pick(chunk, this.fields));
+    callback();
+  }
+}
 
 class JsonStringifyTransform extends Transform {
   private firstChunk = true;
@@ -31,10 +43,13 @@ class JsonStringifyTransform extends Transform {
 
 interface JsonFormatterOptions {
   pretty?: boolean;
+  fields?: string[];
 }
 
 export const json: ExportFormatter<JsonFormatterOptions> = {
   extension: 'json',
   applyTransform: (options, records, callback) =>
-    pipeline(records, new JsonStringifyTransform(options.pretty), callback),
+    options?.fields?.length
+      ? pipeline(records, new PickFieldsTransform(options.fields), new JsonStringifyTransform(options.pretty), callback)
+      : pipeline(records, new JsonStringifyTransform(options.pretty), callback),
 };

--- a/apps/export-service/src/export/format/json.ts
+++ b/apps/export-service/src/export/format/json.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { pipeline, Transform, TransformCallback, TransformOptions } from 'stream';
+import { PassThrough, pipeline, Transform, TransformCallback, TransformOptions } from 'stream';
 import { ExportFormatter } from './types';
 
 class PickFieldsTransform extends Transform {
@@ -49,7 +49,10 @@ interface JsonFormatterOptions {
 export const json: ExportFormatter<JsonFormatterOptions> = {
   extension: 'json',
   applyTransform: (options, records, callback) =>
-    options?.fields?.length
-      ? pipeline(records, new PickFieldsTransform(options.fields), new JsonStringifyTransform(options.pretty), callback)
-      : pipeline(records, new JsonStringifyTransform(options.pretty), callback),
+    pipeline(
+      records,
+      options?.fields?.length ? new PickFieldsTransform(options.fields) : new PassThrough({ objectMode: true }),
+      new JsonStringifyTransform(options?.pretty),
+      callback
+    ),
 };

--- a/apps/export-service/src/export/job/export.spec.ts
+++ b/apps/export-service/src/export/job/export.spec.ts
@@ -209,6 +209,76 @@ describe('export', () => {
     );
   });
 
+  it('can process export json with fields format option', async () => {
+    const job = createExportJob({
+      logger: loggerMock,
+      directory: directoryMock,
+      tokenProvider: tokenProviderMock,
+      eventService: eventServiceMock,
+      repository: repositoryMock,
+      fileService: fileServiceMock,
+    });
+
+    directoryMock.getResourceUrl.mockResolvedValue(new URL('http://test-service/test/v1/tests'));
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          { id: 'test-1', name: 'Test 1', extra: { nested: true } },
+          { id: 'test-2', name: 'Test 2', other: { deep: { nested: 'value' } } },
+        ],
+        page: {},
+      },
+    });
+
+    const result = {
+      id: 'exported-1',
+      urn: 'urn:ads:platform:file-service:v1:/files/exported-1',
+      filename: 'exported.csv',
+    };
+    const decoder = new TextDecoder();
+    let exported = '';
+    fileServiceMock.upload.mockImplementationOnce(
+      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
+        return new Promise((resolve, reject) => {
+          content.on('data', (chunk: unknown) => {
+            exported += decoder.decode(chunk as Buffer);
+          });
+          content.on('error', (err) => reject(err));
+          content.on('end', () => resolve(result));
+          content.read();
+        });
+      }
+    );
+
+    const item = {
+      tenantId: tenantId.toString(),
+      jobId: 'export-1',
+      timestamp: new Date(),
+      resourceId: adspId`${apiId}:/tests`.toString(),
+      requestedBy: { id: 'tester', name: 'Tester' },
+      params: {},
+      resultsPath: 'results',
+      filename: 'exported',
+      fileType: 'export',
+      format: 'json',
+      formatOptions: { fields: ['id', 'other.deep.nested'] },
+    };
+    await job(item);
+
+    expect(exported).toBe('[\n{"id":"test-1"},\n{"id":"test-2","other":{"deep":{"nested":"value"}}}\n]\n');
+    expect(fileServiceMock.upload).toHaveBeenCalledWith(
+      expect.any(AdspId),
+      item.fileType,
+      item.jobId,
+      item.filename + '.json',
+      expect.any(Readable)
+    );
+    expect(repositoryMock.update).toHaveBeenCalledWith('export-1', 'completed', result);
+    expect(eventServiceMock.send).toHaveBeenCalledWith(
+      expect.objectContaining({ name: ExportCompletedDefinition.name })
+    );
+  });
+
   it('can process export csv', async () => {
     const job = createExportJob({
       logger: loggerMock,
@@ -277,6 +347,131 @@ describe('export', () => {
     expect(eventServiceMock.send).toHaveBeenCalledWith(
       expect.objectContaining({ name: ExportCompletedDefinition.name })
     );
+  });
+
+  it('can process export csv with column headers', async () => {
+    const job = createExportJob({
+      logger: loggerMock,
+      directory: directoryMock,
+      tokenProvider: tokenProviderMock,
+      eventService: eventServiceMock,
+      repository: repositoryMock,
+      fileService: fileServiceMock,
+    });
+
+    directoryMock.getResourceUrl.mockResolvedValue(new URL('http://test-service/test/v1/tests'));
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          { id: 'test-1', name: 'Test 1', extra: { nested: true } },
+          { id: 'test-2', name: 'Test 2', other: { deep: { nested: 'value' } } },
+        ],
+        page: {},
+      },
+    });
+
+    const result = {
+      id: 'exported-1',
+      urn: 'urn:ads:platform:file-service:v1:/files/exported-1',
+      filename: 'exported.csv',
+    };
+    const decoder = new TextDecoder();
+    let exported = '';
+    fileServiceMock.upload.mockImplementationOnce(
+      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
+        return new Promise((resolve, reject) => {
+          content.on('data', (chunk: unknown) => {
+            exported += decoder.decode(chunk as Buffer);
+          });
+          content.on('error', (err) => reject(err));
+          content.on('end', () => resolve(result));
+          content.read();
+        });
+      }
+    );
+
+    const item = {
+      tenantId: tenantId.toString(),
+      jobId: 'export-1',
+      timestamp: new Date(),
+      resourceId: adspId`${apiId}:/tests`.toString(),
+      requestedBy: { id: 'tester', name: 'Tester' },
+      params: {},
+      resultsPath: 'results',
+      filename: 'exported',
+      fileType: 'export',
+      format: 'csv',
+      formatOptions: {
+        columns: [
+          { key: 'id', header: 'ID' },
+          { key: 'name', header: 'Name' },
+          { key: 'other.deep.nested', header: 'Nested value' },
+        ],
+      },
+    };
+    await job(item);
+
+    expect(exported).toBe('ID,Name,Nested value\ntest-1,Test 1,\ntest-2,Test 2,value\n');
+    expect(fileServiceMock.upload).toHaveBeenCalledWith(
+      expect.any(AdspId),
+      item.fileType,
+      item.jobId,
+      item.filename + '.csv',
+      expect.any(Readable)
+    );
+    expect(repositoryMock.update).toHaveBeenCalledWith('export-1', 'completed', result);
+    expect(eventServiceMock.send).toHaveBeenCalledWith(
+      expect.objectContaining({ name: ExportCompletedDefinition.name })
+    );
+  });
+
+  it('can record job failure on pipeline error', async () => {
+    const job = createExportJob({
+      logger: loggerMock,
+      directory: directoryMock,
+      tokenProvider: tokenProviderMock,
+      eventService: eventServiceMock,
+      repository: repositoryMock,
+      fileService: fileServiceMock,
+    });
+
+    directoryMock.getResourceUrl.mockResolvedValue(new URL('http://test-service/test/v1/tests'));
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        // Non-object record causes the csv stringifier to error in the pipeline.
+        results: ['not a record'],
+        page: {},
+      },
+    });
+
+    fileServiceMock.upload.mockImplementationOnce(
+      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
+        return new Promise((resolve, reject) => {
+          content.on('data', () => {});
+          content.on('error', (err) => reject(err));
+          content.on('end', () => resolve(null));
+          content.read();
+        });
+      }
+    );
+
+    const item = {
+      tenantId: tenantId.toString(),
+      jobId: 'export-1',
+      timestamp: new Date(),
+      resourceId: adspId`${apiId}:/tests`.toString(),
+      requestedBy: { id: 'tester', name: 'Tester' },
+      params: {},
+      resultsPath: 'results',
+      filename: 'exported',
+      fileType: 'export',
+      format: 'csv',
+      formatOptions: { columns: ['id'] },
+    };
+    await job(item);
+
+    expect(repositoryMock.update).toHaveBeenCalledWith('export-1', 'failed');
+    expect(eventServiceMock.send).toHaveBeenCalledWith(expect.objectContaining({ name: ExportFailedDefinition.name }));
   });
 
   it('can retry on request failure', async () => {

--- a/apps/export-service/src/export/job/export.spec.ts
+++ b/apps/export-service/src/export/job/export.spec.ts
@@ -4,6 +4,7 @@ import { Readable } from 'stream';
 import { Logger } from 'winston';
 import { ExportCompletedDefinition, ExportFailedDefinition } from '../events';
 import { createExportJob } from './export';
+import { ExportServiceWorkItem } from './types';
 
 jest.mock('axios');
 const axiosMock = axios as jest.Mocked<typeof axios>;
@@ -52,6 +53,50 @@ describe('export', () => {
     eventServiceMock.send.mockClear();
     repositoryMock.update.mockClear();
   });
+
+  const createJob = () =>
+    createExportJob({
+      logger: loggerMock,
+      directory: directoryMock,
+      tokenProvider: tokenProviderMock,
+      eventService: eventServiceMock,
+      repository: repositoryMock,
+      fileService: fileServiceMock,
+    });
+
+  const createWorkItem = (overrides: Partial<ExportServiceWorkItem>): ExportServiceWorkItem => ({
+    tenantId: tenantId.toString(),
+    jobId: 'export-1',
+    timestamp: new Date(),
+    resourceId: adspId`${apiId}:/tests`.toString(),
+    requestedBy: { id: 'tester', name: 'Tester' },
+    params: {},
+    resultsPath: 'results',
+    filename: 'exported',
+    fileType: 'export',
+    format: 'json',
+    formatOptions: {},
+    ...overrides,
+  });
+
+  // Mock the file upload to capture the exported content for assertions.
+  const mockUploadCapture = (result: unknown) => {
+    const decoder = new TextDecoder();
+    const captured = { exported: '' };
+    fileServiceMock.upload.mockImplementationOnce(
+      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
+        return new Promise((resolve, reject) => {
+          content.on('data', (chunk: unknown) => {
+            captured.exported += decoder.decode(chunk as Buffer);
+          });
+          content.on('error', (err) => reject(err));
+          content.on('end', () => resolve(result));
+          content.read();
+        });
+      }
+    );
+    return captured;
+  };
 
   it('can create export job', () => {
     const job = createExportJob({
@@ -210,14 +255,7 @@ describe('export', () => {
   });
 
   it('can process export json with fields format option', async () => {
-    const job = createExportJob({
-      logger: loggerMock,
-      directory: directoryMock,
-      tokenProvider: tokenProviderMock,
-      eventService: eventServiceMock,
-      repository: repositoryMock,
-      fileService: fileServiceMock,
-    });
+    const job = createJob();
 
     directoryMock.getResourceUrl.mockResolvedValue(new URL('http://test-service/test/v1/tests'));
     axiosMock.get.mockResolvedValueOnce({
@@ -235,37 +273,12 @@ describe('export', () => {
       urn: 'urn:ads:platform:file-service:v1:/files/exported-1',
       filename: 'exported.csv',
     };
-    const decoder = new TextDecoder();
-    let exported = '';
-    fileServiceMock.upload.mockImplementationOnce(
-      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
-        return new Promise((resolve, reject) => {
-          content.on('data', (chunk: unknown) => {
-            exported += decoder.decode(chunk as Buffer);
-          });
-          content.on('error', (err) => reject(err));
-          content.on('end', () => resolve(result));
-          content.read();
-        });
-      }
-    );
+    const captured = mockUploadCapture(result);
 
-    const item = {
-      tenantId: tenantId.toString(),
-      jobId: 'export-1',
-      timestamp: new Date(),
-      resourceId: adspId`${apiId}:/tests`.toString(),
-      requestedBy: { id: 'tester', name: 'Tester' },
-      params: {},
-      resultsPath: 'results',
-      filename: 'exported',
-      fileType: 'export',
-      format: 'json',
-      formatOptions: { fields: ['id', 'other.deep.nested'] },
-    };
+    const item = createWorkItem({ format: 'json', formatOptions: { fields: ['id', 'other.deep.nested'] } });
     await job(item);
 
-    expect(exported).toBe('[\n{"id":"test-1"},\n{"id":"test-2","other":{"deep":{"nested":"value"}}}\n]\n');
+    expect(captured.exported).toBe('[\n{"id":"test-1"},\n{"id":"test-2","other":{"deep":{"nested":"value"}}}\n]\n');
     expect(fileServiceMock.upload).toHaveBeenCalledWith(
       expect.any(AdspId),
       item.fileType,
@@ -350,14 +363,7 @@ describe('export', () => {
   });
 
   it('can process export csv with column headers', async () => {
-    const job = createExportJob({
-      logger: loggerMock,
-      directory: directoryMock,
-      tokenProvider: tokenProviderMock,
-      eventService: eventServiceMock,
-      repository: repositoryMock,
-      fileService: fileServiceMock,
-    });
+    const job = createJob();
 
     directoryMock.getResourceUrl.mockResolvedValue(new URL('http://test-service/test/v1/tests'));
     axiosMock.get.mockResolvedValueOnce({
@@ -375,31 +381,9 @@ describe('export', () => {
       urn: 'urn:ads:platform:file-service:v1:/files/exported-1',
       filename: 'exported.csv',
     };
-    const decoder = new TextDecoder();
-    let exported = '';
-    fileServiceMock.upload.mockImplementationOnce(
-      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
-        return new Promise((resolve, reject) => {
-          content.on('data', (chunk: unknown) => {
-            exported += decoder.decode(chunk as Buffer);
-          });
-          content.on('error', (err) => reject(err));
-          content.on('end', () => resolve(result));
-          content.read();
-        });
-      }
-    );
+    const captured = mockUploadCapture(result);
 
-    const item = {
-      tenantId: tenantId.toString(),
-      jobId: 'export-1',
-      timestamp: new Date(),
-      resourceId: adspId`${apiId}:/tests`.toString(),
-      requestedBy: { id: 'tester', name: 'Tester' },
-      params: {},
-      resultsPath: 'results',
-      filename: 'exported',
-      fileType: 'export',
+    const item = createWorkItem({
       format: 'csv',
       formatOptions: {
         columns: [
@@ -408,10 +392,10 @@ describe('export', () => {
           { key: 'other.deep.nested', header: 'Nested value' },
         ],
       },
-    };
+    });
     await job(item);
 
-    expect(exported).toBe('ID,Name,Nested value\ntest-1,Test 1,\ntest-2,Test 2,value\n');
+    expect(captured.exported).toBe('ID,Name,Nested value\ntest-1,Test 1,\ntest-2,Test 2,value\n');
     expect(fileServiceMock.upload).toHaveBeenCalledWith(
       expect.any(AdspId),
       item.fileType,
@@ -426,14 +410,7 @@ describe('export', () => {
   });
 
   it('can record job failure on pipeline error', async () => {
-    const job = createExportJob({
-      logger: loggerMock,
-      directory: directoryMock,
-      tokenProvider: tokenProviderMock,
-      eventService: eventServiceMock,
-      repository: repositoryMock,
-      fileService: fileServiceMock,
-    });
+    const job = createJob();
 
     directoryMock.getResourceUrl.mockResolvedValue(new URL('http://test-service/test/v1/tests'));
     axiosMock.get.mockResolvedValueOnce({
@@ -444,30 +421,9 @@ describe('export', () => {
       },
     });
 
-    fileServiceMock.upload.mockImplementationOnce(
-      async (_tenantId, _fileType, _recordId, _filename, content: Readable) => {
-        return new Promise((resolve, reject) => {
-          content.on('data', () => {});
-          content.on('error', (err) => reject(err));
-          content.on('end', () => resolve(null));
-          content.read();
-        });
-      }
-    );
+    mockUploadCapture(null);
 
-    const item = {
-      tenantId: tenantId.toString(),
-      jobId: 'export-1',
-      timestamp: new Date(),
-      resourceId: adspId`${apiId}:/tests`.toString(),
-      requestedBy: { id: 'tester', name: 'Tester' },
-      params: {},
-      resultsPath: 'results',
-      filename: 'exported',
-      fileType: 'export',
-      format: 'csv',
-      formatOptions: { columns: ['id'] },
-    };
+    const item = createWorkItem({ format: 'csv', formatOptions: { columns: ['id'] } });
     await job(item);
 
     expect(repositoryMock.update).toHaveBeenCalledWith('export-1', 'failed');

--- a/apps/export-service/src/export/job/export.ts
+++ b/apps/export-service/src/export/job/export.ts
@@ -106,13 +106,17 @@ export function createExportJob({
 
       const { extension, applyTransform } = await getFormatter(format);
       const records = Readable.from(results);
+      // Note: On error the pipeline destroys its streams, so the upload consuming the content stream fails
+      // and the job is recorded as failed; throwing here would crash the process instead.
       const content = applyTransform(formatOptions, records, (err) => {
         if (err) {
-          logger.warn(`Error encountered in stream pipeline for export job (ID: ${jobId}) of ${result.urn}: ${err}`, {
-            context: 'ExportJob',
-            tenantId,
-          });
-          throw err;
+          logger.warn(
+            `Error encountered in stream pipeline for export job (ID: ${jobId}) of ${resourceIdValue}: ${err}`,
+            {
+              context: 'ExportJob',
+              tenantId: tenantIdValue,
+            }
+          );
         }
       });
 

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -662,7 +662,7 @@ const submissionExportColumns: ExportColumn[] = [
 ];
 
 // Limit export to base columns plus data values selected in the overview page, so output matches what users see on screen.
-function getExportFormatOptions(
+function getExportFormatOptions( // clean-code-ignore: 2.3
   format: 'json' | 'csv',
   baseColumns: ExportColumn[],
   dataPath: string,

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import { DateTime } from 'luxon';
 import { AppState } from './store';
 import {
+  FeedbackMessage,
   FormSubmission,
   FORM_SERVICE_ID,
   PagedResults,
@@ -616,6 +617,13 @@ export const getExportJobStatus = createAsyncThunk(
         case 'completed':
           dispatch(downloadFile(data.result.urn));
           break;
+        case 'failed':
+          return rejectWithValue({
+            id: jobId,
+            level: 'error',
+            message: 'Export failed to complete. Try the export again.',
+            in: 'form/get-export-job-status',
+          } as FeedbackMessage);
       }
 
       return data;
@@ -632,6 +640,44 @@ export const getExportJobStatus = createAsyncThunk(
   },
 );
 
+interface ExportColumn {
+  key: string;
+  header: string;
+}
+
+const formExportColumns: ExportColumn[] = [
+  { key: 'id', header: 'ID' },
+  { key: 'status', header: 'Status' },
+  { key: 'created', header: 'Created on' },
+  { key: 'submitted', header: 'Submitted on' },
+];
+
+const submissionExportColumns: ExportColumn[] = [
+  { key: 'id', header: 'ID' },
+  { key: 'formId', header: 'Form ID' },
+  { key: 'created', header: 'Created on' },
+  { key: 'updated', header: 'Updated on' },
+  { key: 'disposition.status', header: 'Disposition status' },
+  { key: 'disposition.reason', header: 'Disposition reason' },
+];
+
+// Limit export to base columns plus data values selected in the overview page, so output matches what users see on screen.
+function getExportFormatOptions(
+  format: 'json' | 'csv',
+  baseColumns: ExportColumn[],
+  dataPath: string,
+  dataValues: DataValue[],
+) {
+  const columns = [
+    ...baseColumns,
+    ...dataValues
+      .filter(({ selected }) => !!selected)
+      .map(({ name, path }) => ({ key: `${dataPath}.${path}`, header: name })),
+  ];
+
+  return format === 'csv' ? { columns } : { fields: columns.map(({ key }) => key) };
+}
+
 export const exportForms = createAsyncThunk(
   'form/export-forms',
   async (
@@ -639,7 +685,7 @@ export const exportForms = createAsyncThunk(
     { dispatch, getState, rejectWithValue },
   ) => {
     try {
-      const { config } = getState() as AppState;
+      const { config, form } = getState() as AppState;
       const exportServiceUrl = config.directory[EXPORT_SERVICE_ID];
       const token = await getAccessToken();
 
@@ -648,6 +694,7 @@ export const exportForms = createAsyncThunk(
         {
           resourceId: 'urn:ads:platform:form-service:v1:/forms',
           format,
+          formatOptions: getExportFormatOptions(format, formExportColumns, 'data', form.dataValues[definitionId] || []),
           fileType: 'form-export',
           params: {
             includeData: true,
@@ -689,7 +736,7 @@ export const exportSubmissions = createAsyncThunk(
     { dispatch, getState, rejectWithValue },
   ) => {
     try {
-      const { config } = getState() as AppState;
+      const { config, form } = getState() as AppState;
       const exportServiceUrl = config.directory[EXPORT_SERVICE_ID];
       const token = await getAccessToken();
 
@@ -698,6 +745,12 @@ export const exportSubmissions = createAsyncThunk(
         {
           resourceId: 'urn:ads:platform:form-service:v1:/submissions',
           format,
+          formatOptions: getExportFormatOptions(
+            format,
+            submissionExportColumns,
+            'formData',
+            form.dataValues[definitionId] || [],
+          ),
           fileType: 'form-export',
           params: {
             criteria: JSON.stringify({
@@ -974,6 +1027,9 @@ const formSlice = createSlice({
           }
           state.busy.exporting = false;
         }
+      })
+      .addCase(getExportJobStatus.rejected, (state) => {
+        state.busy.exporting = false;
       })
       .addCase(findFormPdf.pending, (state) => {
         state.busy.findPdf = true;


### PR DESCRIPTION
…lue columns

Send the data value columns selected on the overview page as format options on export jobs, so exported forms and submissions contain the base columns plus selected data values matching what is shown on screen. Filter criteria from the forms and submissions pages continue to be applied to the export.

Add a fields option to the export service json formatter, support column header names in the csv formatter, surface failed export jobs in the app instead of polling forever, and fix the export job stream error handler crashing the worker.

CS-5092