### PR TITLE
feat(adsp-cli): export getStatus and resolve/persist the tenant display name

### DIFF
--- a/libs/adsp-cli/README.md
+++ b/libs/adsp-cli/README.md
@@ -94,7 +94,7 @@ for the one-time manual setup steps. `--realm`/`--tenant` logins are unaffected 
 | Command | Auth required | Description |
 |---|---|---|
 | `login [--realm <realm> \| --tenant <name>] [--scope <name>]... [--env <dev\|test\|prod>]` | Interactive (opens a browser) | See above. |
-| `status` | No | Prints the current environment and realm (and where each came from — `ADSP_ENV`/`ADSP_TENANT_REALM`, persisted login, or default) and the cached token's state (`valid` / `expired` / `missing`). Read-only — no network calls. |
+| `status` | No | Prints the current environment and realm (and where each came from — `ADSP_ENV`/`ADSP_TENANT_REALM`, persisted login, or default), the tenant's display name when known, and the cached token's state (`valid` / `expired` / `missing`). Read-only — no network calls. |
 | `logout` | No | Clears `~/.adsp-cli/config.json` and `~/.adsp-cli/token-cache.json`. Safe to run when already logged out. |
 | `token` | Yes (`getAccessToken()`) | Prints the raw access token to stdout — refreshed first if expired, same as any other command. Handy for scripting, e.g. `curl -H "Authorization: Bearer $(adsp token)" ...`. |
 | `tenants [name]` | No (with `name`) / core-realm session (without) | With a name: anonymous exact-name lookup, no login needed. Without: lists every tenant — requires a cached core-realm token (established by a prior no-args `login`); this command never triggers an interactive login itself. |
@@ -127,4 +127,14 @@ const serviceUrls = await getServiceUrls(directoryServiceUrl);
 
 // Or, for the common "which roles can I assign" case directly:
 const roles = await getServiceRoles(result.token, directoryServiceUrl);
