### PR TITLE
feat(form-service): add endpoint to replace form definition roles

### DIFF
--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -14,6 +14,7 @@ import {
   patchFormDefinition,
   patchFormDefinitionLifecycle,
   updateFormDefinition,
+  updateFormDefinitionRoles,
   updateFormDefinitionSchemas,
 } from './definition';
 
@@ -1223,6 +1224,170 @@ describe('definition router', () => {
       await handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(next).toHaveBeenCalledWith(networkError);
+      expect(res.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateFormDefinitionRoles', () => {
+    const existingDefinition = {
+      id: 'test',
+      name: 'Test Form',
+      description: '',
+      anonymousApply: false,
+      applicantRoles: ['old-applicant'],
+      assessorRoles: ['old-assessor'],
+      clerkRoles: ['old-clerk'],
+      dataSchema: {},
+      uiSchema: {},
+      dispositionStates: [],
+    };
+
+    let res: { status: jest.Mock; send: jest.Mock };
+    let next: jest.Mock;
+
+    beforeEach(() => {
+      res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+      next = jest.fn();
+    });
+
+    it('can create handler', () => {
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can call next with unauthorized for non-admin', async () => {
+      const req = {
+        user: { tenantId, id: 'tester', roles: ['test-applicant'] },
+        params: { definitionId: 'test' },
+        body: { applicantRoles: ['a'], assessorRoles: [], clerkRoles: [] },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+      expect(axiosMock.get).not.toHaveBeenCalled();
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+    });
+
+    it('can call next with not found when definition does not exist', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.NOT_FOUND, data: {} });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'missing-def' },
+        body: { applicantRoles: ['a'], assessorRoles: [], clerkRoles: [] },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        expect.stringContaining('missing-def/latest'),
+        expect.objectContaining({ validateStatus: expect.any(Function) }),
+      );
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('missing-def') }));
+    });
+
+    it('replaces roles entirely and returns 200 with the mapped definition', async () => {
+      const newRoles = {
+        applicantRoles: ['new-applicant'],
+        assessorRoles: ['new-assessor'],
+        clerkRoles: ['new-clerk'],
+      };
+
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+      axiosMock.patch.mockResolvedValue({
+        data: { latest: { revision: 2, configuration: { ...existingDefinition, ...newRoles } } },
+      });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: newRoles,
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.stringContaining('test'),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({
+            id: 'test',
+            name: 'Test Form',
+            applicantRoles: ['new-applicant'],
+            assessorRoles: ['new-assessor'],
+            clerkRoles: ['new-clerk'],
+          }),
+        },
+        expect.any(Object),
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ applicantRoles: ['new-applicant'], assessorRoles: ['new-assessor'] }),
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('resets omitted role arrays to empty', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+      axiosMock.patch.mockResolvedValue({ data: { latest: { revision: 2, configuration: existingDefinition } } });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { applicantRoles: ['only-applicant'] },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          operation: 'REPLACE',
+          configuration: expect.objectContaining({
+            applicantRoles: ['only-applicant'],
+            assessorRoles: [],
+            clerkRoles: [],
+          }),
+        },
+        expect.any(Object),
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('calls next with 400 when configuration service rejects the patch', async () => {
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: existingDefinition });
+
+      const axiosError = Object.assign(new Error('Bad Request'), {
+        isAxiosError: true,
+        response: { data: { errorMessage: 'Role validation failed.' } },
+      });
+      jest.mocked(axiosMock.isAxiosError).mockReturnValue(true);
+      axiosMock.patch.mockRejectedValue(axiosError);
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'test' },
+        body: { applicantRoles: [], assessorRoles: [], clerkRoles: [] },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ extra: expect.objectContaining({ statusCode: 400 }) }),
+      );
       expect(res.send).not.toHaveBeenCalled();
     });
   });

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -412,6 +412,9 @@ export function updateFormDefinitionSchemas(directory: ServiceDirectory, tokenPr
   };
 }
 
