### PR TITLE
feat(adsp-cli): surface owned tenants first in the login tenant picker

### DIFF
--- a/libs/adsp-cli/package.json
+++ b/libs/adsp-cli/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "enquirer": "^2.3.6",
     "express": "^4.22.1",
+    "jwt-decode": "^3.1.2",
     "open": "^8.4.0",
     "simple-oauth2": "^5.0.0",
     "tslib": "^2.3.0"

--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -32,7 +32,10 @@ jest.mock('./tenants', () => ({
   listTenants: jest.fn(),
 }));
 
+jest.mock('jwt-decode');
+
 // Imported after the mocks above so login.ts picks up the mocked modules.
+import jwtDecode from 'jwt-decode';
 import { getAccessToken, getStatus, loginInteractive, logout } from './login';
 import { findTenantByName, findTenantByRealm, listTenants } from './tenants';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
@@ -43,6 +46,7 @@ const mockFindTenantByName = findTenantByName as jest.Mock;
 const mockFindTenantByRealm = findTenantByRealm as jest.Mock;
 const mockListTenants = listTenants as jest.Mock;
 const mockAuthorizationCode = AuthorizationCode as unknown as jest.Mock;
+const mockJwtDecode = jwtDecode as jest.Mock;
 
 const ACCESS_SERVICE_URL = 'https://access.example.com';
 const REALM = 'my-realm';
@@ -91,6 +95,12 @@ describe('login', () => {
     mockFindTenantByName.mockReset();
     mockFindTenantByRealm.mockReset();
     mockListTenants.mockReset();
+    // Default: simulate a token jwt-decode can't parse, matching the plain placeholder tokens
+    // used throughout this suite (e.g. 'fresh-access-token') — tests that care about the
+    // owned-tenant annotation override this explicitly.
+    mockJwtDecode.mockReset().mockImplementation(() => {
+      throw new Error('invalid token');
+    });
   });
 
   afterEach(() => {
@@ -446,6 +456,77 @@ describe('login', () => {
       );
       expect(readConfig()).toEqual({ tenantRealm: 'realm-a', tenantName: 'tenant-a' });
       expect(mockFindTenantByRealm).not.toHaveBeenCalled();
+    });
+
+    it('sorts and annotates a tenant the caller administers first in the picker', async () => {
+      mockListTenants.mockResolvedValue([
+        { name: 'tenant-b', realm: 'realm-b', adminEmail: 'someone.else@example.com' },
+        { name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' },
+        { name: 'tenant-c', realm: 'realm-c', adminEmail: 'someone.else@example.com' },
+      ]);
+      mockJwtDecode.mockReturnValue({ email: 'me@example.com' });
+      mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+      const loginPromise = loginInteractive();
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+
+      const result = await loginPromise;
+
+      expect(result).toEqual({ realm: 'realm-a', token: 'fresh-access-token', reused: false });
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'autocomplete',
+          choices: [{ name: 'tenant-a', message: 'tenant-a (yours)' }, 'tenant-b', 'tenant-c'],
+        })
+      );
+    });
+
+    it('falls back to the plain alphabetical list when no tenant is administered by the caller', async () => {
+      mockListTenants.mockResolvedValue([
+        { name: 'tenant-b', realm: 'realm-b', adminEmail: 'someone.else@example.com' },
+        { name: 'tenant-a', realm: 'realm-a', adminEmail: 'another.person@example.com' },
+      ]);
+      mockJwtDecode.mockReturnValue({ email: 'me@example.com' });
+      mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+      const loginPromise = loginInteractive();
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+
+      await loginPromise;
+
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'autocomplete', choices: ['tenant-a', 'tenant-b'] })
+      );
+    });
+
+    it('falls back to the plain alphabetical list when the core token cannot be decoded', async () => {
+      mockListTenants.mockResolvedValue([
+        { name: 'tenant-b', realm: 'realm-b' },
+        { name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' },
+      ]);
+      // mockJwtDecode keeps its default (throwing) implementation from beforeEach.
+      mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+      mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+      const loginPromise = loginInteractive();
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+      await flushAsync();
+      lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+
+      await loginPromise;
+
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'autocomplete', choices: ['tenant-a', 'tenant-b'] })
+      );
     });
 
     it('never sends the caller-requested extra scope to the core listing login, only to the final tenant-realm login', async () => {

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as express from 'express';
+import jwtDecode from 'jwt-decode';
 import * as open from 'open';
 import { AccessToken, AuthorizationCode } from 'simple-oauth2';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
@@ -213,13 +214,30 @@ async function getOrLogin(accessServiceUrl: string, realm: string, scopes: strin
   return { token: await browserLogin(accessServiceUrl, realm, scopes), reused: false };
 }
 
+/** Best-effort decode of the caller's own email from their access token — never throws. */
+function decodeEmail(token: string): string | undefined {
+  try {
+    return jwtDecode<{ email?: string }>(token).email;
+  } catch {
+    return undefined;
+  }
+}
+
 async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string): Promise<Tenant> {
   const tenants = await listTenants(directoryServiceUrl, coreToken);
   if (tenants.length === 0) {
     throw new Error('No tenants found.');
   }
 
-  const choices = tenants.map((t) => t.name).sort((a, b) => a.localeCompare(b));
+  const email = decodeEmail(coreToken);
+  const byName = (a: Tenant, b: Tenant) => a.name.localeCompare(b.name);
+  const owned = tenants.filter((t) => email && t.adminEmail === email).sort(byName);
+  const rest = tenants.filter((t) => !(email && t.adminEmail === email)).sort(byName);
+
+  const choices = [
+    ...owned.map((t) => ({ name: t.name, message: `${t.name} (yours)` })),
+    ...rest.map((t) => t.name),
+  ];
   const { prompt } = await import('enquirer');
   const { tenant: pickedName } = await prompt<{ tenant: string }>({
     type: 'autocomplete',

--- a/libs/adsp-cli/src/tenants.ts
+++ b/libs/adsp-cli/src/tenants.ts
@@ -6,6 +6,7 @@ const TENANT_SERVICE_URN = 'urn:ads:platform:tenant-service:v2';
 export interface Tenant {
   name: string;
   realm: string;
+  adminEmail?: string;
 }
 
 interface TenantsResponse {


### PR DESCRIPTION
After a core-realm login, decode the caller's email from their access token and sort/label any tenant whose adminEmail matches to the top of the picker, so the tenant a developer administers is obvious without already knowing its display name.