### PR TITLE
fix: remove leftover debug console.log statements

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/validation/checkInput.ts
+++ b/apps/tenant-management-webapp/src/app/lib/validation/checkInput.ts
@@ -166,8 +166,7 @@ export const isValidRegexString = (patternStr: string): Validator => {
       }
 
       return '';
-    } catch (err) {
-      console.log('should have failed with err');
+    } catch {
       return `${capitalize(patternStr)} is invalid for regular expression.`;
     }
   };

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/sites/sitesList.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/sites/sitesList.spec.tsx
@@ -70,7 +70,6 @@ describe('SitesListComponent', () => {
     );
 
     const editButtons = baseElement.querySelectorAll("goa-icon-button[testId='site-edit']");
-    console.log('editButtons', editButtons);
     expect(editButtons).toHaveLength(2);
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
@@ -64,7 +64,7 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
       try {
         parsedApplications = notice.tennantServRef;
       } catch (e) {
-        console.log(e);
+        console.error(e);
       } finally {
         setSelectedApplications(parsedApplications);
         setIsAllApplications(notice.isAllApplications);

--- a/apps/tenant-management-webapp/src/app/store/configuration/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/configuration/sagas.ts
@@ -486,7 +486,6 @@ export function* replaceConfigurationData(action: ReplaceConfigurationDataAction
               error: 'JSON schema could not be validated',
             });
 
-            console.log('returning early due to json schema validation failure for service: ', service);
             return;
           }
         }

--- a/apps/tenant-management-webapp/src/app/store/form/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/form/sagas.ts
@@ -523,7 +523,6 @@ export function* fetchAllTags(): SagaIterator {
 
 export function* fetchResourcesByTag({ tag, next, criteria }: FetchResourcesByTagAction): SagaIterator {
   if (!tag) {
-    console.log('Skipping fetchResourcesByTag - No tag selected');
     yield put({
       type: FETCH_RESOURCES_BY_TAG_SUCCESS,
       payload: { tag: '', resources: [] },

--- a/apps/tenant-management-webapp/src/app/store/tenant/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/tenant/sagas.ts
@@ -157,8 +157,6 @@ export function* keycloakCheckSSO(action: KeycloakCheckSSOAction): SagaIterator 
     const realm = action.payload;
     const keycloakAuth: KeycloakAuth = yield call(initializeKeycloakAuth, realm);
 
-    console.log('Run keycloak check sso');
-
     const session = yield call([keycloakAuth, keycloakAuth.checkSSO]);
     if (session) {
       yield put(SessionLoginSuccess(session));
@@ -173,8 +171,6 @@ export function* keycloakCheckSSOWithLogout(action: KeycloakCheckSSOWithLogOutAc
   try {
     const realm = action.payload;
     const keycloakAuth: KeycloakAuth = yield call(initializeKeycloakAuth, realm);
-
-    console.debug('Checkout keycloak SSO');
 
     const session = yield call([keycloakAuth, keycloakAuth.checkSSO]);
     if (!session) {

--- a/libs/jsonforms-components/src/lib/Cells/Cells.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Cells/Cells.spec.tsx
@@ -90,7 +90,6 @@ describe('Cell controls', () => {
     const { container } = render(<GoATimeCell {...props}></GoATimeCell>);
     const element = container.querySelector('goa-input');
     expect(element).toBeInTheDocument();
-    console.log(element?.outerHTML);
     expect(element?.getAttribute('type')).toBe('date');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/PageStepperControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/PageStepperControl.spec.tsx
@@ -542,7 +542,6 @@ describe('PageStepperControl', () => {
         disableNext: true,
       }
     );
-    // console.log(baseElement.innerHTML);
     const nextBtn = baseElement.querySelector("goa-button[testId='pages-save-continue-btn']");
     expect(nextBtn).not.toBeNull();
     if (nextBtn) {

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputbaseReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputbaseReviewControl.spec.tsx
@@ -115,7 +115,6 @@ describe('GoABaseInputReviewComponent', () => {
     };
     const { getByTestId } = render(<GoABaseInputReviewComponent {...props} />);
     const reviewControl = getByTestId('review-control-input-id');
-    console.log('reviewControl.textContent', reviewControl.textContent);
     expect(reviewControl.textContent).toContain('No (test) (required)');
     expect(reviewControl.textContent).toContain('test is required');
   });


### PR DESCRIPTION
## Summary
- Removed leftover `console.log`/`console.debug` debug statements from tenant-management-webapp and jsonforms-components app code and tests
- Kept intentional `console.warn`/`console.error` logging used for real error handling (including converting one debug `console.log(e)` in a real catch block to `console.error(e)`)

## Test plan
- [x] `nx run tenant-management-webapp:test --silent` — 47/47 suites, 194/194 tests pass
- [x] `nx run jsonforms-components:test --silent` — 94/94 suites, 1326/1326 tests pass
- [x] `rg "console\.log"` over both projects returns no matches