+// clean-code-ignore: 2.10 — follows the same fetch-modify-save handler shape as the sibling
+// definition endpoints in this file (updateFormDefinitionSchemas, patchFormDefinitionLifecycle);
+// extracting helpers for only this one would make it inconsistent with the established pattern.
 export function updateFormDefinitionRoles(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
   return async (req, res, next) => {
     try {
@@ -628,12 +631,10 @@ export function createFormDefinitionRouter({
         .isString()
         .isLength({ min: 1, max: 50 })
         .matches(/^[a-zA-Z0-9-]+$/),
-      body('applicantRoles').optional().isArray(),
-      body('applicantRoles.*').isString(),
-      body('assessorRoles').optional().isArray(),
-      body('assessorRoles.*').isString(),
-      body('clerkRoles').optional().isArray(),
-      body('clerkRoles.*').isString(),
+      ...allowedRoleProperties.flatMap((field) => [
+        body(field).optional().isArray(),
+        body(`${field}.*`).isString(),
+      ]),
       body().custom((value) => {
         const extra = Object.keys(value ?? {}).filter((key) => !allowedRoleProperties.includes(key));
         if (extra.length > 0) {

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -28,6 +28,8 @@ import { CalendarService } from '../calendar';
 
 const configurationApiId = adspId`urn:ads:platform:configuration-service:v2`;
 
+const allowedRoleProperties = ['applicantRoles', 'assessorRoles', 'clerkRoles'];
+
 async function fetchExistingDefinition(
   configurationApiUrl: URL,
   token: string,
@@ -410,6 +412,53 @@ export function updateFormDefinitionSchemas(directory: ServiceDirectory, tokenPr
   };
 }
 
+export function updateFormDefinitionRoles(directory: ServiceDirectory, tokenProvider: TokenProvider): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const user = req.user;
+      const tenantId = req.tenant?.id;
+      const { definitionId } = req.params;
+
+      if (!isAllowedUser(user, tenantId, FormServiceRoles.Admin, true)) {
+        throw new UnauthorizedUserError('update form definition roles', user);
+      }
+
+      const encodedDefinitionId = encodeURIComponent(definitionId);
+      const configurationApiUrl = await directory.getServiceUrl(configurationApiId);
+      const token = await tokenProvider.getAccessToken();
+
+      const existingDefinition = await fetchExistingDefinition(
+        configurationApiUrl,
+        token,
+        encodedDefinitionId,
+        tenantId?.toString(),
+        definitionId,
+      );
+
+      // Roles are replaced entirely; any role array omitted from the request is reset to empty.
+      const updatedDefinition: FormDefinition = {
+        ...existingDefinition,
+        applicantRoles: req.body.applicantRoles ?? [],
+        assessorRoles: req.body.assessorRoles ?? [],
+        clerkRoles: req.body.clerkRoles ?? [],
+        id: definitionId,
+      };
+
+      const data = await patchConfigurationDefinition(
+        configurationApiUrl,
+        token,
+        definitionId,
+        tenantId?.toString(),
+        updatedDefinition,
+      );
+
+      res.status(HttpStatusCodes.OK).send(mapFormDefinition(data.latest.configuration, data.latest.revision));
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
 export function patchFormDefinitionLifecycle(
   directory: ServiceDirectory,
   tokenProvider: TokenProvider,
@@ -569,6 +618,31 @@ export function createFormDefinitionRouter({
       body('ui-schema').optional().isObject(),
     ),
     updateFormDefinitionSchemas(directory, tokenProvider),
+  );
+
+  router.put(
+    '/definitions/:definitionId/roles',
+    assertAuthenticatedHandler,
+    createValidationHandler(
+      param('definitionId')
+        .isString()
+        .isLength({ min: 1, max: 50 })
+        .matches(/^[a-zA-Z0-9-]+$/),
+      body('applicantRoles').optional().isArray(),
+      body('applicantRoles.*').isString(),
+      body('assessorRoles').optional().isArray(),
+      body('assessorRoles.*').isString(),
+      body('clerkRoles').optional().isArray(),
+      body('clerkRoles.*').isString(),
+      body().custom((value) => {
+        const extra = Object.keys(value ?? {}).filter((key) => !allowedRoleProperties.includes(key));
+        if (extra.length > 0) {
+          throw new Error(`Unsupported properties: ${extra.join(', ')}`);
+        }
+        return true;
+      }),
+    ),
+    updateFormDefinitionRoles(directory, tokenProvider),
   );
 
   router.patch(

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -507,6 +507,57 @@ components:
       404:
         description: Form definition not found.
 
+/form/v1/definitions/{definitionId}/roles:
+  put:
+    tags:
+      - Form
+    description: Replaces the applicant, assessor, and clerk roles of an existing form definition. Requires the form-service admin role. The provided roles replace the existing roles entirely; any role array omitted from the request is reset to empty.
+    parameters:
+      - name: definitionId
+        description: ID of the form definition whose roles are to be replaced.
+        required: true
+        in: path
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              applicantRoles:
+                type: array
+                items:
+                  type: string
+                description: Roles permitted to apply. Replaces the existing applicant roles entirely.
+              assessorRoles:
+                type: array
+                items:
+                  type: string
+                description: Roles permitted to assess submissions. Replaces the existing assessor roles entirely.
+              clerkRoles:
+                type: array
+                items:
+                  type: string
+                description: Roles permitted to act as clerks. Replaces the existing clerk roles entirely.
+    responses:
+      200:
+        description: Successfully replaced form definition roles.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FormDefinition'
+      400:
+        description: Request body does not conform to the required schema.
+      401:
+        description: User is not authenticated.
+      403:
+        description: User does not have the form-admin role.
+      404:
+        description: Form definition not found.
+
 /form/v1/definitions/{definitionId}/lifecycle:
   patch:
     tags:


### PR DESCRIPTION
Add PUT /form/v1/definitions/:definitionId/roles to replace the applicant, assessor, and clerk roles of a form definition, so TMW can stop calling the configuration service directly for role management (CS-5151).

Provided role arrays replace the existing roles entirely; any omitted array is reset to empty. Validation rejects wrong field types and unsupported additional properties (400); auth requires the form-admin role (401/403); a missing definition returns 404. Includes swagger docs and unit tests.