### PR TITLE
fix: Refactor css in feedback widget

### DIFF
--- a/libs/adsp-feedback/src/main.spec.ts
+++ b/libs/adsp-feedback/src/main.spec.ts
@@ -10,16 +10,16 @@ describe('AdspFeedback selectRating', () => {
         <div class="rating" data-index="2"><img class="adsp-fb-rating-icon" src="defaultImage3" /></div>
         <div class="rating" data-index="3"><img class="adsp-fb-rating-icon" src="defaultImage4" /></div>
         <div class="rating" data-index="4"><img class="adsp-fb-rating-icon" src="defaultImage5" /></div>
-        <div class="ratingText" data-index="0"></div>
-        <div class="ratingText" data-index="1"></div>
-        <div class="ratingText" data-index="2"></div>
-        <div class="ratingText" data-index="3"></div>
-        <div class="ratingText" data-index="4"></div>
-        <div class="tooltip-text" data-index="0"></div>
-        <div class="tooltip-text" data-index="1"></div>
-        <div class="tooltip-text" data-index="2"></div>
-        <div class="tooltip-text" data-index="3"></div>
-        <div class="tooltip-text" data-index="4"></div>
+        <div class="adsp-fb-rating-text" data-index="0"></div>
+        <div class="adsp-fb-rating-text" data-index="1"></div>
+        <div class="adsp-fb-rating-text" data-index="2"></div>
+        <div class="adsp-fb-rating-text" data-index="3"></div>
+        <div class="adsp-fb-rating-text" data-index="4"></div>
+        <div class="adsp-fb-tooltip-text" data-index="0"></div>
+        <div class="adsp-fb-tooltip-text" data-index="1"></div>
+        <div class="adsp-fb-tooltip-text" data-index="2"></div>
+        <div class="adsp-fb-tooltip-text" data-index="3"></div>
+        <div class="adsp-fb-tooltip-text" data-index="4"></div>
         <button class="adsp-fb-form-primary" disabled></button>
       </div>
     `;
@@ -104,7 +104,7 @@ describe('AdspFeedback selectRating', () => {
     // Verify selected rating is updated
     expect(adspFeedback['selectedRating']).toBe(ratingIndex);
     // Verify the text color is updated (Convert RGB to HEX)
-    const texts = document.querySelectorAll('.ratingText') as NodeListOf<HTMLImageElement>;
+    const texts = document.querySelectorAll('.adsp-fb-rating-text') as NodeListOf<HTMLImageElement>;
     const text = texts[ratingIndex] as HTMLImageElement;
     const rgbToHex = (rgb: string) => {
       const rgbValues = rgb.match(/\d+/g)?.map(Number);
@@ -208,6 +208,8 @@ describe('AdspFeedback style isolation', () => {
         <img id="host-rating" class="rating" src="host-default" />
         <p id="host-rating-text" class="ratingText">Host rating text</p>
         <span id="host-tooltip" class="tooltip-text">Host tooltip</span>
+        <input id="host-radio" class="radio" />
+        <div id="host-overlay" class="overlay"></div>
       </main>
       <div id="widget-root">
         <img class="adsp-fb-rating-icon" src="defaultImage1" />
@@ -215,16 +217,16 @@ describe('AdspFeedback style isolation', () => {
         <img class="adsp-fb-rating-icon" src="defaultImage3" />
         <img class="adsp-fb-rating-icon" src="defaultImage4" />
         <img class="adsp-fb-rating-icon" src="defaultImage5" />
-        <p class="ratingText">Very Difficult</p>
-        <p class="ratingText">Difficult</p>
-        <p class="ratingText">Neutral</p>
-        <p class="ratingText">Easy</p>
-        <p class="ratingText">Very Easy</p>
-        <span class="tooltip-text">Very Difficult</span>
-        <span class="tooltip-text">Difficult</span>
-        <span class="tooltip-text">Neutral</span>
-        <span class="tooltip-text">Easy</span>
-        <span class="tooltip-text">Very Easy</span>
+        <p class="adsp-fb-rating-text">Very Difficult</p>
+        <p class="adsp-fb-rating-text">Difficult</p>
+        <p class="adsp-fb-rating-text">Neutral</p>
+        <p class="adsp-fb-rating-text">Easy</p>
+        <p class="adsp-fb-rating-text">Very Easy</p>
+        <span class="adsp-fb-tooltip-text">Very Difficult</span>
+        <span class="adsp-fb-tooltip-text">Difficult</span>
+        <span class="adsp-fb-tooltip-text">Neutral</span>
+        <span class="adsp-fb-tooltip-text">Easy</span>
+        <span class="adsp-fb-tooltip-text">Very Easy</span>
       </div>
     `;
     adspFeedback['rootRef'] = { value: document.getElementById('widget-root') as HTMLDivElement };
@@ -234,11 +236,15 @@ describe('AdspFeedback style isolation', () => {
     const hostRating = document.getElementById('host-rating') as HTMLImageElement;
     const hostText = document.getElementById('host-rating-text') as HTMLElement;
     const hostTooltip = document.getElementById('host-tooltip') as HTMLElement;
+    const hostRadio = document.getElementById('host-radio') as HTMLElement;
+    const hostOverlay = document.getElementById('host-overlay') as HTMLElement;
     const widgetRating = document.querySelector('#widget-root .adsp-fb-rating-icon') as HTMLImageElement;
 
     expect(hostRating.getAttribute('src')).toBe('host-default');
     expect(hostText.style.color).toBe('');
     expect(hostTooltip.style.visibility).toBe('');
+    expect(hostRadio.classList.contains('error')).toBe(false);
+    expect(hostOverlay.style.visibility).toBe('');
     expect(widgetRating.getAttribute('src')).toBe('hoverImage1');
   });
 
@@ -276,15 +282,18 @@ describe('AdspFeedback style isolation', () => {
     expect(styleText).toContain('.adsp-fb .h3-success');
     expect(styleText).toContain('.adsp-fb .adsp-fb-sent .p-content');
     expect(styleText).toContain('.adsp-fb .adsp-fb-sent button.adsp-fb-form-primary');
-    expect(styleText).toContain('.adsp-fb .tooltip-text');
-    expect(styleText).toContain('.adsp-fb .radio');
+    expect(styleText).toContain('.adsp-fb .adsp-fb-tooltip-text');
+    expect(styleText).toContain('.adsp-fb .adsp-fb-radio');
     expect(styleText).toContain('.adsp-fb .adsp-fb-rating-icon');
+    expect(styleText).toContain('.adsp-fb .adsp-fb-rating-text');
     expect(styleText).toContain('width: 46px !important;');
     expect(styleText).toContain('filter: none !important;');
-    expect(styleText).toContain('.adsp-fb-root .overlay');
+    expect(styleText).toContain('.adsp-fb-root .adsp-fb-overlay');
     expect(styleText).not.toMatch(/(^|\n)\s*body\.modal-open\b/);
     expect(styleText).not.toMatch(/(^|\n)\s*\.tooltip-text\b/);
     expect(styleText).not.toMatch(/(^|\n)\s*\.radio\b/);
+    expect(styleText).not.toMatch(/(^|\n)\s*\.ratingText\b/);
+    expect(styleText).not.toMatch(/(^|\n)\s*\.overlay\b/);
   });
 
   it('locks body scrolling without adding a global modal class', () => {

--- a/libs/adsp-feedback/src/main.ts
+++ b/libs/adsp-feedback/src/main.ts
@@ -416,7 +416,7 @@ export class AdspFeedback implements AdspFeedbackApi {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private renderRating = (rating: any, index: number) => {
     return html`
-      <div class="rating-div">
+      <div class="adsp-fb-rating-item">
         <img
           src="${rating.svgDefault}"
           @mouseover="${() => this.updateHover(index, true)}"
@@ -430,14 +430,14 @@ export class AdspFeedback implements AdspFeedbackApi {
         />
 
         <p
-          class="ratingText"
+          class="adsp-fb-rating-text"
           @mouseover="${() => this.updateHover(index, true)}"
           @mouseout="${() => this.updateHover(index, false)}"
           @click="${() => this.selectRating(index)}"
         >
           ${rating.label}
         </p>
-        <span class="tooltip-text">${rating.label}</span>
+        <span class="adsp-fb-tooltip-text">${rating.label}</span>
       </div>
     `;
   };
@@ -453,17 +453,17 @@ export class AdspFeedback implements AdspFeedbackApi {
           ? rating.svgClick
           : rating.svgDefault;
 
-    const texts = this.getWidgetElements<HTMLElement>('.ratingText');
+    const texts = this.getWidgetElements<HTMLElement>('.adsp-fb-rating-text');
     const text = texts[index] as HTMLImageElement;
     text.style.color = isHovering ? '#004F84' : this.selectedRating === index ? '#0081A2' : '#333333';
     if (!isSmallScreen) {
-      const tooltips = this.getWidgetElements<HTMLElement>('.tooltip-text');
+      const tooltips = this.getWidgetElements<HTMLElement>('.adsp-fb-tooltip-text');
       const tooltip = tooltips[index] as HTMLImageElement;
       tooltip.style.visibility = isHovering ? 'visible' : 'hidden';
       tooltip.style.opacity = isHovering ? '1' : '0';
       if (index === 0) {
         tooltip.style.marginLeft = '35px';
-        tooltip.classList.add('modified');
+        tooltip.classList.add('adsp-fb-tooltip-modified');
       }
     }
   };
@@ -475,7 +475,7 @@ export class AdspFeedback implements AdspFeedbackApi {
       const image = images[index] as HTMLImageElement;
       image.src = rating.svgDefault;
 
-      const texts = this.getWidgetElements<HTMLElement>('.ratingText');
+      const texts = this.getWidgetElements<HTMLElement>('.adsp-fb-rating-text');
       const text = texts[index] as HTMLImageElement;
       text.style.color = '#333333';
     }
@@ -557,13 +557,13 @@ export class AdspFeedback implements AdspFeedbackApi {
       const rating = this.ratings[this.selectedRating];
       const image = images[this.selectedRating] as HTMLImageElement;
       image.src = rating.svgDefault;
-      const texts = this.getWidgetElements<HTMLElement>('.ratingText');
+      const texts = this.getWidgetElements<HTMLElement>('.adsp-fb-rating-text');
       const text = texts[this.selectedRating] as HTMLImageElement;
       text.style.color = '#333333';
     }
     this.selectedRating = index;
     this.lastFocusableElement = this.sendButtonRef;
-    const texts = this.getWidgetElements<HTMLElement>('.ratingText');
+    const texts = this.getWidgetElements<HTMLElement>('.adsp-fb-rating-text');
     const text = texts[index] as HTMLImageElement;
     text.style.color = '#0081A2';
   };
@@ -603,7 +603,7 @@ export class AdspFeedback implements AdspFeedbackApi {
       const styleContainer = document.createElement('div');
       render(
         html`<style id="adsp-feedback-widget-styles">
-          .adsp-fb-root .overlay {
+          .adsp-fb-root .adsp-fb-overlay {
             position: fixed;
             top: 0;
             left: 0;
@@ -716,9 +716,9 @@ export class AdspFeedback implements AdspFeedbackApi {
             padding-left: 1.25rem;
             align-items: center;
             height: 74px;
-            > img {
-              cursor: pointer;
-            }
+          }
+          .adsp-fb .adsp-fb-container-heading > img {
+            cursor: pointer;
           }
           .adsp-fb .adsp-fb-form {
             display: flex;
@@ -752,16 +752,15 @@ export class AdspFeedback implements AdspFeedbackApi {
             margin-top: 12px;
             justify-content: space-between;
             width: 98%;
-
-            > div > img {
-              width: 46px;
-              height: 46px;
-            }
-            > div > img:first-child {
-              padding-left: 0px;
-            }
           }
-          .adsp-fb .tooltip-text {
+          .adsp-fb .adsp-fb-form-rating > div > img {
+            width: 46px;
+            height: 46px;
+          }
+          .adsp-fb .adsp-fb-form-rating > div > img:first-child {
+            padding-left: 0px;
+          }
+          .adsp-fb .adsp-fb-tooltip-text {
             visibility: hidden;
             margin-left: 25px;
             background-color: #666666;
@@ -779,7 +778,7 @@ export class AdspFeedback implements AdspFeedbackApi {
             transition: opacity 0.3s;
             -webkit-transition: opacity 0.3s;
           }
-          .adsp-fb .tooltip-text:before {
+          .adsp-fb .adsp-fb-tooltip-text:before {
             content: '';
             position: absolute;
             top: -10px;
@@ -791,19 +790,19 @@ export class AdspFeedback implements AdspFeedbackApi {
             -webkit-transform: translateX(-50%);
             border-color: transparent transparent #666666 transparent;
           }
-          .adsp-fb .tooltip-text.modified:before {
+          .adsp-fb .adsp-fb-tooltip-text.adsp-fb-tooltip-modified:before {
             left: 40%;
           }
-          .adsp-fb .ratingText {
+          .adsp-fb .adsp-fb-rating-text {
             display: none;
           }
           .adsp-fb .adsp-fb-form-comment {
             display: flex;
             flex-direction: column;
             margin-bottom: 12px;
-            > label {
-              margin-top: 32px;
-            }
+          }
+          .adsp-fb .adsp-fb-form-comment > label {
+            margin-top: 32px;
           }
           .adsp-fb .adsp-fb-form-comment span {
             color: var(--color-gray-600, #666666);
@@ -905,7 +904,7 @@ export class AdspFeedback implements AdspFeedbackApi {
           }
 
           .adsp-fb button.adsp-fb-form-secondary {
-            border: 2x solid #0070c4;
+            border: 2px solid #0070c4;
             background-color: #ffffff;
             color: #0070c4;
           }
@@ -942,7 +941,7 @@ export class AdspFeedback implements AdspFeedbackApi {
             box-sizing: border-box;
             padding: 24px 24px;
           }
-          .adsp-fb .rating-div {
+          .adsp-fb .adsp-fb-rating-item {
             display: flex;
             flex-direction: column;
             padding-left: 2px;
@@ -976,17 +975,17 @@ export class AdspFeedback implements AdspFeedbackApi {
             visibility: visible;
             transition: visibility 0s 0.1s;
           }
-          .adsp-fb .radios {
+          .adsp-fb .adsp-fb-radios {
             margin-top: 16px;
             margin-bottom: 16px;
             display: flex;
             flex-direction: row;
           }
-          .adsp-fb .radio-span {
+          .adsp-fb .adsp-fb-radio-span {
             display: flex;
             align-items: center;
           }
-          .adsp-fb .radio-span:focus-visible {
+          .adsp-fb .adsp-fb-radio-span:focus-visible {
             border-radius: 0.25rem;
             border: 1px solid #feba35;
             outline: #feba35 solid 1px;
@@ -1019,7 +1018,7 @@ export class AdspFeedback implements AdspFeedbackApi {
             color: #333333;
             font-size: var(--fs-xl, 1.5rem);
             font-weight: 700;
-            line-height: 1.5rem
+            line-height: 1.5rem;
             text-align: left;
             margin-bottom: 0px;
           }
@@ -1032,16 +1031,16 @@ export class AdspFeedback implements AdspFeedbackApi {
             margin-bottom: 12px;
             line-height: 28px;
           }
-          .adsp-fb .radio-container {
+          .adsp-fb .adsp-fb-radio-container {
             display: flex;
             flex-direction: column;
             cursor: pointer;
           }
-          .adsp-fb .radio-container span {
+          .adsp-fb .adsp-fb-radio-container span {
             color: var(--color-gray-600, #666666);
             font-size: 14px;
           }
-          .adsp-fb .radio {
+          .adsp-fb .adsp-fb-radio {
             appearance: none;
             width: 24px;
             height: 24px;
@@ -1052,42 +1051,42 @@ export class AdspFeedback implements AdspFeedbackApi {
             transition: box-shadow 100ms ease-in-out;
             cursor: pointer;
           }
-          .adsp-fb .radio *,
-          .adsp-fb .radio *:before,
-          .adsp-fb .radio *:after {
+          .adsp-fb .adsp-fb-radio *,
+          .adsp-fb .adsp-fb-radio *:before,
+          .adsp-fb .adsp-fb-radio *:after {
             box-sizing: border-box;
           }
 
-          .adsp-fb .radio::not(:checked) {
+          .adsp-fb .adsp-fb-radio::not(:checked) {
             border: 1px solid #666666;
           }
 
-          .adsp-fb .radio:checked:hover {
+          .adsp-fb .adsp-fb-radio:checked:hover {
             border: 7px solid #004f84;
             box-shadow: 0 0 0 1px #004f84;
           }
 
-          .adsp-fb .radio:hover,
-          .adsp-fb .radio:focus-visible,
-          .adsp-fb .radio:focus:active {
+          .adsp-fb .adsp-fb-radio:hover,
+          .adsp-fb .adsp-fb-radio:focus-visible,
+          .adsp-fb .adsp-fb-radio:focus:active {
             outline: initial;
             border: 1px solid #004f84;
             box-shadow: 0 0 0 1px #004f84;
           }
 
-          .adsp-fb .radio:hover:active,
-          .adsp-fb .radio:hover:focus {
+          .adsp-fb .adsp-fb-radio:hover:active,
+          .adsp-fb .adsp-fb-radio:hover:focus {
             box-shadow: 0 0 0 3px #feba35;
           }
 
-          .adsp-fb .radio:checked {
+          .adsp-fb .adsp-fb-radio:checked {
             border: 7px solid #0070c4;
           }
-          .adsp-fb .radio.error {
+          .adsp-fb .adsp-fb-radio.error {
             border: 1px solid red;
             box-shadow: 0 0 0 1px red;
           }
-          .adsp-fb .radio-label {
+          .adsp-fb .adsp-fb-radio-label {
             color: #333333;
             font-size: 1.125rem;
             padding: 0 8px;
@@ -1168,11 +1167,11 @@ export class AdspFeedback implements AdspFeedbackApi {
             font-weight: 400;
             line-height: 28px;
             margin: 0;
-            > a,
-            > a:link,
-            > a:visited {
-              color: #0070c4;
-            }
+          }
+          .adsp-fb .p-content > a,
+          .adsp-fb .p-content > a:link,
+          .adsp-fb .p-content > a:visited {
+            color: #0070c4;
           }
 
           .adsp-fb .adsp-fb-sent .p-content a {
@@ -1233,10 +1232,10 @@ export class AdspFeedback implements AdspFeedbackApi {
               bottom: 0;
               margin-top: 0px;
               flex-direction: column-reverse;
-              > button {
-                width: 100%;
-                margin-top: 12px;
-              }
+            }
+            .adsp-fb .adsp-fb-actions > button {
+              width: 100%;
+              margin-top: 12px;
             }
             .adsp-fb button.adsp-fb-form-primary {
               margin-left: 0;
@@ -1244,41 +1243,40 @@ export class AdspFeedback implements AdspFeedbackApi {
             .adsp-fb .adsp-fb-container-heading {
               height: 55px !important;
             }
-            .adsp-fb .rating-div {
+            .adsp-fb .adsp-fb-rating-item {
               flex-direction: row;
               gap: 6px;
             }
             .adsp-fb .adsp-fb-form-rating {
               flex-direction: column-reverse;
               gap: 16px;
-
-              > div {
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-              }
-              > div > img {
-                height: 32px !important;
-                width: 32px !important;
-                min-width: 32px !important;
-                max-width: 32px !important;
-                min-height: 32px !important;
-                max-height: 32px !important;
-                margin-right: 8px;
-              }
             }
-            .adsp-fb .tooltip-text {
+            .adsp-fb .adsp-fb-form-rating > div {
+              display: flex;
+              flex-direction: row;
+              align-items: center;
+            }
+            .adsp-fb .adsp-fb-form-rating > div > img {
+              height: 32px !important;
+              width: 32px !important;
+              min-width: 32px !important;
+              max-width: 32px !important;
+              min-height: 32px !important;
+              max-height: 32px !important;
+              margin-right: 8px;
+            }
+            .adsp-fb .adsp-fb-tooltip-text {
               visibility: hidden;
               opacity: 0;
             }
-            .adsp-fb .ratingText {
+            .adsp-fb .adsp-fb-rating-text {
               padding-top: 12px;
               cursor: pointer;
               margin-bottom: 0px !important;
               display: block;
               padding: 0;
             }
-            .adsp-fb .ratingText:hover {
+            .adsp-fb .adsp-fb-rating-text:hover {
               color: #004f84;
             }
           }
@@ -1331,7 +1329,7 @@ export class AdspFeedback implements AdspFeedbackApi {
                 <span>Feedback</span>
               </div>
             </div>
-            <div ${ref(this.dimRef)} class="overlay">
+            <div ${ref(this.dimRef)} class="adsp-fb-overlay">
               <div class="adsp-fb">
                 <div ${ref(this.startRef)} class="adsp-fb-form-container adsp-fb-start" data-show="false">
                   <div class="adsp-fb-container-heading">
@@ -1419,33 +1417,33 @@ export class AdspFeedback implements AdspFeedbackApi {
                       </div>
                       <hr class="hr-width" />
                       <br />
-                      <div class="radio-container">
+                      <div class="adsp-fb-radio-container">
                         <label><b>Did you experience any technical issues?</b></label>
-                        <div class="radios" @change=${this.onIssueChange}>
-                          <div id="technicalIssueYes" class="radio-span">
+                        <div class="adsp-fb-radios" @change=${this.onIssueChange}>
+                          <div id="technicalIssueYes" class="adsp-fb-radio-span">
                             <input
                               tabindex="0"
                               name="YesOrNo"
                               type="radio"
                               id="yes"
                               value="Yes"
-                              class="radio"
+                              class="adsp-fb-radio"
                               ${ref(this.ratingSelector)}
                               aria-label="Yes"
                               @keydown=${(e: KeyboardEvent) => {
                                 this.handleRadioKeyDown(e);
                               }}
                             />
-                            <label for="yes" class="radio-label"> Yes </label>
+                            <label for="yes" class="adsp-fb-radio-label"> Yes </label>
                           </div>
-                          <div class="radio-span">
+                          <div class="adsp-fb-radio-span">
                             <input
                               tabindex="0"
                               name="YesOrNo"
                               type="radio"
                               id="no"
                               value="No"
-                              class="radio"
+                              class="adsp-fb-radio"
                               ${ref(this.commentSelector)}
                               aria-label="No"
                               @keydown=${(e: KeyboardEvent) => {
@@ -1453,7 +1451,7 @@ export class AdspFeedback implements AdspFeedbackApi {
                               }}
                             />
 
-                            <label for="no" class="radio-label"> No </label>
+                            <label for="no" class="adsp-fb-radio-label"> No </label>
                           </div>
                         </div>
                         <span class="inline-error" ${ref(this.issueSelectionErrorText)}>


### PR DESCRIPTION
Refactor the CSS in the feedback widget to make the injected styles valid and reduce CSS collisions with the host app.