### PR TITLE
feat(adsp-cli): let developers create a tenant from the login picker in pre-prod

### DIFF
--- a/apps/tenant-management-api/src/tenant/router/tenantV2.spec.ts
+++ b/apps/tenant-management-api/src/tenant/router/tenantV2.spec.ts
@@ -306,6 +306,23 @@ describe('createTenantV2Router', () => {
       expect(res.send).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledWith(expect.any(Error));
     });
+
+    it('can throw not found for a deleted/unknown tenant', async () => {
+      const req = {
+        params: { id: 'tenant-a' },
+        user: { isCore: true },
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+      const handler = getTenant(loggerMock, repositoryMock);
+
+      repositoryMock.get.mockResolvedValueOnce(null);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+    });
   });
 
   describe('deleteTenant', () => {

--- a/apps/tenant-management-api/src/tenant/router/tenantV2.ts
+++ b/apps/tenant-management-api/src/tenant/router/tenantV2.ts
@@ -93,6 +93,10 @@ export function getTenant(logger: Logger, repository: TenantRepository): Request
       }
 
       const tenant = await repository.get(id);
+      if (!tenant) {
+        throw new NotFoundError('tenant', id);
+      }
+
       res.send(mapTenant(tenant));
     } catch (err) {
       logger.error(`Failed to get tenant with error: ${err.message}`, LOG_CONTEXT);

--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -30,6 +30,8 @@ jest.mock('./tenants', () => ({
   findTenantByName: jest.fn(),
   findTenantByRealm: jest.fn(),
   listTenants: jest.fn(),
+  createTenant: jest.fn(),
+  waitForTenantActive: jest.fn(),
 }));
 
 jest.mock('jwt-decode');
@@ -37,7 +39,8 @@ jest.mock('jwt-decode');
 // Imported after the mocks above so login.ts picks up the mocked modules.
 import jwtDecode from 'jwt-decode';
 import { getAccessToken, getStatus, loginInteractive, logout } from './login';
-import { findTenantByName, findTenantByRealm, listTenants } from './tenants';
+import { createTenant, findTenantByName, findTenantByRealm, listTenants, waitForTenantActive } from './tenants';
+import { HttpRequestError } from './httpError';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
 import { getCachedToken, getCacheFilePath, setCachedToken } from './tokenCache';
 import { AuthorizationCode } from 'simple-oauth2';
@@ -45,6 +48,8 @@ import { AuthorizationCode } from 'simple-oauth2';
 const mockFindTenantByName = findTenantByName as jest.Mock;
 const mockFindTenantByRealm = findTenantByRealm as jest.Mock;
 const mockListTenants = listTenants as jest.Mock;
+const mockCreateTenant = createTenant as jest.Mock;
+const mockWaitForTenantActive = waitForTenantActive as jest.Mock;
 const mockAuthorizationCode = AuthorizationCode as unknown as jest.Mock;
 const mockJwtDecode = jwtDecode as jest.Mock;
 
@@ -95,6 +100,8 @@ describe('login', () => {
     mockFindTenantByName.mockReset();
     mockFindTenantByRealm.mockReset();
     mockListTenants.mockReset();
+    mockCreateTenant.mockReset();
+    mockWaitForTenantActive.mockReset();
     // Default: simulate a token jwt-decode can't parse, matching the plain placeholder tokens
     // used throughout this suite (e.g. 'fresh-access-token') — tests that care about the
     // owned-tenant annotation override this explicitly.
@@ -527,6 +534,166 @@ describe('login', () => {
       expect(mockPrompt).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'autocomplete', choices: ['tenant-a', 'tenant-b'] })
       );
+    });
+
+    describe('offering to create a new tenant', () => {
+      function autocompleteChoices(): unknown[] {
+        const call = mockPrompt.mock.calls.find(([args]) => args.type === 'autocomplete');
+        return call?.[0].choices ?? [];
+      }
+
+      it('adds a create-tenant entry when logging into a pre-prod env with no owned tenant', async () => {
+        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+        await loginPromise;
+
+        expect(autocompleteChoices()).toContainEqual({ name: '__create_tenant__', message: '+ Create a new tenant' });
+      });
+
+      it('never adds a create-tenant entry when logging into prod, even with no owned tenant', async () => {
+        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'prod' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+        await loginPromise;
+
+        expect(autocompleteChoices()).toEqual(['tenant-a']);
+      });
+
+      it('never adds a create-tenant entry in pre-prod for a non-admin who already owns a tenant', async () => {
+        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' }]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+        await loginPromise;
+
+        expect(autocompleteChoices()).not.toContainEqual(
+          expect.objectContaining({ message: '+ Create a new tenant' })
+        );
+      });
+
+      it('still adds a create-tenant entry in pre-prod for a tenant-service-admin who already owns a tenant', async () => {
+        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' }]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['tenant-service-admin'] } });
+        mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+        await loginPromise;
+
+        expect(autocompleteChoices()).toContainEqual({ name: '__create_tenant__', message: '+ Create a new tenant' });
+      });
+
+      it('picking the create-tenant entry prompts for a name, creates it, waits for provisioning, then logs into the new realm', async () => {
+        mockListTenants.mockResolvedValue([]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockPrompt.mockImplementation(async (args: { type: string; choices?: { name: string; message?: string }[] }) => {
+          if (args.type === 'autocomplete') {
+            const createChoice = args.choices.find((c) => typeof c === 'object' && c.message === '+ Create a new tenant');
+            return { tenant: createChoice.name };
+          }
+          return { name: 'new-tenant' };
+        });
+        const createdTenant = {
+          id: 'urn:ads:platform:tenant-service:v2:/tenants/new-tenant-id',
+          name: 'new-tenant',
+          realm: 'new-tenant-realm',
+          status: 'provisioning',
+        };
+        mockCreateTenant.mockResolvedValue(createdTenant);
+        mockWaitForTenantActive.mockResolvedValue({ name: 'new-tenant', realm: 'new-tenant-realm', status: 'active' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+
+        const result = await loginPromise;
+
+        expect(mockCreateTenant).toHaveBeenCalledWith(expect.any(String), 'fresh-access-token', 'new-tenant');
+        expect(mockWaitForTenantActive).toHaveBeenCalledWith(expect.any(String), 'fresh-access-token', createdTenant);
+        expect(result).toEqual({ realm: 'new-tenant-realm', token: 'fresh-access-token', reused: false });
+        expect(readConfig()).toEqual({ tenantRealm: 'new-tenant-realm', tenantName: 'new-tenant', env: 'dev' });
+      });
+
+      it('re-prompts for a name when createTenant rejects with a 400 (validation failure)', async () => {
+        mockListTenants.mockResolvedValue([]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        let inputCalls = 0;
+        mockPrompt.mockImplementation(async (args: { type: string; choices?: { name: string; message?: string }[] }) => {
+          if (args.type === 'autocomplete') {
+            const createChoice = args.choices.find((c) => typeof c === 'object' && c.message === '+ Create a new tenant');
+            return { tenant: createChoice.name };
+          }
+          inputCalls += 1;
+          return { name: inputCalls === 1 ? 'taken-name' : 'new-tenant' };
+        });
+        mockCreateTenant
+          .mockRejectedValueOnce(new HttpRequestError(400, 'This tenant name has already been used.'))
+          .mockResolvedValueOnce({ name: 'new-tenant', realm: 'new-tenant-realm', status: 'provisioning' });
+        mockWaitForTenantActive.mockResolvedValue({ name: 'new-tenant', realm: 'new-tenant-realm', status: 'active' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+
+        await loginPromise;
+
+        expect(mockCreateTenant).toHaveBeenCalledTimes(2);
+        expect(mockCreateTenant).toHaveBeenNthCalledWith(1, expect.any(String), 'fresh-access-token', 'taken-name');
+        expect(mockCreateTenant).toHaveBeenNthCalledWith(2, expect.any(String), 'fresh-access-token', 'new-tenant');
+      });
+
+      it('propagates a non-400 error from createTenant (e.g. missing beta-tester role) without retrying', async () => {
+        mockListTenants.mockResolvedValue([]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockPrompt.mockImplementation(async (args: { type: string; choices?: { name: string; message?: string }[] }) => {
+          if (args.type === 'autocomplete') {
+            const createChoice = args.choices.find((c) => typeof c === 'object' && c.message === '+ Create a new tenant');
+            return { tenant: createChoice.name };
+          }
+          return { name: 'new-tenant' };
+        });
+        mockCreateTenant.mockImplementation(() => Promise.reject(new HttpRequestError(401, "missing the 'beta-tester' role")));
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+
+        await expect(loginPromise).rejects.toThrow("missing the 'beta-tester' role");
+        expect(mockCreateTenant).toHaveBeenCalledTimes(1);
+        expect(mockWaitForTenantActive).not.toHaveBeenCalled();
+      });
     });
 
     it('never sends the caller-requested extra scope to the core listing login, only to the final tenant-realm login', async () => {

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -6,7 +6,8 @@ import { AccessToken, AuthorizationCode } from 'simple-oauth2';
 import { getConfigFilePath, readConfig, writeConfig } from './config';
 import { EnvironmentName, resolveEnvironmentName, resolveEnvironmentUrls, resolveTenantRealm } from './environments';
 import { generatePkcePair } from './pkce';
-import { findTenantByName, findTenantByRealm, listTenants, Tenant } from './tenants';
+import { HttpRequestError } from './httpError';
+import { createTenant, findTenantByName, findTenantByRealm, listTenants, Tenant, waitForTenantActive } from './tenants';
 import { CacheEntry, getCacheFilePath, getCachedToken, hasScopes, isExpired, setCachedToken } from './tokenCache';
 
 export type AccessTokenResult = { status: 'ok'; token: string } | { status: 'not-authenticated' };
@@ -223,19 +224,76 @@ function decodeEmail(token: string): string | undefined {
   }
 }
 
-async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string): Promise<Tenant> {
-  const tenants = await listTenants(directoryServiceUrl, coreToken);
-  if (tenants.length === 0) {
-    throw new Error('No tenants found.');
+/**
+ * Best-effort decode of the tenant-service-admin realm role from the caller's access token —
+ * never throws. tenant-service-admin/beta-tester are plain core-realm roles (not client-qualified),
+ * so the raw realm_access.roles claim is enough — no need for the SDK's full role-resolution logic.
+ */
+function isTenantServiceAdmin(token: string): boolean {
+  try {
+    const roles = jwtDecode<{ realm_access?: { roles?: string[] } }>(token).realm_access?.roles ?? [];
+    return roles.includes('tenant-service-admin');
+  } catch {
+    return false;
   }
+}
+
+const CREATE_TENANT_CHOICE = '__create_tenant__';
+const TENANT_NAME_PATTERN = /^[0-9a-zA-Z _]{1,50}$/;
+
+/**
+ * Prompts for a new tenant name, creates it, and waits for provisioning to finish. Validation
+ * failures (bad characters, name already taken, one-tenant-per-email) re-prompt for a new name
+ * since the caller can fix those and retry; any other failure (e.g. missing beta-tester role)
+ * rethrows immediately since retrying the name won't help.
+ */
+async function createTenantInteractive(directoryServiceUrl: string, coreToken: string): Promise<Tenant> {
+  const { prompt } = await import('enquirer');
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { name } = await prompt<{ name: string }>({
+      type: 'input',
+      name: 'name',
+      message: 'What would you like to name your tenant?',
+      validate: (value) =>
+        TENANT_NAME_PATTERN.test(value) || 'Names can only contain letters, numbers, spaces, and underscores (1-50 characters).',
+    });
+
+    let created: Tenant;
+    try {
+      created = await createTenant(directoryServiceUrl, coreToken, name);
+    } catch (err) {
+      if (err instanceof HttpRequestError && err.status === 400) {
+        // eslint-disable-next-line no-console
+        console.log(err.message);
+        continue;
+      }
+      throw err;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`Creating tenant '${name}'... this can take a minute.`);
+    return waitForTenantActive(directoryServiceUrl, coreToken, created);
+  }
+}
+
+async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string, preProd: boolean): Promise<Tenant> {
+  const tenants = await listTenants(directoryServiceUrl, coreToken);
 
   const email = decodeEmail(coreToken);
   const byName = (a: Tenant, b: Tenant) => a.name.localeCompare(b.name);
   const owned = tenants.filter((t) => email && t.adminEmail === email).sort(byName);
   const rest = tenants.filter((t) => !(email && t.adminEmail === email)).sort(byName);
+  const showCreateOption = preProd && (owned.length === 0 || isTenantServiceAdmin(coreToken));
+
+  if (tenants.length === 0 && !showCreateOption) {
+    throw new Error('No tenants found.');
+  }
 
   const choices = [
     ...owned.map((t) => ({ name: t.name, message: `${t.name} (yours)` })),
+    ...(showCreateOption ? [{ name: CREATE_TENANT_CHOICE, message: '+ Create a new tenant' }] : []),
     ...rest.map((t) => t.name),
   ];
   const { prompt } = await import('enquirer');
@@ -245,6 +303,10 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
     message: 'Which tenant?',
     choices,
   });
+
+  if (pickedName === CREATE_TENANT_CHOICE) {
+    return createTenantInteractive(directoryServiceUrl, coreToken);
+  }
 
   const picked = tenants.find((t) => t.name === pickedName);
   if (!picked) {
@@ -334,7 +396,8 @@ export async function loginInteractive(
     // doesn't have (and doesn't need) scopes like adsp-cli-admin registered; that scope is only
     // meaningful on the tenant-realm login below, once a realm is actually known.
     const core = await getOrLogin(accessServiceUrl, CORE_REALM, ['email']);
-    const picked = await promptForTenantRealm(directoryServiceUrl, core.token);
+    const preProd = resolveEnvironmentName(options.env) !== 'prod';
+    const picked = await promptForTenantRealm(directoryServiceUrl, core.token, preProd);
     realm = picked.realm;
     tenantName = picked.name;
   }

--- a/libs/adsp-cli/src/tenants.spec.ts
+++ b/libs/adsp-cli/src/tenants.spec.ts
@@ -4,7 +4,7 @@ jest.mock('./directory', () => ({
 
 import { getServiceUrls } from './directory';
 import { HttpRequestError } from './httpError';
-import { findTenantByName, findTenantByRealm, listTenants } from './tenants';
+import { createTenant, findTenantByName, findTenantByRealm, getTenantById, listTenants, waitForTenantActive } from './tenants';
 
 const mockGetServiceUrls = getServiceUrls as jest.Mock;
 
@@ -116,5 +116,169 @@ describe('listTenants', () => {
     await expect(listTenants('https://directory-service.example.com', 'core-token')).rejects.toBeInstanceOf(
       HttpRequestError
     );
+  });
+});
+
+describe('createTenant', () => {
+  it('POSTs the name with a bearer token and returns the provisioning tenant', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'my-tenant', realm: 'generated-realm', status: 'provisioning' }),
+    });
+    global.fetch = fetchMock as never;
+
+    const tenant = await createTenant('https://directory-service.example.com', 'core-token', 'my-tenant');
+
+    expect(tenant).toEqual({ name: 'my-tenant', realm: 'generated-realm', status: 'provisioning' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${TENANT_SERVICE_URL}/v2/tenants`);
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer core-token');
+    expect(JSON.parse(init.body)).toEqual({ name: 'my-tenant' });
+  });
+
+  it('surfaces the server-provided errorMessage on a 400 validation failure', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ errorMessage: 'This tenant name has already been used. Please enter a different tenant name.' }),
+    }) as never;
+
+    await expect(createTenant('https://directory-service.example.com', 'core-token', 'taken-name')).rejects.toMatchObject({
+      status: 400,
+      message: 'This tenant name has already been used. Please enter a different tenant name.',
+    });
+  });
+
+  it('surfaces a hardcoded message on a bare 401 (missing beta-tester role)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => {
+        throw new Error('no body');
+      },
+    }) as never;
+
+    await expect(createTenant('https://directory-service.example.com', 'core-token', 'my-tenant')).rejects.toMatchObject({
+      status: 401,
+      message: expect.stringContaining("beta-tester"),
+    });
+  });
+
+  it('falls back to a generic message when the JSON error body has no errorMessage field', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({}),
+    }) as never;
+
+    await expect(createTenant('https://directory-service.example.com', 'core-token', 'my-tenant')).rejects.toMatchObject({
+      status: 400,
+      message: 'Tenant service request failed with status 400.',
+    });
+  });
+
+  it('falls back to a generic message when the error body is not JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('no body');
+      },
+    }) as never;
+
+    await expect(createTenant('https://directory-service.example.com', 'core-token', 'my-tenant')).rejects.toMatchObject({
+      status: 500,
+      message: 'Tenant service request failed with status 500.',
+    });
+  });
+});
+
+describe('getTenantById', () => {
+  it('GETs by id with a bearer token', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'my-tenant', realm: 'r', status: 'active' }),
+    });
+    global.fetch = fetchMock as never;
+
+    const tenant = await getTenantById('https://directory-service.example.com', 'core-token', 'tenant-a');
+
+    expect(tenant).toEqual({ name: 'my-tenant', realm: 'r', status: 'active' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${TENANT_SERVICE_URL}/v2/tenants/tenant-a`);
+    expect(init.headers.Authorization).toBe('Bearer core-token');
+  });
+
+  it('returns null on a 404 (tenant rolled back after a failed provisioning)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as never;
+
+    expect(await getTenantById('https://directory-service.example.com', 'core-token', 'tenant-a')).toBeNull();
+  });
+
+  it('throws an HttpRequestError carrying the status on a non-404 error response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('no body');
+      },
+    }) as never;
+
+    await expect(
+      getTenantById('https://directory-service.example.com', 'core-token', 'tenant-a')
+    ).rejects.toBeInstanceOf(HttpRequestError);
+  });
+});
+
+describe('waitForTenantActive', () => {
+  const createdTenant = { id: 'urn:ads:platform:tenant-service:v2:/tenants/tenant-a', name: 'my-tenant', realm: 'r' };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves once status flips to active', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ name: 'my-tenant', realm: 'r', status: 'provisioning' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ name: 'my-tenant', realm: 'r', status: 'active' }) });
+    global.fetch = fetchMock as never;
+
+    const resultPromise = waitForTenantActive('https://directory-service.example.com', 'core-token', createdTenant);
+    await jest.advanceTimersByTimeAsync(3000);
+
+    expect(await resultPromise).toEqual({ name: 'my-tenant', realm: 'r', status: 'active' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${TENANT_SERVICE_URL}/v2/tenants/tenant-a`);
+    expect(init.headers.Authorization).toBe('Bearer core-token');
+  });
+
+  it('throws if the tenant disappears (provisioning failed and was rolled back)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as never;
+
+    await expect(
+      waitForTenantActive('https://directory-service.example.com', 'core-token', createdTenant)
+    ).rejects.toThrow('provisioning failed');
+  });
+
+  it('throws when provisioning does not finish before the timeout', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'my-tenant', realm: 'r', status: 'provisioning' }),
+    }) as never;
+
+    const resultPromise = waitForTenantActive('https://directory-service.example.com', 'core-token', createdTenant, {
+      intervalMs: 10,
+      timeoutMs: 20,
+    });
+    const assertion = expect(resultPromise).rejects.toThrow('Timed out waiting');
+    await jest.advanceTimersByTimeAsync(1000);
+
+    await assertion;
   });
 });

--- a/libs/adsp-cli/src/tenants.ts
+++ b/libs/adsp-cli/src/tenants.ts
@@ -4,9 +4,11 @@ import { HttpRequestError } from './httpError';
 const TENANT_SERVICE_URN = 'urn:ads:platform:tenant-service:v2';
 
 export interface Tenant {
+  id?: string;
   name: string;
   realm: string;
   adminEmail?: string;
+  status?: string;
 }
 
 interface TenantsResponse {
@@ -75,4 +77,101 @@ export async function listTenants(directoryServiceUrl: string, accessToken: stri
 
   const data = (await response.json()) as TenantsResponse;
   return data.results ?? [];
+}
+
+/**
+ * tenant-service's role guard (`requireBetaTesterOrAdmin`) rejects a caller lacking the
+ * beta-tester/tenant-service-admin role with a bare 401 and no body, so that case needs its own
+ * message; other failures (name validation, one-tenant-per-email) come back as
+ * `{ errorMessage: string }` from the shared core-common error handler.
+ */
+async function extractErrorMessage(response: Response): Promise<string> {
+  if (response.status === 401) {
+    return "Your account doesn't have permission to create a tenant. Ask the ADSP team to grant your account the 'beta-tester' role, then try again.";
+  }
+  try {
+    const body = (await response.json()) as { errorMessage?: string };
+    return body.errorMessage ?? `Tenant service request failed with status ${response.status}.`;
+  } catch {
+    return `Tenant service request failed with status ${response.status}.`;
+  }
+}
+
+/**
+ * Creates a new tenant — requires an authenticated core-realm token with the beta-tester or
+ * tenant-service-admin role. Returns immediately once the tenant record is created (status
+ * 'provisioning'); the Keycloak realm itself is provisioned asynchronously — see
+ * waitForTenantActive.
+ */
+export async function createTenant(directoryServiceUrl: string, accessToken: string, name: string): Promise<Tenant> {
+  const tenantServiceUrl = await resolveTenantServiceUrl(directoryServiceUrl);
+  const url = new URL('v2/tenants', tenantServiceUrl);
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!response.ok) {
+    throw new HttpRequestError(response.status, await extractErrorMessage(response));
+  }
+
+  return (await response.json()) as Tenant;
+}
+
+/** Tenant ids are returned as a full URN (`urn:ads:platform:tenant-service:v2:/tenants/<id>`) — this pulls the raw id back out. */
+function extractTenantId(urn: string): string {
+  return urn.substring(urn.lastIndexOf('/') + 1);
+}
+
+/**
+ * Authenticated point lookup of a tenant by id — a much cheaper read than the name/realm-filtered
+ * list queries (a direct lookup by primary key vs. a filtered scan), so this is what polling
+ * should use. Returns null on a 404 (the tenant was rolled back after a provisioning failure, per
+ * tenant-service's getTenant handler); throws on any other non-ok response.
+ */
+export async function getTenantById(directoryServiceUrl: string, accessToken: string, id: string): Promise<Tenant | null> {
+  const tenantServiceUrl = await resolveTenantServiceUrl(directoryServiceUrl);
+  const url = new URL(`v2/tenants/${encodeURIComponent(id)}`, tenantServiceUrl);
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new HttpRequestError(response.status, await extractErrorMessage(response));
+  }
+
+  return (await response.json()) as Tenant;
+}
+
+/**
+ * Polls the newly created tenant by id (see getTenantById) until its realm finishes provisioning.
+ * Throws if the tenant disappears (provisioning failed and the record was rolled back) or if
+ * provisioning takes longer than timeoutMs.
+ */
+export async function waitForTenantActive(
+  directoryServiceUrl: string,
+  accessToken: string,
+  tenant: Tenant,
+  { intervalMs = 3000, timeoutMs = 120_000 } = {}
+): Promise<Tenant> {
+  const id = extractTenantId(tenant.id);
+  const deadline = Date.now() + timeoutMs;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const found = await getTenantById(directoryServiceUrl, accessToken, id);
+    if (!found) {
+      throw new Error(`Tenant '${tenant.name}' provisioning failed. Contact the ADSP team and try again.`);
+    }
+    if (found.status === 'active') {
+      return found;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for tenant '${tenant.name}' to finish provisioning.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
 }


### PR DESCRIPTION
## Summary
- When logging into a pre-production environment (`dev`/`test`) via `adsp login` with no owned tenant, the interactive picker now offers a `+ Create a new tenant` entry alongside the existing list.
- Picking it prompts for a tenant name, creates it via `POST /v2/tenants`, and polls the new tenant **by id** (a cheap point read, not a filtered scan) until its realm finishes provisioning, then continues the normal tenant-realm login.
- `tenant-service-admin` callers keep the create option even if they already own tenants, since the server-side one-tenant-per-email rule (`validateEmailInDB`) doesn't apply to them and nothing in the schema prevents it (`adminEmail` isn't unique).
- 400-class validation failures (bad characters, duplicate name, one-tenant-per-email) re-prompt for a new name; anything else (e.g. missing `beta-tester` role) propagates immediately.
- **Server fix**: `GET /v2/tenants/:id` now returns a clean 404 (`NotFoundError`) instead of crashing into an unhandled 500 when the tenant record was rolled back after a failed provisioning — the CLI's new by-id polling depends on that 404 to detect provisioning failure.

## Test plan
- [x] `nx test adsp-cli` — 121/121 passing, 100% coverage on `tenants.ts`, covering the gating logic (pre-prod/prod, owned/admin-exempt), the create-and-poll happy path, and both error branches
- [x] `nx test tenant-management-api` — 57/57 passing, including the new 404-on-deleted-tenant case
- [x] `nx build`/`nx lint` clean on both projects
- [ ] Manual: `adsp login` (no args, `--env dev`) as a user with no owned tenant → confirm the create option appears, provisions successfully, and logs into the new tenant; confirm the option is absent against `--env prod` and for a non-admin who already owns a tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)