### PR TITLE
fix(adsp-cli): only offer create-tenant option to accounts that can actually create one

### DIFF
--- a/libs/adsp-cli/README.md
+++ b/libs/adsp-cli/README.md
@@ -45,11 +45,13 @@ token, it returns immediately — no core-realm login, no tenant listing, no pro
 ## Creating a new tenant
 
 When the no-args `login` mode prompts you to pick a tenant, it also offers a `+ Create a new tenant` choice —
-but only in `dev`/`test` (never `prod`), and only when you don't already own a tenant or you hold the
-`tenant-service-admin` role. Picking it prompts for a name (letters, numbers, spaces, and underscores; 1-50
-characters), creates the tenant, and waits for its realm to finish provisioning before continuing the login as
-that tenant. A name that's already taken, or an ineligible account (e.g. one tenant per email), re-prompts for a
-different name rather than failing outright.
+but only in `dev`/`test` (never `prod`), and only for an account that can actually create one: your core-realm
+roles must include `beta-tester` or `tenant-service-admin` (the same roles tenant-management-api's `POST
+/tenants` requires), and — unless you're a `tenant-service-admin` — you must not already own a tenant (the
+tenant service allows only one per admin email). Picking it prompts for a name (letters, numbers, spaces, and
+underscores; 1-50 characters), creates the tenant, and waits for its realm to finish provisioning before
+continuing the login as that tenant. A name that's already taken re-prompts for a different name rather than
+failing outright.
 
 ## Requesting additional scopes
 

--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -542,9 +542,9 @@ describe('login', () => {
         return call?.[0].choices ?? [];
       }
 
-      it('adds a create-tenant entry when logging into a pre-prod env with no owned tenant', async () => {
+      it('adds a create-tenant entry when logging into a pre-prod env with no owned tenant and the beta-tester role', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
-        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
         mockAuthClient.getToken.mockResolvedValue(tokenPayload());
 
@@ -558,9 +558,9 @@ describe('login', () => {
         expect(autocompleteChoices()).toContainEqual({ name: '__create_tenant__', message: '+ Create a new tenant' });
       });
 
-      it('never adds a create-tenant entry when logging into prod, even with no owned tenant', async () => {
+      it('never adds a create-tenant entry when logging into prod, even with no owned tenant and the beta-tester role', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
-        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
         mockAuthClient.getToken.mockResolvedValue(tokenPayload());
 
@@ -574,9 +574,27 @@ describe('login', () => {
         expect(autocompleteChoices()).toEqual(['tenant-a']);
       });
 
-      it('never adds a create-tenant entry in pre-prod for a non-admin who already owns a tenant', async () => {
-        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' }]);
+      it('never adds a create-tenant entry in pre-prod for a caller with no owned tenant but neither the beta-tester nor tenant-service-admin role', async () => {
+        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
         mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
+        mockAuthClient.getToken.mockResolvedValue(tokenPayload());
+
+        const loginPromise = loginInteractive({ env: 'dev' });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'core-auth-code' } }, { send: jest.fn() });
+        await flushAsync();
+        lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
+        await loginPromise;
+
+        expect(autocompleteChoices()).not.toContainEqual(
+          expect.objectContaining({ message: '+ Create a new tenant' })
+        );
+      });
+
+      it('never adds a create-tenant entry in pre-prod for a non-admin beta-tester who already owns a tenant', async () => {
+        mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' }]);
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
         mockAuthClient.getToken.mockResolvedValue(tokenPayload());
 
@@ -610,7 +628,7 @@ describe('login', () => {
 
       it('picking the create-tenant entry prompts for a name, creates it, waits for provisioning, then logs into the new realm', async () => {
         mockListTenants.mockResolvedValue([]);
-        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockImplementation(async (args: { type: string; choices?: { name: string; message?: string }[] }) => {
           if (args.type === 'autocomplete') {
             const createChoice = args.choices.find((c) => typeof c === 'object' && c.message === '+ Create a new tenant');
@@ -644,7 +662,7 @@ describe('login', () => {
 
       it('re-prompts for a name when createTenant rejects with a 400 (validation failure)', async () => {
         mockListTenants.mockResolvedValue([]);
-        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         let inputCalls = 0;
         mockPrompt.mockImplementation(async (args: { type: string; choices?: { name: string; message?: string }[] }) => {
           if (args.type === 'autocomplete') {
@@ -673,9 +691,9 @@ describe('login', () => {
         expect(mockCreateTenant).toHaveBeenNthCalledWith(2, expect.any(String), 'fresh-access-token', 'new-tenant');
       });
 
-      it('propagates a non-400 error from createTenant (e.g. missing beta-tester role) without retrying', async () => {
+      it('propagates a non-400 error from createTenant (e.g. the role was revoked between the picker prompt and the create call) without retrying', async () => {
         mockListTenants.mockResolvedValue([]);
-        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
+        mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockImplementation(async (args: { type: string; choices?: { name: string; message?: string }[] }) => {
           if (args.type === 'autocomplete') {
             const createChoice = args.choices.find((c) => typeof c === 'object' && c.message === '+ Create a new tenant');

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -225,17 +225,26 @@ function decodeEmail(token: string): string | undefined {
 }
 
 /**
- * Best-effort decode of the tenant-service-admin realm role from the caller's access token —
- * never throws. tenant-service-admin/beta-tester are plain core-realm roles (not client-qualified),
- * so the raw realm_access.roles claim is enough — no need for the SDK's full role-resolution logic.
+ * Best-effort decode of the caller's core-realm roles from their access token — never throws.
+ * tenant-service-admin/beta-tester are plain core-realm roles (not client-qualified), so the raw
+ * realm_access.roles claim is enough — no need for the SDK's full role-resolution logic.
  */
-function isTenantServiceAdmin(token: string): boolean {
+function getCoreRealmRoles(token: string): string[] {
   try {
-    const roles = jwtDecode<{ realm_access?: { roles?: string[] } }>(token).realm_access?.roles ?? [];
-    return roles.includes('tenant-service-admin');
+    return jwtDecode<{ realm_access?: { roles?: string[] } }>(token).realm_access?.roles ?? [];
   } catch {
-    return false;
+    return [];
   }
+}
+
+function isTenantServiceAdmin(token: string): boolean {
+  return getCoreRealmRoles(token).includes('tenant-service-admin');
+}
+
+/** Mirrors tenant-management-api's requireBetaTesterOrAdmin guard on POST /tenants — see tenants.ts's createTenant. */
+function canCreateTenant(token: string): boolean {
+  const roles = getCoreRealmRoles(token);
+  return roles.includes('tenant-service-admin') || roles.includes('beta-tester');
 }
 
 const CREATE_TENANT_CHOICE = '__create_tenant__';
@@ -285,7 +294,7 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
   const byName = (a: Tenant, b: Tenant) => a.name.localeCompare(b.name);
   const owned = tenants.filter((t) => email && t.adminEmail === email).sort(byName);
   const rest = tenants.filter((t) => !(email && t.adminEmail === email)).sort(byName);
-  const showCreateOption = preProd && (owned.length === 0 || isTenantServiceAdmin(coreToken));
+  const showCreateOption = preProd && canCreateTenant(coreToken) && (owned.length === 0 || isTenantServiceAdmin(coreToken));
 
   if (tenants.length === 0 && !showCreateOption) {
     throw new Error('No tenants found.');


### PR DESCRIPTION
## Summary
- Verified against tenant-management-api's `requireBetaTesterOrAdmin` guard on `POST /tenants` (`apps/tenant-management-api/src/middleware/authentication.ts`) that tenant creation requires the `beta-tester` or `tenant-service-admin` core-realm role.
- The interactive `login` tenant picker's `+ Create a new tenant` option (merged in #5660) was previously shown to any caller with no owned tenant, regardless of role — such an account would only find out it lacked permission after attempting to create. Added a `canCreateTenant` role check in `login.ts` so the option only appears for accounts that can actually use it.
- Added/updated unit tests in `login.spec.ts` covering the role gate (present/absent, combined with ownership) and updated the README's description of the gating rule.

## Test plan
- [x] `nx test adsp-cli` — 122 tests passing.
- [x] `nx lint adsp-cli` — clean.