+```
+
+`getStatus()` (same function backing the `status` command) is also exported, for consumers that want the
+current realm/tenant name/environment without shelling out — e.g. generator templates that need to embed which
+tenant/realm they were scaffolded against:
+
+```typescript
+import { getStatus } from '@abgov/adsp-cli';
+
+const { realm, tenantName, env } = getStatus();
 ```

--- a/libs/adsp-cli/src/config.ts
+++ b/libs/adsp-cli/src/config.ts
@@ -5,6 +5,8 @@ import type { EnvironmentName } from './environments';
 
 export interface CliConfig {
   tenantRealm: string;
+  /** The tenant's display name, when it was resolvable at login time (see login.ts's loginInteractive). */
+  tenantName?: string;
   env?: EnvironmentName;
 }
 

--- a/libs/adsp-cli/src/index.ts
+++ b/libs/adsp-cli/src/index.ts
@@ -1,5 +1,5 @@
-export { getAccessToken } from './login';
-export type { AccessTokenResult } from './login';
+export { getAccessToken, getStatus } from './login';
+export type { AccessTokenResult, LoginStatus } from './login';
 export { getDirectoryServiceUrl, getServiceUrls } from './directory';
 export { getConfiguration } from './configuration';
 export { getServiceRoles, ServiceNotInDirectoryError } from './serviceRoles';

--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -28,17 +28,19 @@ jest.mock('enquirer', () => ({ prompt: mockPrompt }));
 
 jest.mock('./tenants', () => ({
   findTenantByName: jest.fn(),
+  findTenantByRealm: jest.fn(),
   listTenants: jest.fn(),
 }));
 
 // Imported after the mocks above so login.ts picks up the mocked modules.
 import { getAccessToken, getStatus, loginInteractive, logout } from './login';
-import { findTenantByName, listTenants } from './tenants';
+import { findTenantByName, findTenantByRealm, listTenants } from './tenants';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
 import { getCacheFilePath, setCachedToken } from './tokenCache';
 import { AuthorizationCode } from 'simple-oauth2';
 
 const mockFindTenantByName = findTenantByName as jest.Mock;
+const mockFindTenantByRealm = findTenantByRealm as jest.Mock;
 const mockListTenants = listTenants as jest.Mock;
 const mockAuthorizationCode = AuthorizationCode as unknown as jest.Mock;
 
@@ -87,6 +89,7 @@ describe('login', () => {
     mockOpen.mockReset().mockResolvedValue(undefined);
     mockPrompt.mockReset();
     mockFindTenantByName.mockReset();
+    mockFindTenantByRealm.mockReset();
     mockListTenants.mockReset();
   });
 
@@ -215,6 +218,33 @@ describe('login', () => {
       expect(result).toEqual({ realm: REALM, token: 'fresh-access-token', reused: false });
       expect(mockFindTenantByName).not.toHaveBeenCalled();
       expect(mockListTenants).not.toHaveBeenCalled();
+      expect(mockFindTenantByRealm).toHaveBeenCalledWith(expect.any(String), REALM);
+      expect(readConfig()).toEqual({ tenantRealm: REALM });
+    });
+
+    it('best-effort resolves and persists the tenant name via a reverse lookup, since --realm alone does not have it', async () => {
+      mockFindTenantByRealm.mockResolvedValue({ name: 'my-tenant', realm: REALM });
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+      const loginPromise = loginInteractive({ realm: REALM });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'auth-code' } }, { send: jest.fn() });
+      await loginPromise;
+
+      expect(readConfig()).toEqual({ tenantRealm: REALM, tenantName: 'my-tenant' });
+    });
+
+    it('still logs in successfully when the reverse tenant-name lookup fails', async () => {
+      mockFindTenantByRealm.mockRejectedValue(new Error('network error'));
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+      const loginPromise = loginInteractive({ realm: REALM });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'auth-code' } }, { send: jest.fn() });
+
+      const result = await loginPromise;
+
+      expect(result).toEqual({ realm: REALM, token: 'fresh-access-token', reused: false });
       expect(readConfig()).toEqual({ tenantRealm: REALM });
     });
 
@@ -341,7 +371,8 @@ describe('login', () => {
       expect(result).toEqual({ realm: REALM, token: 'fresh-access-token', reused: false });
       expect(mockFindTenantByName).toHaveBeenCalledWith(expect.any(String), 'my-tenant');
       expect(mockListTenants).not.toHaveBeenCalled();
-      expect(readConfig()).toEqual({ tenantRealm: REALM });
+      expect(readConfig()).toEqual({ tenantRealm: REALM, tenantName: 'my-tenant' });
+      expect(mockFindTenantByRealm).not.toHaveBeenCalled();
     });
 
     it('throws when the tenant name is not found', async () => {
@@ -390,7 +421,8 @@ describe('login', () => {
       expect(mockPrompt).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'autocomplete', choices: ['tenant-a', 'tenant-b'] })
       );
-      expect(readConfig()).toEqual({ tenantRealm: 'realm-a' });
+      expect(readConfig()).toEqual({ tenantRealm: 'realm-a', tenantName: 'tenant-a' });
+      expect(mockFindTenantByRealm).not.toHaveBeenCalled();
     });
 
     it('short-circuits entirely when the persisted realm already has a valid cached token', async () => {
@@ -604,6 +636,25 @@ describe('login', () => {
         env: 'test',
         envSource: 'config',
       });
+    });
+
+    it('reports the persisted tenant name when the realm itself came from that same persisted config', () => {
+      writeConfig({ tenantRealm: REALM, tenantName: 'My Tenant' });
+      setCachedToken(ACCESS_SERVICE_URL, REALM, 'cached-token', undefined, 3600, ['email']);
+
+      expect(getStatus()).toMatchObject({ realm: REALM, tenantName: 'My Tenant' });
+    });
+
+    it('does not report a tenant name when ADSP_TENANT_REALM overrides the persisted realm, even if config has one', () => {
+      writeConfig({ tenantRealm: 'other-realm', tenantName: 'Some Other Tenant' });
+      process.env.ADSP_TENANT_REALM = REALM;
+      setCachedToken(ACCESS_SERVICE_URL, REALM, 'cached-token', undefined, 3600, ['email']);
+
+      const status = getStatus();
+
+      expect(status.realm).toBe(REALM);
+      expect(status.realmSource).toBe('env');
+      expect(status.tenantName).toBeUndefined();
     });
   });
 

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -5,7 +5,7 @@ import { AccessToken, AuthorizationCode } from 'simple-oauth2';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
 import { EnvironmentName, resolveEnvironmentName, resolveEnvironmentUrls, resolveTenantRealm } from './environments';
 import { generatePkcePair } from './pkce';
-import { findTenantByName, listTenants } from './tenants';
+import { findTenantByName, findTenantByRealm, listTenants, Tenant } from './tenants';
 import { CacheEntry, getCacheFilePath, getCachedToken, hasScopes, isExpired, setCachedToken } from './tokenCache';
 
 export type AccessTokenResult = { status: 'ok'; token: string } | { status: 'not-authenticated' };
@@ -198,7 +198,7 @@ async function getOrLogin(accessServiceUrl: string, realm: string, scopes: strin
   return { token: await browserLogin(accessServiceUrl, realm, scopes), reused: false };
 }
 
-async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string): Promise<string> {
+async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string): Promise<Tenant> {
   const tenants = await listTenants(directoryServiceUrl, coreToken);
   if (tenants.length === 0) {
     throw new Error('No tenants found.');
@@ -217,7 +217,21 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
   if (!picked) {
     throw new Error(`Tenant '${pickedName}' not found.`);
   }
-  return picked.realm;
+  return picked;
+}
+
+/**
+ * Best-effort reverse lookup for a --realm login, which doesn't already know the tenant's
+ * display name the way --tenant/the interactive picker do. Never throws — a lookup failure just
+ * leaves the name unresolved rather than blocking the login itself.
+ */
+async function resolveTenantName(directoryServiceUrl: string, realm: string): Promise<string | undefined> {
+  try {
+    const found = await findTenantByRealm(directoryServiceUrl, realm);
+    return found?.name;
+  } catch {
+    return undefined;
+  }
 }
 
 export interface LoginResult {
@@ -261,6 +275,7 @@ export async function loginInteractive(
   const { accessServiceUrl, directoryServiceUrl } = resolveEnvironmentUrls(options.env);
   const scopes = ['email', ...(options.scopes ?? [])];
   let realm = options.realm;
+  let tenantName: string | undefined;
 
   if (!realm && !options.tenant && !options.scopes?.length && !options.env) {
     const current = resolveTenantRealm();
@@ -278,15 +293,24 @@ export async function loginInteractive(
       throw new Error(`Tenant '${options.tenant}' not found.`);
     }
     realm = found.realm;
+    tenantName = found.name;
   }
 
   if (!realm) {
     const core = await getOrLogin(accessServiceUrl, CORE_REALM, scopes);
-    realm = await promptForTenantRealm(directoryServiceUrl, core.token);
+    const picked = await promptForTenantRealm(directoryServiceUrl, core.token);
+    realm = picked.realm;
+    tenantName = picked.name;
+  }
+
+  // --realm logins don't already know the display name the other two modes do — best-effort
+  // resolve it so it can still be persisted/reported by `status`.
+  if (!tenantName) {
+    tenantName = await resolveTenantName(directoryServiceUrl, realm);
   }
 
   const final = await getOrLogin(accessServiceUrl, realm, scopes);
-  writeConfig({ tenantRealm: realm, env: options.env ?? readConfig()?.env });
+  writeConfig({ tenantRealm: realm, tenantName, env: options.env ?? readConfig()?.env });
 
   return { realm, token: final.token, reused: final.reused };
 }
@@ -295,6 +319,8 @@ export interface LoginStatus {
   authenticated: boolean;
   realm?: string;
   realmSource?: 'env' | 'config';
+  /** The tenant's display name, when it was resolvable at login time — see loginInteractive. */
+  tenantName?: string;
   tokenState?: 'valid' | 'expired' | 'missing';
   env: EnvironmentName;
   envSource: 'env' | 'config' | 'default';
@@ -302,15 +328,16 @@ export interface LoginStatus {
 
 /**
  * Pure, read-only snapshot of the current session — no network calls, no cache mutation.
- * Used by the CLI's `status` command.
+ * Used by the CLI's `status` command, and exported for library consumers (e.g. nx-adsp's
+ * generator templates, which use the tenant name/realm) that want the same information.
  */
 export function getStatus(): LoginStatus {
+  const config = readConfig();
   const validEnvVar = process.env.ADSP_ENV === 'dev' || process.env.ADSP_ENV === 'test' || process.env.ADSP_ENV === 'prod';
-  const persistedEnv = readConfig()?.env;
   const envStatus: Pick<LoginStatus, 'env' | 'envSource'> = validEnvVar
     ? { env: resolveEnvironmentName(), envSource: 'env' }
-    : persistedEnv
-    ? { env: persistedEnv, envSource: 'config' }
+    : config?.env
+    ? { env: config.env, envSource: 'config' }
     : { env: 'prod', envSource: 'default' };
 
   const realmResolution = resolveTenantRealm();
@@ -321,11 +348,16 @@ export function getStatus(): LoginStatus {
   const { accessServiceUrl } = resolveEnvironmentUrls();
   const cached = getCachedToken(accessServiceUrl, realmResolution.tenantRealm);
   const tokenState = !cached ? 'missing' : isExpired(cached) ? 'expired' : 'valid';
+  const realmSource: 'env' | 'config' = process.env.ADSP_TENANT_REALM ? 'env' : 'config';
 
   return {
     authenticated: tokenState === 'valid',
     realm: realmResolution.tenantRealm,
-    realmSource: process.env.ADSP_TENANT_REALM ? 'env' : 'config',
+    realmSource,
+    // Only trust the persisted tenantName when the realm itself came from that same persisted
+    // config — if ADSP_TENANT_REALM overrode the realm, config.json's tenantName may belong to a
+    // different (stale) realm entirely.
+    tenantName: realmSource === 'config' ? config?.tenantName : undefined,
     tokenState,
     ...envStatus,
   };

--- a/libs/adsp-cli/src/main.ts
+++ b/libs/adsp-cli/src/main.ts
@@ -92,7 +92,7 @@ function runStatus(): void {
       : 'no cached token — run `adsp login`';
 
   // eslint-disable-next-line no-console
-  console.log(`Realm: ${status.realm} (from ${sourceLabel})`);
+  console.log(`Realm: ${status.realm}${status.tenantName ? ` (${status.tenantName})` : ''} (from ${sourceLabel})`);
   // eslint-disable-next-line no-console
   console.log(`Token: ${tokenLabel}`);
 }

--- a/libs/adsp-cli/src/tenants.spec.ts
+++ b/libs/adsp-cli/src/tenants.spec.ts
@@ -4,7 +4,7 @@ jest.mock('./directory', () => ({
 
 import { getServiceUrls } from './directory';
 import { HttpRequestError } from './httpError';
-import { findTenantByName, listTenants } from './tenants';
+import { findTenantByName, findTenantByRealm, listTenants } from './tenants';
 
 const mockGetServiceUrls = getServiceUrls as jest.Mock;
 
@@ -53,6 +53,37 @@ describe('findTenantByName', () => {
 
     await expect(findTenantByName('https://directory-service.example.com', 'my-tenant')).rejects.toThrow(
       'was not found in the directory'
+    );
+  });
+});
+
+describe('findTenantByRealm', () => {
+  it('GETs by realm with no Authorization header (anonymous)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ name: 'my-tenant', realm: 'my-realm' }] }),
+    });
+    global.fetch = fetchMock as never;
+
+    const tenant = await findTenantByRealm('https://directory-service.example.com', 'my-realm');
+
+    expect(tenant).toEqual({ name: 'my-tenant', realm: 'my-realm' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${TENANT_SERVICE_URL}/v2/tenants?realm=my-realm`);
+    expect(init).toBeUndefined();
+  });
+
+  it('returns null when no tenant matches', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) }) as never;
+
+    expect(await findTenantByRealm('https://directory-service.example.com', 'unknown-realm')).toBeNull();
+  });
+
+  it('throws an HttpRequestError carrying the status on a non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as never;
+
+    await expect(findTenantByRealm('https://directory-service.example.com', 'my-realm')).rejects.toBeInstanceOf(
+      HttpRequestError
     );
   });
 });

