### PR TITLE
feat: Remove empty useEffect hooks from tenant management webapp

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/access/overview.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/access/overview.tsx
@@ -47,13 +47,6 @@ export const Overview = (): JSX.Element => {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Paul Li Nov-16-2022: Please do not remove the following useEffect,
-   * it will affect the page clean up function in the previous useEffect function.
-   **/
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   return (
     <OverviewLayout
       description={

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/access/serviceRoles/serviceRoleList.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/access/serviceRoles/serviceRoleList.tsx
@@ -19,7 +19,7 @@ export const selectKeycloakServiceRoles = createSelector(
   (state: RootState) => state.serviceRoles,
   (serviceRoles) => {
     return serviceRoles?.keycloak || {};
-  }
+  },
 );
 
 const isConfigRoleExisted = (
@@ -27,7 +27,7 @@ const isConfigRoleExisted = (
   tenantAdminRoles: Record<string, { roles: string[] }>,
   isInTenantAdmin,
   clientId: string,
-  roleName: string
+  roleName: string,
 ) => {
   if (clientId in kcRoleConfig) {
     const isRoleInClient = kcRoleConfig[clientId].roles.find((role) => {
@@ -83,7 +83,7 @@ export const ServiceRoleList = ({ roles, clientId, addRoleFunc, inProcess }: Ser
                 tenantAdminRoles,
                 role?.inTenantAdmin,
                 clientId,
-                role.role
+                role.role,
               );
               return (
                 <tr key={`${role.role}`}>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/access/serviceRoles/serviceRoles.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/access/serviceRoles/serviceRoles.tsx
@@ -9,27 +9,26 @@ import { ServiceRoleListContainer } from '../styled-component';
 import { PageIndicator } from '@components/Indicator';
 import { ConfirmationModal } from './addRoleModal';
 import { ServiceRoleSyncStatus } from '@store/access/models';
-import { sortedIndex } from 'lodash';
 
 export const selectServiceTenantRoles = createSelector(
   (state: RootState) => state.serviceRoles,
   (serviceRoles) => {
     return serviceRoles?.tenant || {};
-  }
+  },
 );
 
 export const selectServiceCoreRoles = createSelector(
   (state: RootState) => state.serviceRoles,
   (serviceRoles) => {
     return serviceRoles?.core || {};
-  }
+  },
 );
 
 export const selectKeycloakServiceRoles = createSelector(
   (state: RootState) => state.serviceRoles,
   (serviceRoles) => {
     return serviceRoles?.keycloak || {};
-  }
+  },
 );
 
 export const ServiceRoles = (): JSX.Element => {
@@ -54,11 +53,6 @@ export const ServiceRoles = (): JSX.Element => {
       return {};
     }
   });
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
-  // eslint-disable-next-line
-  useEffect(() => {}, [updateState]);
 
   useEffect(() => {
     dispatch(fetchServiceRoles());

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/deleteModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/deleteModal.tsx
@@ -13,8 +13,6 @@ export const DeleteModal = ({ calendarName }: deleteModalProps) => {
   const event = useSelector((state) => selectDeleteEventById(state, calendarName));
   const dispatch = useDispatch();
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [event]);
   return (
     <GoabModal
       testId="delete-confirmation"

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/eventList.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/eventList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectSelectedCalendarEvents, selectSelectedCalendarNextEvents } from '@store/calendar/selectors';
 import { CalendarEvent, EventAddEditModalType, EventDeleteModalType } from '@store/calendar/models';
@@ -79,9 +79,6 @@ const LoadMoreEvents = ({ next, calendarName }: LoadMoreEventsProps): JSX.Elemen
   const { indicator } = useSelector((state: RootState) => ({
     indicator: state.session?.elementIndicator,
   }));
-
-  //eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
 
   if (indicator?.show) {
     return <GoabSkeleton type="text" key={1} />;
@@ -165,7 +162,7 @@ const EventListRow = ({ event }: EventListRowProps): JSX.Element => {
                       type: EventAddEditModalType,
                       id: `${event.id}`,
                       isOpen: true,
-                    })
+                    }),
                   );
                 }}
               />
@@ -179,7 +176,7 @@ const EventListRow = ({ event }: EventListRowProps): JSX.Element => {
                       type: EventDeleteModalType,
                       id: `${event.id}`,
                       isOpen: true,
-                    })
+                    }),
                   );
                 }}
               />
