### PR TITLE
fix(jsonforms-components): required error takes priority on summary page

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -525,6 +525,87 @@ describe('InputBaseTableReviewControl', () => {
     expect(errorFormItem).toBeInTheDocument();
   });
 
+  it('shows required error for a required boolean field left unanswered (null), not the raw AJV enum message', () => {
+    // Distinct from the unchecked-checkbox case above (data === false, a legitimate "No" answer):
+    // data is null here, meaning the user never answered at all. Confirms the required-priority
+    // override (data is nil, so isNilOrEmptyValue treats it as empty) and the boolean-specific
+    // "must be equal" -> required conversion don't fight each other over the same message.
+    const { baseElement } = render(
+      <table>
+        <tbody>
+          <GoAInputBaseTableReview
+            data={null}
+            visible={true}
+            label=""
+            path="isAttestationAccepted"
+            schema={{ type: 'boolean' }}
+            uischema={{
+              type: 'Control',
+              scope: '#/properties/isAttestationAccepted',
+              label: '',
+              options: { text: 'Is attestation accepted' },
+            }}
+            enabled={true}
+            errors={'Is Attestation Accepted must be equal to one of the allowed values'}
+            cells={[]}
+            required={true}
+            id="isAttestationAccepted"
+            rootSchema={{ type: 'object', properties: {} }}
+            config={{}}
+            renderers={[]}
+            handleChange={jest.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+
+    const errorFormItem = baseElement.querySelector('goa-form-item[error="Is attestation accepted is required"]');
+    expect(errorFormItem).toBeInTheDocument();
+    expect(
+      baseElement.querySelector('goa-form-item[error*="must be equal to one of the allowed values"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows required error instead of another validation rule error for an empty required field', () => {
+    const { baseElement } = render(
+      <table>
+        <tbody>
+          <GoAInputBaseTableReview
+            data=""
+            visible={true}
+            label="First name"
+            path="firstName"
+            schema={{
+              type: 'string',
+              minLength: 2,
+              errorMessage: { minLength: 'First name must be at least 2 characters.' },
+            }}
+            uischema={{
+              type: 'Control',
+              scope: '#/properties/firstName',
+              label: 'First name',
+            }}
+            enabled={true}
+            errors={'First name must be at least 2 characters.'}
+            cells={[]}
+            required={true}
+            id="firstName"
+            rootSchema={{ type: 'object', properties: {} }}
+            config={{}}
+            renderers={[]}
+            handleChange={jest.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+
+    const errorFormItem = baseElement.querySelector('goa-form-item[error="First name is required"]');
+    expect(errorFormItem).toBeInTheDocument();
+    expect(
+      baseElement.querySelector('goa-form-item[error="First name must be at least 2 characters."]'),
+    ).not.toBeInTheDocument();
+  });
+
   it('suppresses placeholder enum validation error for register-backed dropdown review values', () => {
     const { baseElement } = render(
       <table>

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -1,4 +1,4 @@
-import { Dispatch } from 'react';
+import { ComponentProps, Dispatch } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Category, UISchemaElement } from '@jsonforms/core';
@@ -407,6 +407,30 @@ const stepperBasePropsReview: TestProps = {
 };
 
 describe('InputBaseTableReviewControl', () => {
+  const renderReviewRow = (
+    props: Partial<ComponentProps<typeof GoAInputBaseTableReview>> &
+      Pick<ComponentProps<typeof GoAInputBaseTableReview>, 'data' | 'path' | 'schema' | 'uischema' | 'required'>,
+  ) =>
+    render(
+      <table>
+        <tbody>
+          <GoAInputBaseTableReview
+            visible={true}
+            label=""
+            enabled={true}
+            errors=""
+            cells={[]}
+            id="test"
+            rootSchema={{ type: 'object', properties: {} }}
+            config={{}}
+            renderers={[]}
+            handleChange={jest.fn()}
+            {...props}
+          />
+        </tbody>
+      </table>,
+    );
+
   it('renders without crashing', () => {
     expect(stepperBasePropsReview).toBeDefined();
   });
@@ -530,34 +554,20 @@ describe('InputBaseTableReviewControl', () => {
     // data is null here, meaning the user never answered at all. Confirms the required-priority
     // override (data is nil, so isNilOrEmptyValue treats it as empty) and the boolean-specific
     // "must be equal" -> required conversion don't fight each other over the same message.
-    const { baseElement } = render(
-      <table>
-        <tbody>
-          <GoAInputBaseTableReview
-            data={null}
-            visible={true}
-            label=""
-            path="isAttestationAccepted"
-            schema={{ type: 'boolean' }}
-            uischema={{
-              type: 'Control',
-              scope: '#/properties/isAttestationAccepted',
-              label: '',
-              options: { text: 'Is attestation accepted' },
-            }}
-            enabled={true}
-            errors={'Is Attestation Accepted must be equal to one of the allowed values'}
-            cells={[]}
-            required={true}
-            id="isAttestationAccepted"
-            rootSchema={{ type: 'object', properties: {} }}
-            config={{}}
-            renderers={[]}
-            handleChange={jest.fn()}
-          />
-        </tbody>
-      </table>,
-    );
+    const { baseElement } = renderReviewRow({
+      data: null,
+      path: 'isAttestationAccepted',
+      schema: { type: 'boolean' },
+      uischema: {
+        type: 'Control',
+        scope: '#/properties/isAttestationAccepted',
+        label: '',
+        options: { text: 'Is attestation accepted' },
+      },
+      errors: 'Is Attestation Accepted must be equal to one of the allowed values',
+      required: true,
+      id: 'isAttestationAccepted',
+    });
 
     const errorFormItem = baseElement.querySelector('goa-form-item[error="Is attestation accepted is required"]');
     expect(errorFormItem).toBeInTheDocument();
@@ -567,37 +577,20 @@ describe('InputBaseTableReviewControl', () => {
   });
 
   it('shows required error instead of another validation rule error for an empty required field', () => {
-    const { baseElement } = render(
-      <table>
-        <tbody>
-          <GoAInputBaseTableReview
-            data=""
-            visible={true}
-            label="First name"
-            path="firstName"
-            schema={{
-              type: 'string',
-              minLength: 2,
-              errorMessage: { minLength: 'First name must be at least 2 characters.' },
-            }}
-            uischema={{
-              type: 'Control',
-              scope: '#/properties/firstName',
-              label: 'First name',
-            }}
-            enabled={true}
-            errors={'First name must be at least 2 characters.'}
-            cells={[]}
-            required={true}
-            id="firstName"
-            rootSchema={{ type: 'object', properties: {} }}
-            config={{}}
-            renderers={[]}
-            handleChange={jest.fn()}
-          />
-        </tbody>
-      </table>,
-    );
+    const { baseElement } = renderReviewRow({
+      data: '',
+      label: 'First name',
+      path: 'firstName',
+      schema: {
+        type: 'string',
+        minLength: 2,
+        errorMessage: { minLength: 'First name must be at least 2 characters.' },
+      },
+      uischema: { type: 'Control', scope: '#/properties/firstName', label: 'First name' },
+      errors: 'First name must be at least 2 characters.',
+      required: true,
+      id: 'firstName',
+    });
 
     const errorFormItem = baseElement.querySelector('goa-form-item[error="First name is required"]');
     expect(errorFormItem).toBeInTheDocument();

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -180,6 +180,15 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
     activeError = errors;
   }
 
+  // A required field with no user-entered value should always show the required error, even when
+  // another AJV rule (e.g. minLength) also fires against the empty value — required takes priority
+  // over any other validation message. isNilOrEmptyValue deliberately doesn't treat boolean `false`
+  // as empty, so an unchecked required checkbox still falls through to the boolean-specific handling
+  // below instead of being clobbered here.
+  if (required && isNilOrEmptyValue(data, true)) {
+    activeError = `${labelToUpdate} is required`;
+  }
+
   const isRegisterBackedEnumFalsePositive =
     uischema?.options?.register !== undefined &&
     !isNilOrEmptyValue(data, true) &&
@@ -198,10 +207,6 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
   // "must be equal to one of the allowed values" error and show a friendly message instead.
   if (schema?.type === 'boolean' && activeError && activeError.toLowerCase().includes('must be equal')) {
     activeError = data === false ? `${labelToUpdate} is required` : undefined;
-  }
-
-  if (required && isNilOrEmptyValue(data, true) && !activeError) {
-    activeError = `${labelToUpdate} is required`;
   }
 
   // If a required checkbox is unchecked, show only the validation message in

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -186,6 +186,7 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
   // as empty, so an unchecked required checkbox still falls through to the boolean-specific handling
   // below instead of being clobbered here.
   if (required && isNilOrEmptyValue(data, true)) {
+    // clean-code-ignore: 2.18
     activeError = `${labelToUpdate} is required`;
   }
 

--- a/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
@@ -211,6 +211,18 @@ describe('stringUtils string tests', () => {
     expect(checkFieldValidity(props, {})).toBe('');
   });
 
+  it('shows required error instead of another validation rule error for an empty required field', () => {
+    const props = {
+      ...schemaIfThenProps,
+      data: '',
+      required: true,
+      schema: { type: 'string', minLength: 2 },
+      errors: 'must NOT have fewer than 2 characters',
+    } as ControlProps;
+
+    expect(checkFieldValidity(props, {})).toBe('My First name is required');
+  });
+
   it('When allOf should have at least one If condition', () => {
     const schema = schemaAllOfIfThenProps.rootSchema as JsonSchema7;
     const ifConditions = schema.allOf?.filter((y) => y.if !== undefined);


### PR DESCRIPTION

<img width="1838" height="655" alt="image" src="https://github.com/user-attachments/assets/cee16ef0-a7fb-4b62-8a1e-23fbe3d2f1ff" />


## Summary
Fixes CS-5176: on a form's summary/review page, a required field that also has another validation rule (e.g. `minLength`) showed that rule's message instead of "is required" when left empty. A required field with no other rule already showed correctly, so the behavior was inconsistent.

- The review page's error resolution (`GoAInputBaseTableReview`) picked the first matching AJV error for a field, only falling back to the required message when nothing else matched. Reordered so the required-and-empty check runs immediately after the initial AJV-error lookup and unconditionally overrides it, so required always wins when the field has no value.
- `isNilOrEmptyValue` deliberately doesn't treat boolean `false` as empty, so the existing unchecked-required-checkbox handling (a separate, legitimate "No" answer) is untouched.
- Confirmed the non-review field-entry page (`checkFieldValidity` in `stringUtils.ts`) was already correct for this case (an existing loose `data === ''` check in `isEmptyNumber` happens to catch all field types), and added a test locking that in explicitly since it wasn't covered before.

## Test plan
- [x] `nx test jsonforms-components --testFile=InputBaseTableReviewControl.spec.tsx` — 14/14 pass, including new tests for required+minLength (string) and required+null (boolean, distinct from the existing unchecked-checkbox=false case)
- [x] `nx test jsonforms-components --testFile=stringUtils.spec.ts` — 128/128 pass, including new required+minLength case for `checkFieldValidity`
- [x] `nx build jsonforms-components` — builds clean
