### PR TITLE
refactor: update API parameters and improve template handling in PDF service UI

### DIFF
--- a/apps/tenant-management-webapp/src/app/store/pdf/api.tsx
+++ b/apps/tenant-management-webapp/src/app/store/pdf/api.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { PdfTemplate, UpdatePdfConfig, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./saga.spec.tsx, the established one-spec-per-slice convention in this folder
+import { PdfTemplate, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./saga.spec.tsx, the established one-spec-per-slice convention in this folder
 
 export const fetchPdfTemplatesApi = async (token: string, url: string): Promise<Record<string, PdfTemplate>> => {
   const res = await axios.get(url, {
@@ -8,7 +8,7 @@ export const fetchPdfTemplatesApi = async (token: string, url: string): Promise<
   return res.data;
 };
 
-export const updatePDFTemplateApi = async (token: string, url: string, body: UpdatePdfConfig) => {
+export const updatePDFTemplateApi = async (token: string, url: string, body: Partial<PdfTemplate>) => {
   const res = await axios.patch(url, body, { headers: { Authorization: `Bearer ${token}` } });
   return res.data;
 };
@@ -22,7 +22,7 @@ export const deletePdfTemplateApi = async (token: string, url: string): Promise<
   await axios.delete(url, { headers: { Authorization: `Bearer ${token}` } });
 };
 
-export const generatePdfApi = async (token: string, url: string, body: UpdatePdfConfig) => {
+export const generatePdfApi = async (token: string, url: string, body: Partial<PdfTemplate>) => {
   const res = await axios.patch(url, body, { headers: { Authorization: `Bearer ${token}` } });
   return res.data;
 };
@@ -36,7 +36,15 @@ export const createPdfJobApi = async (token: string, url: string, body: CreatePd
 export const createPdfTemplateApi = async (
   token: string,
   url: string,
-  body: { name: string; description: string; template?: string; header?: string; footer?: string; additionalStyles?: string; variables?: string }
+  body: {
+    name: string;
+    description: string;
+    template?: string;
+    header?: string;
+    footer?: string;
+    additionalStyles?: string;
+    variables?: string;
+  },
 ) => {
   const res = await axios.post(url, body, { headers: { Authorization: `Bearer ${token}` } });
   return res.data;

--- a/apps/tenant-management-webapp/src/app/store/pdf/saga.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/store/pdf/saga.spec.tsx
@@ -1,6 +1,13 @@
 import { expectSaga } from 'redux-saga-test-plan';
 import { fetchPdfTemplates, createPdfTemplateSaga, deletePdfTemplate, updatePdfTemplate, generatePdf } from './sagas';
-import { fetchPdfTemplatesApi, createPdfTemplateApi, deletePdfTemplateApi, updatePDFTemplateApi, generatePdfApi, createPdfJobApi } from './api';
+import {
+  fetchPdfTemplatesApi,
+  createPdfTemplateApi,
+  deletePdfTemplateApi,
+  updatePDFTemplateApi,
+  generatePdfApi,
+  createPdfJobApi,
+} from './api';
 import {
   FETCH_PDF_TEMPLATES_SUCCESS_ACTION,
   CREATE_PDF_TEMPLATE_SUCCESS_ACTION,
@@ -20,12 +27,17 @@ const mockTemplates = {
   },
 };
 it('Fetch Pdf templates', () => {
+  const templateArray = Object.entries(mockTemplates).map(([id, template]) => ({ id, ...template }));
+  const expectedTemplates = {
+    'mock-template': { id: 'mock-template', ...mockTemplates['mock-template'] },
+  };
   return expectSaga(fetchPdfTemplates)
     .withState(storeState)
     .provide({
       call(effect, next) {
         if (effect.fn === fetchPdfTemplatesApi) {
-          return mockTemplates;
+          expect(effect.args[1]).toBe('http://mock-pdf-servie.com/pdf/v1/templates');
+          return templateArray;
         }
         return next();
       },
@@ -33,7 +45,7 @@ it('Fetch Pdf templates', () => {
     .put.like({
       action: {
         type: FETCH_PDF_TEMPLATES_SUCCESS_ACTION,
-        payload: mockTemplates,
+        payload: expectedTemplates,
       },
     })
     .run();
@@ -135,21 +147,24 @@ it('Delete Pdf template', () => {
 });
 
 it('Update Pdf template', () => {
-  const templateToDelete = {
+  const templateToUpdate = {
     id: 'pdf-to-delete',
     ...mockTemplates['mock-template'],
   };
 
-  return expectSaga(updatePdfTemplate, { type: 'update-action', template: templateToDelete })
+  const updatedTemplate = {
+    id: 'pdf-to-delete',
+    ...mockTemplates['mock-template'],
+    template: '<div>Updated body</div>',
+  };
+
+  return expectSaga(updatePdfTemplate, { type: 'update-action', template: templateToUpdate })
     .withState(storeState)
     .provide({
       call(effect, next) {
         if (effect.fn === updatePDFTemplateApi) {
-          return {
-            latest: {
-              configuration: mockTemplates['mock-template'],
-            },
-          };
+          expect(effect.args[1]).toBe('http://mock-pdf-servie.com/pdf/v1/templates/pdf-to-delete');
+          return updatedTemplate;
         }
         return next();
       },
@@ -157,7 +172,10 @@ it('Update Pdf template', () => {
     .put.like({
       action: {
         type: UPDATE_PDF_TEMPLATE_SUCCESS_ACTION,
-        payload: mockTemplates['mock-template'],
+        payload: {
+          'pdf-to-delete': updatedTemplate,
+          'mock-template': mockTemplates['mock-template'],
+        },
       },
     })
     .run();

--- a/apps/tenant-management-webapp/src/app/store/pdf/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/sagas.ts
@@ -49,7 +49,7 @@ import { readFileAsync } from './readFile';
 import { io } from 'socket.io-client';
 import { getAccessToken as getAccessTokenThunk } from '@store/tenant/actions';
 import { getAccessToken } from '@store/tenant/sagas';
-import { PdfGenerationResponse, PdfTemplate, UpdatePdfConfig, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./saga.spec.tsx, the established one-spec-per-slice convention in this folder
+import { PdfGenerationResponse, PdfTemplate, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./saga.spec.tsx, the established one-spec-per-slice convention in this folder
 import {
   fetchPdfTemplatesApi,
   createPdfTemplateApi,
@@ -70,14 +70,16 @@ export function* fetchPdfTemplates(): SagaIterator {
     }),
   );
 
-  const configBaseUrl: string = yield select(
-    (state: RootState) => state.config.serviceUrls?.configurationServiceApiUrl,
-  );
+  const pdfServiceUrl: string = yield select((state: RootState) => state.config.serviceUrls?.pdfServiceApiUrl);
   const token: string = yield call(getAccessToken);
-  if (configBaseUrl && token) {
+  if (pdfServiceUrl && token) {
     try {
-      const url = `${configBaseUrl}/configuration/v2/configuration/platform/pdf-service/latest`;
-      const templates = yield call(fetchPdfTemplatesApi, token, url);
+      const url = `${pdfServiceUrl}/pdf/v1/templates`;
+      const templateList: PdfTemplate[] = yield call(fetchPdfTemplatesApi, token, url);
+      const templates = templateList.reduce(
+        (acc, template) => ({ ...acc, [template.id]: template }),
+        {} as Record<string, PdfTemplate>,
+      );
       yield put(getPdfTemplatesSuccess(templates));
       yield put(
         UpdateIndicator({
@@ -230,34 +232,38 @@ export function* createPdfTemplateSaga({ template }: CreatePdfTemplateAction): S
 }
 
 export function* updatePdfTemplate({ template, options }: UpdatePdfTemplatesAction): SagaIterator {
-  const baseUrl: string = yield select((state: RootState) => state.config.serviceUrls?.configurationServiceApiUrl);
+  const pdfServiceUrl: string = yield select((state: RootState) => state.config.serviceUrls?.pdfServiceApiUrl);
 
   yield put(UpdateElementIndicator({ show: true }));
 
   const token: string = yield call(getAccessToken);
-  if (baseUrl && token) {
+  if (pdfServiceUrl && token) {
     try {
-      const pdfTemplate = {
-        [template.id]: {
-          ...template,
-        },
+      const body: Partial<PdfTemplate> = {
+        name: template.name,
+        description: template.description,
+        template: template.template,
+        header: template.header,
+        footer: template.footer,
+        additionalStyles: template.additionalStyles,
+        variables: template.variables,
       };
-
-      const body: UpdatePdfConfig = { operation: 'UPDATE', update: { ...pdfTemplate } };
-      const url = `${baseUrl}/configuration/v2/configuration/platform/pdf-service`;
-      const { latest } = yield call(updatePDFTemplateApi, token, url, body);
+      const url = `${pdfServiceUrl}/pdf/v1/templates/${template.id}`;
+      const updated: PdfTemplate = yield call(updatePDFTemplateApi, token, url, body);
 
       if (options === 'no-refresh') {
         yield put(
           updatePdfTemplateSuccessNoRefresh({
-            ...latest.configuration,
+            [updated.id]: updated,
           }),
         );
       } else {
+        const existing: Record<string, PdfTemplate> = yield select((state: RootState) => state.pdf.pdfTemplates);
         yield put(
           updatePdfTemplateSuccess(
             {
-              ...latest.configuration,
+              ...existing,
+              [updated.id]: updated,
             },
             { templateId: template.id },
           ),
@@ -374,7 +380,6 @@ function* emitResponse(socket) {
 
 export function* generatePdf({ payload, agentTemplate }: GeneratePdfAction): SagaIterator {
   const pdfServiceUrl: string = yield select((state: RootState) => state.config.serviceUrls?.pdfServiceApiUrl);
-  const baseUrl: string = yield select((state: RootState) => state.config.serviceUrls?.configurationServiceApiUrl);
   let tempTemplate: PdfTemplate = yield select((state: RootState) => state.pdf.tempTemplate);
 
   const token: string = yield call(getAccessToken);
@@ -386,23 +391,30 @@ export function* generatePdf({ payload, agentTemplate }: GeneratePdfAction): Sag
     }),
   );
 
-  if (pdfServiceUrl && token && baseUrl) {
+  if (pdfServiceUrl && token) {
     try {
       if (agentTemplate) {
         tempTemplate = agentTemplate;
       }
 
-      const pdfTemplate = {
+      const templateMap = {
         [tempTemplate.id]: {
           ...tempTemplate,
         },
       };
 
-      const saveBody: UpdatePdfConfig = { operation: 'UPDATE', update: { ...pdfTemplate } };
-
       if (!agentTemplate) {
-        const url = `${baseUrl}/configuration/v2/configuration/platform/pdf-service`;
-        yield call(generatePdfApi, token, url, saveBody);
+        const saveBody: Partial<PdfTemplate> = {
+          name: tempTemplate.name,
+          description: tempTemplate.description,
+          template: tempTemplate.template,
+          header: tempTemplate.header,
+          footer: tempTemplate.footer,
+          additionalStyles: tempTemplate.additionalStyles,
+          variables: tempTemplate.variables,
+        };
+        const saveUrl = `${pdfServiceUrl}/pdf/v1/templates/${tempTemplate.id}`;
+        yield call(generatePdfApi, token, saveUrl, saveBody);
       }
 
       const combinedData = payload.data;
@@ -421,7 +433,7 @@ export function* generatePdf({ payload, agentTemplate }: GeneratePdfAction): Sag
       const body: CreatePdfConfig = { operation: 'generate', ...pdfData };
       const data = yield call(createPdfJobApi, token, createJobUrl, body);
       const pdfResponse = { ...body, ...data };
-      yield put(generatePdfSuccess(pdfResponse, saveBody.update));
+      yield put(generatePdfSuccess(pdfResponse, templateMap));
       yield put(
         UpdateIndicator({
           show: false,


### PR DESCRIPTION
## CS-5143 — Migrate PDF templates to PDF service API

**Tenant webapp (TMW)**
- Template list, create, update, delete, and generate/preview now call the PDF service (`/pdf/v1/templates`, `/pdf/v1/jobs`) instead of configuration-service.
- Sagas updated for the new response shapes (array→map on fetch, single-template merge on update); removed unused config-envelope types.


https://github.com/user-attachments/assets/c4a24301-439f-40e5-97d2-eb1e9e41ea63

