### PR TITLE
fix(jsonforms-components): Tasklist step status on save and navigation

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.spec.tsx
@@ -240,7 +240,7 @@ const { customDispatch, ...stepperBasePropsNoDispatch } = stepperBaseProps;
 const getForm = (
   data: object,
   uiSchema: UISchemaElement = categorization,
-  componentProps: object | undefined = undefined
+  componentProps: object | undefined = undefined,
 ): JSX.Element => {
   combineOptions(uiSchema, componentProps);
 
@@ -261,13 +261,13 @@ afterEach(() => {
 describe('Form Stepper Control', () => {
   it('can render an initial Categorization', () => {
     const renderer = render(
-      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />
+      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />,
     );
   });
 
   it('can render a nested Categorization', () => {
     const renderer = render(
-      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />
+      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />,
     );
     const step0 = renderer.getByTestId('step_0-content');
     expect(step0).toBeVisible();
@@ -278,7 +278,7 @@ describe('Form Stepper Control', () => {
 
   it('can input a text value', () => {
     const { baseElement } = render(
-      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />
+      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />,
     );
     const lastName = baseElement.querySelector("goa-input[testId='last-name-input']");
     expect(lastName).toBeInTheDocument();
@@ -296,7 +296,7 @@ describe('Form Stepper Control', () => {
       <JsonFormsStepperContextProvider
         StepperProps={stepperBaseProps}
         children={getForm({ ...formData, name: { firstName: 'Bob', lastName: 'Bing' } })}
-      />
+      />,
     );
     const lastName = baseElement.querySelector("goa-input[testId='last-name-input']");
     expect(lastName?.getAttribute('value')).toBe('Bing');
@@ -304,12 +304,12 @@ describe('Form Stepper Control', () => {
     expect(firstName?.getAttribute('value')).toBe('Bob');
   });
 
-  it('will recognize status as not-started because its unvisited', () => {
+  it('will recognize status as not-started because stepper context data is unvisited', () => {
     const { baseElement } = render(
       <JsonFormsStepperContextProvider
         StepperProps={stepperBaseProps}
         children={getForm({ ...formData, name: { lastName: 'Bing' } })}
-      />
+      />,
     );
 
     const step1 = baseElement.querySelector('goa-form-step[text="Name"]');
@@ -317,22 +317,22 @@ describe('Form Stepper Control', () => {
     expect(step1!.getAttribute('status')).toBe(null);
   });
 
-  it('will recognize status as not-started because unvisited', () => {
+  it('will recognize status as incomplete for populated name step state', () => {
     const { baseElement } = render(
       <JsonFormsStepperContextProvider
         StepperProps={{ ...stepperBaseProps, data: { ...formData, name: { firstName: 'Bob', lastName: 'Bing' } } }}
         children={getForm({ ...formData, name: { firstName: 'Bob', lastName: 'Bing' } })}
-      />
+      />,
     );
     const step1 = baseElement.querySelector('goa-form-step[text="Name"]');
     expect(step1).toBeInTheDocument();
-    expect(step1!.getAttribute('status')).toBe(null);
+    expect(step1!.getAttribute('status')).toBe('incomplete');
   });
 
   describe('step navigation', () => {
     it('can navigate between steps with the nav buttons', async () => {
       const { container, baseElement } = render(
-        <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />
+        <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />,
       );
       window.HTMLElement.prototype.scrollIntoView = function () {};
       const stepperHeader = container.querySelector("goa-form-stepper[testId='form-stepper-headers-stepper-test']");
@@ -351,7 +351,7 @@ describe('Form Stepper Control', () => {
 
     it('will hide Prev Nav button on 1st step', () => {
       const { baseElement } = render(
-        <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />
+        <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={getForm(formData)} />,
       );
       const nextButton = baseElement.querySelector("goa-button[testId='next-button']");
 
@@ -366,7 +366,7 @@ describe('Form Stepper Control', () => {
       // eslint-disable-next-line
       newStepperProps.activeId = 1;
       const { baseElement } = render(
-        <JsonFormsStepperContextProvider StepperProps={newStepperProps} children={getForm(formData)} />
+        <JsonFormsStepperContextProvider StepperProps={newStepperProps} children={getForm(formData)} />,
       );
 
       const prevButton = baseElement.querySelector("goa-button[testId='prev-button']");
@@ -390,7 +390,7 @@ describe('Form Stepper Control', () => {
         <JsonFormsStepperContextProvider
           StepperProps={newStepperProps}
           children={getForm(newStepperProps.data, categorizationWithDisabledAddressCategory)}
-        />
+        />,
       );
 
       const prevButton = baseElement.querySelector("goa-button[testId='prev-button']");
@@ -414,7 +414,7 @@ describe('Form Stepper Control', () => {
         <JsonFormsStepperContextProvider
           StepperProps={newStepperProps}
           children={getForm(formData, categorizationPages)}
-        />
+        />,
       );
     });
 
@@ -428,7 +428,7 @@ describe('Form Stepper Control', () => {
         <JsonFormsStepperContextProvider
           StepperProps={newStepperProps}
           children={getForm(formData, categorizationPages)}
-        />
+        />,
       );
 
       const nextButton = renderer.baseElement.querySelector("goa-button[testId='pages-save-continue-btn']");
@@ -450,7 +450,7 @@ describe('Form Stepper Control', () => {
         <JsonFormsStepperContextProvider
           StepperProps={newStepperProps}
           children={getForm(formData, categorizationPages)}
-        />
+        />,
       );
 
       const toc = renderer.getByTestId('table-of-contents');
@@ -473,7 +473,7 @@ describe('Form Stepper Control', () => {
         <JsonFormsStepperContextProvider
           StepperProps={newStepperProps}
           children={getForm(formData, categorizationPages)}
-        />
+        />,
       );
 
       const toc = renderer.getByTestId('table-of-contents');
@@ -494,7 +494,7 @@ describe('Form Stepper Control', () => {
         <JsonFormsStepperContextProvider
           StepperProps={newStepperProps}
           children={getForm(formData, categorizationPages)}
-        />
+        />,
       );
     });
   });
@@ -514,7 +514,7 @@ describe('Form Stepper Control', () => {
             name: { firstName: 'Bob', lastName: 'Bing' },
             address: { street: 'Sesame', city: 'Seattle' },
           })}
-        />
+        />,
       );
       const submitBtn = baseElement.querySelector("goa-button[testId='stepper-submit-btn']");
 
@@ -550,9 +550,9 @@ describe('Form Stepper Control', () => {
               address: { street: 'Sesame', city: 'Seattle' },
             },
             categorization,
-            componentProps
+            componentProps,
           )}
-        />
+        />,
       );
       window.HTMLElement.prototype.scrollIntoView = function () {};
       const testNext = screen.getByText('testNext');
@@ -625,7 +625,10 @@ describe('Form Stepper Control', () => {
             data: { name: { firstName: 'Bob', lastName: 'Bing' }, address: { street: 'Sesame', city: 'Seattle' } },
             activeId: 2,
           }}
-          children={getForm({ name: { firstName: 'Bob', lastName: 'Bing' }, address: { street: 'Sesame', city: 'Seattle' } })}
+          children={getForm({
+            name: { firstName: 'Bob', lastName: 'Bing' },
+            address: { street: 'Sesame', city: 'Seattle' },
+          })}
         />,
       );
       expect(container).toBeInTheDocument();

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -53,7 +53,7 @@ describe('JsonFormsStepperContext', () => {
     ajv: ajvInstance,
     t: jest.fn(),
     locale: 'en',
-    customDispatch: mockDispatch,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as unknown as CategorizationStepperLayoutRendererProps & { customDispatch: Dispatch<any> };
 
   afterEach(() => {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -3,20 +3,12 @@ import React, { useContext } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { JsonFormsStepperContextProvider, JsonFormsStepperContext, JsonFormsStepperContextProps } from './index';
 import { CategorizationStepperLayoutRendererProps } from '../types';
-import { StepperContextDataType } from './types';
+import Ajv from 'ajv';
 
-import Ajv, { ErrorObject } from 'ajv';
-import { stepperReducer } from './reducer';
-import { subErrorInParent, hasDataInScopes } from './util';
-import { hasMeaningfulValue } from './util';
-import { getEmptyRequiredStringErrors } from './index';
-
-describe('Test jsonforms stepper context', () => {
+describe('JsonFormsStepperContext', () => {
   const ajvInstance = new Ajv({ allErrors: true, verbose: true, strict: false });
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
   const mockDispatch = jest.fn();
+
   const schema = {
     type: 'object',
     properties: {
@@ -24,19 +16,6 @@ describe('Test jsonforms stepper context', () => {
       lastName: { type: 'string' },
     },
   };
-
-  const schemaWithRequired = {
-    type: 'object',
-    properties: {
-      firstName: { type: 'string' },
-      lastName: { type: 'string' },
-    },
-    required: ['firstName'],
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
 
   const uischema = {
     type: 'Categorization',
@@ -62,6 +41,7 @@ describe('Test jsonforms stepper context', () => {
       showNavButtons: true,
     },
   };
+
   const stepperBaseProps: CategorizationStepperLayoutRendererProps = {
     uischema: uischema,
     schema: schema,
@@ -73,584 +53,64 @@ describe('Test jsonforms stepper context', () => {
     t: jest.fn(),
     locale: 'en',
     customDispatch: mockDispatch,
-    // eslint-disable-next-line
   } as unknown as CategorizationStepperLayoutRendererProps & { customDispatch: Dispatch<any> };
 
-  const ComponentForTest = (): JSX.Element => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const TestComponent = (): JSX.Element => {
     const ctx = useContext(JsonFormsStepperContext);
     const { selectStepperState, selectPath, selectIsDisabled, selectIsActive, selectCategory, goToPage } =
       ctx as JsonFormsStepperContextProps;
-    return (
-      <div>
-        <div data-testid="number-of-category">
-          {selectStepperState().categories.length === 1 ? 'Found' : 'Not found'}
-        </div>
-        <div data-testid="path-of-category">{selectPath() === 'test-path' ? 'Found' : 'Not found'}</div>
-        <div data-testid="disabled-of-category">{selectIsDisabled() === false ? 'Found' : 'Not found'}</div>
-        <div data-testid="active-of-category">{selectIsActive(0) === true ? 'Found' : 'Not found'}</div>
-        <div data-testid="0-of-category">{selectCategory(0).id === 0 ? 'Found' : 'Not found'}</div>
-      </div>
-    );
-  };
 
-  const ComponentForTestWithGoToPage = (): JSX.Element => {
-    const ctx = useContext(JsonFormsStepperContext);
-    const { goToPage } = ctx as JsonFormsStepperContextProps;
     return (
       <div>
-        <button
-          data-testid="go-to-0"
-          onClick={() => {
-            goToPage(0);
-          }}
-        >
-          Go 1
-        </button>
-        <button
-          data-testid="go-to-0-0"
-          onClick={() => {
-            goToPage(0, 1);
-          }}
-        >
-          Go 1 with update
+        <div data-testid="path">{selectPath()}</div>
+        <div data-testid="is-disabled">{selectIsDisabled().toString()}</div>
+        <div data-testid="is-active">{selectIsActive(0).toString()}</div>
+        <div data-testid="category-label">{selectCategory(0).label}</div>
+        <button data-testid="go-to-page" onClick={() => goToPage(1)}>
+          Go to Page
         </button>
       </div>
     );
   };
 
-  it('can render jsonforms stepper context provider', async () => {
-    const stepper = render(
-      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={<ComponentForTest />} />,
-    );
-    expect(stepper).toBeTruthy();
-  });
-
-  it('can render jsonforms stepper context provider with required field', async () => {
+  test('provides the correct context values', () => {
     render(
-      <JsonFormsStepperContextProvider
-        StepperProps={{ ...stepperBaseProps, schema: schemaWithRequired }}
-        children={<ComponentForTest />}
-      />,
+      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps}>
+        <TestComponent />
+      </JsonFormsStepperContextProvider>,
     );
-    expect(screen.getByTestId('number-of-category').textContent).toContain('Found');
-    expect(screen.getByTestId('path-of-category').textContent).toContain('Found');
-    expect(screen.getByTestId('disabled-of-category').textContent).toContain('Found');
-    expect(screen.getByTestId('active-of-category').textContent).toContain('Found');
+
+    // Assert default path
+    expect(screen.getByTestId('path').textContent).toBe('test-path');
+
+    // Assert default isDisabled
+    expect(screen.getByTestId('is-disabled').textContent).toBe('false');
+
+    // Assert default isActive for step 0
+    expect(screen.getByTestId('is-active').textContent).toBe('true');
+
+    // Assert category label (falls back to Step 1 when no translation is resolved)
+    expect(screen.getByTestId('category-label').textContent).toBe('Step 1');
   });
-  it('can render jsonforms stepper context provider without required field', async () => {
+
+  test('goToPage updates active page', () => {
     render(
-      <JsonFormsStepperContextProvider
-        StepperProps={{ ...stepperBaseProps, schema: schema }}
-        children={<ComponentForTest />}
-      />,
-    );
-    expect(screen.getByTestId('number-of-category').textContent).toContain('Found');
-  });
-
-  it('can run reducer actions ', async () => {
-    const stateOneCategory: StepperContextDataType = {
-      activeId: 0,
-      hasNextButton: false,
-      hasPrevButton: false,
-      path: 'test-path',
-      isOnReview: false,
-      isValid: false,
-      maxReachedStep: 0,
-      categories: [
-        {
-          isCompleted: false,
-          isVisited: false,
-          isValid: false,
-          id: 0,
-          isEnabled: true,
-          scopes: [],
-          label: 'First category',
-        },
-      ],
-    };
-    const stateTwoCategory: StepperContextDataType = {
-      activeId: 0,
-      hasNextButton: false,
-      hasPrevButton: false,
-      path: 'test-path',
-      isOnReview: false,
-      isValid: false,
-      maxReachedStep: 0,
-      categories: [
-        {
-          isCompleted: false,
-          isVisited: false,
-          isValid: false,
-          id: 0,
-          isEnabled: true,
-          scopes: ['#/properties/firstName'],
-          label: 'First category',
-        },
-        {
-          isCompleted: false,
-          isVisited: false,
-          isValid: true,
-          id: 1,
-          isEnabled: true,
-          scopes: ['#/properties/secondName'],
-          label: 'Second category',
-        },
-      ],
-    };
-
-    expect(stepperReducer(stateOneCategory, { type: 'page/next' }).isOnReview).toBe(true);
-    expect(stepperReducer(stateTwoCategory, { type: 'page/next' }).isOnReview).toBe(false);
-    expect(stepperReducer(stateTwoCategory, { type: 'page/prev' }).activeId).toBe(0);
-    expect(stepperReducer({ ...stateTwoCategory, activeId: 1 }, { type: 'page/prev' }).activeId).toBe(0);
-    expect(stepperReducer({ ...stateTwoCategory, activeId: 1 }, { type: 'page/prev' }).hasPrevButton).toBe(false);
-    expect(
-      stepperReducer({ ...stateTwoCategory, activeId: 1 }, { type: 'page/to/index', payload: { id: 0 } }).activeId,
-    ).toBe(0);
-    expect(
-      stepperReducer({ ...stateTwoCategory, activeId: 0 }, { type: 'page/to/index', payload: { id: 2 } }).isOnReview,
-    ).toBe(true);
-
-    expect(
-      stepperReducer(
-        { ...stateTwoCategory, activeId: 0 },
-        {
-          type: 'update/category',
-          payload: {
-            ajv: ajvInstance,
-            id: 0,
-            errors: [],
-            schema: { type: 'object', properties: {} },
-            data: { firstName: 'test' },
-          },
-        },
-      ).categories[0].isValid,
-    ).toBe(true);
-    expect(hasMeaningfulValue(123)).toBe(true);
-
-    // boolean
-    expect(hasMeaningfulValue(true)).toBe(true);
-
-    // symbol
-    expect(hasMeaningfulValue(Symbol('x'))).toBe(true);
-
-    // bigint
-    expect(hasMeaningfulValue(10n)).toBe(true);
-
-    // function
-    expect(hasMeaningfulValue(() => {})).toBe(true);
-
-    // once visited return true
-    expect(
-      stepperReducer(
-        { ...stateTwoCategory, activeId: 0 },
-        {
-          type: 'update/category',
-          payload: {
-            ajv: ajvInstance,
-            id: 0,
-            errors: [],
-            schema: { type: 'object', properties: {} },
-            data: {},
-          },
-        },
-      ).categories[0].isValid,
-    ).toBe(true);
-
-    const yyy = stepperReducer(
-      { ...stateTwoCategory, activeId: 0 },
-      {
-        type: 'update/category',
-        payload: {
-          ajv: ajvInstance,
-          id: 1,
-          errors: [
-            {
-              keyword: 'required',
-              instancePath: '/secondName',
-              schemaPath: '',
-              params: {},
-            },
-          ],
-          schema: { type: 'object', properties: {} },
-          data: { firstName: 'test' },
-        },
-      },
+      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps}>
+        <TestComponent />
+      </JsonFormsStepperContextProvider>,
     );
 
-    const noData = stepperReducer(
-      { ...stateTwoCategory, activeId: 0 },
-      {
-        type: 'update/category',
-        payload: {
-          ajv: ajvInstance,
-          id: 1,
-          errors: [
-            {
-              keyword: 'required',
-              instancePath: '/secondName',
-              schemaPath: '',
-              params: {},
-            },
-          ],
-          schema: { type: 'object', properties: {} },
-          data: {},
-        },
-      },
-    );
-
-    expect(noData.categories[1].isVisited).toBe(false);
-
-    const visited = stepperReducer(
-      { ...stateTwoCategory, activeId: 0 },
-      {
-        type: 'set/visited',
-        payload: { id: 1 },
-      },
-    );
-
-    expect(visited.categories[1].isVisited).toBe(true);
-
-    expect(visited.categories.find((cat) => cat.id === 1)?.isVisited).toBe(true);
-
-    expect(visited.categories[1].isValid).toBe(true);
-
-    const filledOut = stepperReducer(
-      { ...stateTwoCategory, activeId: 0 },
-      {
-        type: 'update/category',
-        payload: {
-          ajv: ajvInstance,
-          id: 1,
-          errors: [
-            {
-              keyword: 'required',
-              instancePath: '/secondName',
-              schemaPath: '',
-              params: {},
-            },
-          ],
-          schema: { type: 'object', properties: {} },
-          data: { secondName: 'test' },
-        },
-      },
-    );
-
-    expect(filledOut.categories[1].isValid).toBe(true);
-
-    expect(
-      stepperReducer(
-        { ...stateTwoCategory, activeId: 0 },
-        {
-          type: 'validate/form',
-          payload: {
-            errors: [
-              {
-                keyword: 'required',
-                instancePath: '/secondName',
-                schemaPath: '',
-                params: {},
-              },
-            ],
-          },
-        },
-      ).isValid,
-    ).toBe(false);
-  });
-
-  it('can go to category with required', async () => {
-    const { getByTestId } = render(
-      <JsonFormsStepperContextProvider
-        StepperProps={{ ...stepperBaseProps, schema: schemaWithRequired }}
-        children={<ComponentForTestWithGoToPage />}
-      />,
-    );
-    const to0CategoryBtn = getByTestId('go-to-0');
-    const to0CategoryBtnWithUpdate = getByTestId('go-to-0-0');
-
-    fireEvent.click(to0CategoryBtn);
-    fireEvent.click(to0CategoryBtnWithUpdate);
-
-    expect(mockDispatch.mock.calls[4][0].type === 'page/to/index');
-  });
-
-  it('should call validatePage when navigating back to show validation errors', async () => {
-    const multiStepUischema = {
-      type: 'Categorization',
-      elements: [
-        {
-          type: 'Category',
-          label: 'Page 1',
-          elements: [
-            {
-              type: 'Control',
-              scope: '#/properties/firstName',
-            },
-          ],
-        },
-        {
-          type: 'Category',
-          label: 'Page 2',
-          elements: [
-            {
-              type: 'Control',
-              scope: '#/properties/lastName',
-            },
-          ],
-        },
-      ],
-      options: {
-        variant: 'pages',
-      },
-    };
-
-    const multiStepSchema = {
-      type: 'object',
-      properties: {
-        firstName: { type: 'string' },
-        lastName: { type: 'string' },
-      },
-      required: ['firstName', 'lastName'],
-    };
-
-    const ComponentWithNavigation = (): JSX.Element => {
-      const ctx = useContext(JsonFormsStepperContext);
-      const { goToPage, selectStepperState } = ctx as JsonFormsStepperContextProps;
-      const { activeId } = selectStepperState();
-
-      return (
-        <div>
-          <div data-testid="active-page">{activeId}</div>
-          <button data-testid="go-to-page-1" onClick={() => goToPage(1)}>
-            Go to Page 2
-          </button>
-          <button data-testid="go-to-page-0" onClick={() => goToPage(0)}>
-            Go to Page 1
-          </button>
-        </div>
-      );
-    };
-
-    const props = {
-      ...stepperBaseProps,
-      uischema: multiStepUischema,
-      schema: multiStepSchema,
-      data: {}, // Empty data means validation will fail for required fields
-    };
-
-    const { getByTestId } = render(
-      <JsonFormsStepperContextProvider StepperProps={props} children={<ComponentWithNavigation />} />,
-    );
-
-    // Should start at page 2 (pages variant starts at index = categories.length + 1)
-    // But we're testing navigation
-
-    // Navigate to page 2 (index 1)
-    fireEvent.click(getByTestId('go-to-page-1'));
-
-    // Clear mock to focus on next navigation
+    // Ignore dispatches from provider lifecycle effects and assert click behavior only.
     mockDispatch.mockClear();
 
-    // Navigate back to page 1 (index 0)
-    fireEvent.click(getByTestId('go-to-page-0'));
+    // Trigger goToPage
+    fireEvent.click(screen.getByTestId('go-to-page'));
 
-    // Verify page/to/index was dispatched for navigation
-    const navigationCalls = mockDispatch.mock.calls.filter(
-      (call) => call[0].type === 'page/to/index' && call[0].payload.id === 0,
-    );
-    expect(navigationCalls.length).toBeGreaterThan(0);
-  });
-
-  it('test the util', async () => {
-    const error: ErrorObject = {
-      instancePath: '/Users/0/firstname',
-      schemaPath: '#/properties/Users/items/required',
-      keyword: 'required',
-      params: { missingProperty: 'firstname' },
-      message: "must have required property 'firstname'",
-      schema: ['firstname'],
-      parentSchema: {
-        type: 'object',
-        title: 'Users',
-        required: [Array],
-        properties: [Object],
-      },
-      data: { lastname: 'test' },
-    };
-    ajvInstance.validate(schema, { Users: [{ lastname: 'test' }] });
-    const result = subErrorInParent(error, ['/Users']);
-
-    expect(result).toBe(true);
-
-    expect(
-      hasDataInScopes(
-        {
-          whichOfThemApplies: ['Access to condominium documents or records'],
-        },
-        ['#/properties/whichOfThemApplies'],
-      ),
-    ).toBe(true);
-
-    expect(hasDataInScopes({}, ['#/properties/whichOfThemApplies'])).toBe(false);
-  });
-
-  it('marks the form invalid when a required string is present but empty', async () => {
-    const ComponentWithValidity = (): JSX.Element => {
-      const ctx = useContext(JsonFormsStepperContext);
-      const { selectStepperState, selectCategory } = ctx as JsonFormsStepperContextProps;
-      const state = selectStepperState();
-
-      return (
-        <div>
-          <div data-testid="form-valid">{state.isValid ? 'valid' : 'invalid'}</div>
-          <div data-testid="category-status">{selectCategory(0).status}</div>
-        </div>
-      );
-    };
-
-    render(
-      <JsonFormsStepperContextProvider
-        StepperProps={{ ...stepperBaseProps, schema: schemaWithRequired, data: { firstName: '' } }}
-        children={<ComponentWithValidity />}
-      />,
-    );
-
-    expect(screen.getByTestId('form-valid').textContent).toBe('invalid');
-    expect(screen.getByTestId('category-status').textContent).toBe('NotStarted');
-  });
-
-  it('counts only visible completed categories included in the task list', async () => {
-    const multiCategoryUischema = {
-      type: 'Categorization',
-      elements: [
-        {
-          type: 'Category',
-          label: 'First name',
-          elements: [{ type: 'Control', scope: '#/properties/firstName' }],
-        },
-        {
-          type: 'Category',
-          label: 'Last name',
-          options: { showInTaskList: false },
-          elements: [{ type: 'Control', scope: '#/properties/lastName' }],
-        },
-      ],
-      options: {
-        variant: 'stepper',
-      },
-    };
-
-    const ComponentWithCompletedCount = (): JSX.Element => {
-      const ctx = useContext(JsonFormsStepperContext);
-      const { selectNumberOfCompletedCategories } = ctx as JsonFormsStepperContextProps;
-
-      return <div data-testid="completed-count">{selectNumberOfCompletedCategories()}</div>;
-    };
-
-    render(
-      <JsonFormsStepperContextProvider
-        StepperProps={{
-          ...stepperBaseProps,
-          uischema: multiCategoryUischema,
-          data: { firstName: 'Jane', lastName: 'Smith' },
-        }}
-        children={<ComponentWithCompletedCount />}
-      />,
-    );
-
-    expect(screen.getByTestId('completed-count').textContent).toBe('0');
-  });
-
-  it('dispatches context actions with the expected payloads', async () => {
-    const ComponentWithActions = (): JSX.Element => {
-      const ctx = useContext(JsonFormsStepperContext);
-      const { goToTableOfContext, setVisited, validatePage, toggleShowReviewLink } =
-        ctx as JsonFormsStepperContextProps;
-
-      return (
-        <div>
-          <button data-testid="go-to-review" onClick={() => goToTableOfContext()}>
-            Review
-          </button>
-          <button data-testid="set-visited" onClick={() => setVisited(0)}>
-            Visited
-          </button>
-          <button data-testid="validate-page" onClick={() => validatePage(0)}>
-            Validate
-          </button>
-          <button data-testid="toggle-review-link" onClick={() => toggleShowReviewLink(0)}>
-            Toggle
-          </button>
-        </div>
-      );
-    };
-
-    render(<JsonFormsStepperContextProvider StepperProps={stepperBaseProps} children={<ComponentWithActions />} />);
-
-    mockDispatch.mockClear();
-
-    fireEvent.click(screen.getByTestId('go-to-review'));
-    fireEvent.click(screen.getByTestId('set-visited'));
-    fireEvent.click(screen.getByTestId('validate-page'));
-    fireEvent.click(screen.getByTestId('toggle-review-link'));
-
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'page/to/index', payload: { id: 2 } });
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'set/visited', payload: { id: 0 } });
-    expect(mockDispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'update/category',
-        payload: expect.objectContaining({ id: 0, ajv: ajvInstance, schema, data: undefined }),
-      }),
-    );
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'toggle/category/review-link', payload: { id: 0 } });
-  });
-
-  it('returns requiredString errors for nested empty required strings only', async () => {
-    const nestedSchema = {
-      type: 'object',
-      required: ['firstName', 'age'],
-      properties: {
-        firstName: { type: 'string' },
-        age: { type: 'number' },
-        mailingAddress: {
-          type: 'object',
-          required: ['city', 'province', 'postalCode'],
-          properties: {
-            city: { type: 'string' },
-            province: { type: 'string' },
-            postalCode: { type: 'string' },
-          },
-        },
-        tags: {
-          type: 'array',
-          items: { type: 'string' },
-        },
-      },
-    };
-
-    const errors = getEmptyRequiredStringErrors(
-      {
-        firstName: '',
-        age: '',
-        mailingAddress: {
-          city: '',
-          province: 'AB',
-        },
-        tags: [],
-      },
-      nestedSchema,
-    );
-
-    expect(errors).toHaveLength(2);
-    expect(errors.map((error) => error.instancePath)).toEqual(['/firstName', '/mailingAddress/city']);
-    expect(errors.map((error) => error.schemaPath)).toEqual([
-      '#/requiredString',
-      '#/properties/mailingAddress/requiredString',
-    ]);
-    expect(errors.every((error) => error.keyword === 'requiredString' && error.message === 'is required')).toBe(true);
-  });
-
-  it('returns no requiredString errors for non-object schemas or non-object data', async () => {
-    expect(getEmptyRequiredStringErrors('', schemaWithRequired)).toEqual([]);
-    expect(getEmptyRequiredStringErrors({}, true as unknown as typeof schemaWithRequired)).toEqual([]);
+    // Assert that the mock dispatch was called with the correct action
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'page/to/index', payload: { id: 1, targetScope: undefined } });
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -103,8 +103,10 @@ describe('JsonFormsStepperContext', () => {
 
   test('goToPage function updates the active page', () => {
     // Arrange
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const propsWithDispatch = { ...stepperBaseProps, customDispatch: mockDispatch as any };
     render(
-      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps}>
+      <JsonFormsStepperContextProvider StepperProps={propsWithDispatch}>
         <TestComponent />
       </JsonFormsStepperContextProvider>,
     );

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -1,6 +1,7 @@
 import { Dispatch } from 'react';
 import React, { useContext } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { JsonFormsStepperContextProvider, JsonFormsStepperContext, JsonFormsStepperContextProps } from './index';
 import { CategorizationStepperLayoutRendererProps } from '../types';
 import Ajv from 'ajv';
@@ -61,8 +62,15 @@ describe('JsonFormsStepperContext', () => {
 
   const TestComponent = (): JSX.Element => {
     const ctx = useContext(JsonFormsStepperContext);
-    const { selectStepperState, selectPath, selectIsDisabled, selectIsActive, selectCategory, goToPage } =
-      ctx as JsonFormsStepperContextProps;
+    const {
+      selectStepperState,
+      selectPath,
+      selectIsDisabled,
+      selectIsActive,
+      selectCategory,
+      goToPage,
+      selectNumberOfCompletedCategories,
+    } = ctx as JsonFormsStepperContextProps;
 
     return (
       <div>
@@ -70,6 +78,7 @@ describe('JsonFormsStepperContext', () => {
         <div data-testid="is-disabled">{selectIsDisabled().toString()}</div>
         <div data-testid="is-active">{selectIsActive(0).toString()}</div>
         <div data-testid="category-label">{selectCategory(0).label}</div>
+        <div data-testid="completed-categories">{selectNumberOfCompletedCategories()}</div>
         <button data-testid="go-to-page" onClick={() => goToPage(1)}>
           Go to Page
         </button>
@@ -77,40 +86,60 @@ describe('JsonFormsStepperContext', () => {
     );
   };
 
-  test('provides the correct context values', () => {
+  test('provides the correct context values for path and category', () => {
+    // Arrange
     render(
       <JsonFormsStepperContextProvider StepperProps={stepperBaseProps}>
         <TestComponent />
       </JsonFormsStepperContextProvider>,
     );
 
-    // Assert default path
+    // Assert
     expect(screen.getByTestId('path').textContent).toBe('test-path');
-
-    // Assert default isDisabled
     expect(screen.getByTestId('is-disabled').textContent).toBe('false');
-
-    // Assert default isActive for step 0
     expect(screen.getByTestId('is-active').textContent).toBe('true');
-
-    // Assert category label (falls back to Step 1 when no translation is resolved)
     expect(screen.getByTestId('category-label').textContent).toBe('Step 1');
   });
 
-  test('goToPage updates active page', () => {
+  test('goToPage function updates the active page', () => {
+    // Arrange
     render(
       <JsonFormsStepperContextProvider StepperProps={stepperBaseProps}>
         <TestComponent />
       </JsonFormsStepperContextProvider>,
     );
 
-    // Ignore dispatches from provider lifecycle effects and assert click behavior only.
+    // Act
     mockDispatch.mockClear();
-
-    // Trigger goToPage
     fireEvent.click(screen.getByTestId('go-to-page'));
 
-    // Assert that the mock dispatch was called with the correct action
+    // Assert
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'page/to/index', payload: { id: 1, targetScope: undefined } });
+  });
+
+  test('selectNumberOfCompletedCategories returns correct count', () => {
+    // Arrange
+    render(
+      <JsonFormsStepperContextProvider StepperProps={stepperBaseProps}>
+        <TestComponent />
+      </JsonFormsStepperContextProvider>,
+    );
+
+    // Assert
+    expect(screen.getByTestId('completed-categories').textContent).toBe('0');
+  });
+
+  test('handles missing context gracefully', () => {
+    // Arrange
+    const MissingContextComponent = (): JSX.Element => {
+      const ctx = useContext(JsonFormsStepperContext);
+      return <div>{ctx ? 'Context Found' : 'Context Missing'}</div>;
+    };
+
+    // Act
+    render(<MissingContextComponent />);
+
+    // Assert
+    expect(screen.getByText('Context Missing')).toBeInTheDocument();
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -58,7 +58,7 @@ const createStepperContextInitData = (
     // that getStepStatus returns the real data-driven status on initial mount initially.
     let visited = scopes.some((scope) => hasValueAtScope(data, scope));
 
-    const statusData = getStepStatus({
+    const { status, hasRequiredFields } = getStepStatus({
       scopes,
       data,
       errors: filteredErrors ?? [],
@@ -66,9 +66,9 @@ const createStepperContextInitData = (
       visited,
     });
 
-    //If the step has all conditional fields, set to visited to true so that the step status will be
+    //If the step has all conditional fields, set visited to true so that the step status will be
     //completed to enable form to be saved.
-    if (!statusData.hasRequiredFields) {
+    if (!hasRequiredFields) {
       visited = true;
     }
 
@@ -76,10 +76,10 @@ const createStepperContextInitData = (
       id,
       label: deriveLabelForUISchemaElement(c, t) ?? `Step ${id + 1}`,
       scopes,
-      isCompleted: statusData.status === StepStatus.COMPLETED || (visited && !statusData.hasRequiredFields),
-      isValid: statusData.status === StepStatus.COMPLETED || (visited && !statusData.hasRequiredFields),
-      isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(statusData.status),
-      status: statusData.status,
+      isCompleted: status === StepStatus.COMPLETED || (visited && !hasRequiredFields),
+      isValid: status === StepStatus.COMPLETED || (visited && !hasRequiredFields),
+      isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(status),
+      status,
       uischema: c,
       isEnabled: isEnabled(c, data, '', ajv, undefined),
       visible: isVisible(c, data, '', ajv, undefined),

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -8,8 +8,9 @@ import { JsonFormStepperDispatch } from './reducer';
 import { JsonSchema7, JsonSchema } from '@jsonforms/core';
 import { ErrorObject } from 'ajv';
 import { useJsonForms } from '@jsonforms/react';
-import { getIsVisitFromLocalStorage, saveIsVisitFromLocalStorage } from './util';
+import { getIsVisitFromLocalStorage, hasValueAtScope, saveIsVisitFromLocalStorage } from './util';
 import { getStepStatus } from './util';
+import { StepStatus } from '../../../common/Constants';
 export interface JsonFormsStepperContextProviderProps {
   children: ReactNode;
   StepperProps: CategorizationStepperLayoutRendererProps & {
@@ -44,13 +45,18 @@ const createStepperContextInitData = (
   const valid = ajv.validate(schema, data || {});
 
   const isPage = uischema?.options?.variant === 'pages';
+
+  //TODO: Determine if cachedStatus still being used by anything in the library`
+  //      If not, do a proper clean up.
   const isCacheStatus = uischema.options?.cacheStatus;
   const cachedStatus = (isCacheStatus && getIsVisitFromLocalStorage()) || [];
 
   const categories = categorization.elements?.map((c, id) => {
     const scopes = pickPropertyValues(c, 'scope', 'ListWithDetail');
 
-    const visited = false;
+    // Treat a step as visited when its scoped fields already contain data so
+    // that getStepStatus returns the real data-driven status on initial mount.
+    const visited = scopes.some((scope) => hasValueAtScope(data, scope));
 
     const status = getStepStatus({
       scopes,
@@ -64,9 +70,9 @@ const createStepperContextInitData = (
       id,
       label: deriveLabelForUISchemaElement(c, t) ?? `Step ${id + 1}`,
       scopes,
-      isCompleted: status === 'Completed',
-      isValid: status === 'Completed',
-      isVisited: status === 'Completed',
+      isCompleted: status === StepStatus.COMPLETED,
+      isValid: status === StepStatus.COMPLETED,
+      isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(status),
       status,
       uischema: c,
       isEnabled: isEnabled(c, data, '', ajv, undefined),
@@ -228,7 +234,7 @@ export const JsonFormsStepperContextProvider = ({
       }
     }
     //eslint-disable-next-line
-  }, [JSON.stringify(StepperProps.uischema), JSON.stringify(StepperProps.schema)]);
+  }, [JSON.stringify(StepperProps.uischema), JSON.stringify(StepperProps.schema), JSON.stringify(StepperProps.data)]);
 
   return <JsonFormsStepperContext.Provider value={context}>{children}</JsonFormsStepperContext.Provider>;
 };

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -46,7 +46,7 @@ const createStepperContextInitData = (
 
   const isPage = uischema?.options?.variant === 'pages';
 
-  //TODO: Determine if cachedStatus still being used by anything in the library`
+  //TODO: Determine if cachedStatus is still being used by anything in the library
   //      If not, do a proper clean up.
   const isCacheStatus = uischema.options?.cacheStatus;
   const cachedStatus = (isCacheStatus && getIsVisitFromLocalStorage()) || [];
@@ -55,10 +55,10 @@ const createStepperContextInitData = (
     const scopes = pickPropertyValues(c, 'scope', 'ListWithDetail');
 
     // Treat a step as visited when its scoped fields already contain data so
-    // that getStepStatus returns the real data-driven status on initial mount.
-    const visited = scopes.some((scope) => hasValueAtScope(data, scope));
+    // that getStepStatus returns the real data-driven status on initial mount initially.
+    let visited = scopes.some((scope) => hasValueAtScope(data, scope));
 
-    const status = getStepStatus({
+    const statusData = getStepStatus({
       scopes,
       data,
       errors: filteredErrors ?? [],
@@ -66,14 +66,20 @@ const createStepperContextInitData = (
       visited,
     });
 
+    //If the step has all conditional fields, set to visited to true so that the step status will be
+    //completed to enable form to be saved.
+    if (!statusData.hasRequiredFields) {
+      visited = true;
+    }
+
     return {
       id,
       label: deriveLabelForUISchemaElement(c, t) ?? `Step ${id + 1}`,
       scopes,
-      isCompleted: status === StepStatus.COMPLETED,
-      isValid: status === StepStatus.COMPLETED,
-      isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(status),
-      status,
+      isCompleted: statusData.status === StepStatus.COMPLETED || (visited && !statusData.hasRequiredFields),
+      isValid: statusData.status === StepStatus.COMPLETED || (visited && !statusData.hasRequiredFields),
+      isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(statusData.status),
+      status: statusData.status,
       uischema: c,
       isEnabled: isEnabled(c, data, '', ajv, undefined),
       visible: isVisible(c, data, '', ajv, undefined),

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.spec.ts
@@ -1,0 +1,264 @@
+import Ajv from 'ajv';
+import { stepperReducer } from './reducer';
+import { StepperContextDataType, CategoryState } from './types';
+import { StepStatus } from '../../../common/Constants';
+
+const buildCategory = (id: number, scopes: string[] = [`#/properties/field${id}`]): CategoryState => ({
+  id,
+  label: `Step ${id + 1}`,
+  scopes,
+  isCompleted: false,
+  isValid: false,
+  isVisited: false,
+  status: StepStatus.NOT_STARTED,
+});
+
+const buildState = (overrides: Partial<StepperContextDataType> = {}): StepperContextDataType => ({
+  categories: [buildCategory(0), buildCategory(1)],
+  activeId: 0,
+  hasNextButton: true,
+  hasPrevButton: false,
+  path: 'test-path',
+  isOnReview: false,
+  isValid: true,
+  maxReachedStep: 0,
+  validationTrigger: 0,
+  ...overrides,
+});
+
+describe('stepperReducer', () => {
+  test('returns the same state for an unknown action type', () => {
+    // Arrange
+    const state = buildState();
+
+    // Act
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = stepperReducer(state, { type: 'unknown/action' } as any);
+
+    // Assert
+    expect(result).toBe(state);
+  });
+
+  describe('page/next', () => {
+    test('advances the active page and marks the current category as visited', () => {
+      // Arrange
+      const state = buildState({ activeId: 0 });
+
+      // Act
+      const result = stepperReducer(state, { type: 'page/next' });
+
+      // Assert
+      expect(result.activeId).toBe(1);
+      expect(result.categories[0].isVisited).toBe(true);
+      expect(result.isOnReview).toBe(false);
+      expect(result.hasNextButton).toBe(true);
+      expect(result.hasPrevButton).toBe(true);
+    });
+
+    test('marks the state as on review when the last category is passed', () => {
+      // Arrange
+      const state = buildState({ activeId: 1 });
+
+      // Act
+      const result = stepperReducer(state, { type: 'page/next' });
+
+      // Assert
+      expect(result.activeId).toBe(2);
+      expect(result.isOnReview).toBe(true);
+      expect(result.hasNextButton).toBe(false);
+    });
+  });
+
+  describe('page/prev', () => {
+    test('moves the active page back and marks the current category as visited', () => {
+      // Arrange
+      const state = buildState({ activeId: 1 });
+
+      // Act
+      const result = stepperReducer(state, { type: 'page/prev' });
+
+      // Assert
+      expect(result.activeId).toBe(0);
+      expect(result.categories[1].isVisited).toBe(true);
+      expect(result.isOnReview).toBe(false);
+      expect(result.hasPrevButton).toBe(false);
+    });
+
+    test('does not move before the first page', () => {
+      // Arrange
+      const state = buildState({ activeId: 0 });
+
+      // Act
+      const result = stepperReducer(state, { type: 'page/prev' });
+
+      // Assert
+      expect(result.activeId).toBe(0);
+      expect(result.hasPrevButton).toBe(false);
+    });
+  });
+
+  describe('page/to/index', () => {
+    test('navigates directly to the given page index', () => {
+      // Arrange
+      const state = buildState({ activeId: 0, maxReachedStep: 0, validationTrigger: 0 });
+
+      // Act
+      const result = stepperReducer(state, {
+        type: 'page/to/index',
+        payload: { id: 1, targetScope: '#/properties/field1' },
+      });
+
+      // Assert
+      expect(result.activeId).toBe(1);
+      expect(result.targetScope).toBe('#/properties/field1');
+      expect(result.maxReachedStep).toBe(0);
+      expect(result.validationTrigger).toBe(1);
+      expect(result.hasPrevButton).toBe(true);
+    });
+
+    test('marks the state as on review when navigating to the review page', () => {
+      // Arrange
+      const state = buildState({ activeId: 0 });
+
+      // Act
+      const result = stepperReducer(state, { type: 'page/to/index', payload: { id: 2 } });
+
+      // Assert
+      expect(result.isOnReview).toBe(true);
+      expect(result.hasNextButton).toBe(false);
+    });
+  });
+
+  describe('update/category', () => {
+    test('updates the status of the targeted category based on validation', () => {
+      // Arrange
+      const schema = { type: 'object', required: ['field0'], properties: { field0: { type: 'string' } } };
+      const ajv = new Ajv({ allErrors: true });
+      const state = buildState();
+
+      // Act
+      const result = stepperReducer(state, {
+        type: 'update/category',
+        payload: { id: 0, ajv, schema, data: { field0: 'value' } },
+      });
+
+      // Assert
+      expect(result.categories[0].status).toBe(StepStatus.COMPLETED);
+      expect(result.categories[0].isCompleted).toBe(true);
+      expect(result.categories[0].isValid).toBe(true);
+      expect(result.categories[1]).toBe(state.categories[1]);
+    });
+
+    test('leaves the category incomplete when required data is missing', () => {
+      // Arrange
+      const schema = { type: 'object', required: ['field0'], properties: { field0: { type: 'string' } } };
+      const ajv = new Ajv({ allErrors: true });
+      const state = buildState();
+
+      // Act
+      const result = stepperReducer(state, {
+        type: 'update/category',
+        payload: { id: 0, ajv, schema, data: {} },
+      });
+
+      // Assert
+      expect(result.categories[0].isCompleted).toBe(false);
+      expect(result.categories[0].isValid).toBe(false);
+    });
+  });
+
+  describe('set/visited', () => {
+    test('marks the specified category as visited', () => {
+      // Arrange
+      const state = buildState();
+
+      // Act
+      const result = stepperReducer(state, { type: 'set/visited', payload: { id: 1 } });
+
+      // Assert
+      expect(result.categories[1].isVisited).toBe(true);
+      expect(result.categories[0].isVisited).toBe(false);
+    });
+  });
+
+  describe('validate/form', () => {
+    test('marks the form valid when there are no errors', () => {
+      // Arrange
+      const state = buildState({ isValid: false });
+
+      // Act
+      const result = stepperReducer(state, { type: 'validate/form', payload: { errors: [] } });
+
+      // Assert
+      expect(result.isValid).toBe(true);
+    });
+
+    test('marks the form invalid when there are errors', () => {
+      // Arrange
+      const state = buildState({ isValid: true });
+
+      // Act
+      const result = stepperReducer(state, {
+        type: 'validate/form',
+        payload: {
+          errors: [{ instancePath: '/field0', message: 'required' }] as unknown as import('ajv').ErrorObject[],
+        },
+      });
+
+      // Assert
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  describe('toggle/category/review-link', () => {
+    test('toggles the review link visibility for the targeted category', () => {
+      // Arrange
+      const state = buildState();
+
+      // Act
+      const result = stepperReducer(state, { type: 'toggle/category/review-link', payload: { id: 0 } });
+
+      // Assert
+      expect(result.categories[0].showReviewPageLink).toBe(true);
+
+      // Act again to verify it toggles back off
+      const toggledBack = stepperReducer(result, { type: 'toggle/category/review-link', payload: { id: 0 } });
+
+      // Assert
+      expect(toggledBack.categories[0].showReviewPageLink).toBe(false);
+    });
+  });
+
+  describe('update/uischema', () => {
+    test('preserves previously visited categories when recomputed state marks them unvisited', () => {
+      // Arrange
+      const state = buildState({
+        categories: [{ ...buildCategory(0), isVisited: true }, buildCategory(1)],
+      });
+      const newState = buildState({
+        categories: [buildCategory(0), buildCategory(1)],
+      });
+
+      // Act
+      const result = stepperReducer(state, { type: 'update/uischema', payload: { state: newState } });
+
+      // Assert
+      expect(result.categories[0].isVisited).toBe(true);
+      expect(result.categories[1].isVisited).toBe(false);
+    });
+
+    test('keeps the new visited flag when the recomputed category reports visited', () => {
+      // Arrange
+      const state = buildState({ categories: [buildCategory(0), buildCategory(1)] });
+      const newState = buildState({
+        categories: [{ ...buildCategory(0), isVisited: true }, buildCategory(1)],
+      });
+
+      // Act
+      const result = stepperReducer(state, { type: 'update/uischema', payload: { state: newState } });
+
+      // Assert
+      expect(result.categories[0].isVisited).toBe(true);
+    });
+  });
+});

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
@@ -3,6 +3,8 @@ import { ErrorObject } from 'ajv';
 import { Dispatch } from 'react';
 import Ajv from 'ajv';
 import { getStepStatus } from './util';
+import { StepStatus } from '../../../common/Constants';
+import { JsonSchema } from '@jsonforms/core';
 
 export type JsonFormStepperDispatch = Dispatch<StepperAction>;
 
@@ -12,7 +14,10 @@ export type StepperAction =
   | { type: 'page/to/index'; payload: { id: number; targetScope?: string } }
   | { type: 'set/visited'; payload: { id: number } }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | { type: 'update/category'; payload: { errors?: ErrorObject[]; id: number; ajv: Ajv; schema: any; data: any } }
+  | {
+      type: 'update/category';
+      payload: { errors?: ErrorObject[]; id: number; ajv: Ajv; schema: JsonSchema; data: any };
+    }
   | { type: 'validate/form'; payload: { errors?: ErrorObject[] } }
   | { type: 'toggle/category/review-link'; payload: { id: number } }
   | { type: 'update/uischema'; payload: { state: StepperContextDataType } };
@@ -23,7 +28,23 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
 
   switch (action.type) {
     case 'update/uischema': {
-      return { ...action.payload.state };
+      const newState = action.payload.state;
+
+      // createStepperContextInitData recomputes categories purely from the
+      // current data/schema snapshot, so a category with no data in its scopes
+      // is reported as not visited even if the user already navigated through it
+      // (page/next, page/prev, or setVisited previously marked it visited).
+      // Preserve any previously-tracked isVisited=true so navigation history
+      // isn't lost whenever unrelated form data changes trigger this recompute.
+      const mergedCategories = newState.categories.map((newCategory) => {
+        const previousCategory = categories.find((c) => c.id === newCategory.id);
+        return {
+          ...newCategory,
+          isVisited: previousCategory?.isVisited || newCategory.isVisited,
+        };
+      });
+
+      return { ...newState, categories: mergedCategories };
     }
 
     case 'page/next': {
@@ -90,7 +111,7 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
         }
         const filteredErrors = ajv.errors && ajv.errors.filter((error) => error?.data != null);
         const visited = true;
-        const status = getStepStatus({
+        const statusData = getStepStatus({
           scopes: cat.scopes,
           data,
           errors: filteredErrors ?? [],
@@ -100,9 +121,9 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
 
         return {
           ...cat,
-          isCompleted: status === 'Completed',
-          isValid: status === 'Completed',
-          status,
+          isCompleted: statusData.status === StepStatus.COMPLETED,
+          isValid: statusData.status === StepStatus.COMPLETED,
+          status: statusData.status,
         };
       });
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
@@ -112,7 +112,7 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
         }
         const filteredErrors = ajv.errors && ajv.errors.filter((error) => error?.data != null);
         const visited = true;
-        const statusData = getStepStatus({
+        const { status } = getStepStatus({
           scopes: cat.scopes,
           data,
           errors: filteredErrors ?? [],
@@ -122,9 +122,9 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
 
         return {
           ...cat,
-          isCompleted: statusData.status === StepStatus.COMPLETED,
-          isValid: statusData.status === StepStatus.COMPLETED,
-          status: statusData.status,
+          isCompleted: status === StepStatus.COMPLETED,
+          isValid: status === StepStatus.COMPLETED,
+          status: status,
         };
       });
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
@@ -16,6 +16,7 @@ export type StepperAction =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | {
       type: 'update/category';
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       payload: { errors?: ErrorObject[]; id: number; ajv: Ajv; schema: JsonSchema; data: any };
     }
   | { type: 'validate/form'; payload: { errors?: ErrorObject[] } }

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
@@ -20,6 +20,11 @@ export interface CategoryConfig {
 export type CategoryState = CategoryInternalState & CategoryConfig;
 
 export type CategoriesState = Array<CategoryState>;
+export interface StepConfig {
+  id: string;
+  label: string;
+  scopePaths: string[];
+}
 
 export interface StepperContextDataType {
   categories: CategoriesState;

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
@@ -1,4 +1,5 @@
 import { Categorization, Category } from '@jsonforms/core';
+import { StepStatusType } from '../../../common/Constants';
 
 export interface CategoryInternalState {
   isCompleted?: boolean;
@@ -26,6 +27,10 @@ export interface StepConfig {
   scopePaths: string[];
 }
 
+export interface StepStatusData {
+  status: StepStatusType;
+  hasRequiredFields: boolean;
+}
 export interface StepperContextDataType {
   categories: CategoriesState;
   activeId: number;

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
@@ -11,6 +11,7 @@ import {
   hasMeaningfulValue,
   isErrorPathIncluded,
   isJson,
+  isScopeRequired,
   normalizeInstancePath,
   normalizeSchemaPath,
   saveIsVisitFromLocalStorage,
@@ -235,6 +236,16 @@ describe('getIncompletePaths', () => {
     ];
 
     expect(getIncompletePaths(errors, scopes)).toEqual([]);
+  });
+});
+
+describe('isScopeRequired', () => {
+  it('returns true when a required field matches a normalized scope value', () => {
+    expect(isScopeRequired(['fullName', 'email'], ['fullName'], {} as any)).toBe(true);
+  });
+
+  it('returns false when no required field matches a normalized scope value', () => {
+    expect(isScopeRequired(['fullName', 'email'], ['phone'], {} as any)).toBe(false);
   });
 });
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
@@ -1,4 +1,21 @@
-import { hasMeaningfulValue, isScopeRequired, hasValueAtScope } from './util';
+import { ErrorObject } from 'ajv';
+import { VALIDATION_KEYWORDS, StepStatus } from '../../../common/Constants';
+import {
+  hasMeaningfulValue,
+  isScopeRequired,
+  hasValueAtScope,
+  getStepStatus,
+  isErrorPathIncluded,
+  normalizeSchemaPath,
+  normalizeInstancePath,
+  getIncompletePaths,
+  subErrorInParent,
+  getErrorsInScopes,
+  hasDataInScopes,
+  isJson,
+  saveIsVisitFromLocalStorage,
+  getIsVisitFromLocalStorage,
+} from './util';
 
 describe('hasMeaningfulValue', () => {
   test('returns false for undefined', () => {
@@ -88,6 +105,28 @@ describe('hasMeaningfulValue', () => {
     // Assert
     expect(result).toBe(true);
   });
+
+  test('returns true for boolean true', () => {
+    // Arrange
+    const value = true;
+
+    // Act
+    const result = hasMeaningfulValue(value);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns true for boolean false', () => {
+    // Arrange
+    const value = false;
+
+    // Act
+    const result = hasMeaningfulValue(value);
+
+    // Assert
+    expect(result).toBe(true);
+  });
 });
 
 describe('isScopeRequired', () => {
@@ -138,13 +177,25 @@ describe('isScopeRequired', () => {
     // Assert
     expect(result).toBe(false);
   });
+
+  test('returns true when multiple scopes are required', () => {
+    // Arrange
+    const normalizedScopes: string[] = ['field1', 'field2', 'field3'];
+    const required: string[] = ['field2', 'field3'];
+
+    // Act
+    const result = isScopeRequired(normalizedScopes, required);
+
+    // Assert
+    expect(result).toBe(true);
+  });
 });
 
 describe('hasValueAtScope', () => {
-  test('returns false when path is invalid', () => {
+  test('returns false for undefined data', () => {
     // Arrange
-    const data = { field1: 'value1' };
-    const scope = 'invalid.path';
+    const data = undefined;
+    const scope = 'field1';
 
     // Act
     const result = hasValueAtScope(data, scope);
@@ -153,7 +204,31 @@ describe('hasValueAtScope', () => {
     expect(result).toBe(false);
   });
 
-  test('returns true when value at scope is meaningful', () => {
+  test('returns false for null data', () => {
+    // Arrange
+    const data = null;
+    const scope = 'field1';
+
+    // Act
+    const result = hasValueAtScope(data, scope);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  test('returns false for empty scope', () => {
+    // Arrange
+    const data = { field1: 'value1' };
+    const scope = '';
+
+    // Act
+    const result = hasValueAtScope(data, scope);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  test('returns true for existing value at scope', () => {
     // Arrange
     const data = { field1: 'value1' };
     const scope = '#/field1';
@@ -165,15 +240,486 @@ describe('hasValueAtScope', () => {
     expect(result).toBe(true);
   });
 
-  test('returns false when value at scope is not meaningful', () => {
+  test('returns false for non-existing value at scope', () => {
     // Arrange
-    const data = { field1: '' };
-    const scope = '#/field1';
+    const data = { field1: 'value1' };
+    const scope = 'field2';
 
     // Act
     const result = hasValueAtScope(data, scope);
 
     // Assert
     expect(result).toBe(false);
+  });
+
+  test('returns true for nested value at scope', () => {
+    // Arrange
+    const data = { field1: { nestedField: 'value' } };
+    const scope = '#/field1/nestedField';
+
+    // Act
+    const result = hasValueAtScope(data, scope);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns false for missing nested value at scope', () => {
+    // Arrange
+    const data = { field1: { nestedField: 'value' } };
+    const scope = 'field1.missingField';
+
+    // Act
+    const result = hasValueAtScope(data, scope);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe('getStepStatus', () => {
+  test('returns NOT_STARTED when step has no required fields and no data', () => {
+    // Arrange
+    const opts = {
+      scopes: ['#/name'],
+      data: {},
+      errors: [] as ErrorObject[],
+      schema: {},
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.NOT_STARTED);
+    expect(result.hasRequiredFields).toBe(false);
+  });
+
+  test('returns COMPLETED when step has no required fields and has been visited', () => {
+    // Arrange
+    const opts = {
+      scopes: ['#/optional'],
+      data: {},
+      errors: [] as ErrorObject[],
+      schema: {},
+      visited: true,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.COMPLETED);
+    expect(result.hasRequiredFields).toBe(false);
+  });
+
+  test('returns IN_PROGRESS when there are validation errors within the step scope', () => {
+    // Arrange
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+    const opts = {
+      scopes: ['#/name'],
+      data: { name: 'Bob' },
+      errors: [{ instancePath: '/name', message: 'invalid' }] as unknown as ErrorObject[],
+      schema,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.IN_PROGRESS);
+    expect(result.hasRequiredFields).toBe(true);
+  });
+
+  test('returns IN_PROGRESS when a required field is empty', () => {
+    // Arrange
+    const schema = {
+      required: ['name'],
+      properties: { name: { type: 'string' }, other: { type: 'string' } },
+    };
+    const opts = {
+      scopes: ['#/name', '#/other'],
+      data: { name: '', other: 'x' },
+      errors: [] as ErrorObject[],
+      schema,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.IN_PROGRESS);
+    expect(result.hasRequiredFields).toBe(true);
+  });
+
+  test('returns COMPLETED when all required fields are filled and there are no conditional dependents', () => {
+    // Arrange
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+    const opts = {
+      scopes: ['#/name'],
+      data: { name: 'Bob' },
+      errors: [] as ErrorObject[],
+      schema,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.COMPLETED);
+    expect(result.hasRequiredFields).toBe(true);
+  });
+
+  test('returns COMPLETED when conditional dependents exist but have no errors', () => {
+    // Arrange
+    const schema = {
+      required: ['hasPet'],
+      if: { properties: { hasPet: { const: true } } },
+      then: { required: ['petName'] },
+      properties: { hasPet: { type: 'boolean' }, petName: { type: 'string' } },
+    };
+    const opts = {
+      scopes: ['#/hasPet'],
+      data: { hasPet: true },
+      errors: [] as ErrorObject[],
+      schema,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.COMPLETED);
+  });
+
+  test('returns IN_PROGRESS when a conditional dependent field has an error', () => {
+    // Arrange
+    const schema = {
+      required: ['hasPet'],
+      if: { properties: { hasPet: { const: true } } },
+      then: { required: ['petName'] },
+      properties: { hasPet: { type: 'boolean' }, petName: { type: 'string' } },
+    };
+    const opts = {
+      scopes: ['#/hasPet'],
+      data: { hasPet: true },
+      errors: [
+        {
+          instancePath: '/petName',
+          keyword: VALIDATION_KEYWORDS.REQUIRED,
+          params: { missingProperty: 'petName' },
+          message: 'is a required property',
+        },
+      ] as unknown as ErrorObject[],
+      schema,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.IN_PROGRESS);
+  });
+
+  test('falls back to the visited flag when scopes cannot be normalized', () => {
+    // Arrange
+    const opts = {
+      scopes: ['not-a-schema-path'],
+      data: {},
+      errors: [] as ErrorObject[],
+      schema: {},
+      visited: true,
+    };
+
+    // Act
+    const result = getStepStatus(opts);
+
+    // Assert
+    expect(result.status).toBe(StepStatus.COMPLETED);
+  });
+});
+
+describe('isErrorPathIncluded', () => {
+  test('returns true for an exact path match', () => {
+    // Arrange
+    const errorPaths = ['name'];
+
+    // Act
+    const result = isErrorPathIncluded(errorPaths, 'name');
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns true for a nested path match', () => {
+    // Arrange
+    const errorPaths = ['name'];
+
+    // Act
+    const result = isErrorPathIncluded(errorPaths, 'name.firstName');
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns false when no error path matches', () => {
+    // Arrange
+    const errorPaths = ['address'];
+
+    // Act
+    const result = isErrorPathIncluded(errorPaths, 'name');
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe('normalizeSchemaPath', () => {
+  test('returns empty string for a path that does not start with #/', () => {
+    // Arrange & Act
+    const result = normalizeSchemaPath('name');
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  test('converts a schema path to dot notation and strips properties segments', () => {
+    // Arrange & Act
+    const result = normalizeSchemaPath('#/properties/name/properties/firstName');
+
+    // Assert
+    expect(result).toBe('name.firstName');
+  });
+});
+
+describe('normalizeInstancePath', () => {
+  test('returns empty string for an empty instance path', () => {
+    // Arrange & Act
+    const result = normalizeInstancePath('');
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  test('converts an instance path to dot notation and drops array indices', () => {
+    // Arrange & Act
+    const result = normalizeInstancePath('/roadmap/0/when');
+
+    // Assert
+    expect(result).toBe('roadmap.when');
+  });
+});
+
+describe('getIncompletePaths', () => {
+  test('returns an empty array when there are no errors', () => {
+    // Arrange & Act
+    const result = getIncompletePaths(undefined, ['#/name']);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  test('matches a required error against the scoped path', () => {
+    // Arrange
+    const errors = [
+      {
+        instancePath: '',
+        keyword: VALIDATION_KEYWORDS.REQUIRED,
+        params: { missingProperty: 'name' },
+      },
+    ] as unknown as ErrorObject[];
+
+    // Act
+    const result = getIncompletePaths(errors, ['#/name']);
+
+    // Assert
+    expect(result).toEqual(['name']);
+  });
+
+  test('matches a non-required error against the scoped path via instancePath', () => {
+    // Arrange
+    const errors = [{ instancePath: '/name', keyword: 'minLength' }] as unknown as ErrorObject[];
+
+    // Act
+    const result = getIncompletePaths(errors, ['#/name']);
+
+    // Assert
+    expect(result).toEqual(['name']);
+  });
+
+  test('ignores errors that do not fall within any scoped path', () => {
+    // Arrange
+    const errors = [{ instancePath: '/address', keyword: 'minLength' }] as unknown as ErrorObject[];
+
+    // Act
+    const result = getIncompletePaths(errors, ['#/name']);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+});
+
+describe('subErrorInParent', () => {
+  test('returns false when the instance path has fewer than two segments', () => {
+    // Arrange
+    const error = { instancePath: '/roadmap' } as ErrorObject;
+
+    // Act
+    const result = subErrorInParent(error, ['roadmap']);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  test('returns true when the array item path matches a parent path', () => {
+    // Arrange
+    const error = { instancePath: '/roadmap/0' } as ErrorObject;
+
+    // Act
+    const result = subErrorInParent(error, ['/roadmap']);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns true when a nested array item property path matches a parent path', () => {
+    // Arrange
+    const error = { instancePath: '/roadmap/0/when' } as ErrorObject;
+
+    // Act
+    const result = subErrorInParent(error, ['/roadmap']);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns false when neither pattern matches', () => {
+    // Arrange
+    const error = { instancePath: '/roadmap/when' } as ErrorObject;
+
+    // Act
+    const result = subErrorInParent(error, ['/other']);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe('getErrorsInScopes', () => {
+  test('returns an empty array when there are no errors', () => {
+    // Arrange & Act
+    const result = getErrorsInScopes(undefined, ['#/properties/name']);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  test('returns an empty array when there are no scopes', () => {
+    // Arrange
+    const errors = [{ instancePath: '/name' }] as unknown as ErrorObject[];
+
+    // Act
+    const result = getErrorsInScopes(errors, []);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  test('includes a required error whose missing property matches a scope', () => {
+    // Arrange
+    const errors = [
+      {
+        instancePath: '',
+        keyword: VALIDATION_KEYWORDS.REQUIRED,
+        params: { missingProperty: 'name' },
+      },
+    ] as unknown as ErrorObject[];
+
+    // Act
+    const result = getErrorsInScopes(errors, ['#/properties/name']);
+
+    // Assert
+    expect(result).toEqual(errors);
+  });
+
+  test('excludes errors whose path does not match any scope', () => {
+    // Arrange
+    const errors = [{ instancePath: '/address' }] as unknown as ErrorObject[];
+
+    // Act
+    const result = getErrorsInScopes(errors, ['#/properties/name']);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+});
+
+describe('hasDataInScopes', () => {
+  test('returns true when at least one scope has data', () => {
+    // Arrange
+    const data = { name: 'Bob' };
+    const scopes = ['#/properties/name'];
+
+    // Act
+    const result = hasDataInScopes(data, scopes);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns false when no scopes have data', () => {
+    // Arrange
+    const data = {};
+    const scopes = ['#/properties/name'];
+
+    // Act
+    const result = hasDataInScopes(data, scopes);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe('isJson', () => {
+  test('returns true for a valid JSON string', () => {
+    // Arrange & Act
+    const result = isJson('{"key":"value"}');
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('returns false for an invalid JSON string', () => {
+    // Arrange & Act
+    const result = isJson('not-json');
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe('saveIsVisitFromLocalStorage / getIsVisitFromLocalStorage', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('round-trips visited status through localStorage', () => {
+    // Arrange
+    const status = [true, false, true];
+
+    // Act
+    saveIsVisitFromLocalStorage(status);
+    const result = getIsVisitFromLocalStorage();
+
+    // Assert
+    expect(result).toEqual(status);
+  });
+
+  test('returns undefined when nothing has been saved', () => {
+    // Arrange & Act
+    const result = getIsVisitFromLocalStorage();
+
+    // Assert
+    expect(result).toBeUndefined();
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
@@ -1,618 +1,109 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { ErrorObject } from 'ajv';
-import { buildConditionalDeps } from '../util/conditionalDeps';
-import {
-  getErrorsInScopes,
-  getIncompletePaths,
-  getIsVisitFromLocalStorage,
-  getStepStatus,
-  hasDataInScopes,
-  hasMeaningfulValue,
-  isErrorPathIncluded,
-  isJson,
-  normalizeInstancePath,
-  normalizeSchemaPath,
-  saveIsVisitFromLocalStorage,
-  subErrorInParent,
-} from './util';
-
-jest.mock('../util/conditionalDeps', () => ({
-  buildConditionalDeps: jest.fn(),
-}));
-
-type AjvError = ErrorObject & { dataPath?: string };
-
-const localStorageMock = {
-  store: {} as Record<string, string>,
-  setItem(key: string, value: unknown) {
-    this.store[key] = String(value);
-  },
-  getItem(key: string) {
-    return this.store[key] || null;
-  },
-  removeItem(key: string) {
-    delete this.store[key];
-  },
-  clear() {
-    this.store = {};
-  },
-};
-
-Object.defineProperty(global, 'localStorage', { value: localStorageMock });
-
-function requiredErr(instancePath: string, missingProperty: string, schemaPath = '#/required'): AjvError {
-  return {
-    keyword: 'required',
-    instancePath,
-    schemaPath,
-    params: { missingProperty },
-    message: `must have required property '${missingProperty}'`,
-  } as AjvError;
-}
-
-function errorMessageErr(instancePath: string, schemaPath: string, message: string): AjvError {
-  return {
-    keyword: 'errorMessage',
-    instancePath,
-    schemaPath,
-    params: {},
-    message,
-  } as AjvError;
-}
-
-function dataPathErr(dataPath: string): AjvError {
-  return {
-    keyword: 'minLength',
-    instancePath: '',
-    dataPath,
-    schemaPath: '#/properties/name/minLength',
-    params: { limit: 1 },
-    message: 'must NOT have fewer than 1 characters',
-  } as AjvError;
-}
-
-describe('isJson', () => {
-  it('returns true only for valid JSON strings', () => {
-    expect(isJson('{}')).toBe(true);
-    expect(isJson('[]')).toBe(true);
-    expect(isJson('"hello"')).toBe(true);
-    expect(isJson('test')).toBe(false);
-    expect(isJson('{')).toBe(false);
-  });
-});
-
-describe('localStorage helpers', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('saves and restores visited state for today and current URL', () => {
-    const value = [true, false, true];
-
-    saveIsVisitFromLocalStorage(value);
-
-    expect(getIsVisitFromLocalStorage()).toEqual(value);
-  });
-
-  it('returns undefined when no value exists', () => {
-    expect(getIsVisitFromLocalStorage()).toBeUndefined();
-  });
-
-  it('returns undefined when stored value is invalid JSON', () => {
-    const dateKey = new Date().toISOString().slice(0, 10);
-    const key = `${window.location.href}_${dateKey}`;
-
-    localStorage.setItem(key, '[tru]');
-
-    expect(getIsVisitFromLocalStorage()).toBeUndefined();
-  });
-});
+import { hasMeaningfulValue, hasValueAtScope, getStepStatus } from './util';
+import { StepStatus } from '../../../common/Constants';
 
 describe('hasMeaningfulValue', () => {
-  it('returns false for undefined, null, blank strings, empty arrays, and empty objects', () => {
+  test('returns false for undefined or null', () => {
     expect(hasMeaningfulValue(undefined)).toBe(false);
     expect(hasMeaningfulValue(null)).toBe(false);
+  });
+
+  test('returns false for empty string or string with only spaces', () => {
     expect(hasMeaningfulValue('')).toBe(false);
     expect(hasMeaningfulValue('   ')).toBe(false);
+  });
+
+  test('returns true for non-empty string', () => {
+    expect(hasMeaningfulValue('hello')).toBe(true);
+  });
+
+  test('returns false for empty array', () => {
     expect(hasMeaningfulValue([])).toBe(false);
+  });
+
+  test('returns true for non-empty array', () => {
+    expect(hasMeaningfulValue([1, 2, 3])).toBe(true);
+  });
+
+  test('returns false for empty object', () => {
     expect(hasMeaningfulValue({})).toBe(false);
   });
 
-  it('returns true for non-empty strings, arrays, objects, numbers, and booleans', () => {
-    expect(hasMeaningfulValue('Jane')).toBe(true);
-    expect(hasMeaningfulValue(['x'])).toBe(true);
-    expect(hasMeaningfulValue({ firstName: 'Jane' })).toBe(true);
+  test('returns true for non-empty object', () => {
+    expect(hasMeaningfulValue({ key: 'value' })).toBe(true);
+  });
+
+  test('returns true for numbers and booleans', () => {
     expect(hasMeaningfulValue(0)).toBe(true);
+    expect(hasMeaningfulValue(42)).toBe(true);
+    expect(hasMeaningfulValue(true)).toBe(true);
     expect(hasMeaningfulValue(false)).toBe(true);
   });
 });
 
-describe('normalizeSchemaPath', () => {
-  it('converts #/properties/a/properties/b to a.b', () => {
-    expect(normalizeSchemaPath('#/properties/a/properties/b')).toBe('a.b');
+describe('hasValueAtScope', () => {
+  test('returns false if scope cannot be normalized', () => {
+    expect(hasValueAtScope({}, '')).toBe(false);
   });
 
-  it('returns empty string for non #/ paths', () => {
-    expect(normalizeSchemaPath('a/b')).toBe('');
+  test('returns true if meaningful value exists at normalized scope', () => {
+    const data = { user: { name: 'John' } };
+    expect(hasValueAtScope(data, '#/user/name')).toBe(true);
   });
 
-  it('keeps non-properties segments', () => {
-    expect(normalizeSchemaPath('#/allOf/0/then/required')).toBe('allOf.0.then.required');
-  });
-
-  it('normalizes a root property scope', () => {
-    expect(normalizeSchemaPath('#/properties/email')).toBe('email');
-  });
-});
-
-describe('normalizeInstancePath', () => {
-  it('converts /a/b/c to a.b.c', () => {
-    expect(normalizeInstancePath('/a/b/c')).toBe('a.b.c');
-  });
-
-  it('drops numeric indices', () => {
-    expect(normalizeInstancePath('/roadmap/0/when')).toBe('roadmap.when');
-  });
-
-  it('returns empty string for empty input', () => {
-    expect(normalizeInstancePath('')).toBe('');
-  });
-
-  it('drops multiple numeric indices', () => {
-    expect(normalizeInstancePath('/sections/0/items/2/name')).toBe('sections.items.name');
-  });
-});
-
-describe('getIncompletePaths', () => {
-  it('returns [] when no errors are provided', () => {
-    expect(getIncompletePaths([], ['#/properties/a'])).toEqual([]);
-    expect(getIncompletePaths(null, ['#/properties/a'])).toEqual([]);
-    expect(getIncompletePaths(undefined, ['#/properties/a'])).toEqual([]);
-  });
-
-  it('matches required error to exact nested scope', () => {
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-    const errors: AjvError[] = [requiredErr('/applicantContactDetails', 'firstName')];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual(['applicantContactDetails.firstName']);
-  });
-
-  it('matches required error on parent object to child scope', () => {
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-    const errors: AjvError[] = [requiredErr('', 'applicantContactDetails')];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual(['applicantContactDetails.firstName']);
-  });
-
-  it('matches non-required instancePath errors inside scope', () => {
-    const scopes = ['#/properties/whichOfThemApplies'];
-    const errors: AjvError[] = [
-      errorMessageErr(
-        '/whichOfThemApplies',
-        '#/properties/whichOfThemApplies/errorMessage',
-        'Choose all that apply is required',
-      ),
-    ];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual(['whichOfThemApplies']);
-  });
-
-  it('matches non-required dataPath errors when instancePath is empty', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [dataPathErr('/fullName')];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual(['fullName']);
-  });
-
-  it('deduplicates multiple errors for the same scope', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [
-      errorMessageErr('/fullName', '#/properties/fullName/errorMessage', 'required'),
-      dataPathErr('/fullName'),
-    ];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual(['fullName']);
-  });
-
-  it('ignores errors that do not match any scope', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [errorMessageErr('/email', '#/properties/email/errorMessage', 'required')];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual([]);
-  });
-
-  it('ignores errors without usable candidate paths', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [
-      {
-        keyword: 'errorMessage',
-        instancePath: '',
-        schemaPath: '#/errorMessage',
-        params: {},
-        message: 'required',
-      } as AjvError,
-    ];
-
-    expect(getIncompletePaths(errors, scopes)).toEqual([]);
+  test('returns false if no meaningful value exists at normalized scope', () => {
+    const data = { user: { name: '' } };
+    expect(hasValueAtScope(data, '#/user/name')).toBe(false);
   });
 });
 
 describe('getStepStatus', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
+  const schema = {
+    required: ['name'],
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'number' },
+    },
+  };
 
-  it('returns NotStarted when step has not been visited, even if errors exist', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map());
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fullName'],
+  test('returns NOT_STARTED if no data exists in scopes', () => {
+    const opts = {
+      scopes: ['#/name'],
       data: {},
-      errors: [errorMessageErr('/fullName', '#/properties/fullName/errorMessage', 'required')],
-      schema: {},
-      visited: false,
-    });
-
-    expect(status).toBe('NotStarted');
-  });
-
-  it('returns InProgress when visited step has incomplete fields in its scopes', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map());
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fullName'],
-      data: {},
-      errors: [errorMessageErr('/fullName', '#/properties/fullName/errorMessage', 'required')],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
-  });
-
-  it('returns InProgress when top-level required field is empty', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map());
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fullName'],
-      data: { fullName: '' },
-      errors: [],
-      schema: { required: ['fullName'] },
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
-  });
-
-  it('returns InProgress when nested required field is empty', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map());
-
-    const schema = {
-      properties: {
-        applicantContactDetails: {
-          type: 'object',
-          required: ['firstName'],
-          properties: {
-            firstName: { type: 'string' },
-          },
-        },
-      },
-    };
-
-    const status = getStepStatus({
-      scopes: ['#/properties/applicantContactDetails/properties/firstName'],
-      data: { applicantContactDetails: { firstName: '   ' } },
       errors: [],
       schema,
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
+    };
+    expect(getStepStatus(opts)).toBe(StepStatus.NOT_STARTED);
   });
 
-  it('returns InProgress when required array field is empty', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map());
+  test('returns IN_PROGRESS if there are errors in the scope after step has started', () => {
+    const opts = {
+      scopes: ['#/name'],
+      data: { name: 'John' },
+      errors: [{ instancePath: '/name', message: 'must not be empty' }],
+      schema,
+    };
+    expect(getStepStatus(opts)).toBe(StepStatus.IN_PROGRESS);
+  });
 
-    const status = getStepStatus({
-      scopes: ['#/properties/selectedOptions'],
-      data: { selectedOptions: [] },
+  test('returns NOT_STARTED if required fields are empty and step has not started', () => {
+    const opts = {
+      scopes: ['#/name'],
+      data: { name: '' },
       errors: [],
-      schema: { required: ['selectedOptions'] },
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
+      schema,
+    };
+    expect(getStepStatus(opts)).toBe(StepStatus.NOT_STARTED);
   });
 
-  it('returns Completed when visited step has no scoped errors, no empty required fields, and no controllers', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map());
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fullName'],
-      data: { fullName: 'Jane Doe' },
+  test('returns COMPLETED if all required fields are filled and no errors exist', () => {
+    const opts = {
+      scopes: ['#/name'],
+      data: { name: 'John' },
       errors: [],
-      schema: { required: ['fullName'] },
-      visited: true,
-    });
-
-    expect(status).toBe('Completed');
-  });
-
-  it('returns Completed when controller step has no affected-path errors', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(
-      new Map<string, string[]>([['fillingApplicationOnbehalf', ['applicantContactDetails']]]),
-    );
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fillingApplicationOnbehalf'],
-      data: { fillingApplicationOnbehalf: 'No' },
-      errors: [errorMessageErr('/whichOfThemApplies', '#/properties/whichOfThemApplies/errorMessage', 'required')],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('Completed');
-  });
-
-  it('returns InProgress when controller step has required error under affected path', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(
-      new Map<string, string[]>([['fillingApplicationOnbehalf', ['applicantContactDetails']]]),
-    );
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fillingApplicationOnbehalf'],
-      data: { fillingApplicationOnbehalf: 'No' },
-      errors: [requiredErr('/applicantContactDetails', 'firstName', '#/allOf/0/then/required')],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
-  });
-
-  it('returns InProgress when controller step has root required error for affected path', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(
-      new Map<string, string[]>([['fillingApplicationOnbehalf', ['applicantContactDetails']]]),
-    );
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fillingApplicationOnbehalf'],
-      data: { fillingApplicationOnbehalf: 'No' },
-      errors: [requiredErr('', 'applicantContactDetails', '#/allOf/0/then/required')],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
-  });
-
-  it('returns InProgress when controller step has dataPath error under affected path', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(
-      new Map<string, string[]>([['fillingApplicationOnbehalf', ['applicantContactDetails']]]),
-    );
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fillingApplicationOnbehalf'],
-      data: { fillingApplicationOnbehalf: 'No' },
-      errors: [dataPathErr('/applicantContactDetails/firstName')],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('InProgress');
-  });
-
-  it('returns Completed when controller has no affected paths', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(
-      new Map<string, string[]>([['fillingApplicationOnbehalf', []]]),
-    );
-
-    const status = getStepStatus({
-      scopes: ['#/properties/fillingApplicationOnbehalf'],
-      data: { fillingApplicationOnbehalf: 'No' },
-      errors: [requiredErr('/applicantContactDetails', 'firstName')],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('Completed');
-  });
-
-  it('returns Completed when a non-normalizable scope cannot be matched to conditional deps', () => {
-    (buildConditionalDeps as jest.Mock).mockReturnValue(new Map<string, string[]>([['field', ['otherField']]]));
-
-    const status = getStepStatus({
-      scopes: ['field'],
-      data: { field: 'x' },
-      errors: [],
-      schema: {},
-      visited: true,
-    });
-
-    expect(status).toBe('Completed');
-  });
-});
-
-describe('getErrorsInScopes', () => {
-  it('filters required error to matching scope path', () => {
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-    const errors: AjvError[] = [requiredErr('/applicantContactDetails', 'firstName')];
-
-    const result = getErrorsInScopes(errors, scopes);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].keyword).toBe('required');
-  });
-
-  it('filters root required error to matching top-level scope path', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [requiredErr('', 'fullName')];
-
-    const result = getErrorsInScopes(errors, scopes);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].keyword).toBe('required');
-  });
-
-  it('filters non-required error to matching scope path', () => {
-    const scopes = ['#/properties/whichOfThemApplies'];
-    const errors: AjvError[] = [
-      errorMessageErr('/whichOfThemApplies', '#/properties/whichOfThemApplies/errorMessage', 'required'),
-    ];
-
-    const result = getErrorsInScopes(errors, scopes);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].keyword).toBe('errorMessage');
-  });
-
-  it('matches parent object error to child scope', () => {
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-    const errors: AjvError[] = [
-      errorMessageErr(
-        '/applicantContactDetails',
-        '#/properties/applicantContactDetails/errorMessage',
-        'Applicant contact details is required',
-      ),
-    ];
-
-    expect(getErrorsInScopes(errors, scopes)).toHaveLength(1);
-  });
-
-  it('returns [] when no scopes or errors are provided', () => {
-    expect(getErrorsInScopes([], [])).toEqual([]);
-    expect(getErrorsInScopes(undefined, ['#/properties/a'])).toEqual([]);
-    expect(getErrorsInScopes(null, ['#/properties/a'])).toEqual([]);
-    expect(getErrorsInScopes([requiredErr('', 'a')], [])).toEqual([]);
-  });
-
-  it('excludes errors outside provided scopes', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [errorMessageErr('/email', '#/properties/email/errorMessage', 'required')];
-
-    expect(getErrorsInScopes(errors, scopes)).toEqual([]);
-  });
-
-  it('excludes errors without a full path', () => {
-    const scopes = ['#/properties/fullName'];
-    const errors: AjvError[] = [
-      {
-        keyword: 'errorMessage',
-        instancePath: '',
-        schemaPath: '#/errorMessage',
-        params: {},
-        message: 'required',
-      } as AjvError,
-    ];
-
-    expect(getErrorsInScopes(errors, scopes)).toEqual([]);
-  });
-});
-
-describe('subErrorInParent', () => {
-  it('detects /roadmap/0 belongs to /roadmap', () => {
-    const err = {
-      instancePath: '/roadmap/0',
-      keyword: 'required',
-      schemaPath: '#/required',
-      params: {},
-    } as ErrorObject;
-
-    expect(subErrorInParent(err, ['/roadmap'])).toBe(true);
-  });
-
-  it('detects /roadmap/0/when belongs to /roadmap', () => {
-    const err = {
-      instancePath: '/roadmap/0/when',
-      keyword: 'required',
-      schemaPath: '#/required',
-      params: {},
-    } as ErrorObject;
-
-    expect(subErrorInParent(err, ['/roadmap'])).toBe(true);
-  });
-
-  it('returns false when not array-index pattern', () => {
-    const err = {
-      instancePath: '/roadmap/when',
-      keyword: 'required',
-      schemaPath: '#/required',
-      params: {},
-    } as ErrorObject;
-
-    expect(subErrorInParent(err, ['/roadmap'])).toBe(false);
-  });
-
-  it('returns false when parent path is not included', () => {
-    const err = {
-      instancePath: '/roadmap/0/when',
-      keyword: 'required',
-      schemaPath: '#/required',
-      params: {},
-    } as ErrorObject;
-
-    expect(subErrorInParent(err, ['/other'])).toBe(false);
-  });
-
-  it('returns false for shallow paths', () => {
-    const err = { instancePath: '', keyword: 'required', schemaPath: '#/required', params: {} } as ErrorObject;
-
-    expect(subErrorInParent(err, ['/roadmap'])).toBe(false);
-  });
-});
-
-describe('hasDataInScopes', () => {
-  it('returns true if any scope has defined data', () => {
-    const data = { applicantContactDetails: { firstName: 'A' } };
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-
-    expect(hasDataInScopes(data, scopes)).toBe(true);
-  });
-
-  it('returns true for empty string because the scoped value is defined', () => {
-    const data = { applicantContactDetails: { firstName: '' } };
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-
-    expect(hasDataInScopes(data, scopes)).toBe(true);
-  });
-
-  it('returns false if all scoped data is undefined', () => {
-    const data = {};
-    const scopes = ['#/properties/applicantContactDetails/properties/firstName'];
-
-    expect(hasDataInScopes(data, scopes)).toBe(false);
-  });
-
-  it('returns false when no scopes are provided', () => {
-    expect(hasDataInScopes({ fullName: 'Jane' }, [])).toBe(false);
-  });
-});
-
-describe('isErrorPathIncluded', () => {
-  it('returns true when path exactly matches an errorPath', () => {
-    expect(isErrorPathIncluded(['name'], 'name')).toBe(true);
-  });
-
-  it('returns true when path is a descendant of an errorPath', () => {
-    expect(isErrorPathIncluded(['name'], 'name.firstName')).toBe(true);
-    expect(isErrorPathIncluded(['name'], 'name.firstName.middle')).toBe(true);
-  });
-
-  it('returns false when path is not included by any errorPath', () => {
-    expect(isErrorPathIncluded(['name'], 'other')).toBe(false);
-    expect(isErrorPathIncluded(['name'], 'names')).toBe(false);
-    expect(isErrorPathIncluded(['name'], 'nameX.firstName')).toBe(false);
-    expect(isErrorPathIncluded(['name'], 'na.me')).toBe(false);
-  });
-
-  it('handles multiple errorPaths', () => {
-    expect(isErrorPathIncluded(['a', 'b', 'c'], 'b')).toBe(true);
-    expect(isErrorPathIncluded(['a', 'b', 'c'], 'c.child')).toBe(true);
-    expect(isErrorPathIncluded(['a', 'b', 'c'], 'd.child')).toBe(false);
-  });
-
-  it('returns false when errorPaths is empty', () => {
-    expect(isErrorPathIncluded([], 'name')).toBe(false);
+      schema,
+    };
+    expect(getStepStatus(opts)).toBe(StepStatus.COMPLETED);
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -18,6 +18,7 @@ export function hasMeaningfulValue(val: any): boolean {
   return true;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getSubSchema(schema: JsonSchema, path: string): any {
   const parts = path
     .replace(/^#\//, '')
@@ -25,6 +26,7 @@ function getSubSchema(schema: JsonSchema, path: string): any {
     .filter((p) => p !== 'properties') // remove 'properties' segments
     .slice(0, -1);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let current: any = schema;
   for (const part of parts) {
     if (!current) return undefined;

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -3,6 +3,7 @@ import get from 'lodash/get';
 import type { ErrorObject } from 'ajv';
 import { buildConditionalDeps } from '../util/conditionalDeps';
 import { StepStatus, StepStatusType, VALIDATION_KEYWORDS } from '../../../common/Constants';
+import { StepStatusData } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getValueAtPath(obj: any, path: string) {
@@ -58,7 +59,7 @@ export function isScopeRequired(normalizedScopes: string[], required: string[]):
 // schema's top-level required array plus the required array of each scope's
 // immediate parent (sub)schema (for nested objects).
 function getRequiredForScopes(scopes: string[], schema: JsonSchema): string[] {
-  const topLevelRequired: string[] = (schema as { required?: string[] })?.required || [];
+  const topLevelRequired: string[] = schema.required || [];
 
   const scopeSets = scopes.reduce((acc: string[], scope) => {
     const subSchema = getSubSchema(schema, scope);
@@ -116,10 +117,6 @@ export function hasValueAtScope(data: any, scope: string): boolean {
   return hasMeaningfulValue(getValueAtPath(data, path));
 }
 
-interface StepStatusData {
-  status: StepStatusType;
-  hasRequiredFields: boolean;
-}
 export function getStepStatus(opts: {
   scopes: string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { JsonSchema, toDataPath } from '@jsonforms/core';
 import get from 'lodash/get';
 import type { ErrorObject } from 'ajv';
@@ -16,13 +14,6 @@ export function hasMeaningfulValue(val: any): boolean {
   if (Array.isArray(val)) return val.length > 0;
   if (typeof val === 'object') return Object.keys(val).length > 0;
   return true;
-}
-
-function isStepStarted(normalizedScopes: string[], data: any): boolean {
-  return normalizedScopes.some((path) => {
-    const value = getValueAtPath(data, path);
-    return hasMeaningfulValue(value);
-  });
 }
 
 function getSubSchema(schema: JsonSchema, path: string): any {
@@ -45,6 +36,32 @@ function getSubSchema(schema: JsonSchema, path: string): any {
     }
   }
   return current;
+}
+
+// Checks whether any of the given normalized scopes (dot-path form, e.g. "a.b.c")
+// resolve to a property name present in the required array. Returns true if at
+// least one scope's property name is required, false otherwise.
+export function isScopeRequired(normalizedScopes: string[], required: string[]): boolean {
+  if (!normalizedScopes?.length || !required?.length) return false;
+
+  return normalizedScopes.some((scope) => {
+    const propertyName = scope.split('.').pop();
+    return !!propertyName && required.includes(propertyName);
+  });
+}
+
+// Aggregates the required property names applicable to a step's scopes: the
+// schema's top-level required array plus the required array of each scope's
+// immediate parent (sub)schema (for nested objects).
+function getRequiredForScopes(scopes: string[], schema: JsonSchema): string[] {
+  const topLevelRequired: string[] = (schema as { required?: string[] })?.required || [];
+
+  const scopeSets = scopes.reduce((acc: string[], scope) => {
+    const subSchema = getSubSchema(schema, scope);
+    return acc.concat(subSchema?.required || []);
+  }, topLevelRequired);
+
+  return Array.from(new Set(scopeSets));
 }
 
 function anyRequiredFieldEmpty(scopes: string[], data: any, required: string[], schema: JsonSchema): boolean {
@@ -93,16 +110,28 @@ export function hasValueAtScope(data: any, scope: string): boolean {
   return hasMeaningfulValue(getValueAtPath(data, path));
 }
 
+interface StepStatusData {
+  status: StepStatusType;
+  hasRequiredFields: boolean;
+}
 export function getStepStatus(opts: {
   scopes: string[];
   data: any;
   errors: AjvError[];
   schema: any;
   visited?: boolean;
-}): StepStatusType {
-  const { scopes, errors, schema, data } = opts;
+}): StepStatusData {
+  const { scopes, errors, schema, data, visited } = opts;
 
   const normalizedScopes = scopes.map(normalizeSchemaPath).filter(Boolean);
+
+  // A step with no required fields has nothing that must be filled in, so once
+  // the user has visited it (e.g. navigated back to the application overview
+  // page) it is trivially Completed, regardless of whether its optional
+  // fields hold any data.
+  const requiredForScopes = getRequiredForScopes(scopes, schema);
+
+  const stepHasRequiredFields = isScopeRequired(normalizedScopes, requiredForScopes);
 
   // NotStarted is data-driven: if any scoped field has a defined value the step has been started.
   // For non-standard scopes that cannot be normalised, fall back to the visited flag so those
@@ -110,28 +139,32 @@ export function getStepStatus(opts: {
   const stepHasData =
     normalizedScopes.length > 0
       ? normalizedScopes.some((path) => hasMeaningfulValue(get(data || {}, path)))
-      : (opts.visited ?? false);
+      : (visited ?? false);
+
+  if (!stepHasRequiredFields && (visited || stepHasData)) {
+    return { status: StepStatus.COMPLETED, hasRequiredFields: stepHasRequiredFields };
+  }
 
   if (!stepHasData) {
-    return StepStatus.NOT_STARTED;
+    return { status: StepStatus.NOT_STARTED, hasRequiredFields: stepHasRequiredFields };
   }
   const incompleteInStep = getIncompletePaths(errors, scopes);
 
   if (incompleteInStep.length > 0) {
-    return StepStatus.IN_PROGRESS;
+    return { status: StepStatus.IN_PROGRESS, hasRequiredFields: stepHasRequiredFields };
   }
 
   const required = schema.required || [];
 
   if (anyRequiredFieldEmpty(scopes, data, required, schema)) {
-    return StepStatus.IN_PROGRESS;
+    return { status: StepStatus.IN_PROGRESS, hasRequiredFields: stepHasRequiredFields };
   }
 
   const deps = buildConditionalDeps(schema);
   const controllersInStep = normalizedScopes.filter((s) => deps.has(s));
 
   if (controllersInStep.length === 0) {
-    return StepStatus.COMPLETED;
+    return { status: StepStatus.COMPLETED, hasRequiredFields: stepHasRequiredFields };
   }
 
   const affected = new Set<string>();
@@ -143,7 +176,7 @@ export function getStepStatus(opts: {
   }
 
   if (affected.size === 0) {
-    return StepStatus.COMPLETED;
+    return { status: StepStatus.COMPLETED, hasRequiredFields: stepHasRequiredFields };
   }
 
   const affectedPaths = [...affected];
@@ -151,12 +184,12 @@ export function getStepStatus(opts: {
   for (const err of errors || []) {
     for (const candidate of collectErrorCandidates(err)) {
       if (affectedPaths.some((path) => isUnder(candidate, path))) {
-        return StepStatus.IN_PROGRESS;
+        return { status: StepStatus.IN_PROGRESS, hasRequiredFields: stepHasRequiredFields };
       }
     }
   }
 
-  return StepStatus.COMPLETED;
+  return { status: StepStatus.COMPLETED, hasRequiredFields: stepHasRequiredFields };
 }
 
 export const isErrorPathIncluded = (errorPaths: string[], path: string): boolean => {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -4,10 +4,12 @@ import type { ErrorObject } from 'ajv';
 import { buildConditionalDeps } from '../util/conditionalDeps';
 import { StepStatus, StepStatusType, VALIDATION_KEYWORDS } from '../../../common/Constants';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getValueAtPath(obj: any, path: string) {
   return path.split('.').reduce((acc, key) => acc?.[key], obj);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hasMeaningfulValue(val: any): boolean {
   if (val === undefined || val === null) return false;
   if (typeof val === 'string') return val.trim() !== '';
@@ -64,6 +66,7 @@ function getRequiredForScopes(scopes: string[], schema: JsonSchema): string[] {
   return Array.from(new Set(scopeSets));
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function anyRequiredFieldEmpty(scopes: string[], data: any, required: string[], schema: JsonSchema): boolean {
   for (const scope of scopes) {
     const path = scope
@@ -104,6 +107,7 @@ function anyRequiredFieldEmpty(scopes: string[], data: any, required: string[], 
 // Resolve a single schema scope against the provided data and determine whether
 // it already holds a meaningful value. Used to derive the initial "visited"
 // state of a step from populated form data.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hasValueAtScope(data: any, scope: string): boolean {
   const path = normalizeSchemaPath(scope);
   if (!path) return false;
@@ -208,6 +212,7 @@ export const isErrorPathIncluded = (errorPaths: string[], path: string): boolean
 function collectErrorCandidates(e: AjvError): string[] {
   const out: string[] = [];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const missing = (e.params as any)?.missingProperty as string | undefined;
   if (e.keyword === VALIDATION_KEYWORDS.REQUIRED && missing) {
     const base = normalizeInstancePath(e.instancePath || '');
@@ -216,6 +221,7 @@ function collectErrorCandidates(e: AjvError): string[] {
 
   if (e.instancePath) out.push(normalizeInstancePath(e.instancePath));
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (e.dataPath) out.push(normalizeInstancePath((e as any).dataPath));
 
   return out.filter(Boolean);
@@ -263,6 +269,7 @@ export function getIncompletePaths(errors: AjvError[] | null | undefined, scopeP
   const incomplete = new Set<string>();
 
   for (const error of errors) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const missingProperty = (error.params as any)?.missingProperty as string | undefined;
     const candidates: string[] = [];
 
@@ -335,6 +342,7 @@ export const getErrorsInScopes = (errors: ErrorObject[] | null | undefined, scop
     let fullPath = '';
 
     if (err.keyword === VALIDATION_KEYWORDS.REQUIRED) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const missingProp = (err.params as any)?.missingProperty;
       const instancePath = err.instancePath || '';
       const instanceDot = instancePath.replace(/^\//, '').replace(/\//g, '.');

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { toDataPath } from '@jsonforms/core';
+import { JsonSchema, toDataPath } from '@jsonforms/core';
 import get from 'lodash/get';
 import type { ErrorObject } from 'ajv';
 import { buildConditionalDeps } from '../util/conditionalDeps';
+import { StepStatus, StepStatusType, VALIDATION_KEYWORDS } from '../../../common/Constants';
 
 function getValueAtPath(obj: any, path: string) {
   return path.split('.').reduce((acc, key) => acc?.[key], obj);
@@ -19,11 +20,12 @@ export function hasMeaningfulValue(val: any): boolean {
 
 function isStepStarted(normalizedScopes: string[], data: any): boolean {
   return normalizedScopes.some((path) => {
-    return hasMeaningfulValue(getValueAtPath(data, path));
+    const value = getValueAtPath(data, path);
+    return hasMeaningfulValue(value);
   });
 }
 
-function getSubSchema(schema: any, path: string): any {
+function getSubSchema(schema: JsonSchema, path: string): any {
   const parts = path
     .replace(/^#\//, '')
     .split('/')
@@ -45,7 +47,7 @@ function getSubSchema(schema: any, path: string): any {
   return current;
 }
 
-function anyRequiredFieldEmpty(scopes: string[], data: any, required: string[], schema: any): boolean {
+function anyRequiredFieldEmpty(scopes: string[], data: any, required: string[], schema: JsonSchema): boolean {
   for (const scope of scopes) {
     const path = scope
       .replace(/^#\//, '')
@@ -81,37 +83,55 @@ function anyRequiredFieldEmpty(scopes: string[], data: any, required: string[], 
 
   return false;
 }
+
+// Resolve a single schema scope against the provided data and determine whether
+// it already holds a meaningful value. Used to derive the initial "visited"
+// state of a step from populated form data.
+export function hasValueAtScope(data: any, scope: string): boolean {
+  const path = normalizeSchemaPath(scope);
+  if (!path) return false;
+  return hasMeaningfulValue(getValueAtPath(data, path));
+}
+
 export function getStepStatus(opts: {
   scopes: string[];
   data: any;
   errors: AjvError[];
   schema: any;
-  visited: boolean;
-}): 'Completed' | 'InProgress' | 'NotStarted' {
-  const { scopes, errors, schema, data, visited } = opts;
-
-  if (!visited) {
-    return 'NotStarted';
-  }
+  visited?: boolean;
+}): StepStatusType {
+  const { scopes, errors, schema, data } = opts;
 
   const normalizedScopes = scopes.map(normalizeSchemaPath).filter(Boolean);
+
+  // NotStarted is data-driven: if any scoped field has a defined value the step has been started.
+  // For non-standard scopes that cannot be normalised, fall back to the visited flag so those
+  // steps are never stuck in NotStarted when the form is pre-populated or already visited.
+  const stepHasData =
+    normalizedScopes.length > 0
+      ? normalizedScopes.some((path) => hasMeaningfulValue(get(data || {}, path)))
+      : (opts.visited ?? false);
+
+  if (!stepHasData) {
+    return StepStatus.NOT_STARTED;
+  }
   const incompleteInStep = getIncompletePaths(errors, scopes);
 
   if (incompleteInStep.length > 0) {
-    return 'InProgress';
+    return StepStatus.IN_PROGRESS;
   }
 
   const required = schema.required || [];
 
   if (anyRequiredFieldEmpty(scopes, data, required, schema)) {
-    return 'InProgress';
+    return StepStatus.IN_PROGRESS;
   }
 
   const deps = buildConditionalDeps(schema);
   const controllersInStep = normalizedScopes.filter((s) => deps.has(s));
 
   if (controllersInStep.length === 0) {
-    return 'Completed';
+    return StepStatus.COMPLETED;
   }
 
   const affected = new Set<string>();
@@ -123,7 +143,7 @@ export function getStepStatus(opts: {
   }
 
   if (affected.size === 0) {
-    return 'Completed';
+    return StepStatus.COMPLETED;
   }
 
   const affectedPaths = [...affected];
@@ -131,13 +151,14 @@ export function getStepStatus(opts: {
   for (const err of errors || []) {
     for (const candidate of collectErrorCandidates(err)) {
       if (affectedPaths.some((path) => isUnder(candidate, path))) {
-        return 'InProgress';
+        return StepStatus.IN_PROGRESS;
       }
     }
   }
 
-  return 'Completed';
+  return StepStatus.COMPLETED;
 }
+
 export const isErrorPathIncluded = (errorPaths: string[], path: string): boolean => {
   return errorPaths.some((ePath) => {
     /**
@@ -153,7 +174,7 @@ function collectErrorCandidates(e: AjvError): string[] {
   const out: string[] = [];
 
   const missing = (e.params as any)?.missingProperty as string | undefined;
-  if (e.keyword === 'required' && missing) {
+  if (e.keyword === VALIDATION_KEYWORDS.REQUIRED && missing) {
     const base = normalizeInstancePath(e.instancePath || '');
     out.push(base ? `${base}.${missing}` : missing);
   }
@@ -210,7 +231,7 @@ export function getIncompletePaths(errors: AjvError[] | null | undefined, scopeP
     const missingProperty = (error.params as any)?.missingProperty as string | undefined;
     const candidates: string[] = [];
 
-    if (error.keyword === 'required' && missingProperty) {
+    if (error.keyword === VALIDATION_KEYWORDS.REQUIRED && missingProperty) {
       candidates.push(missingProperty);
 
       if (error.instancePath) {
@@ -235,7 +256,7 @@ export function getIncompletePaths(errors: AjvError[] | null | undefined, scopeP
 
     for (const candidate of candidates) {
       const match = normalizedScopes.find(
-        (scope) => candidate === scope || candidate.startsWith(scope + '.') || scope.startsWith(candidate + '.')
+        (scope) => candidate === scope || candidate.startsWith(scope + '.') || scope.startsWith(candidate + '.'),
       );
       if (!match) continue;
       incomplete.add(match);
@@ -245,14 +266,6 @@ export function getIncompletePaths(errors: AjvError[] | null | undefined, scopeP
   const result = [...incomplete];
 
   return result;
-}
-
-export type StepStatus = 'not-started' | 'in-progress' | 'completed';
-
-export interface StepConfig {
-  id: string;
-  label: string;
-  scopePaths: string[];
 }
 
 export const subErrorInParent = (error: ErrorObject, paths: string[]): boolean => {
@@ -286,7 +299,7 @@ export const getErrorsInScopes = (errors: ErrorObject[] | null | undefined, scop
   return errors.filter((err) => {
     let fullPath = '';
 
-    if (err.keyword === 'required') {
+    if (err.keyword === VALIDATION_KEYWORDS.REQUIRED) {
       const missingProp = (err.params as any)?.missingProperty;
       const instancePath = err.instancePath || '';
       const instanceDot = instancePath.replace(/^\//, '').replace(/\//g, '.');

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/util/conditionalDeps.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/util/conditionalDeps.ts
@@ -1,3 +1,5 @@
+import { JsonSchema } from '@jsonforms/core';
+
 // eslint-disable-next-line
 type AnyRecord = Record<string, any>;
 
@@ -23,8 +25,8 @@ function collectRequiredPaths(schema: any, basePath = ''): string[] {
 
   return out;
 }
-// eslint-disable-next-line
-function collectControllerKeys(ifSchema: any): string[] {
+
+function collectControllerKeys(ifSchema: JsonSchema): string[] {
   if (!isObj(ifSchema)) return [];
   const keys = new Set<string>();
 
@@ -39,8 +41,8 @@ function collectControllerKeys(ifSchema: any): string[] {
 
   return [...keys];
 }
-// eslint-disable-next-line
-export function buildConditionalDeps(rootSchema: any): Map<string, string[]> {
+
+export function buildConditionalDeps(rootSchema: JsonSchema): Map<string, string[]> {
   const deps = new Map<string, Set<string>>();
   // eslint-disable-next-line
   function walk(node: any) {

--- a/libs/jsonforms-components/src/lib/common/Constants.ts
+++ b/libs/jsonforms-components/src/lib/common/Constants.ts
@@ -22,6 +22,13 @@ export const VALIDATION_KEYWORDS = {
   ERROR_MESSAGE: 'errorMessage',
 };
 
+export enum StepStatus {
+  NOT_STARTED = 'NotStarted',
+  IN_PROGRESS = 'InProgress',
+  COMPLETED = 'Completed',
+}
+export type StepStatusType = StepStatus.COMPLETED | StepStatus.NOT_STARTED | StepStatus.IN_PROGRESS;
+
 export const getAddressLookupFieldLabel = (fieldName: string): string => {
   return ADDRESS_LOOKUP_LABELS[fieldName as keyof typeof ADDRESS_LOOKUP_LABELS] || fieldName;
 };


### PR DESCRIPTION
- fix the correct step status on the initial form load to display when there is data that is saved for the step
- fix step status to be `completed` when there is only conditional fields  to allow a form to be saved
- code clean up and add typing for `schema` parameter instead of using `any`
- update unit tests

