### PR TITLE
fix(pdf-service): retain and correctly wrap template additionalStyles

### DIFF
--- a/apps/form-service/src/form/pdf.spec.ts
+++ b/apps/form-service/src/form/pdf.spec.ts
@@ -2,6 +2,14 @@ import { SubmittedFormPdfTemplate } from './pdf';
 
 describe('SubmittedFormPdfTemplate', () => {
   describe('additionalStyles', () => {
+    it('is raw css with no style element wrapper', () => {
+      // Regression guard: pdf-service wraps additionalStyles in <style> when it renders. Shipping
+      // an already wrapped value produced <style><style>…</style></style>, and the parser closes
+      // the style element at the first </style> — CSS error recovery then consumed the leading
+      // token along with the first rule in the file.
+      expect(SubmittedFormPdfTemplate.additionalStyles).not.toMatch(/<\/?style/i);
+    });
+
     it('does not set white-space: nowrap on .body', () => {
       // Regression guard: white-space: nowrap on .body caused sections with long
       // field labels (e.g. cadditionalInformation with 230+ chars) to render the

--- a/apps/form-service/src/form/pdf.ts
+++ b/apps/form-service/src/form/pdf.ts
@@ -40,8 +40,8 @@ const template = `
 
 `;
 
+// Raw CSS only — pdf-service wraps additionalStyles in a <style> element when it renders.
 const additionalStyles = `
-<style>
 /*
  * The CSS tab is useful for CSS that applies throughout your template i.e. to the header, footer,
  * and body segments. Define your default, common styles for fonts, margins, padding, colours, etc.
@@ -202,8 +202,6 @@ html {
 .content img {
   width: 100%;
 }
-</style>
-
 `;
 
 const header = `

--- a/apps/pdf-service/src/pdf/model/template.spec.ts
+++ b/apps/pdf-service/src/pdf/model/template.spec.ts
@@ -1,5 +1,5 @@
 import { adspId } from '@abgov/adsp-service-sdk';
-import { PdfTemplateEntity } from './template';
+import { PdfTemplateEntity, wrapAdditionalStyles } from './template';
 import { Logger } from 'winston';
 
 describe('PdfTemplateEntity', () => {
@@ -93,6 +93,34 @@ describe('PdfTemplateEntity', () => {
     expect(result).toBe(stream);
   });
 
+  it('retains additionalStyles so it can be read back from configuration', () => {
+    const entity = new PdfTemplateEntity(templateServiceMock, pdfServiceMock, {
+      tenantId,
+      id: 'test-template',
+      name: 'Test Template',
+      description: null,
+      template: 'template',
+      additionalStyles: '.pb20 { padding-bottom: 20px; }',
+      logger: loggerMock,
+    });
+
+    expect(entity.additionalStyles).toBe('.pb20 { padding-bottom: 20px; }');
+  });
+
+  it('wraps additionalStyles in a single style element when generating', () => {
+    const entity = new PdfTemplateEntity(templateServiceMock, pdfServiceMock, {
+      tenantId,
+      id: 'test-template',
+      name: 'Test Template',
+      description: null,
+      template: 'template',
+      additionalStyles: '.pb20 { padding-bottom: 20px; }',
+      logger: loggerMock,
+    });
+
+    expect(entity.additionalStylesWrapped).toBe('<style>.pb20 { padding-bottom: 20px; }</style>');
+  });
+
   it('can create entity with header and footer', async () => {
     const entity = new PdfTemplateEntity(templateServiceMock, pdfServiceMock, {
       tenantId,
@@ -105,5 +133,29 @@ describe('PdfTemplateEntity', () => {
       logger: loggerMock,
     });
     expect(entity).toBeTruthy();
+  });
+
+  describe('wrapAdditionalStyles', () => {
+    it('wraps raw css', () => {
+      expect(wrapAdditionalStyles('.a { color: red; }')).toBe('<style>.a { color: red; }</style>');
+    });
+
+    it('does not double wrap css that already carries a style element', () => {
+      expect(wrapAdditionalStyles('<style>\n.a { color: red; }\n</style>')).toBe(
+        '<style>\n.a { color: red; }\n</style>',
+      );
+    });
+
+    it('wraps css that only partially resembles a style element', () => {
+      // Only a wrapper spanning the whole value is unwrapped; anything else is passed through
+      // as-is rather than guessing where the author meant the css to end.
+      expect(wrapAdditionalStyles('<style>.a { color: red; }</style>.b { color: blue; }')).toBe(
+        '<style><style>.a { color: red; }</style>.b { color: blue; }</style>',
+      );
+    });
+
+    it.each([undefined, null, '', '   '])('returns no style element for %p', (styles) => {
+      expect(wrapAdditionalStyles(styles)).toBe('');
+    });
   });
 });

--- a/apps/pdf-service/src/pdf/model/template.ts
+++ b/apps/pdf-service/src/pdf/model/template.ts
@@ -5,19 +5,22 @@ import { Logger } from 'winston';
 
 const STYLE_ELEMENT = /^\s*<style[^>]*>([\s\S]*)<\/style>\s*$/i;
 
-// additionalStyles is stored as raw CSS, but templates seeded from the ADSP defaults were saved
-// with their own <style> wrapper. Wrapping those again yields <style><style>…</style></style>: the
-// parser closes the style element at the first </style>, so the CSS text starts with a literal
-// <style> token, and CSS error recovery consumes it — along with the first rule in the file.
-// Normalize to exactly one wrapper, and to no style element at all when there are no styles.
+// Templates seeded from the ADSP defaults were saved with their own <style> wrapper. Strip it so
+// the caller can apply exactly one. A wrapper that does not span the whole value is left alone
+// rather than guessing where the author meant the css to end.
+function unwrapStyleElement(styles: string): string {
+  const wrapped = STYLE_ELEMENT.exec(styles);
+  return wrapped ? wrapped[1] : styles;
+}
+
+// additionalStyles is stored as raw CSS. Wrapping an already wrapped value yields
+// <style><style>…</style></style>: the parser closes the style element at the first </style>, so
+// the CSS text starts with a literal <style> token, and CSS error recovery consumes it — along
+// with the first rule in the file. Normalize to exactly one wrapper, and to no style element at
+// all when there are no styles.
 export function wrapAdditionalStyles(additionalStyles?: string): string {
   const styles = additionalStyles?.trim();
-  if (!styles) {
-    return '';
-  }
-
-  const alreadyWrapped = STYLE_ELEMENT.exec(styles);
-  return `<style>${alreadyWrapped ? alreadyWrapped[1] : styles}</style>`;
+  return styles ? `<style>${unwrapStyleElement(styles)}</style>` : '';
 }
 
 export class PdfTemplateEntity implements PdfTemplate {

--- a/apps/pdf-service/src/pdf/model/template.ts
+++ b/apps/pdf-service/src/pdf/model/template.ts
@@ -3,6 +3,23 @@ import { Readable } from 'stream';
 import { PdfService, PdfTemplate, TemplateService } from '../types';
 import { Logger } from 'winston';
 
+const STYLE_ELEMENT = /^\s*<style[^>]*>([\s\S]*)<\/style>\s*$/i;
+
+// additionalStyles is stored as raw CSS, but templates seeded from the ADSP defaults were saved
+// with their own <style> wrapper. Wrapping those again yields <style><style>…</style></style>: the
+// parser closes the style element at the first </style>, so the CSS text starts with a literal
+// <style> token, and CSS error recovery consumes it — along with the first rule in the file.
+// Normalize to exactly one wrapper, and to no style element at all when there are no styles.
+export function wrapAdditionalStyles(additionalStyles?: string): string {
+  const styles = additionalStyles?.trim();
+  if (!styles) {
+    return '';
+  }
+
+  const alreadyWrapped = STYLE_ELEMENT.exec(styles);
+  return `<style>${alreadyWrapped ? alreadyWrapped[1] : styles}</style>`;
+}
+
 export class PdfTemplateEntity implements PdfTemplate {
   tenantId: AdspId;
   id: string;
@@ -52,7 +69,8 @@ export class PdfTemplateEntity implements PdfTemplate {
     this.templateService = templateService;
     this.startWithDefault = startWithDefault;
 
-    this.additionalStylesWrapped = '<style>' + additionalStyles + '</style>';
+    this.additionalStyles = additionalStyles;
+    this.additionalStylesWrapped = wrapAdditionalStyles(additionalStyles);
     this.logger = logger;
   }
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -62,13 +62,18 @@ interface TemplateEditorProps {
   errors?: any;
 }
 
+// A segment that has never been set comes back undefined, while Monaco reports an empty editor as
+// ''. Treat those as the same so an untouched tab is not flagged as an edit — otherwise Save is
+// enabled on load and writes '' over segments the user never opened.
+const isSegmentUpdated = (prev?: string, next?: string): boolean => (prev ?? '') !== (next ?? '');
+
 const isPDFUpdated = (prev: PdfTemplate, next: PdfTemplate): boolean => {
   return (
-    prev?.template !== next?.template ||
-    prev?.header !== next?.header ||
-    prev?.footer !== next?.footer ||
-    prev?.additionalStyles !== next?.additionalStyles ||
-    prev?.variables !== next?.variables
+    isSegmentUpdated(prev?.template, next?.template) ||
+    isSegmentUpdated(prev?.header, next?.header) ||
+    isSegmentUpdated(prev?.footer, next?.footer) ||
+    isSegmentUpdated(prev?.additionalStyles, next?.additionalStyles) ||
+    isSegmentUpdated(prev?.variables, next?.variables)
   );
 };
 
@@ -94,7 +99,7 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
 
   const pdfTemplate = useSelector((state) => selectPdfTemplateById(state, id) || selectCorePdfTemplateById(state, id));
 
-  const [tmpTemplate, setTmpTemplate] = useState(JSON.parse(JSON.stringify(pdfTemplate || '')));
+  const [tmpTemplate, setTmpTemplate] = useState(JSON.parse(JSON.stringify(pdfTemplate || {})));
 
   const suggestion =
     pdfTemplate && pdfTemplate.variables && convertToEditorSuggestion(JSON.parse(pdfTemplate.variables));
@@ -174,7 +179,7 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
 
   //eslint-disable-next-line
   useEffect(() => {
-    setTmpTemplate(JSON.parse(JSON.stringify(pdfTemplate || '')));
+    setTmpTemplate(JSON.parse(JSON.stringify(pdfTemplate || {})));
   }, [pdfTemplate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -99,6 +99,9 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
 
   const pdfTemplate = useSelector((state) => selectPdfTemplateById(state, id) || selectCorePdfTemplateById(state, id));
 
+  // clean-code-ignore: 2.18 — pdfTemplate is a plain object deserialized from the pdf-service
+  // response (seven string fields, no methods or non-serializable values), so a JSON round trip is
+  // an adequate deep clone and avoids pulling in lodash for it.
   const [tmpTemplate, setTmpTemplate] = useState(JSON.parse(JSON.stringify(pdfTemplate || {})));
 
   const suggestion =
@@ -179,6 +182,7 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
 
   //eslint-disable-next-line
   useEffect(() => {
+    // clean-code-ignore: 2.18 — see the note on the useState initializer above.
     setTmpTemplate(JSON.parse(JSON.stringify(pdfTemplate || {})));
   }, [pdfTemplate]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.spec.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.spec.ts
@@ -1,0 +1,15 @@
+import { defaultTemplateCss } from './css';
+
+describe('defaultTemplateCss', () => {
+  it('is raw css with no style element wrapper', () => {
+    // Regression guard: pdf-service wraps additionalStyles in <style> when it renders. Seeding the
+    // CSS tab with an already wrapped value produced <style><style>…</style></style>, and the
+    // parser closes the style element at the first </style> — CSS error recovery then consumed the
+    // leading token along with the first rule in the file.
+    expect(defaultTemplateCss).not.toMatch(/<\/?style/i);
+  });
+
+  it('keeps the rule that was previously swallowed by the double wrapper', () => {
+    expect(defaultTemplateCss).toMatch(/div,\s*p\s*\{[^}]*margin:/s);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.ts
@@ -1,5 +1,5 @@
-export const defaultTemplateCss = `<style>
-/*
+// Raw CSS only — pdf-service wraps additionalStyles in a <style> element when it renders.
+export const defaultTemplateCss = `/*
  * The CSS tab is useful for CSS that applies throughout your template i.e. to the header, footer,
  * and body segments. Define your default, common styles for fonts, margins, padding, colours, etc.
  * here.
@@ -32,5 +32,4 @@ html {
 .clear {
   clear: both;
 }
-</style>
 `;


### PR DESCRIPTION
PdfTemplateEntity never assigned this.additionalStyles, so mapPdfTemplate read undefined off the entity and GET /pdf/v1/templates always omitted the field. The CSS tab rendered empty even though the stored CSS was applied to every generated PDF.

The wrapping was also unconditional: an unset field produced <style>undefined</style>, and templates seeded from the ADSP defaults - which ship their own <style> wrapper - produced <style><style>...</style></style>. The parser closes the style element at the first </style>, so CSS error recovery consumed the leading token along with the first rule in the file.

- assign additionalStyles in the entity constructor
- add wrapAdditionalStyles: emit exactly one wrapper, unwrap a value that already carries one, emit nothing when there are no styles
- drop the <style> wrapper from the seeded defaults in tenant-management-webapp and from the form-service submitted-form template
- treat undefined and empty string as equal in the editor dirty check, so an untouched tab no longer enables Save and writes an empty segment
- default tmpTemplate to {} rather than the empty string