--- a/libs/adsp-cli/src/tenants.ts
+++ b/libs/adsp-cli/src/tenants.ts
@@ -40,6 +40,24 @@ export async function findTenantByName(directoryServiceUrl: string, name: string
 }
 
 /**
+ * Anonymous reverse lookup of a tenant by realm — the exact-name lookup's realm-keyed
+ * counterpart, for resolving a display name when only the realm is known (e.g. `login --realm`).
+ */
+export async function findTenantByRealm(directoryServiceUrl: string, realm: string): Promise<Tenant | null> {
+  const tenantServiceUrl = await resolveTenantServiceUrl(directoryServiceUrl);
+  const url = new URL('v2/tenants', tenantServiceUrl);
+  url.searchParams.set('realm', realm);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new HttpRequestError(response.status, `Tenant service request failed with status ${response.status}.`);
+  }
+
+  const data = (await response.json()) as TenantsResponse;
+  return data.results?.[0] ?? null;
+}
+
+/**
  * Full tenant list — requires an authenticated (core-realm) token. Used for the interactive
  * tenant-picker flow when the caller doesn't already know their tenant name or realm.
  */


### PR DESCRIPTION
## Summary
- `login` now resolves the tenant's display name alongside the realm (already known from `--tenant`/the interactive picker; a best-effort reverse lookup via `findTenantByRealm` for `--realm`, which never throws — a failed lookup just leaves the name unresolved) and persists it to `~/.adsp-cli/config.json`.
- `status` reports the tenant name when known.
- `getStatus` (and its `LoginStatus` type) is now exported from the package, so library consumers — e.g. `nx-adsp`'s generator templates, which use tenant name/realm — can read it directly instead of shelling out.

## Test plan
- [x] `nx build/lint/test adsp-cli` — 97 tests passing
- [x] `nx build/test adsp-sdk-mcp-server` — unaffected, 39 tests passing
- [x] Live-verified against a real ADSP dev tenant: `login --tenant autotest --env dev` persists `tenantName: "autotest"` to `~/.adsp-cli/config.json`, and `status` prints `Realm: <realm> (autotest) (from persisted login)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)