@@ -202,8 +199,6 @@ interface EventListProps {
 export const EventList = ({ calendarName }: EventListProps): JSX.Element => {
   const selectedEvents = useSelector((state: RootState) => selectSelectedCalendarEvents(state, calendarName));
   const next = useSelector((state: RootState) => selectSelectedCalendarNextEvents(state, calendarName));
-  // eslint-disable-next-line
-  useEffect(() => {}, [selectedEvents]);
 
   if (!selectedEvents) {
     return (

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/comment/comments/commentsTable.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/comment/comments/commentsTable.tsx
@@ -92,8 +92,7 @@ export const CommentListTable: FunctionComponent<CommentTableProps> = ({ topic, 
   const elementIndicator = useSelector((state: RootState) => {
     return state?.session?.elementIndicator;
   });
-  // eslint-disable-next-line
-  useEffect(() => {}, [elementIndicator]);
+
   return (
     <section>
       <HeaderFont>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topicTypes/addEditCommentTopicType.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topicTypes/addEditCommentTopicType.tsx
@@ -54,9 +54,6 @@ export const AddEditCommentTopicType: FunctionComponent<AddEditCommentTopicTypeP
     }
   }, [topicTypes, topicType.id, spinner, navigate, isEdit, onClose]);
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   useEffect(() => {
     setTopicType(initialValue);
   }, [open, initialValue]);
@@ -66,7 +63,7 @@ export const AddEditCommentTopicType: FunctionComponent<AddEditCommentTopicTypeP
     'name',
     badCharsCheck,
     wordMaxLengthCheck(32, 'Name'),
-    isNotEmptyCheck('name')
+    isNotEmptyCheck('name'),
   )
     .add('duplicate', 'name', duplicateNameCheck(topicTypeNames, 'topicType'))
     .add('description', 'description', wordMaxLengthCheck(180, 'Description'))
@@ -141,7 +138,7 @@ export const AddEditCommentTopicType: FunctionComponent<AddEditCommentTopicTypeP
                   setTopicType(
                     isEdit
                       ? { ...topicType, name: detail.value }
-                      : { ...topicType, name: detail.value, id: toKebabName(detail.value) }
+                      : { ...topicType, name: detail.value, id: toKebabName(detail.value) },
                   );
                 }}
                 onBlur={() => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topicTypes/addEditCommentTopicTypeEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topicTypes/addEditCommentTopicTypeEditor.tsx
@@ -58,7 +58,7 @@ const isCommentUpdated = (prev: CommentTopicTypes, next: CommentTopicTypes): boo
 export function AddEditCommentTopicTypeEditor(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const [topicType, setTopicType] = useState<CommentTopicTypes>(
-    id ? defaultEditCommentTopicType : defaultCommentTopicType
+    id ? defaultEditCommentTopicType : defaultCommentTopicType,
   );
   const [initialTopicType, setInitialTopicType] = useState<CommentTopicTypes>(defaultCommentTopicType);
   const [spinner, setSpinner] = useState<boolean>(false);
@@ -66,7 +66,7 @@ export function AddEditCommentTopicTypeEditor(): JSX.Element {
 
   const [saveModal, setSaveModal] = useState({ visible: false, closeEditor: false });
   const latestNotification = useSelector(
-    (state: RootState) => state.notifications.notifications[state.notifications.notifications.length - 1]
+    (state: RootState) => state.notifications.notifications[state.notifications.notifications.length - 1],
   );
   const scrollPaneRef = useRef<HTMLDivElement>(null);
   const { height } = useWindowDimensions();
@@ -94,7 +94,7 @@ export function AddEditCommentTopicTypeEditor(): JSX.Element {
     (state: RootState) => state.serviceRoles,
     (serviceRoles) => {
       return serviceRoles?.keycloak || {};
-    }
+    },
   );
 
   useEffect(() => {
@@ -124,8 +124,6 @@ export function AddEditCommentTopicTypeEditor(): JSX.Element {
   const { fetchKeycloakRolesState } = useSelector((state: RootState) => ({
     fetchKeycloakRolesState: state.session.indicator?.details[FETCH_KEYCLOAK_SERVICE_ROLES] || '',
   }));
-  //eslint-disable-next-line
-  useEffect(() => {}, [fetchKeycloakRolesState]);
 
   const ClientRole = ({ roleNames, clientId }) => {
     const applicantRoles = types[0];
@@ -201,22 +199,19 @@ export function AddEditCommentTopicTypeEditor(): JSX.Element {
     }
   }, [topicTypes]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   const { validators, errors } = useValidators(
     'name',
     'name',
     badCharsCheck,
     wordMaxLengthCheck(32, 'Name'),
     isNotEmptyCheck('name'),
-    isNotEmptyCheck('securityClassification')
+    isNotEmptyCheck('securityClassification'),
   )
     .add('duplicate', 'name', duplicateNameCheck(topicTypeNames, 'topicType'))
     .add(
       'securityClassification',
       'securityClassification',
-      isNotUndefinedCheck(topicType.securityClassification, 'Security classification')
+      isNotUndefinedCheck(topicType.securityClassification, 'Security classification'),
     )
     .add('description', 'description', wordMaxLengthCheck(180, 'Description'))
     .build();

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topicTypes/topicTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topicTypes/topicTypes.tsx
@@ -66,8 +66,6 @@ export const CommentTopicTypes = ({ openAddTopicTypes }: CommentTopicTypesProps)
     setOpenAddCommentTopicType(false);
   };
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [commentTopicTypes]);
   useEffect(() => {
     document.body.style.overflow = 'unset';
   }, []);

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/directory/modals/deleteModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/directory/modals/deleteModal.tsx
@@ -15,9 +15,6 @@ export const DirectoryDeleteModal = (): JSX.Element => {
   const modal = useSelector(selectModalStateByType(DeleteModalType));
   const content = directory && `${directory?.api ? `${directory?.service}:${directory?.api}` : directory.service}`;
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [modal?.isOpen]);
-
   return (
     <DeleteModal
       title={title}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/directory/serviceList.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/directory/serviceList.tsx
@@ -35,9 +35,6 @@ const ServiceItemComponent = ({ service, id, headerId }: serviceItemProps): JSX.
     return state?.session?.elementIndicator;
   });
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [elementIndicator]);
-
   return (
     <>
       <tr key={service.urn}>
@@ -63,7 +60,7 @@ const ServiceItemComponent = ({ service, id, headerId }: serviceItemProps): JSX.
                         type: AddModalType,
                         id: service.urn,
                         isOpen: true,
-                      })
+                      }),
                     );
                   }}
                   testId={`directory-add-${service.service}`}
