### PR TITLE
feat: add tenantId to the status endpoint

### DIFF
--- a/apps/status-service/src/app/jobs/checkEndpoint.ts
+++ b/apps/status-service/src/app/jobs/checkEndpoint.ts
@@ -61,7 +61,7 @@ export function createCheckEndpointJob(props: CreateCheckEndpointProps) {
       props.logger?.info(`Successfully finished the check endpoint job.`);
     } catch (error) {
       props.logger?.error(
-        `Error checking endpoint ${props?.app?.url} of tenant ${props?.app?.tenantId}: ${error.message}.`
+        `Error checking endpoint ${props?.app?.url} of tenant ${props?.app?.tenantId}: ${error.message}.`,
       );
       props.logger?.error(`Error Job: `, error);
     }
@@ -72,8 +72,8 @@ async function checkEndpoint(
   getEndpointResponse: GetEndpointResponse,
   url: string,
   appKey: string,
-  logger: Logger
-): Promise<EndpointStatusEntry> {
+  logger: Logger,
+): Promise<Omit<EndpointStatusEntry, 'tenantId'>> {
   const start = Date.now();
   try {
     const { status } = await getEndpointResponse(url);
@@ -105,7 +105,7 @@ async function checkEndpoint(
 
 export const getNewEndpointStatus = (
   current: EndpointStatusType,
-  samples: EndpointStatusEntry[]
+  samples: EndpointStatusEntry[],
 ): EndpointStatusType => {
   const failed = samples.filter((sample) => !sample.ok).length;
 
@@ -125,7 +125,11 @@ export const getNewEndpointStatus = (
   return current;
 };
 
-async function saveStatus(props: CreateCheckEndpointProps, statusEntry: EndpointStatusEntry, tenantId: AdspId) {
+async function saveStatus(
+  props: CreateCheckEndpointProps,
+  statusEntry: Omit<EndpointStatusEntry, 'tenantId'>,
+  tenantId: AdspId,
+) {
   const {
     app,
     serviceStatusRepository,
@@ -138,8 +142,10 @@ async function saveStatus(props: CreateCheckEndpointProps, statusEntry: Endpoint
     serviceId,
   } = props;
   // create endpoint status entry before determining if the state is changed
-
-  await EndpointStatusEntryEntity.create(endpointStatusEntryRepository, statusEntry);
+  await EndpointStatusEntryEntity.create(endpointStatusEntryRepository, {
+    ...statusEntry,
+    tenantId: tenantId.toString(),
+  });
   // verify that in the last [ENTRY_SAMPLE_SIZE] minutes, at least [MIN_OK_COUNT] are ok
 
   const user = {
@@ -151,7 +157,7 @@ async function saveStatus(props: CreateCheckEndpointProps, statusEntry: Endpoint
   const { webhooks } = await configurationService.getConfiguration<PushServiceConfiguration, PushServiceConfiguration>(
     adspId`urn:ads:platform:push-service`,
     token,
-    app.tenantId
+    app.tenantId,
   );
 
   const { applicationWebhookIntervals } = await configurationService.getConfiguration<
@@ -175,7 +181,8 @@ async function saveStatus(props: CreateCheckEndpointProps, statusEntry: Endpoint
           const waitTimePings = await endpointStatusEntryRepository.findRecentByUrlAndApplicationId(
             app.url,
             app.appKey,
-            waitTimeInterval
+            tenantId.toString(),
+            waitTimeInterval,
           );
 
           let switchOffCount = 0;
@@ -224,7 +231,8 @@ async function saveStatus(props: CreateCheckEndpointProps, statusEntry: Endpoint
   const recentHistory = await endpointStatusEntryRepository.findRecentByUrlAndApplicationId(
     app.url,
     app.appKey,
-    ENTRY_SAMPLE_SIZE
+    tenantId.toString(),
+    ENTRY_SAMPLE_SIZE,
   );
 
   const status = await serviceStatusRepository.get(app.appKey);
@@ -264,13 +272,13 @@ const updateAppStatus = async (
   tokenProvider: TokenProvider,
   webhook: Webhooks,
   key: string,
-  serviceId: AdspId
+  serviceId: AdspId,
 ) => {
   const token = await tokenProvider.getAccessToken();
   const baseUrl = await directory.getServiceUrl(adspId`urn:ads:platform:configuration-service:v2`);
   const pushConfiguration = new URL(
     `/configuration/v2/configuration/${serviceId.namespace}/push-service?tenantId=${tenantId}`,
-    baseUrl
+    baseUrl,
   );
 
   const response = await axios.patch(
@@ -283,7 +291,7 @@ const updateAppStatus = async (
     },
     {
       headers: { Authorization: `Bearer ${token}` },
-    }
+    },
   );
 
   return response;
@@ -302,7 +310,8 @@ async function checkAndUpdateAutoChangeStatus(props: CreateCheckEndpointProps) {
       const recentHistory = await endpointStatusEntryRepository.findRecentByUrlAndApplicationId(
         app.url,
         app.appKey,
-        QUERY_SIZE
+        app.tenantId.toString(),
+        QUERY_SIZE,
       );
 
       //Get first and last date time to make sure the time is 5 minutes apart.

--- a/apps/status-service/src/app/model/endpointStatusEntry.ts
+++ b/apps/status-service/src/app/model/endpointStatusEntry.ts
@@ -10,22 +10,27 @@ export class EndpointStatusEntryEntity implements EndpointStatusEntry {
   responseTime: number;
   status: number | string;
   applicationId: string;
+  tenantId: string;
 
   static create(
     repository: EndpointStatusEntryRepository,
-    entry: NewOrExisting<EndpointStatusEntry>
+    entry: NewOrExisting<EndpointStatusEntry>,
   ): Promise<EndpointStatusEntryEntity> {
     const entity = new EndpointStatusEntryEntity(repository, entry);
     return repository.save(entity);
   }
 
-  constructor(private repository: EndpointStatusEntryRepository, entry: NewOrExisting<EndpointStatusEntry>) {
+  constructor(
+    private repository: EndpointStatusEntryRepository,
+    entry: NewOrExisting<EndpointStatusEntry>,
+  ) {
     this.ok = entry.ok;
     this.url = entry?.url;
     this.timestamp = entry.timestamp;
     this.responseTime = entry.responseTime;
     this.status = entry.status;
     this.applicationId = entry.applicationId;
+    this.tenantId = entry.tenantId;
   }
 
   async delete(user: User): Promise<boolean> {

--- a/apps/status-service/src/app/model/spec/endpointStatus.spec.ts
+++ b/apps/status-service/src/app/model/spec/endpointStatus.spec.ts
@@ -19,6 +19,7 @@ describe('EndpointStatusEntryEntity', () => {
     responseTime: 179,
     status: '200',
     applicationId: '1234',
+    tenantId: 'urn:ads:platform:tenant-service:v2:/tenants/test',
   };
   const userMock = {} as User;
 
@@ -30,7 +31,7 @@ describe('EndpointStatusEntryEntity', () => {
     expect(repositoryMock.save).toHaveBeenLastCalledWith(
       expect.objectContaining({
         url: endpointStatusEntityMock.url,
-      })
+      }),
     );
   });
 
@@ -40,7 +41,7 @@ describe('EndpointStatusEntryEntity', () => {
     expect(repositoryMock.delete).toHaveBeenLastCalledWith(
       expect.objectContaining({
         url: endpointStatusEntityMock.url,
-      })
+      }),
     );
   });
 });

--- a/apps/status-service/src/app/repository/endpointStatusEntry.ts
+++ b/apps/status-service/src/app/repository/endpointStatusEntry.ts
@@ -3,8 +3,13 @@ import { EndpointStatusEntryEntity } from '../model/endpointStatusEntry';
 import { EndpointStatusEntry } from '../types';
 
 export interface EndpointStatusEntryRepository extends Repository<EndpointStatusEntryEntity, EndpointStatusEntry> {
-  findRecentByUrlAndApplicationId(url: string, applicationId: string, top): Promise<EndpointStatusEntryEntity[]>;
+  findRecentByUrlAndApplicationId(
+    url: string,
+    applicationId: string,
+    tenantId: string,
+    top,
+  ): Promise<EndpointStatusEntryEntity[]>;
   findRecent(ageInMinutes?: number): Promise<EndpointStatusEntryEntity[]>;
   deleteOldUrlStatus(): Promise<boolean>;
-  deleteAll(appKey: string): Promise<number>;
+  deleteAll(appKey: string, tenantId: string): Promise<number>;
 }

--- a/apps/status-service/src/app/router/ApplicationRepo.ts
+++ b/apps/status-service/src/app/router/ApplicationRepo.ts
@@ -40,7 +40,7 @@ export class ApplicationRepo {
     serviceId: AdspId,
     directoryService: ServiceDirectory,
     tokenProvider: TokenProvider,
-    configurationService: ConfigurationService
+    configurationService: ConfigurationService,
   ) {
     this.#repository = repository;
     this.#serviceId = serviceId;
@@ -133,7 +133,7 @@ export class ApplicationRepo {
     monitorOnly: boolean,
     status: PublicServiceStatusType,
     tenant: Tenant,
-    user?: User
+    user?: User,
   ) => {
     const newApp = {
       appKey: appKey,
@@ -170,7 +170,7 @@ export class ApplicationRepo {
       },
       {
         headers: { Authorization: `Bearer ${token}` },
-      }
+      },
     );
     return newApp.appKey;
   };
@@ -188,7 +188,7 @@ export class ApplicationRepo {
     }
 
     // Delete its health status
-    await this.#endpointStatusEntryRepository.deleteAll(app.appKey);
+    await this.#endpointStatusEntryRepository.deleteAll(app.appKey, user.tenantId.toString());
 
     // Delete the app itself.
     this.#deleteConfigurationApp(appKey, user.tenantId);
@@ -206,7 +206,7 @@ export class ApplicationRepo {
       },
       {
         headers: { Authorization: `Bearer ${token}` },
-      }
+      },
     );
   };
 

--- a/apps/status-service/src/app/router/serviceStatus.ts
+++ b/apps/status-service/src/app/router/serviceStatus.ts
@@ -132,7 +132,7 @@ export const createNewApplication =
         monitorOnly,
         status,
         tenant,
-        user
+        user,
       );
       res.status(201).json(newApp);
     } catch (err) {
@@ -272,7 +272,7 @@ export const getApplicationEntries =
   (
     logger: Logger,
     applicationRepo: ApplicationRepo,
-    endpointStatusEntryRepository: EndpointStatusEntryRepository
+    endpointStatusEntryRepository: EndpointStatusEntryRepository,
   ): RequestHandler =>
   async (req, res, next) => {
     const { tenantId } = req.user as User;
@@ -290,7 +290,12 @@ export const getApplicationEntries =
         throw new NotFoundError('Status application', appKey);
       }
 
-      const entries = await endpointStatusEntryRepository.findRecentByUrlAndApplicationId(app.url, app.appKey, top);
+      const entries = await endpointStatusEntryRepository.findRecentByUrlAndApplicationId(
+        app.url,
+        app.appKey,
+        tenantId.toString(),
+        top,
+      );
       res.send(entries.map(mapEndpointStatusEntry));
     } catch (err) {
       logger.error(`Failed to get application: ${err.message}`);
@@ -327,7 +332,7 @@ export const testWebhook =
     logger: Logger,
     webhookRepo: WebhookRepo,
     applicationRepo: ApplicationRepo,
-    eventService: EventService
+    eventService: EventService,
   ): RequestHandler =>
   async (req, res, next) => {
     try {
@@ -353,8 +358,8 @@ export const testWebhook =
       await delay(2000);
       res.json(
         `event is sent - app: ${JSON.stringify(app)}, user: ${JSON.stringify(user)}, webhook: ${JSON.stringify(
-          webhook
-        )}`
+          webhook,
+        )}`,
       );
     } catch (err) {
       logger.error(`Failed to send event: ${err.message}`);
@@ -380,7 +385,7 @@ export function createServiceStatusRouter({
     serviceId,
     directory,
     tokenProvider,
-    configurationService
+    configurationService,
   );
 
   const webhookRepo = new WebhookRepo(
@@ -389,7 +394,7 @@ export function createServiceStatusRouter({
     serviceId,
     directory,
     tokenProvider,
-    configurationService
+    configurationService,
   );
 
   // Get the service for the tenant
@@ -402,35 +407,35 @@ export function createServiceStatusRouter({
   router.patch(
     '/applications/:appKey/disable',
     assertAuthenticatedHandler,
-    disableApplication(logger, applicationRepo)
+    disableApplication(logger, applicationRepo),
   );
   // add application
   router.post(
     '/applications',
     assertAuthenticatedHandler,
-    createNewApplication(logger, applicationRepo, tenantService)
+    createNewApplication(logger, applicationRepo, tenantService),
   );
   router.put('/applications/:appKey', assertAuthenticatedHandler, updateApplication(logger, applicationRepo));
   router.delete(
     '/applications/:appKey',
     assertAuthenticatedHandler,
-    deleteApplication(logger, applicationRepo, eventService)
+    deleteApplication(logger, applicationRepo, eventService),
   );
   router.patch(
     '/applications/:appKey/status',
     assertAuthenticatedHandler,
-    updateApplicationStatus(logger, applicationRepo, eventService)
+    updateApplicationStatus(logger, applicationRepo, eventService),
   );
 
   router.patch(
     '/applications/:appKey/toggle',
     assertAuthenticatedHandler,
-    toggleApplication(logger, applicationRepo, eventService)
+    toggleApplication(logger, applicationRepo, eventService),
   );
 
   router.get(
     '/applications/:appKey/endpoint-status-entries',
-    getApplicationEntries(logger, applicationRepo, endpointStatusEntryRepository)
+    getApplicationEntries(logger, applicationRepo, endpointStatusEntryRepository),
   );
 
   router.get('/applications/endpoint-status-entries', getAllApplicationEntries(logger, endpointStatusEntryRepository));
@@ -438,7 +443,7 @@ export function createServiceStatusRouter({
   router.get(
     '/webhook/:id/test/:eventName',
     assertAuthenticatedHandler,
-    testWebhook(logger, webhookRepo, applicationRepo, eventService)
+    testWebhook(logger, webhookRepo, applicationRepo, eventService),
   );
 
   return router;

--- a/apps/status-service/src/app/types/endpointStatusEntry.ts
+++ b/apps/status-service/src/app/types/endpointStatusEntry.ts
@@ -5,6 +5,7 @@ export interface EndpointStatusEntry {
   responseTime: number;
   status: number | string;
   applicationId: string;
+  tenantId: string;
 }
 
 export interface EndpointStatusEntryRepositoryOptions {

--- a/apps/status-service/src/mongo/endpointStatusEntry.ts
+++ b/apps/status-service/src/mongo/endpointStatusEntry.ts
@@ -14,7 +14,10 @@ export const defaultStatusEntryOptions: EndpointStatusEntryRepositoryOptions = {
 
 export default class MongoEndpointStatusEntryRepository implements EndpointStatusEntryRepository {
   model: Model<EndpointStatusEntry & Document>;
-  constructor(private logger: Logger, private opts: EndpointStatusEntryRepositoryOptions = defaultStatusEntryOptions) {
+  constructor(
+    private logger: Logger,
+    private opts: EndpointStatusEntryRepositoryOptions = defaultStatusEntryOptions,
+  ) {
     this.model = model<EndpointStatusEntry & Document>('EndpointStatusEntry', endpointStatusEntrySchema);
     this.model.on('index', (err: unknown) => {
       if (err) {
@@ -29,9 +32,13 @@ export default class MongoEndpointStatusEntryRepository implements EndpointStatu
   async findRecentByUrlAndApplicationId(
     url: string,
     applicationId: string,
-    top = this.opts.limit
+    tenantId: string,
+    top = this.opts.limit,
   ): Promise<EndpointStatusEntryEntity[]> {
-    const docs = await this.model.find({ url: url, applicationId: applicationId }).sort({ timestamp: -1 }).limit(top);
+    const docs = await this.model
+      .find({ url: url, applicationId: applicationId, tenantId: tenantId })
+      .sort({ timestamp: -1 })
+      .limit(top);
 
     const entries = docs.map((doc) => this.fromDoc(doc));
 
@@ -51,8 +58,8 @@ export default class MongoEndpointStatusEntryRepository implements EndpointStatu
     throw new Error('not implemented');
   }
 
-  async deleteAll(appKey: string): Promise<number> {
-    const count = await this.model.deleteMany({ applicationId: appKey });
+  async deleteAll(appKey: string, tenantId: string): Promise<number> {
+    const count = await this.model.deleteMany({ applicationId: appKey, tenantId: tenantId });
     return count.deletedCount;
   }
 
@@ -75,6 +82,7 @@ export default class MongoEndpointStatusEntryRepository implements EndpointStatu
       ok: endpoint.ok,
       responseTime: endpoint.responseTime,
       applicationId: endpoint.applicationId,
+      tenantId: endpoint.tenantId,
       status: endpoint.status,
       timestamp: endpoint.timestamp,
       url: endpoint.url,
@@ -89,6 +97,7 @@ export default class MongoEndpointStatusEntryRepository implements EndpointStatu
       ok: doc.ok,
       responseTime: doc.responseTime,
       applicationId: doc.applicationId,
+      tenantId: doc.tenantId,
       status: doc.status,
       timestamp: doc.timestamp,
       url: doc.url,

--- a/apps/status-service/src/mongo/schema.ts
+++ b/apps/status-service/src/mongo/schema.ts
@@ -8,7 +8,7 @@ export const serviceStatusEndpointSchema = new Schema(
       required: true,
     },
   },
-  { _id: false }
+  { _id: false },
 );
 
 export const endpointStatusEntrySchema = new Schema({
@@ -24,6 +24,10 @@ export const endpointStatusEntrySchema = new Schema({
   },
   applicationId: {
     type: String,
+  },
+  tenantId: {
+    type: String,
+    index: true,
   },
   responseTime: {
     type: Number,
@@ -57,7 +61,7 @@ export const serviceStatusApplicationSchema = new Schema(
     },
     endpoint: serviceStatusEndpointSchema,
   },
-  { timestamps: true }
+  { timestamps: true },
 );
 
 export const noticeEndpointSchema = new Schema(
@@ -67,7 +71,7 @@ export const noticeEndpointSchema = new Schema(
       required: true,
     },
   },
-  { _id: false }
+  { _id: false },
 );
 
 export const noticeApplicationSchema = new Schema(
@@ -105,7 +109,7 @@ export const noticeApplicationSchema = new Schema(
       type: String,
     },
   },
-  { timestamps: true }
+  { timestamps: true },
 );
 
 // An application property is pretty wide open.


### PR DESCRIPTION
* Added tenantId field to the EndpointStatusEntry type, entity model, Mongoose schema (indexed), and Mongo repository serialization
* Updated findRecentByUrlAndApplicationId to filter by tenantId in addition to url and applicationId
* Updated deleteAll to filter by tenantId in addition to applicationId
* All call sites pass tenantId sourced from the JWT bearer token — via req.user.tenantId in request handlers and app.tenantId in the health check job
* Updated test fixture to include tenantId