### PR TITLE
fix(adsp-cli): verify the token endpoint actually granted a requested scope

### DIFF
--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -36,7 +36,7 @@ jest.mock('./tenants', () => ({
 import { getAccessToken, getStatus, loginInteractive, logout } from './login';
 import { findTenantByName, findTenantByRealm, listTenants } from './tenants';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
-import { getCacheFilePath, setCachedToken } from './tokenCache';
+import { getCachedToken, getCacheFilePath, setCachedToken } from './tokenCache';
 import { AuthorizationCode } from 'simple-oauth2';
 
 const mockFindTenantByName = findTenantByName as jest.Mock;
@@ -332,6 +332,29 @@ describe('login', () => {
 
       const [authorizeArgs] = mockAuthClient.authorizeURL.mock.calls.at(-1);
       expect(authorizeArgs.scope).toEqual(['email', 'adsp-cli-admin']);
+    });
+
+    it('throws when the identity provider does not grant a requested scope, without caching the token', async () => {
+      // e.g. the scope isn't registered as an optional client scope on this realm's adsp-cli client.
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload({ scope: 'email' }));
+
+      const loginPromise = loginInteractive({ realm: REALM, scopes: ['adsp-cli-admin'] });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'auth-code' } }, { send: jest.fn() });
+
+      await expect(loginPromise).rejects.toThrow(/did not grant the requested scope.*adsp-cli-admin/);
+      expect(getCachedToken(ACCESS_SERVICE_URL, REALM)).toBeNull();
+    });
+
+    it('caches the scope actually granted by the identity provider rather than just what was requested', async () => {
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload({ scope: 'email adsp-cli-admin offline_access' }));
+
+      const loginPromise = loginInteractive({ realm: REALM, scopes: ['adsp-cli-admin'] });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'auth-code' } }, { send: jest.fn() });
+      await loginPromise;
+
+      expect(getCachedToken(ACCESS_SERVICE_URL, REALM)?.scopes).toEqual(['email', 'adsp-cli-admin', 'offline_access']);
     });
 
     it('reuses a cached token that already covers the newly requested scope, without a fresh browser login', async () => {

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -170,6 +170,21 @@ async function browserLogin(accessServiceUrl: string, realm: string, scopes: str
     server.close();
   });
 
+  // The token endpoint echoes back the scope it actually granted (RFC 6749 §5.1) — trust that over
+  // what was merely requested, since Keycloak silently drops any scope not registered/grantable on
+  // the client rather than erroring. Falls back to the requested list only if the field is absent
+  // entirely (some environments/mocks don't echo it), rather than treating that as a hard failure.
+  const grantedScopeField = token['scope'];
+  const grantedScopes = typeof grantedScopeField === 'string' ? grantedScopeField.split(' ').filter(Boolean) : scopes;
+  const missingScopes = scopes.filter((scope) => !grantedScopes.includes(scope));
+  if (missingScopes.length > 0) {
+    throw new Error(
+      `Login succeeded, but the '${realm}' realm did not grant the requested scope(s): ${missingScopes.join(
+        ', '
+      )}. Check that they're registered as optional client scopes on that realm's adsp-cli client.`
+    );
+  }
+
   const expiresIn = (token['expires_in'] as number) ?? 300;
   setCachedToken(
     accessServiceUrl,
@@ -177,7 +192,7 @@ async function browserLogin(accessServiceUrl: string, realm: string, scopes: str
     token['access_token'] as string,
     token['refresh_token'] as string | undefined,
     expiresIn,
-    scopes
+    grantedScopes
   );
 
   return token['access_token'] as string;


### PR DESCRIPTION
## Summary
- `browserLogin` now checks the OAuth token response's `scope` field against what was requested, instead of blindly trusting the request.
- If a requested scope is missing from what the identity provider actually granted (e.g. it's not registered as an optional client scope on that realm's `adsp-cli` client), login now throws immediately rather than caching a token that silently lacks it.
- The cache stores the actually-granted scope list going forward (falling back to the requested list only if the IDP omits the `scope` field entirely).

## Why
Previously, once a scope silently failed to land in a token, `adsp-cli login --scope <name>` would keep reusing the deficient cached token on every subsequent run — `hasScopes()` only checked whether the scope *name* had been requested before, not whether the actual grant held up. Only a full `logout` (wiping the entire cache) could recover. This surfaces the failure immediately and prevents the bad cache entry from being written at all.

## Test plan
- [x] `nx test adsp-cli` — all 49 tests pass, including two new cases: throwing (and not caching) when a requested scope isn't granted, and caching the actually-granted scope string when it differs from the request.
- [x] `nx lint adsp-cli` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)