@@ -88,7 +85,7 @@ const ServiceItemComponent = ({ service, id, headerId }: serviceItemProps): JSX.
                         type: EditModalType,
                         id: service.urn,
                         isOpen: true,
-                      })
+                      }),
                     );
                   }}
                 />
@@ -105,7 +102,7 @@ const ServiceItemComponent = ({ service, id, headerId }: serviceItemProps): JSX.
                         id: service.urn,
                         type: DeleteModalType,
                         isOpen: true,
-                      })
+                      }),
                     );
                   }}
                 />

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/definitions.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/definitions.tsx
@@ -32,9 +32,6 @@ export const EventDefinitions: FunctionComponent<ParentCompProps> = ({ activeEdi
     setCoreNamespaces(namespaces);
   }, [definitions]);
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   const dispatch = useDispatch();
 
   function reset() {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/index.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/index.tsx
@@ -36,7 +36,7 @@ export const EventStreams = (): JSX.Element => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // eslint-disable-next-line
-  useEffect(() => {}, [tenantStreams]);
+  //useEffect(() => {}, [tenantStreams]);
 
   return (
     <section>
@@ -51,7 +51,7 @@ export const EventStreams = (): JSX.Element => {
                   type: AddModalType,
                   id: null,
                   isOpen: true,
-                })
+                }),
               );
             }}
           >
@@ -82,7 +82,7 @@ export const EventStreams = (): JSX.Element => {
                     type: EditModalType,
                     id: streamId,
                     isOpen: true,
-                  })
+                  }),
                 );
               }}
               streams={{ ...tenantStreams }}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/sites/sites.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/sites/sites.tsx
