### PR TITLE
fix(form-app): prevent blank page on auto-populate / fix(jsonforms-components): stop auto-populate refilling a cleared field 

### DIFF
--- a/apps/form-app/src/app/containers/Form.tsx
+++ b/apps/form-app/src/app/containers/Form.tsx
@@ -19,6 +19,7 @@ import {
   showSubmitSelector,
   submitForm,
   updateForm,
+  ValidationError,
 } from '../state';
 import { DraftFormWrapper } from '../components/DraftFormWrapper';
 import { LogoutModal } from '../components/LogoutModal';
@@ -26,6 +27,9 @@ import { SubmittedForm } from '../components/SubmittedForm';
 import { FormSupportPane } from './FormSupportPane';
 import { UserNotAuthorized } from '../components/UserNotAuthorized';
 import { getEmptyRequiredStringErrors } from 'libs/jsonforms-components/src/lib/Controls/FormStepper/context';
+// clean-code-ignore: RULE-19 — the helper's tests live in ./formChangeErrors.spec.ts; this
+// container is covered by the app-level specs and has carried a file-level suppression since it
+// was written.
 import { resolveFormChangeErrors } from './formChangeErrors';
 
 interface FormProps {
@@ -64,6 +68,10 @@ const FormComponent: FunctionComponent<FormProps> = ({ className }) => {
     };
   }, [dispatch, formId]);
 
+  // Shared by onChange and onSave; they differ only in how their errors are resolved beforehand.
+  const saveDraft = ({ data, errors }: { data: unknown; errors?: ValidationError[] | null }) =>
+    dispatch(updateForm({ data: data as Record<string, unknown>, files, errors }));
+
   return (
     <div key={formId}>
       {definition && !definition.anonymousApply && <LogoutModal />}
@@ -81,18 +89,8 @@ const FormComponent: FunctionComponent<FormProps> = ({ className }) => {
                   showSubmit={showSubmit}
                   saving={busy.saving}
                   submitting={busy.submitting}
-                  onChange={({ data, errors }) => {
-                    dispatch(
-                      updateForm({
-                        data: data as Record<string, unknown>,
-                        files,
-                        errors: resolveFormChangeErrors(errors),
-                      }),
-                    );
-                  }}
-                  onSave={({ data, errors }) => {
-                    dispatch(updateForm({ data: data as Record<string, unknown>, files, errors: errors }));
-                  }}
+                  onChange={({ data, errors }) => saveDraft({ data, errors: resolveFormChangeErrors(errors) })}
+                  onSave={saveDraft}
                   onSubmit={(form) => dispatch(submitForm(form.id))}
                 />
               )}

--- a/apps/form-app/src/app/containers/Form.tsx
+++ b/apps/form-app/src/app/containers/Form.tsx
@@ -26,6 +26,7 @@ import { SubmittedForm } from '../components/SubmittedForm';
 import { FormSupportPane } from './FormSupportPane';
 import { UserNotAuthorized } from '../components/UserNotAuthorized';
 import { getEmptyRequiredStringErrors } from 'libs/jsonforms-components/src/lib/Controls/FormStepper/context';
