### PR TITLE
feat(pdf-service): add variables and additionalStyles to PDF template configuration

### DIFF
--- a/apps/pdf-service/src/pdf/configuration.ts
+++ b/apps/pdf-service/src/pdf/configuration.ts
@@ -20,6 +20,7 @@ export const configurationSchema = {
         footer: { type: ['string', 'null'] },
         header: { type: ['string', 'null'] },
         additionalStyles: { type: ['string', 'null'] },
+        variables: { type: ['string', 'null'] },
         startWithDefault: { type: ['boolean'] },
       },
       required: ['id', 'name', 'template'],

--- a/apps/pdf-service/src/pdf/model/template.ts
+++ b/apps/pdf-service/src/pdf/model/template.ts
@@ -15,6 +15,7 @@ export class PdfTemplateEntity implements PdfTemplate {
   header?: string;
   footer?: string;
   additionalStyles?: string;
+  variables?: string;
   startWithDefault?: boolean;
   additionalStylesWrapped?: string;
   logger: Logger;
@@ -35,9 +36,10 @@ export class PdfTemplateEntity implements PdfTemplate {
       header,
       footer,
       additionalStyles,
+      variables,
       startWithDefault,
       logger,
-    }: PdfTemplate
+    }: PdfTemplate,
   ) {
     this.tenantId = tenantId;
     this.id = id;
@@ -46,6 +48,7 @@ export class PdfTemplateEntity implements PdfTemplate {
     this.template = template;
     this.header = header;
     this.footer = footer;
+    this.variables = variables;
     this.templateService = templateService;
     this.startWithDefault = startWithDefault;
 
@@ -58,15 +61,15 @@ export class PdfTemplateEntity implements PdfTemplate {
     if (!this.evaluateTemplate) {
       this.evaluateTemplate = this.templateService.getTemplateFunction(
         this.additionalStylesWrapped.concat(this.template),
-        null
+        null,
       );
       this.evaluateFooterTemplate = this.templateService.getTemplateFunction(
         this.footer ? this.additionalStylesWrapped.concat(this.footer) : this.footer,
-        'pdf-footer'
+        'pdf-footer',
       );
       this.evaluateHeaderTemplate = this.templateService.getTemplateFunction(
         this.header ? this.additionalStylesWrapped.concat(this.header) : this.header,
-        'pdf-header'
+        'pdf-header',
       );
     }
   }

--- a/apps/pdf-service/src/pdf/router/__snapshots__/pdf.spec.ts.snap
+++ b/apps/pdf-service/src/pdf/router/__snapshots__/pdf.spec.ts.snap
@@ -30,12 +30,14 @@ exports[`pdf getGeneratedFile can get file 1`] = `
 exports[`pdf getTemplates can get templates 1`] = `
 [
   {
+    "additionalStyles": undefined,
     "description": "This is a test.",
     "footer": undefined,
     "header": undefined,
     "id": "test",
     "name": "Test template",
     "template": "",
+    "variables": undefined,
   },
 ]
 `;

--- a/apps/pdf-service/src/pdf/router/pdf.spec.ts
+++ b/apps/pdf-service/src/pdf/router/pdf.spec.ts
@@ -5,7 +5,16 @@ import * as HttpStatusCodes from 'http-status-codes';
 import { Logger } from 'winston';
 import { PDF_GENERATION_QUEUED } from '../events';
 import { ServiceRoles } from '../roles';
-import { createPdfRouter, createPdfTemplate, deletePdfTemplate, generatePdf, getGeneratedFile, getTemplate, getTemplates, updatePdfTemplate } from './pdf';
+import {
+  createPdfRouter,
+  createPdfTemplate,
+  deletePdfTemplate,
+  generatePdf,
+  getGeneratedFile,
+  getTemplate,
+  getTemplates,
+  updatePdfTemplate,
+} from './pdf';
 import axios from 'axios';
 
 jest.mock('axios');
@@ -57,15 +66,15 @@ describe('pdf', () => {
   };
 
   const createMockResponse = (): Partial<Response> => {
-  const res: Partial<Response> = {
-    status: jest.fn(),
-    send: jest.fn(),
-    json: jest.fn(),
-  };
+    const res: Partial<Response> = {
+      status: jest.fn(),
+      send: jest.fn(),
+      json: jest.fn(),
+    };
 
-  (res.status as jest.Mock).mockReturnValue(res);
-  return res;
-};
+    (res.status as jest.Mock).mockReturnValue(res);
+    return res;
+  };
 
   beforeEach(() => {
     eventServiceMock.send.mockReset();
@@ -100,8 +109,6 @@ describe('pdf', () => {
 
   // clean-code-ignore: 2.3
   describe('createPdfTemplate', () => {
-
-
     it('creates an empty PDF template', async () => {
       const req = {
         tenant: { id: tenantId },
@@ -119,9 +126,8 @@ describe('pdf', () => {
       await createPdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
-
 
       expect(serviceDirectoryMock.getServiceUrl).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -147,7 +153,7 @@ describe('pdf', () => {
         {
           headers: { Authorization: 'Bearer test-token' },
           params: { tenantId: tenantId.toString() },
-        }
+        },
       );
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.CREATED);
       expect(res.json).toHaveBeenCalledWith({
@@ -176,7 +182,7 @@ describe('pdf', () => {
       await createPdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(axiosMock.patch).toHaveBeenCalledWith(
@@ -195,7 +201,7 @@ describe('pdf', () => {
         {
           headers: { Authorization: 'Bearer test-token' },
           params: { tenantId: tenantId.toString() },
-        }
+        },
       );
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.CREATED);
       expect(res.json).toHaveBeenCalledWith({
@@ -224,7 +230,7 @@ describe('pdf', () => {
       await createPdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(res.json).toHaveBeenCalledWith({
@@ -257,7 +263,7 @@ describe('pdf', () => {
       await createPdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.CONFLICT);
@@ -288,7 +294,7 @@ describe('pdf', () => {
       await createPdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(error);
@@ -309,7 +315,7 @@ describe('pdf', () => {
       await createPdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
@@ -334,6 +340,39 @@ describe('pdf', () => {
 
       expect(res.send).toHaveBeenCalledWith(expect.arrayContaining([configuration.test]));
       expect(res.send.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it('includes additionalStyles and variables in the mapped templates', async () => {
+      const req = {
+        getConfiguration: jest.fn(),
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+      req.getConfiguration.mockResolvedValueOnce([
+        {
+          styled: {
+            id: 'styled',
+            name: 'Styled template',
+            description: 'Has styles.',
+            template: '<p>body</p>',
+            header: '<h1>header</h1>',
+            footer: '<p>footer</p>',
+            additionalStyles: '.a { color: red; }',
+            variables: '{"foo":"bar"}',
+          },
+        },
+      ]);
+      await getTemplates(req as unknown as Request, res as unknown as Response, next);
+
+      expect(res.send).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'styled',
+          additionalStyles: '.a { color: red; }',
+          variables: '{"foo":"bar"}',
+        }),
+      ]);
     });
 
     it('can call next for error', async () => {
@@ -445,7 +484,7 @@ describe('pdf', () => {
       await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(axiosMock.patch).toHaveBeenCalledWith(
@@ -466,7 +505,7 @@ describe('pdf', () => {
         {
           headers: { Authorization: 'Bearer test-token' },
           params: { tenantId: tenantId.toString() },
-        }
+        },
       );
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.CREATED);
       expect(res.json).toHaveBeenCalledWith({
@@ -477,6 +516,82 @@ describe('pdf', () => {
         header: '<h1>New header</h1>',
         footer: '<p>New footer</p>',
       });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('updates name, description, additionalStyles, and variables when provided', async () => {
+      const req = {
+        tenant: { id: tenantId },
+        user: { tenantId, id: 'test', name: 'tester', roles: [ServiceRoles.Admin] },
+        params: { templateId: 'test' },
+        body: {
+          name: 'Renamed template',
+          description: 'Updated description.',
+          additionalStyles: '.a { color: red; }',
+          variables: '{"foo":"bar"}',
+        },
+        template: existingTemplate,
+      };
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      serviceDirectoryMock.getServiceUrl.mockResolvedValueOnce(new URL('http://localhost:80'));
+      tokenProviderMock.getAccessToken.mockResolvedValueOnce('test-token');
+      axiosMock.patch.mockResolvedValueOnce({ data: {} });
+
+      await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
+        req as unknown as Request,
+        res as unknown as Response,
+        next,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test',
+          name: 'Renamed template',
+          description: 'Updated description.',
+          template: '<p>Old body</p>',
+          header: '<h1>Old header</h1>',
+          footer: '<p>Old footer</p>',
+          additionalStyles: '.a { color: red; }',
+          variables: '{"foo":"bar"}',
+        }),
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('preserves existing additionalStyles and variables when not in the request body', async () => {
+      const req = {
+        tenant: { id: tenantId },
+        user: { tenantId, id: 'test', name: 'tester', roles: [ServiceRoles.Admin] },
+        params: { templateId: 'test' },
+        body: { template: '<p>New body only</p>' },
+        template: {
+          ...existingTemplate,
+          additionalStyles: '.keep { color: blue; }',
+          variables: '{"kept":true}',
+        },
+      };
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      serviceDirectoryMock.getServiceUrl.mockResolvedValueOnce(new URL('http://localhost:80'));
+      tokenProviderMock.getAccessToken.mockResolvedValueOnce('test-token');
+      axiosMock.patch.mockResolvedValueOnce({ data: {} });
+
+      await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
+        req as unknown as Request,
+        res as unknown as Response,
+        next,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          template: '<p>New body only</p>',
+          additionalStyles: '.keep { color: blue; }',
+          variables: '{"kept":true}',
+        }),
+      );
       expect(next).not.toHaveBeenCalled();
     });
 
@@ -498,7 +613,7 @@ describe('pdf', () => {
       await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(res.json).toHaveBeenCalledWith(
@@ -506,7 +621,7 @@ describe('pdf', () => {
           template: '<p>New body only</p>',
           header: '<h1>Old header</h1>',
           footer: '<p>Old footer</p>',
-        })
+        }),
       );
       expect(next).not.toHaveBeenCalled();
     });
@@ -525,7 +640,7 @@ describe('pdf', () => {
       await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
@@ -552,7 +667,7 @@ describe('pdf', () => {
       await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(error);
@@ -573,7 +688,7 @@ describe('pdf', () => {
       await updatePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(expect.any(TypeError));
@@ -603,7 +718,7 @@ describe('pdf', () => {
       await deletePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(serviceDirectoryMock.getServiceUrl).toHaveBeenCalledWith(
@@ -620,7 +735,7 @@ describe('pdf', () => {
         {
           headers: { Authorization: 'Bearer test-token' },
           params: { tenantId: tenantId.toString() },
-        }
+        },
       );
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.NO_CONTENT);
       expect(res.send).toHaveBeenCalledWith();
@@ -639,7 +754,7 @@ describe('pdf', () => {
       await deletePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
@@ -666,7 +781,7 @@ describe('pdf', () => {
       await deletePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(error);
@@ -688,7 +803,7 @@ describe('pdf', () => {
       await deletePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(error);
@@ -711,7 +826,7 @@ describe('pdf', () => {
       await deletePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(error);
@@ -732,7 +847,7 @@ describe('pdf', () => {
       await deletePdfTemplate(serviceDirectoryMock, tokenProviderMock)(
         req as unknown as Request,
         res as unknown as Response,
-        next
+        next,
       );
 
       expect(next).toHaveBeenCalledWith(expect.any(TypeError));
@@ -748,7 +863,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       expect(handler).toBeTruthy();
     });
@@ -785,7 +900,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(next).not.toHaveBeenCalled();
@@ -797,10 +912,10 @@ describe('pdf', () => {
           data: req.body.data,
           filename: req.body.filename,
           requestedBy: expect.objectContaining({ id: req.user.id, name: req.user.name }),
-        })
+        }),
       );
       expect(eventServiceMock.send).toHaveBeenCalledWith(
-        expect.objectContaining({ tenantId, name: PDF_GENERATION_QUEUED })
+        expect.objectContaining({ tenantId, name: PDF_GENERATION_QUEUED }),
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'job1' }));
       expect(res.send.mock.calls[0][0]).toMatchSnapshot();
@@ -838,7 +953,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(next).not.toHaveBeenCalled();
@@ -850,7 +965,7 @@ describe('pdf', () => {
           data: req.body.data,
           filename: req.body.filename,
           requestedBy: expect.objectContaining({ id: req.user.id, name: req.user.name }),
-        })
+        }),
       );
 
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'job1' }));
@@ -884,7 +999,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       await handler(req as unknown as Request, res as unknown as Response, next);
 
@@ -934,7 +1049,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(next).not.toHaveBeenCalled();
@@ -946,10 +1061,10 @@ describe('pdf', () => {
           data: req.body.data,
           filename: req.body.filename,
           requestedBy: expect.objectContaining({ id: req.user.id, name: req.user.name }),
-        })
+        }),
       );
       expect(eventServiceMock.send).toHaveBeenCalledWith(
-        expect.objectContaining({ tenantId, name: PDF_GENERATION_QUEUED })
+        expect.objectContaining({ tenantId, name: PDF_GENERATION_QUEUED }),
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'job1' }));
       expect(res.send.mock.calls[0][0]).toMatchSnapshot();
@@ -988,7 +1103,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(next).toHaveBeenCalledWith(expect.any(InvalidOperationError));
@@ -1024,7 +1139,7 @@ describe('pdf', () => {
         eventServiceMock,
         fileServiceMock,
         queueServiceMock,
-        loggerMock
+        loggerMock,
       );
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));

--- a/apps/pdf-service/src/pdf/router/pdf.swagger.yml
+++ b/apps/pdf-service/src/pdf/router/pdf.swagger.yml
@@ -27,6 +27,13 @@ components:
           type: string
           description: Page footers, designed with HTML/CSS
           example: <p>Thank you, thank you very much</p>
+        additionalStyles:
+          type: string
+          description: CSS styles shared across the template, header, and footer.
+          example: ".label { font-weight: bold; }"
+        variables:
+          type: string
+          description: Variable assignments available to the template.
     Job:
       type: object
       properties:
@@ -78,11 +85,11 @@ components:
           example: user-jane-doe
         context:
           description: The context in which the PDF is being generated. This is an arbitrary JSON object that can include any relevant information about the generation request.
-          example: { "requestId": "12345", "source": "user-action" }
+          example: {"requestId": "12345", "source": "user-action"}
           type: object
         data:
           description: The variable (Handlebars) assignments to be applied to the template when generating a PDF.  This is an arbitrary JSON object, but its properties must match those expected by the template.
-          example: { "user": { "name": "Jane Doe" } }
+          example: {"user": {"name": "Jane Doe"}}
           type: object
         filename:
           description: The name of the file that will be given to the generated PDF document.  It must be unique within your tenant.
@@ -172,7 +179,7 @@ components:
   patch:
     tags:
       - Templates
-    description: Update the template body, header, and/or footer of an existing PDF template. Only the fields included in the request body are updated; all other fields are left unchanged.
+    description: Update an existing PDF template. Only the fields included in the request body are updated; all other fields are left unchanged.
     parameters:
       - name: templateId
         description: ID of template to update.
@@ -187,6 +194,16 @@ components:
           schema:
             type: object
             properties:
+              name:
+                type: string
+                description: Name of the template. Can contain letters, numbers, spaces, and hyphens.
+                minLength: 1
+                maxLength: 50
+                example: My Template
+              description:
+                type: string
+                description: Description of the template's purpose.
+                example: A template for rendering a user name
               template:
                 type: string
                 description: The template body, designed with HTML/CSS.
@@ -199,6 +216,13 @@ components:
                 type: string
                 description: Page footer, designed with HTML/CSS.
                 example: <p>Thank you, thank you very much</p>
+              additionalStyles:
+                type: string
+                description: CSS styles shared across the template, header, and footer.
+                example: ".label { font-weight: bold; }"
+              variables:
+                type: string
+                description: Variable assignments available to the template.
     responses:
       201:
         description: The PDF template was successfully updated.

--- a/apps/pdf-service/src/pdf/router/pdf.ts
+++ b/apps/pdf-service/src/pdf/router/pdf.ts
@@ -5,7 +5,7 @@ import {
   isAllowedUser,
   ServiceDirectory,
   UnauthorizedUserError,
-  TokenProvider
+  TokenProvider,
 } from '@abgov/adsp-service-sdk';
 import * as HttpStatusCodes from 'http-status-codes';
 import axios from 'axios';
@@ -24,7 +24,7 @@ import { GENERATED_PDF } from '../fileTypes';
 import { PdfServiceWorkItem } from '../job';
 import { PdfTemplateEntity } from '../model';
 import { ServiceRoles } from '../roles';
-import { ConfigurationDeleteOperation, ConfigurationUpdateOperation, PdfTemplateConfiguration  } from '../types';
+import { ConfigurationDeleteOperation, ConfigurationUpdateOperation, PdfTemplateConfiguration } from '../types';
 
 export interface RouterProps {
   serviceId: AdspId;
@@ -37,7 +37,16 @@ export interface RouterProps {
   tokenProvider: TokenProvider;
 }
 
-function mapPdfTemplate({ id, name, description, template, header, footer }: PdfTemplateEntity) {
+function mapPdfTemplate({
+  id,
+  name,
+  description,
+  template,
+  header,
+  footer,
+  additionalStyles,
+  variables,
+}: PdfTemplateEntity) {
   return {
     id,
     name,
@@ -45,6 +54,8 @@ function mapPdfTemplate({ id, name, description, template, header, footer }: Pdf
     template,
     header,
     footer,
+    additionalStyles,
+    variables,
   };
 }
 
@@ -79,9 +90,7 @@ export function getTemplate(templateIn: 'params' | 'body'): RequestHandler {
   };
 }
 
-
-const toTemplateId = (name: string): string =>
-  name.trim().toLowerCase().replace(/\s+/g, '-');
+const toTemplateId = (name: string): string => name.trim().toLowerCase().replace(/\s+/g, '-');
 
 // clean-code-ignore: 2.3 2.10
 const createPdfTemplatePatch = (
@@ -109,10 +118,8 @@ const createPdfTemplatePatch = (
   },
 });
 
-const isTemplateIdAlreadyInUse = (
-  configuration: Record<string, PdfTemplateEntity>,
-  name: string,
-): boolean => Boolean(configuration[name]);
+const isTemplateIdAlreadyInUse = (configuration: Record<string, PdfTemplateEntity>, name: string): boolean =>
+  Boolean(configuration[name]);
 
 async function savePdfTemplate(
   directory: ServiceDirectory,
@@ -120,42 +127,29 @@ async function savePdfTemplate(
   tenantId: string,
   patch: ReturnType<typeof createPdfTemplatePatch>,
 ): Promise<void> {
-  const configurationServiceId =
-    adspId`urn:ads:platform:configuration-service:v2`;
-  const configurationApiUrl =
-    await directory.getServiceUrl(configurationServiceId);
+  const configurationServiceId = adspId`urn:ads:platform:configuration-service:v2`;
+  const configurationApiUrl = await directory.getServiceUrl(configurationServiceId);
   const token = await tokenProvider.getAccessToken();
 
-  await axios.patch(
-    new URL(
-      'v2/configuration/platform/pdf-service',
-      configurationApiUrl,
-    ).href,
-    patch,
-    {
-      headers: { Authorization: `Bearer ${token}` },
-      params: { tenantId },
-    },
-  );
+  await axios.patch(new URL('v2/configuration/platform/pdf-service', configurationApiUrl).href, patch, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { tenantId },
+  });
 }
 
-export function createPdfTemplate(
-  directory: ServiceDirectory,
-  tokenProvider: TokenProvider,
-): RequestHandler {
+export function createPdfTemplate(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
   return async (req, res, next) => {
     try {
-
       const user = req.user;
       const tenantId = req.tenant?.id;
 
-      if (!isAllowedUser(user, tenantId, ServiceRoles.Admin, true)) { // clean-code-ignore: 2.4
+      if (!isAllowedUser(user, tenantId, ServiceRoles.Admin, true)) {
+        // clean-code-ignore: 2.4
         throw new UnauthorizedUserError('create pdf template', user);
       }
       const { name, description = '', template = '', header, footer, additionalStyles, variables } = req.body;
       const id = toTemplateId(name);
-      const [configuration] =
-        await req.getConfiguration<Record<string, PdfTemplateEntity>>();
+      const [configuration] = await req.getConfiguration<Record<string, PdfTemplateEntity>>();
 
       if (isTemplateIdAlreadyInUse(configuration, id)) {
         return res.status(HttpStatusCodes.CONFLICT).send({
@@ -163,14 +157,18 @@ export function createPdfTemplate(
         });
       }
 
-      const patch = createPdfTemplatePatch(id, name, description, template, header, footer, additionalStyles, variables);
-
-      await savePdfTemplate(
-        directory,
-        tokenProvider,
-        req.tenant.id.toString(),
-        patch,
+      const patch = createPdfTemplatePatch(
+        id,
+        name,
+        description,
+        template,
+        header,
+        footer,
+        additionalStyles,
+        variables,
       );
+
+      await savePdfTemplate(directory, tokenProvider, req.tenant.id.toString(), patch);
 
       res.status(HttpStatusCodes.CREATED).json(patch.update[id]);
     } catch (err) {
@@ -190,40 +188,36 @@ async function deletePdfTemplateFromConfig(
   const token = await tokenProvider.getAccessToken();
 
   const patch: ConfigurationDeleteOperation = { operation: 'DELETE', property: templateId };
-  await axios.patch(
-    new URL('v2/configuration/platform/pdf-service', configurationApiUrl).href,
-    patch,
-    {
-      headers: { Authorization: `Bearer ${token}` },
-      params: { tenantId },
-    },
-  );
+  await axios.patch(new URL('v2/configuration/platform/pdf-service', configurationApiUrl).href, patch, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { tenantId },
+  });
 }
 
 // clean-code-ignore: 2.3 2.10
-export function updatePdfTemplate(
-  directory: ServiceDirectory,
-  tokenProvider: TokenProvider,
-): RequestHandler {
+export function updatePdfTemplate(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
   return async (req, res, next) => {
     try {
       const user = req.user;
       const tenantId = req.tenant?.id;
 
-      if (!isAllowedUser(user, tenantId, ServiceRoles.Admin, true)) { // clean-code-ignore: 2.4
+      if (!isAllowedUser(user, tenantId, ServiceRoles.Admin, true)) {
+        // clean-code-ignore: 2.4
         throw new UnauthorizedUserError('update pdf template', user);
       }
 
       const template: PdfTemplateEntity = req[TEMPLATE];
-      const { template: templateBody, header, footer } = req.body;
+      const { name, description, template: templateBody, header, footer, additionalStyles, variables } = req.body;
 
       const updated: PdfTemplateConfiguration = {
         id: template.id,
-        name: template.name,
-        description: template.description,
+        name: name !== undefined ? name : template.name,
+        description: description !== undefined ? description : template.description,
         template: templateBody !== undefined ? templateBody : template.template,
         header: header !== undefined ? header : template.header,
         footer: footer !== undefined ? footer : template.footer,
+        additionalStyles: additionalStyles !== undefined ? additionalStyles : template.additionalStyles,
+        variables: variables !== undefined ? variables : template.variables,
       };
 
       const patch: ConfigurationUpdateOperation<PdfTemplateConfiguration> = {
@@ -241,16 +235,14 @@ export function updatePdfTemplate(
 }
 
 // clean-code-ignore: 2.18
-export function deletePdfTemplate(
-  directory: ServiceDirectory,
-  tokenProvider: TokenProvider,
-): RequestHandler {
+export function deletePdfTemplate(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
   return async (req, res, next) => {
     try {
       const user = req.user;
       const tenantId = req.tenant?.id;
 
-      if (!isAllowedUser(user, tenantId, ServiceRoles.Admin, true)) { // clean-code-ignore: 2.4
+      if (!isAllowedUser(user, tenantId, ServiceRoles.Admin, true)) {
+        // clean-code-ignore: 2.4
         throw new UnauthorizedUserError('delete pdf template', user);
       }
 
@@ -269,7 +261,7 @@ export function generatePdf(
   eventService: EventService,
   fileService: FileService,
   queueService: WorkQueueService<PdfServiceWorkItem>,
-  logger: Logger
+  logger: Logger,
 ): RequestHandler {
   return async (req, res, next) => {
     try {
@@ -353,7 +345,7 @@ export function createPdfRouter({
   queueService,
   logger,
   directory,
-  tokenProvider
+  tokenProvider,
 }: RouterProps): Router {
   const router = Router();
 
@@ -372,9 +364,7 @@ export function createPdfRouter({
         .isLength({ min: 1, max: 50 })
         .withMessage('name must be between 1 and 50 characters')
         .matches(/^[a-zA-Z0-9 -]+$/)
-        .withMessage(
-          'name can contain only letters, numbers, spaces, and hyphens',
-        ),
+        .withMessage('name can contain only letters, numbers, spaces, and hyphens'),
       body('description').optional().isString(),
       body('template').optional().isString(),
       body('header').optional().isString(),
@@ -388,15 +378,19 @@ export function createPdfRouter({
     '/templates/:templateId',
     createValidationHandler(param('templateId').isString().isLength({ min: 1, max: 50 })),
     getTemplate('params'),
-    (req: Request, res: Response) => res.send(mapPdfTemplate(req[TEMPLATE]))
+    (req: Request, res: Response) => res.send(mapPdfTemplate(req[TEMPLATE])),
   );
   router.patch(
     '/templates/:templateId',
     createValidationHandler(
       param('templateId').isString().isLength({ min: 1, max: 50 }),
+      body('name').optional().isString().isLength({ min: 1, max: 50 }),
+      body('description').optional().isString(),
       body('template').optional().isString(),
       body('header').optional().isString(),
       body('footer').optional().isString(),
+      body('additionalStyles').optional().isString(),
+      body('variables').optional().isString(),
     ),
     getTemplate('params'),
     updatePdfTemplate(directory, tokenProvider),
@@ -416,10 +410,10 @@ export function createPdfRouter({
       body('filename').isString().isLength({ min: 1, max: 60 }),
       body('fileType').optional().isString().isLength({ min: 1, max: 50 }),
       body('recordId').optional().isString(),
-      body('context').optional().isObject()
+      body('context').optional().isObject(),
     ),
     getTemplate('body'),
-    generatePdf(serviceId, repository, eventService, fileService, queueService, logger)
+    generatePdf(serviceId, repository, eventService, fileService, queueService, logger),
   );
   router.get('/jobs/:jobId', createValidationHandler(param('jobId').isUUID()), getGeneratedFile(serviceId, repository));
 

--- a/apps/pdf-service/src/pdf/types.ts
+++ b/apps/pdf-service/src/pdf/types.ts
@@ -38,12 +38,13 @@ export interface PdfTemplate {
   footer?: string;
   header?: string;
   additionalStyles?: string;
+  variables?: string;
   startWithDefault?: boolean;
   logger: Logger;
 }
 
-
-export interface PdfTemplateConfiguration { // clean-code-ignore: RULE-19
+export interface PdfTemplateConfiguration {
+  // clean-code-ignore: RULE-19
   id: string;
   name: string;
   description: string;
@@ -53,7 +54,6 @@ export interface PdfTemplateConfiguration { // clean-code-ignore: RULE-19
   additionalStyles?: string; // clean-code-ignore: RULE-19
   variables?: string;
 }
-
 
 export interface ConfigurationUpdateOperation<T> {
   operation: 'UPDATE';


### PR DESCRIPTION
**Context:** Supports CS-5143 (TMW migration to the PDF service template API). Closes gaps where the PDF service template endpoints silently dropped editable fields.

- **PATCH `/pdf/v1/templates/:id` now accepts and persists `name`, `description`, `additionalStyles`, and `variables`** — previously only `template`, `header`, and `footer` were updatable; other fields were dropped on save.
- **GET template mapping (`mapPdfTemplate`) now returns `additionalStyles` and `variables`** so reads round-trip the full template.
- **OpenAPI/Swagger** updated: `additionalStyles` and `variables` added to the `Template` schema; PATCH request body expanded to document all editable fields.