@@ -22,7 +22,7 @@ export const FeedbackSites: FunctionComponent<ParentCompProps> = ({ activeEdit }
   const sites = useSelector((state: RootState) => {
     return (
       state.feedback.sites?.sort((a, b) =>
-        a.url.replace(/^https?:\/\//, '').localeCompare(b.url.replace(/^https?:\/\//, ''))
+        a.url.replace(/^https?:\/\//, '').localeCompare(b.url.replace(/^https?:\/\//, '')),
       ) || []
     );
   });
@@ -40,8 +40,6 @@ export const FeedbackSites: FunctionComponent<ParentCompProps> = ({ activeEdit }
     setEditSite(false);
     setDeleteSiteConfirmation(false);
   };
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
 
   const dispatch = useDispatch();
   useEffect(() => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypes/fileTypeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypes/fileTypeModal.tsx
@@ -7,10 +7,7 @@ import { FileTypeItem, RetentionPolicy } from '@store/file/models';
 import { useDispatch } from 'react-redux';
 import { toKebabName } from '@lib/kebabName';
 
-import { RootState } from '@store/index';
-import { useSelector } from 'react-redux';
 import { useValidators } from '@lib/validation/useValidators';
-import { FETCH_KEYCLOAK_SERVICE_ROLES } from '@store/access/actions';
 import { isNotEmptyCheck, wordMaxLengthCheck, badCharsCheck, duplicateNameCheck } from '@lib/validation/checkInput';
 import { useNavigate } from 'react-router-dom';
 import { GoabInputOnChangeDetail } from '@abgov/ui-components-common';
@@ -40,19 +37,12 @@ export const FileTypeModal = ({ initialValue, isOpen, fileTypeNames, onCancel }:
     'name',
     badCharsCheck,
     wordMaxLengthCheck(32, 'Name'),
-    isNotEmptyCheck('name')
+    isNotEmptyCheck('name'),
   )
     .add('duplicated', 'name', duplicateNameCheck(fileTypeNames, 'File type'))
     .build();
 
   const dispatch = useDispatch();
-
-  const { fetchKeycloakRolesState } = useSelector((state: RootState) => ({
-    fetchKeycloakRolesState: state.session.indicator?.details[FETCH_KEYCLOAK_SERVICE_ROLES] || '',
-  }));
-
-  //eslint-disable-next-line
-  useEffect(() => {}, [fetchKeycloakRolesState]);
 
   useEffect(() => {
     setFileType(initialValue);

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypes/fileTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/fileTypes/fileTypes.tsx
@@ -1,6 +1,5 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import React from 'react';
 import { FetchFileTypeService } from '@store/file/actions';
 
 import { RootState } from '@store/index';
@@ -44,9 +43,6 @@ const FileTypesTableContainer = ({ roles, activeEdit }: FileTypesTableContainerP
       dispatch(FetchFileTypeService());
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
 
   useEffect(() => {
     document.body.style.overflow = 'unset';

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/file/uploadedFiles/fileList.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/file/uploadedFiles/fileList.tsx
@@ -151,9 +151,6 @@ const FileList = (): JSX.Element => {
     dispatch(FetchFilesService(null, criteria));
   };
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator, isUploadingFile, hasUploadingFileCompleted]);
-
   const renderFileTable = () => {
     return (
       <FileTableStyles>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/export/formExport.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/export/formExport.tsx
@@ -38,7 +38,7 @@ export const FormExport = (): JSX.Element => {
   const [downloadDisable, setDownloadDisable] = useState(true);
   const [loadingMessage, setLoadingMessage] = useState('');
   const formDefinitions = useSelector((state: RootState) => state.form.definitions);
-  const exportResult = useSelector((state: RootState) => state.form.exportResult);
+
   const formList: FormDefinition[] = Object.entries(formDefinitions)
     .map(([, value]) => value)
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -58,12 +58,6 @@ export const FormExport = (): JSX.Element => {
   const onDownloadFile = async (file) => {
     file && dispatch(DownloadFileService(file));
   };
-
-  const indicator = useSelector((state: RootState) => {
-    return state?.session?.indicator;
-  });
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
 
   const exportToFile = () => {
     let selectedColumns = [];
@@ -116,9 +110,6 @@ export const FormExport = (): JSX.Element => {
       dispatch(getFormDefinitions(next));
     } //eslint-disable-next-line
   }, [dispatch, next === 'NTA=']);
-
-  // eslint-disable-next-line
-  useEffect(() => {}, [exportResult]);
 
   useEffect(() => {
     socket?.on('connect', () => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/contactInformation/index.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/contactInformation/index.tsx
@@ -15,7 +15,7 @@ import { phoneWrapper } from '@lib/wrappers';
 import { TextGoASkeleton } from '@core-services/app-common';
 import { useActionStateCheck } from '@components/Indicator';
 import { NoPaddingH2 } from '@components/AppHeader';
-import {GoabGrid} from '@abgov/react-components';
+import { GoabGrid } from '@abgov/react-components';
 
 interface SubscribersProps {
   subscribers?: Subscriber[];
@@ -29,12 +29,9 @@ export const ContactInformation: FunctionComponent<SubscribersProps> = () => {
     dispatch(FetchNotificationConfigurationService());
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [isFetchLoading]);
-
   const contact = useSelector((state: RootState) => state.notification.supportContact);
   const hasConfigurationAdminRole = useSelector((state: RootState) =>
-    state.session?.resourceAccess?.['urn:ads:platform:configuration-service']?.roles?.includes('configuration-admin')
+    state.session?.resourceAccess?.['urn:ads:platform:configuration-service']?.roles?.includes('configuration-admin'),
   );
 
   const [editContactInformation, setEditContactInformation] = useState<boolean>(false);
@@ -82,22 +79,22 @@ export const ContactInformation: FunctionComponent<SubscribersProps> = () => {
           management application so they know how to get support for notification related issues.
         </p>
 
-        <GoabGrid minChildWidth='25ch' gap='s'>
-          <div data-testid="email" className="word-break contact-border" >
+        <GoabGrid minChildWidth="25ch" gap="s">
+          <div data-testid="email" className="word-break contact-border">
             <h4>Contact email</h4>
             {isFetchLoading && <TextGoASkeleton key="email" />}
             {!isFetchLoading && contact?.contactEmail}
           </div>
-          <div data-testid="phone" className="contact-border" >
+          <div data-testid="phone" className="contact-border">
             <h4>Phone number</h4>
             {isFetchLoading && <TextGoASkeleton key="Phone" />}
 
             {!isFetchLoading && phoneWrapper(contact?.phoneNumber)}
           </div>
         </GoabGrid>
-        <br/>
-        <GoabGrid minChildWidth='320'>
-          <div data-testid="support-instructions" className="contact-border" >
+        <br />
+        <GoabGrid minChildWidth="320">
+          <div data-testid="support-instructions" className="contact-border">
             <h4>Support instructions</h4>
             {isFetchLoading && <TextGoASkeleton key="instructions" />}
             {!isFetchLoading && contact?.supportInstructions}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/emailinformation/emailSection.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/emailinformation/emailSection.tsx
@@ -4,19 +4,13 @@ import styled from 'styled-components';
 import { NoPaddingH2 } from '@components/AppHeader';
 import { GoAContextMenuIcon } from '@components/ContextMenu';
 import { RootState } from '@store/index';
-import { useActionStateCheck } from '@components/Indicator';
-import {
-  FETCH_NOTIFICATION_CONFIGURATION,
-  FetchNotificationConfigurationService,
-  UpdateEmailInformationService,
-} from '@store/notification/actions';
+import { FetchNotificationConfigurationService, UpdateEmailInformationService } from '@store/notification/actions';
 import { ReactComponent as Edit } from '@icons/edit.svg';
 import { EditEmailInformationTypeModalForm } from './editEmail';
 import { GoabGrid } from '@abgov/react-components';
 export const EmailInformation: FunctionComponent = () => {
   const [editEmailInformation, setEditEmailInformation] = useState<boolean>(false);
   const dispatch = useDispatch();
-  const isFetchLoading = useActionStateCheck(FETCH_NOTIFICATION_CONFIGURATION, 'start');
   const fromEmail = useSelector((state: RootState) => state.notification.email);
 
   const openModalFunction = () => {
@@ -31,11 +25,8 @@ export const EmailInformation: FunctionComponent = () => {
     dispatch(FetchNotificationConfigurationService());
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [isFetchLoading]);
-
   const hasConfigurationAdminRole = useSelector((state: RootState) =>
-    state.session?.resourceAccess?.['urn:ads:platform:configuration-service']?.roles?.includes('configuration-admin')
+    state.session?.resourceAccess?.['urn:ads:platform:configuration-service']?.roles?.includes('configuration-admin'),
   );
 
   return (

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationType/notificationTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationType/notificationTypes.tsx
@@ -190,8 +190,6 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
       }
     }
   }, [selectedEvent]); // eslint-disable-line react-hooks/exhaustive-deps
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
 
   useEffect(() => {
     dispatch(FetchNotificationConfigurationService());

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.tsx
@@ -64,9 +64,6 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
     }
   }, [templates]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   useEffect(() => {
     setTemplate(initialValue);
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -76,7 +73,7 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
     'name',
     badCharsCheck,
     wordMaxLengthCheck(32, 'Name'),
-    isNotEmptyCheck('name')
+    isNotEmptyCheck('name'),
   )
     .add('duplicate', 'name', duplicateNameCheck(templateIds, 'template'))
     .add('description', 'description', wordMaxLengthCheck(180, 'Description'))
@@ -148,7 +145,7 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
               setTemplate(
                 isEdit
                   ? { ...template, name: detail.value }
-                  : { ...template, name: detail.value, id: toKebabName(detail.value) }
+                  : { ...template, name: detail.value, id: toKebabName(detail.value) },
               );
             }}
             onBlur={() => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/addScriptModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/addScriptModal.tsx
@@ -61,9 +61,6 @@ export const AddScriptModal = ({
     .add('duplicated', 'name', duplicateNameCheck(scriptNames, 'Script'))
     .build();
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [roles]);
-
   useEffect(() => {
     dispatch(FetchRealmRoles());
     dispatch(fetchKeycloakServiceRoles());

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.tsx
@@ -43,7 +43,6 @@ import { getEventDefinitions } from '@store/event/actions';
 import { scriptEditorConfig, scriptEditorJsonConfig } from './config';
 import { CustomLoader } from '@components/CustomLoader';
 import { FetchRealmRoles } from '@store/tenant/actions';
-import useWindowDimensions from '@lib/useWindowDimensions';
 import { NotificationBanner } from 'app/notificationBanner';
 export interface ScriptEditorProps {
   name: string;
@@ -108,7 +107,7 @@ export const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
 
   const roles = useSelector(selectRoleList);
   const latestNotification = useSelector(
-    (state: RootState) => state.notifications.notifications[state.notifications.notifications.length - 1]
+    (state: RootState) => state.notifications.notifications[state.notifications.notifications.length - 1],
   );
   useEffect(() => {
     if (monaco) {
@@ -280,8 +279,6 @@ export const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
   const { fetchKeycloakRolesState } = useSelector((state: RootState) => ({
     fetchKeycloakRolesState: state.session.indicator?.details[FETCH_KEYCLOAK_SERVICE_ROLES] || '',
   }));
-  //eslint-disable-next-line
-  useEffect(() => {}, [fetchKeycloakRolesState]);
 
   const ClientRole = ({ roleNames, clientId }) => {
     const runnerRoles = types[0];

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/contactInformation/contactInformation.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/contactInformation/contactInformation.tsx
@@ -14,7 +14,7 @@ import { ContactInformationModalForm } from './editContactInfo';
 import { ReactComponent as Edit } from '@icons/edit.svg';
 import { useActionStateCheck } from '@components/Indicator';
 import { NoPaddingH2 } from '@components/AppHeader';
-import {GoabGrid} from '@abgov/react-components';
+import { GoabGrid } from '@abgov/react-components';
 interface SubscribersProps {
   subscribers?: Subscriber[];
   readonly?: boolean;
@@ -28,12 +28,9 @@ export const ContactInformation: FunctionComponent<SubscribersProps> = () => {
     dispatch(FetchStatusConfigurationService());
   }, [dispatch]);
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [isFetchConfigCompleted]);
-
   const contact = useSelector((state: RootState) => state.serviceStatus.contact);
   const hasConfigurationAdminRole = useSelector((state: RootState) =>
-    state.session?.resourceAccess?.['urn:ads:platform:configuration-service']?.roles?.includes('configuration-admin')
+    state.session?.resourceAccess?.['urn:ads:platform:configuration-service']?.roles?.includes('configuration-admin'),
   );
 
   const [editContactInformation, setEditContactInformation] = useState<boolean>(false);
@@ -78,8 +75,8 @@ export const ContactInformation: FunctionComponent<SubscribersProps> = () => {
           report service issues.
         </p>
 
-        <GoabGrid minChildWidth='320' >
-          <div data-testid="email" className="word-break contact-border" >
+        <GoabGrid minChildWidth="320">
+          <div data-testid="email" className="word-break contact-border">
             <h4>Contact email</h4>
             {!isFetchConfigCompleted && <TextGoASkeleton />}
             {isFetchConfigCompleted && contact?.contactEmail}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeCard.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Notice } from '@store/notice/models';
 import styled from 'styled-components';
 import { GoabBadge } from '@abgov/react-components';
@@ -72,8 +72,6 @@ export const NoticeCard = (props: NoticeCardProps): JSX.Element => {
     applications: state.serviceStatus.applications,
   }));
   const { isMenuOpen, clickMenuFn } = props;
-  // eslint-disable-next-line
-  useEffect(() => {}, [applications]);
 
   const { notice } = props;
   const CardHeader = (props: CardHeaderProps): JSX.Element => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookDeleteModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookDeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DeleteWebhookService } from '@store/status/actions';
 import { selectWebhookToDeleteInStatus } from '@store/status/selectors';
@@ -8,8 +8,7 @@ import { DeleteModal } from '@components/DeleteModal';
 export const WebhookDeleteModal = (): JSX.Element => {
   const dispatch = useDispatch();
   const webhook = useSelector(selectWebhookToDeleteInStatus);
-  // eslint-disable-next-line
-  useEffect(() => {}, [webhook]);
+
   return (
     <div>
       {webhook && (

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookHistoryForm.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookHistoryForm.tsx
@@ -14,11 +14,7 @@ import { PageIndicator } from '@components/Indicator';
 import { RootState } from '@store/index';
 import { HoverWrapper, ToolTip } from '../styled-components';
 import { ResetModalState } from '@store/session/actions';
-import {
-  GoabTextAreaOnKeyPressDetail,
-  GoabInputOnChangeDetail,
-  GoabDropdownOnChangeDetail,
-} from '@abgov/ui-components-common';
+import { GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface EventLogEntryComponentProps {
   entry: EventLogEntry;
@@ -123,9 +119,6 @@ export const WebhookHistoryModal = (): JSX.Element => {
   useEffect(() => {
     dispatch(getEventDefinitions());
   }, [dispatch]);
-
-  // eslint-disable-next-line
-  useEffect(() => {}, [entries, next]);
 
   const onSearch = (criteria: EventSearchCriteria) => {
     dispatch(clearEventLogEntries());

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhooks.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhooks.tsx
@@ -83,7 +83,7 @@ const WebhookTableRow = ({ webhook }: WebhookRowProps): JSX.Element => {
                     type: StatusWebhookHistoryType,
                     isOpen: true,
                     id,
-                  })
+                  }),
                 );
               }}
             />
@@ -97,7 +97,7 @@ const WebhookTableRow = ({ webhook }: WebhookRowProps): JSX.Element => {
                     type: TestStatusWebhookType,
                     isOpen: true,
                     id,
-                  })
+                  }),
                 );
               }}
             />
@@ -111,7 +111,7 @@ const WebhookTableRow = ({ webhook }: WebhookRowProps): JSX.Element => {
                     type: AddEditStatusWebhookType,
                     isOpen: true,
                     id,
-                  })
+                  }),
                 );
               }}
             />
@@ -125,7 +125,7 @@ const WebhookTableRow = ({ webhook }: WebhookRowProps): JSX.Element => {
                     type: DeleteStatusWebhookType,
                     isOpen: true,
                     id,
-                  })
+                  }),
                 );
               }}
             />
@@ -154,8 +154,6 @@ export const WebhookListTable = () => {
   const indicator = useSelector((state: RootState) => {
     return state?.session?.indicator;
   });
-  // eslint-disable-next-line
-  useEffect(() => {}, [webhooks]);
 
   return (
     <>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/task/queue/deleteConfirmationsView.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/task/queue/deleteConfirmationsView.tsx
@@ -33,8 +33,6 @@ export const DeleteConfirmationsView: FunctionComponent<taskTableProps> = ({ que
       setShowDeleteConfirmation(true);
     }
   }, [tasks]);
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  useEffect(() => {}, [tasks]);
 
   return (
     <TableDiv key="task">

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/task/queue/queueModalEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/task/queue/queueModalEditor.tsx
@@ -46,7 +46,7 @@ export const QueueModalEditor: FunctionComponent = (): JSX.Element => {
   const tenantClients: ServiceRoleConfig = tenant.tenantClients ? tenant.tenantClients : {};
   const { id } = useParams<{ id: string }>();
   const latestNotification = useSelector(
-    (state: RootState) => state.notifications.notifications[state.notifications.notifications.length - 1]
+    (state: RootState) => state.notifications.notifications[state.notifications.notifications.length - 1],
   );
   const { height } = useWindowDimensions();
   const calcHeight = latestNotification && !latestNotification.disabled ? height - 8 : height + 42;
@@ -97,8 +97,6 @@ export const QueueModalEditor: FunctionComponent = (): JSX.Element => {
   const assignerRoles = types[0];
   const workerRoles = types[1];
 
-  //eslint-disable-next-line
-  useEffect(() => {}, [fetchKeycloakRolesState]);
   const ClientRole = ({ roleNames, clientId }) => {
     return (
       <ClientRoleTable
@@ -162,7 +160,7 @@ export const QueueModalEditor: FunctionComponent = (): JSX.Element => {
     'name',
     badCharsCheck,
     wordMaxLengthCheck(32, 'Name'),
-    isNotEmptyCheck('name')
+    isNotEmptyCheck('name'),
   )
     .add('duplicate', 'name', duplicateNameCheck(definitionIds, 'definition'))
     .add('description', 'description', wordMaxLengthCheck(180, 'Description'))
@@ -178,9 +176,6 @@ export const QueueModalEditor: FunctionComponent = (): JSX.Element => {
       setSpinner(false);
     }
   }, [queues]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
 
   return (
     <TaskEditor>

--- a/libs/form-editor-common/src/lib/definitions/addEditDispositionModal.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditDispositionModal.tsx
@@ -33,9 +33,6 @@ export const AddEditDispositionModal: FunctionComponent<AddEditDispositionModalP
     return state?.session?.indicator;
   });
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   useEffect(() => {
     setTemplate(initialValue);
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -45,7 +42,7 @@ export const AddEditDispositionModal: FunctionComponent<AddEditDispositionModalP
     'name',
     badCharsCheck,
     wordMaxLengthCheck(32, 'Name'),
-    isNotEmptyCheck('name')
+    isNotEmptyCheck('name'),
   )
     .add('duplicate', 'name', duplicateNameCheck(templateIds, 'template'))
 
@@ -113,7 +110,7 @@ export const AddEditDispositionModal: FunctionComponent<AddEditDispositionModalP
                 setTemplate(
                   isEdit
                     ? { ...template, name: detail.value }
-                    : { ...template, name: detail.value, id: toKebabName(detail.value) }
+                    : { ...template, name: detail.value, id: toKebabName(detail.value) },
                 );
               }}
             />

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinition.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinition.tsx
@@ -25,17 +25,10 @@ import {
   GoabFormItem,
   GoabButton,
   GoabCheckbox,
-  GoabDropdown,
-  GoabDropdownItem,
   GoabFilterChip,
 } from '@abgov/react-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import {
-  GoabTextAreaOnKeyPressDetail,
-  GoabInputOnChangeDetail,
-  GoabDropdownOnChangeDetail,
-} from '@abgov/ui-components-common';
-import { Tag } from '@store/directory/models';
+import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 import { fetchFormTagByTagName } from '@store/form/action';
 
 interface AddEditFormDefinitionProps {
@@ -135,9 +128,6 @@ export const AddEditFormDefinition = ({
       }
     }
   }, [definitions]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator, defaultFormUrl]);
 
   useEffect(() => {
     setDefinition(initialValue);

--- a/libs/form-editor-common/src/lib/definitions/definitions.tsx
+++ b/libs/form-editor-common/src/lib/definitions/definitions.tsx
@@ -64,7 +64,6 @@ export const FormDefinitions = ({
   };
 
   const navigate = useNavigate();
-  const location = useLocation();
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [showAddRemoveResourceTagModal, setShowAddRemoveResourceTagModal] = useState(false);
@@ -107,9 +106,6 @@ export const FormDefinitions = ({
   const BASE_FORM_CONFIG_URN = `${resourceConfiguration.urn}:/configuration/form-service`;
   const dispatch = useDispatch();
 
-  // eslint-disable-next-line
-  useEffect(() => {}, [indicator]);
-
   useEffect(() => {
     if (openAddDefinition) {
       setOpenAddFormDefinition(true);
@@ -135,7 +131,8 @@ export const FormDefinitions = ({
     }
 
     return () => {
-      if (!window.location.href.includes('/edit/')) { // clean-code-ignore: 2.18
+      if (!window.location.href.includes('/edit/')) {
+        // clean-code-ignore: 2.18
         dispatch(setSelectedTag(null));
       }
     };


### PR DESCRIPTION
Directory service, service list, delete modal.
Calendar service event delete, event list.
Notification service overview page, check email information , contact information, notification type page.
Form service , form export page, definition list, add disposition modal, add form definiation
Status service, webhook page, webhook history , delete webhook, Contact information , and notice page.
Access service , overview page, service role list
Pdf service, add pdf template,
Comment service  commentTable, topictypeTable, addTopictypeModal, topicTypeEditor
File Service, file upload, file type list,  add file type modal.
Feedfack service, site list
Script service, script editor
Event service, event list, stream list
Task service, queue editor, delete queue