### PR TITLE
fix(adsp-cli): don't send caller-requested scopes to the core listing login

### DIFF
--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -425,6 +425,31 @@ describe('login', () => {
       expect(mockFindTenantByRealm).not.toHaveBeenCalled();
     });
 
+    it('never sends the caller-requested extra scope to the core listing login, only to the final tenant-realm login', async () => {
+      mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a' }]);
+      mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+      const loginPromise = loginInteractive({ scopes: ['adsp-cli-admin'] });
+
+      // First browser round-trip: core realm login — must stay scoped to 'email' only, since
+      // core's adsp-cli client has no adsp-cli-admin scope registered.
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+
+      // Second browser round-trip: the resolved tenant realm — this is where the elevated scope belongs.
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+
+      await loginPromise;
+
+      const [coreAuthorizeArgs, tenantAuthorizeArgs] = mockAuthClient.authorizeURL.mock.calls
+        .slice(-2)
+        .map(([args]) => args);
+      expect(coreAuthorizeArgs.scope).toEqual(['email']);
+      expect(tenantAuthorizeArgs.scope).toEqual(['email', 'adsp-cli-admin']);
+    });
+
     it('short-circuits entirely when the persisted realm already has a valid cached token', async () => {
       writeConfig({ tenantRealm: REALM });
       setCachedToken(ACCESS_SERVICE_URL, REALM, 'cached-token', undefined, 3600, ['email']);

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -297,7 +297,10 @@ export async function loginInteractive(
   }
 
   if (!realm) {
-    const core = await getOrLogin(accessServiceUrl, CORE_REALM, scopes);
+    // Only ever 'email' here, never the caller's extra requested scopes — core's adsp-cli client
+    // doesn't have (and doesn't need) scopes like adsp-cli-admin registered; that scope is only
+    // meaningful on the tenant-realm login below, once a realm is actually known.
+    const core = await getOrLogin(accessServiceUrl, CORE_REALM, ['email']);
     const picked = await promptForTenantRealm(directoryServiceUrl, core.token);
     realm = picked.realm;
     tenantName = picked.name;


### PR DESCRIPTION
## Summary
- `loginInteractive`'s no-realm/no-tenant path logs into `core` first (to list tenants for the interactive picker), then into the resolved tenant realm.
- It was passing the caller's full requested scopes — including elevated ones like `adsp-cli-admin` — into *both* logins. Core's `adsp-cli` client has no such optional scope registered, so `login --scope adsp-cli-admin` (with neither `--tenant` nor `--realm`) failed at the core hop.
- The `--tenant` and `--realm` paths were unaffected, since neither does a core login — they resolve the realm directly and only ever request scopes on the one (correct) login.
- Fix: the core hop now always requests only `['email']`, regardless of caller-requested scopes. The elevated scope is requested only on the final tenant-realm login, once a realm is actually known.

## Test plan
- [x] `nx test adsp-cli` — added a regression test asserting the core hop's scope stays `['email']` while the tenant-realm hop gets the full requested scope set; full suite (98 tests) passes.
- [x] `nx lint adsp-cli` / `nx build adsp-cli` pass.