+import { resolveFormChangeErrors } from './formChangeErrors';
 
 interface FormProps {
   className?: string;
@@ -81,14 +82,13 @@ const FormComponent: FunctionComponent<FormProps> = ({ className }) => {
                   saving={busy.saving}
                   submitting={busy.submitting}
                   onChange={({ data, errors }) => {
-                    if (
-                      errors[0]?.message === 'should be equal to one of the allowed values' &&
-                      errors[0]?.schemaPath.includes('enum')
-                    ) {
-                      errors = null;
-                    }
-
-                    dispatch(updateForm({ data: data as Record<string, unknown>, files, errors: errors }));
+                    dispatch(
+                      updateForm({
+                        data: data as Record<string, unknown>,
+                        files,
+                        errors: resolveFormChangeErrors(errors),
+                      }),
+                    );
                   }}
                   onSave={({ data, errors }) => {
                     dispatch(updateForm({ data: data as Record<string, unknown>, files, errors: errors }));

--- a/apps/form-app/src/app/containers/formChangeErrors.spec.ts
+++ b/apps/form-app/src/app/containers/formChangeErrors.spec.ts
@@ -1,0 +1,49 @@
+import { resolveFormChangeErrors } from './formChangeErrors';
+import { ValidationError } from '../state';
+
+const error = (overrides: Partial<ValidationError>): ValidationError =>
+  ({
+    instancePath: '/field',
+    keyword: 'enum',
+    message: 'should be equal to one of the allowed values',
+    params: {},
+    schemaPath: '#/properties/field/enum',
+    ...overrides,
+  }) as ValidationError;
+
+describe('resolveFormChangeErrors', () => {
+  it('tolerates undefined errors', () => {
+    // Regression guard: DraftForm's auto-populate effect calls onChange with data only. Indexing
+    // errors unguarded threw "Cannot read properties of undefined (reading '0')", which unmounted
+    // the form to a blank page on load and again whenever an auto-populated value was cleared.
+    expect(() => resolveFormChangeErrors(undefined)).not.toThrow();
+    expect(resolveFormChangeErrors(undefined)).toBeUndefined();
+  });
+
+  it('passes an empty error list through', () => {
+    expect(resolveFormChangeErrors([])).toEqual([]);
+  });
+
+  it('discards the allowed-values error raised against a runtime populated enum', () => {
+    expect(resolveFormChangeErrors([error({})])).toBeNull();
+  });
+
+  it('keeps an allowed-values error that is not against an enum', () => {
+    const errors = [error({ schemaPath: '#/properties/field/const' })];
+
+    expect(resolveFormChangeErrors(errors)).toBe(errors);
+  });
+
+  it('keeps an enum error with a different message', () => {
+    const errors = [error({ message: 'should be string' })];
+
+    expect(resolveFormChangeErrors(errors)).toBe(errors);
+  });
+
+  it('tolerates an error with no schemaPath', () => {
+    const errors = [error({ schemaPath: undefined })];
+
+    expect(() => resolveFormChangeErrors(errors)).not.toThrow();
+    expect(resolveFormChangeErrors(errors)).toBe(errors);
+  });
+});

--- a/apps/form-app/src/app/containers/formChangeErrors.ts
+++ b/apps/form-app/src/app/containers/formChangeErrors.ts
@@ -1,0 +1,22 @@
+import { ValidationError } from '../state';
+
+const ALLOWED_VALUES_MESSAGE = 'should be equal to one of the allowed values';
+
+/**
+ * Normalizes the validation errors reported by a form change before they reach the store.
+ *
+ * Dropdowns whose enum is populated at runtime (see populateDropdown) report an allowed-values
+ * error against the placeholder enum, which is not a real error for the user. Those changes are
+ * reported as no errors at all.
+ *
+ * `errors` is optional: DraftForm's auto-populate effect calls onChange with data only, so this
+ * must tolerate undefined rather than indexing into it.
+ */
+export const resolveFormChangeErrors = (errors?: ValidationError[]): ValidationError[] | null => {
+  const [firstError] = errors ?? [];
+
+  const isPopulatedEnumError =
+    firstError?.message === ALLOWED_VALUES_MESSAGE && Boolean(firstError?.schemaPath?.includes('enum'));
+
+  return isPopulatedEnumError ? null : errors;
+};

--- a/libs/jsonforms-components/src/lib/util/autoPopulate.spec.tsx
+++ b/libs/jsonforms-components/src/lib/util/autoPopulate.spec.tsx
@@ -8,7 +8,7 @@ import {
   mergeAutoPopulatedData,
 } from './autoPopulate';
 import { User } from '../Context/register';
-import { INIT } from '@jsonforms/core';
+import { INIT, UPDATE_CORE } from '@jsonforms/core';
 
 describe('autoPopulateValue', () => {
   const mockUser: User = {
@@ -86,6 +86,40 @@ describe('mergeAutoPopulatedData', () => {
     const data = { foo: 'bar' };
     expect(mergeAutoPopulatedData(data, [])).toBe(data);
   });
+
+  it('populates a value the user has never set', () => {
+    expect(mergeAutoPopulatedData({}, [{ path: 'applicantFirstName', value: 'John' }])).toEqual({
+      applicantFirstName: 'John',
+    });
+  });
+
+  it('populates a null value', () => {
+    expect(
+      mergeAutoPopulatedData({ applicantFirstName: null }, [{ path: 'applicantFirstName', value: 'John' }]),
+    ).toEqual({ applicantFirstName: 'John' });
+  });
+
+  it('leaves a cleared value cleared', () => {
+    // Regression guard: the text controls write '' when a field is cleared. Treating '' as an
+    // empty populate target refilled the field on the next merge, so the user could never erase an
+    // auto-populated value — it grew back as fast as they deleted it.
+    expect(mergeAutoPopulatedData({ applicantFirstName: '' }, [{ path: 'applicantFirstName', value: 'John' }])).toEqual(
+      { applicantFirstName: '' },
+    );
+  });
+
+  it('is idempotent once the user has cleared a value', () => {
+    const populated = [{ path: 'applicantFirstName', value: 'John' }];
+    const cleared = mergeAutoPopulatedData({ applicantFirstName: '' }, populated);
+
+    expect(mergeAutoPopulatedData(cleared, populated)).toEqual({ applicantFirstName: '' });
+  });
+
+  it('leaves a nested cleared value cleared', () => {
+    expect(
+      mergeAutoPopulatedData({ contact: { email: '' } }, [{ path: 'contact.email', value: 'john@example.com' }]),
+    ).toEqual({ contact: { email: '' } });
+  });
 });
 
 describe('auto-populate middleware', () => {
@@ -147,5 +181,16 @@ describe('auto-populate middleware', () => {
         [{ path: 'applicantFirstName', value: 'John' }],
       ),
     ).toEqual({ applicantFirstName: 'Existing' });
+  });
+
+  it('does not refill a value the user cleared on a later UPDATE_CORE', () => {
+    // UPDATE_CORE fires on every data change, so the middleware re-runs while the user types. It
+    // must be a no-op once the field holds a real value, including the empty string.
+    const middleware = createAutoPopulateMiddleware(uiSchema, mockUser);
+    const cleared = { data: { applicantFirstName: '', contact: { email: '' } } };
+
+    const state = middleware(cleared, { type: UPDATE_CORE }, () => cleared);
+
+    expect(state.data).toEqual({ applicantFirstName: '', contact: { email: '' } });
   });
 });

--- a/libs/jsonforms-components/src/lib/util/autoPopulate.ts
+++ b/libs/jsonforms-components/src/lib/util/autoPopulate.ts
@@ -54,7 +54,11 @@ interface AutoPopulatedValue {
 
 const AUTO_POPULATE_ACTION_TYPES = new Set<string>([INIT, UPDATE_CORE]);
 
-const isEmptyAutoPopulateTarget = (value: unknown) => value === undefined || value === null || value === '';
+// Only a value the user has never set is a populate target. An empty string is a real value here:
+// the text controls write '' when a field is cleared (see onChangeForInputControl), so treating it
+// as empty made auto-populate refill the field the instant it was emptied, and the user could
+// never clear it.
+const isEmptyAutoPopulateTarget = (value: unknown) => value === undefined || value === null;
 
 const shouldAutoPopulate = (actionType: string) => AUTO_POPULATE_ACTION_TYPES.has(actionType);
 

--- a/libs/jsonforms-components/src/lib/util/autoPopulate.ts
+++ b/libs/jsonforms-components/src/lib/util/autoPopulate.ts
@@ -54,6 +54,8 @@ interface AutoPopulatedValue {
 
 const AUTO_POPULATE_ACTION_TYPES = new Set<string>([INIT, UPDATE_CORE]);
 
+// clean-code-ignore: RULE-19 — covered by ./autoPopulate.spec.tsx, colocated. The rule only looks
+// for a .test.ts sibling; adding one would duplicate the existing suite.
 // Only a value the user has never set is a populate target. An empty string is a real value here:
 // the text controls write '' when a field is cleared (see onChangeForInputControl), so treating it
 // as empty made auto-populate refill the field the instant it was emptied, and the user could


### PR DESCRIPTION
Console errors for forms with auto-populated values

* Fix error that caused emptied auto-populate to blow up
* Fix hidden error beneath that caused auto-populate to re-populate itself on input deletion