### PR TITLE
feat: add the data schema and ui schema to the form definition

### DIFF
--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -13,6 +13,7 @@ import {
   getFormDefinitions,
   patchFormDefinition,
   updateFormDefinition,
+  updateFormDefinitionSchemas,
 } from './definition';
 
 jest.mock('axios');
@@ -918,6 +919,308 @@ describe('definition router', () => {
       expect(res.status).toHaveBeenCalledWith(204);
       expect(res.send).toHaveBeenCalled();
       expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateFormDefinitionSchemas', () => {
+    const existingDefinition = {
+      id: 'test',
+      name: 'Test Form',
+      description: '',
+      anonymousApply: false,
+      applicantRoles: [],
+      assessorRoles: [],
+      clerkRoles: [],
+      dataSchema: {},
+      uiSchema: {},
+      dispositionStates: [],
+    };
+
+    let res: { status: jest.Mock; send: jest.Mock };
+    let next: jest.Mock;
+
+    beforeEach(() => {
+      res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      next = jest.fn();
+    });
+
+    it('can create handler', () => {
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can call next with unauthorized for non-admin', async () => {
+      const req = {
+        user: { tenantId, id: 'tester', roles: ['test-applicant'] },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': {}, 'ui-schema': {} },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+      expect(axiosMock.get).not.toHaveBeenCalled();
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+    });
+
+    it('can call next with not found when definition does not exist', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.NOT_FOUND, data: {} });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'missing-def' },
+        body: { 'data-schema': {}, 'ui-schema': {} },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        expect.stringContaining('missing-def/latest'),
+        expect.objectContaining({ validateStatus: expect.any(Function) }),
+      );
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('missing-def') }));
+    });
+
+    it('can call next with not found when response data is null', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: null });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': {}, 'ui-schema': {} },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('test') }));
+    });
+
+    it('can update schemas and return 204', async () => {
+      const newDataSchema = { type: 'object', properties: { name: { type: 'string' } } };
+      const newUiSchema = { type: 'VerticalLayout', elements: [] };
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+      axiosMock.patch.mockResolvedValue({
+        data: {
+          latest: {
+            revision: 2,
+            configuration: { ...existingDefinition, dataSchema: newDataSchema, uiSchema: newUiSchema },
+          },
+        },
+      });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': newDataSchema, 'ui-schema': newUiSchema },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.stringContaining('test'),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({ dataSchema: newDataSchema, uiSchema: newUiSchema }),
+        },
+        expect.any(Object),
+      );
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('preserves existing definition fields when updating schemas', async () => {
+      const newDataSchema = { type: 'object' };
+      const newUiSchema = { type: 'HorizontalLayout', elements: [] };
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+      axiosMock.patch.mockResolvedValue({ data: { latest: { revision: 2, configuration: existingDefinition } } });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': newDataSchema, 'ui-schema': newUiSchema },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({
+            id: 'test',
+            name: 'Test Form',
+            applicantRoles: [],
+            dataSchema: newDataSchema,
+            uiSchema: newUiSchema,
+          }),
+        },
+        expect.any(Object),
+      );
+    });
+
+    it('falls back to existing data-schema when data-schema is omitted', async () => {
+      const existingDataSchema = { type: 'object', properties: { name: { type: 'string' } } };
+      const newUiSchema = { type: 'VerticalLayout', elements: [] };
+      const definitionWithSchema = { ...existingDefinition, dataSchema: existingDataSchema, uiSchema: {} };
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: definitionWithSchema });
+      axiosMock.patch.mockResolvedValue({ data: { latest: { revision: 2, configuration: definitionWithSchema } } });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'ui-schema': newUiSchema },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({
+            dataSchema: existingDataSchema,
+            uiSchema: newUiSchema,
+          }),
+        },
+        expect.any(Object),
+      );
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('falls back to existing ui-schema when ui-schema is omitted', async () => {
+      const newDataSchema = { type: 'object', properties: { email: { type: 'string' } } };
+      const existingUiSchema = { type: 'VerticalLayout', elements: [{ type: 'Control', scope: '#/properties/name' }] };
+      const definitionWithSchema = { ...existingDefinition, dataSchema: {}, uiSchema: existingUiSchema };
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: definitionWithSchema });
+      axiosMock.patch.mockResolvedValue({ data: { latest: { revision: 2, configuration: definitionWithSchema } } });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': newDataSchema },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({
+            dataSchema: newDataSchema,
+            uiSchema: existingUiSchema,
+          }),
+        },
+        expect.any(Object),
+      );
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('uses existing schemas for both when body is empty', async () => {
+      const existingDataSchema = { type: 'object', properties: { age: { type: 'number' } } };
+      const existingUiSchema = { type: 'VerticalLayout', elements: [] };
+      const definitionWithSchemas = {
+        ...existingDefinition,
+        dataSchema: existingDataSchema,
+        uiSchema: existingUiSchema,
+      };
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: definitionWithSchemas });
+      axiosMock.patch.mockResolvedValue({ data: { latest: { revision: 2, configuration: definitionWithSchemas } } });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: {},
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({
+            dataSchema: existingDataSchema,
+            uiSchema: existingUiSchema,
+          }),
+        },
+        expect.any(Object),
+      );
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with 400 when configuration service rejects the patch', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+
+      const axiosError = Object.assign(new Error('Bad Request'), {
+        isAxiosError: true,
+        response: { data: { errorMessage: 'Schema validation failed.' } },
+      });
+      jest.mocked(axiosMock.isAxiosError).mockReturnValue(true);
+      axiosMock.patch.mockRejectedValue(axiosError);
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': {}, 'ui-schema': {} },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ extra: expect.objectContaining({ statusCode: 400 }) }),
+      );
+      expect(res.send).not.toHaveBeenCalled();
+    });
+
+    it('calls next with raw error when patch fails with a non-axios error', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+
+      const networkError = new Error('network failure');
+      jest.mocked(axiosMock.isAxiosError).mockReturnValue(false);
+      axiosMock.patch.mockRejectedValue(networkError);
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { 'data-schema': {}, 'ui-schema': {} },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionSchemas(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(networkError);
+      expect(res.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -350,10 +350,13 @@ export function deleteFormDefinition(directory: ServiceDirectory, tokenProvider:
 
       const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
       const token = await tokenProvider.getAccessToken();
-      await axios.delete(new URL(`v2/configuration/form-service/${encodeURIComponent(definitionId)}`, configurationApiUrl).href, {
-        headers: { Authorization: `Bearer ${token}` },
-        params: { tenantId: tenantId?.toString() },
-      });
+      await axios.delete(
+        new URL(`v2/configuration/form-service/${encodeURIComponent(definitionId)}`, configurationApiUrl).href,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          params: { tenantId: tenantId?.toString() },
+        },
+      );
 
       res.status(HttpStatusCodes.NO_CONTENT).send();
     } catch (err) {

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -60,7 +60,7 @@ async function patchConfigurationDefinition(
 ): Promise<{ latest: { revision: number; configuration: FormDefinition } }> {
   try {
     const response = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
-      new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href,
+      new URL(`v2/configuration/form-service/${encodeURIComponent(definitionId)}`, configurationApiUrl).href,
       { operation: 'REPLACE', configuration: definition },
       {
         headers: { Authorization: `Bearer ${token}` },
@@ -275,7 +275,7 @@ export function updateFormDefinition(directory: ServiceDirectory, tokenProvider:
       const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
       const token = await tokenProvider.getAccessToken();
       const { data } = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
-        new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href,
+        new URL(`v2/configuration/form-service/${encodeURIComponent(definitionId)}`, configurationApiUrl).href,
         { operation: 'REPLACE', configuration: definition },
         {
           headers: { Authorization: `Bearer ${token}` },
@@ -350,7 +350,7 @@ export function deleteFormDefinition(directory: ServiceDirectory, tokenProvider:
 
       const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
       const token = await tokenProvider.getAccessToken();
-      await axios.delete(new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href, {
+      await axios.delete(new URL(`v2/configuration/form-service/${encodeURIComponent(definitionId)}`, configurationApiUrl).href, {
         headers: { Authorization: `Bearer ${token}` },
         params: { tenantId: tenantId?.toString() },
       });

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -28,6 +28,55 @@ import { CalendarService } from '../calendar';
 
 const configurationApiId = adspId`urn:ads:platform:configuration-service:v2`;
 
+async function fetchExistingDefinition(
+  configurationApiUrl: URL,
+  token: string,
+  encodedDefinitionId: string,
+  tenantId: string,
+  definitionId: string,
+): Promise<FormDefinition> {
+  const response = await axios.get(
+    new URL(`v2/configuration/form-service/${encodedDefinitionId}/latest`, configurationApiUrl).href,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      params: { tenantId },
+      validateStatus: (status) => status === HttpStatusCodes.OK || status === HttpStatusCodes.NOT_FOUND,
+    },
+  );
+
+  if (response.status === HttpStatusCodes.NOT_FOUND || !response.data) {
+    throw new NotFoundError('form definition', definitionId);
+  }
+
+  return response.data as FormDefinition;
+}
+
+async function patchConfigurationDefinition(
+  configurationApiUrl: URL,
+  token: string,
+  definitionId: string,
+  tenantId: string,
+  definition: FormDefinition,
+): Promise<{ latest: { revision: number; configuration: FormDefinition } }> {
+  try {
+    const response = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
+      new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href,
+      { operation: 'REPLACE', configuration: definition },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { tenantId },
+      },
+    );
+    return response.data;
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      const message = err.response?.data?.errorMessage || 'Configuration service rejected the request.';
+      throw new InvalidOperationError(message, { statusCode: HttpStatusCodes.BAD_REQUEST });
+    }
+    throw err;
+  }
+}
+
 export function getFormDefinitions(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
   return async (req, res, next) => {
     try {
@@ -84,12 +133,7 @@ export function getFormDefinitions(directory: ServiceDirectory, tokenProvider: T
         results: data.results.map(({ latest, active }) =>
           active
             ? mapFormDefinition(active.configuration, active.revision, undefined, latest.created as unknown as Date)
-            : mapFormDefinition(
-                latest.configuration,
-                latest.revision,
-                undefined,
-                latest.created as unknown as Date,
-              ),
+            : mapFormDefinition(latest.configuration, latest.revision, undefined, latest.created as unknown as Date),
         ),
       });
     } catch (err) {
@@ -200,24 +244,13 @@ export function createFormDefinition(
         });
       }
 
-      let data: { latest: { revision: number; configuration: FormDefinition } };
-      try {
-        const response = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
-          new URL(`v2/configuration/form-service/${definition.id}`, configurationApiUrl).href,
-          { operation: 'REPLACE', configuration: definition },
-          {
-            headers: { Authorization: `Bearer ${token}` },
-            params: { tenantId: tenantId?.toString() },
-          },
-        );
-        data = response.data;
-      } catch (err) {
-        if (axios.isAxiosError(err)) {
-          const message = err.response?.data?.errorMessage || 'Configuration service rejected the request.';
-          throw new InvalidOperationError(message, { statusCode: HttpStatusCodes.BAD_REQUEST });
-        }
-        throw err;
-      }
+      const data = await patchConfigurationDefinition(
+        configurationApiUrl,
+        token,
+        definition.id,
+        tenantId?.toString(),
+        definition,
+      );
 
       res.status(HttpStatusCodes.CREATED).send(mapFormDefinition(data.latest.configuration, data.latest.revision));
     } catch (err) {
@@ -269,24 +302,16 @@ export function patchFormDefinition(directory: ServiceDirectory, tokenProvider: 
       }
 
       const encodedDefinitionId = encodeURIComponent(definitionId);
-
       const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
       const token = await tokenProvider.getAccessToken();
 
-      const existingDefinitionResponse = await axios.get(
-        new URL(`v2/configuration/form-service/${encodedDefinitionId}/latest`, configurationApiUrl).href,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          params: { tenantId: tenantId?.toString() },
-          validateStatus: (status) => status === HttpStatusCodes.OK || status === HttpStatusCodes.NOT_FOUND,
-        },
+      const existingDefinition = await fetchExistingDefinition(
+        configurationApiUrl,
+        token,
+        encodedDefinitionId,
+        tenantId?.toString(),
+        definitionId,
       );
-
-      if (existingDefinitionResponse.status === HttpStatusCodes.NOT_FOUND || !existingDefinitionResponse.data) {
-        throw new NotFoundError('form definition', definitionId);
-      }
-
-      const existingDefinition = existingDefinitionResponse.data;
 
       const patchedDefinition: FormDefinition = {
         ...existingDefinition,
@@ -297,24 +322,13 @@ export function patchFormDefinition(directory: ServiceDirectory, tokenProvider: 
         id: definitionId,
       };
 
-      let data: { latest: { revision: number; configuration: FormDefinition } };
-      try {
-        const response = await axios.patch<{ latest: { revision: number; configuration: FormDefinition } }>(
-          new URL(`v2/configuration/form-service/${definitionId}`, configurationApiUrl).href,
-          { operation: 'REPLACE', configuration: patchedDefinition },
-          {
-            headers: { Authorization: `Bearer ${token}` },
-            params: { tenantId: tenantId?.toString() },
-          },
-        );
-        data = response.data;
-      } catch (err) {
-        if (axios.isAxiosError(err)) {
-          const message = err.response?.data?.errorMessage || 'Configuration service rejected the request.';
-          throw new InvalidOperationError(message, { statusCode: HttpStatusCodes.BAD_REQUEST });
-        }
-        throw err;
-      }
+      const data = await patchConfigurationDefinition(
+        configurationApiUrl,
+        token,
+        definitionId,
+        tenantId?.toString(),
+        patchedDefinition,
+      );
 
       res.status(HttpStatusCodes.OK).send(mapFormDefinition(data.latest.configuration, data.latest.revision));
     } catch (err) {
@@ -340,6 +354,51 @@ export function deleteFormDefinition(directory: ServiceDirectory, tokenProvider:
         headers: { Authorization: `Bearer ${token}` },
         params: { tenantId: tenantId?.toString() },
       });
+
+      res.status(HttpStatusCodes.NO_CONTENT).send();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export function updateFormDefinitionSchemas(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const user = req.user;
+      const tenantId = req.tenant?.id;
+      const { definitionId } = req.params;
+
+      if (!isAllowedUser(user, tenantId, FormServiceRoles.Admin, true)) {
+        throw new UnauthorizedUserError('update form definition schemas', user);
+      }
+
+      const encodedDefinitionId = encodeURIComponent(definitionId);
+      const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
+      const token = await tokenProvider.getAccessToken();
+
+      const existingDefinition = await fetchExistingDefinition(
+        configurationApiUrl,
+        token,
+        encodedDefinitionId,
+        tenantId?.toString(),
+        definitionId,
+      );
+
+      const updatedDefinition: FormDefinition = {
+        ...existingDefinition,
+        dataSchema: req.body['data-schema'] !== undefined ? req.body['data-schema'] : existingDefinition.dataSchema,
+        uiSchema: req.body['ui-schema'] !== undefined ? req.body['ui-schema'] : existingDefinition.uiSchema,
+        id: definitionId,
+      };
+
+      await patchConfigurationDefinition(
+        configurationApiUrl,
+        token,
+        definitionId,
+        tenantId?.toString(),
+        updatedDefinition,
+      );
 
       res.status(HttpStatusCodes.NO_CONTENT).send();
     } catch (err) {
@@ -376,10 +435,7 @@ export function createFormDefinitionRouter({
   router.post(
     '/definitions',
     assertAuthenticatedHandler,
-    createValidationHandler(
-      body('name').isString().isLength({ min: 1 }),
-      body('description').optional().isString(),
-    ),
+    createValidationHandler(body('name').isString().isLength({ min: 1 }), body('description').optional().isString()),
     createFormDefinition(directory, tokenProvider, logger),
   );
   router.get(
@@ -440,6 +496,20 @@ export function createFormDefinitionRouter({
         .matches(/^[a-zA-Z0-9-]+$/),
     ),
     deleteFormDefinition(directory, tokenProvider),
+  );
+
+  router.put(
+    '/definitions/:definitionId/schemas',
+    assertAuthenticatedHandler,
+    createValidationHandler(
+      param('definitionId')
+        .isString()
+        .isLength({ min: 1, max: 50 })
+        .matches(/^[a-zA-Z0-9-]+$/),
+      body('data-schema').optional().isObject(),
+      body('ui-schema').optional().isObject(),
+    ),
+    updateFormDefinitionSchemas(directory, tokenProvider),
   );
 
   return router;

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -467,6 +467,43 @@ components:
       404:
         description: Form definition not found.
 
+/form/v1/definitions/{definitionId}/schemas:
+  put:
+    tags:
+      - Form
+    description: Updates the data and UI schemas for an existing form definition. Requires the form-service admin role.
+    parameters:
+      - name: definitionId
+        description: ID of the form definition whose schemas are to be updated.
+        required: true
+        in: path
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data-schema:
+                type: object
+                description: JSON Schema describing the shape of the form data. If omitted, the existing data schema is preserved.
+              ui-schema:
+                type: object
+                description: UI schema describing the layout and controls of the form. If omitted, the existing UI schema is preserved.
+    responses:
+      204:
+        description: Schemas updated successfully. No content is returned.
+      400:
+        description: Request body does not conform to the required schema.
+      401:
+        description: User is not authenticated.
+      403:
+        description: User does not have the form-admin role.
+      404:
+        description: Form definition not found.
+
 /form/v1/forms:
   get:
     tags:


### PR DESCRIPTION
Summary
Adds a new endpoint for updating the data and UI schemas of an existing form definition without requiring a full definition replace.

Changes
New endpoint — PUT /form/v1/definitions/:definitionId/schemas

Accepts an optional data-schema and/or ui-schema object in the request body
If either field is omitted, the existing value from the stored definition is preserved
Returns 204 No Content on success
Returns 400 if the request body contains a field that is not a valid object
Returns 401 if the caller is not authenticated
Returns 403 if the caller does not have the form-admin role
Returns 404 if no definition with the given ID exists
Refactoring — two shared helpers extracted to eliminate duplication across createFormDefinition, patchFormDefinition, and updateFormDefinitionSchemas:

fetchExistingDefinition — fetches the current definition from the configuration service and throws NotFoundError on a 404 or empty response
patchConfigurationDefinition — performs the configuration service PATCH and wraps axios errors as InvalidOperationError (400)
Swagger — form.swagger.yml updated with the new path, request body schema, and all response codes.