### PR TITLE
fix(ci): serialize nx affected release to avoid racing tag pushes

### DIFF
--- a/.github/actions/nx-production-build/action.yml
+++ b/.github/actions/nx-production-build/action.yml
@@ -35,7 +35,8 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         NUGET_API_KEY: ${{ inputs.github_token }}
-      run: npx nx affected --target=release --base=${{ inputs.affected-base }}
+      # Avoid parallel releases since releases may tag the same ref.
+      run: npx nx affected --target=release --base=${{ inputs.affected-base }} --parallel=1
     # Set affected apps to output.
     - id: nx-affected
       name: Set affected-apps


### PR DESCRIPTION
## Summary
- The `Release` step in `nx-production-build` ran `nx affected --target=release` without `--parallel`, so when more than one project was affected in the same run, their `semantic-release` processes could run concurrently in the shared checkout and race to `git push --tags`, causing one of them to get `[remote rejected]`.
- Seen in https://github.com/GovAlta/adsp-monorepo/actions/runs/28954154818/job/85908521602 — `adsp-cli-v1.1.0` was rejected on push (self-resolved on retry once the race window passed).
- Forces `--parallel=1` for just the release step so per-project releases run one at a time.

## Test plan
- [ ] Next Delivery CI run with multiple affected releasable projects pushes tags without rejection.