### PR TITLE
fix(form-service, core-common): return 404 and 400 per the definition endpoint cri…

### DIFF
--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -1,5 +1,5 @@
 import { adspId, UnauthorizedUserError } from '@abgov/adsp-service-sdk';
-import { ValidationService } from '@core-services/core-common';
+import { NotFoundError, ValidationService } from '@core-services/core-common';
 import * as HttpStatusCodes from 'http-status-codes';
 import axios from 'axios';
 import { Request, Response } from 'express';
@@ -1269,6 +1269,40 @@ describe('definition router', () => {
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
       expect(axiosMock.get).not.toHaveBeenCalled();
       expect(axiosMock.patch).not.toHaveBeenCalled();
+    });
+
+    it('reports an authenticated caller without the admin role as forbidden, not unauthorized', () => {
+      // Acceptance criterion: 403 when authenticated but lacking form-admin. 401 is reserved for
+      // callers the auth middleware never authenticated at all.
+      const err = new UnauthorizedUserError('update form definition roles', {
+        id: 'tester',
+        name: 'Tester',
+      } as never);
+
+      expect(err.extra.statusCode).toBe(HttpStatusCodes.FORBIDDEN);
+    });
+
+    it('can call next with not found when the definition has never been written', async () => {
+      // The configuration service answers /latest with 200 and {} for a definition that does not
+      // exist. Previously this fell through to the PATCH and surfaced the configuration service's
+      // schema error as a 400.
+      axiosMock.get.mockResolvedValue({ status: HttpStatusCodes.OK, data: {} });
+
+      const req = {
+        user: { tenantId, id: 'tester', roles: [FormServiceRoles.Admin], isCore: true },
+        params: { definitionId: 'never-written' },
+        body: { applicantRoles: ['a'], assessorRoles: [], clerkRoles: [] },
+        tenant: { id: tenantId },
+      };
+
+      const handler = updateFormDefinitionRoles(directoryMock, tokenProviderMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(axiosMock.patch).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('never-written') }),
+      );
     });
 
     it('can call next with not found when definition does not exist', async () => {

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -30,6 +30,15 @@ const configurationApiId = adspId`urn:ads:platform:configuration-service:v2`;
 
 const allowedRoleProperties = ['applicantRoles', 'assessorRoles', 'clerkRoles'];
 
+// The configuration service answers /latest with 200 and an empty object when the definition has
+// never been written (see getConfiguration's `configuration.latest?.configuration || {}`), so an
+// empty body is the real not-found signal. Without this the handlers went on to PATCH a spread of
+// {}, and the caller got the configuration service's schema error as a 400 instead of a 404.
+const isDefinitionNotFound = (response: { status: number; data?: unknown }): boolean =>
+  response.status === HttpStatusCodes.NOT_FOUND ||
+  !response.data ||
+  Object.keys(response.data).length === 0;
+
 async function fetchExistingDefinition(
   configurationApiUrl: URL,
   token: string,
@@ -46,7 +55,7 @@ async function fetchExistingDefinition(
     },
   );
 
-  if (response.status === HttpStatusCodes.NOT_FOUND || !response.data) {
+  if (isDefinitionNotFound(response)) {
     throw new NotFoundError('form definition', definitionId);
   }
 

--- a/libs/core-common/src/errors/handler.spec.ts
+++ b/libs/core-common/src/errors/handler.spec.ts
@@ -1,0 +1,113 @@
+import { UnauthorizedUserError } from '@abgov/adsp-service-sdk';
+import * as HttpStatusCodes from 'http-status-codes';
+import { Logger } from 'winston';
+import { createErrorHandler } from './handler';
+import { NotFoundError } from './notFound';
+
+describe('createErrorHandler', () => {
+  const loggerMock = { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } as unknown as Logger;
+
+  // Every method here is exercised: status/json on the recognized and body-parse paths, sendStatus
+  // on the unrecognized path, and end when the headers have already gone out.
+  const createRes = () => {
+    const res = {
+      headersSent: false,
+      status: jest.fn(() => res),
+      json: jest.fn(() => res),
+      sendStatus: jest.fn(() => res),
+      end: jest.fn(() => res),
+    };
+    return res;
+  };
+
+  const req = { path: '/form/v1/definitions/test/roles' };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  // body-parser rejects an unparsable body with a SyntaxError that carries the raw body.
+  const bodyParseError = () => {
+    const err = new SyntaxError('Unexpected token } in JSON at position 12') as SyntaxError & {
+      body?: string;
+      status?: number;
+    };
+    err.body = '{"applicantRoles":}';
+    err.status = HttpStatusCodes.BAD_REQUEST;
+    return err;
+  };
+
+  it('reports malformed JSON as a bad request rather than a server error', () => {
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(bodyParseError(), req as never, res as never, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.BAD_REQUEST);
+    expect(res.json).toHaveBeenCalledWith({ errorMessage: expect.stringContaining('Malformed request body') });
+    expect(res.sendStatus).not.toHaveBeenCalled();
+  });
+
+  it('honours the status body-parser assigned, such as a payload that is too large', () => {
+    const err = bodyParseError();
+    err.status = HttpStatusCodes.REQUEST_TOO_LONG;
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(err, req as never, res as never, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.REQUEST_TOO_LONG);
+  });
+
+  it('falls back to a bad request when body-parser assigned no status', () => {
+    const err = bodyParseError();
+    delete err.status;
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(err, req as never, res as never, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.BAD_REQUEST);
+  });
+
+  it('does not treat an ordinary SyntaxError as a body parse failure', () => {
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(new SyntaxError('boom'), req as never, res as never, jest.fn());
+
+    expect(res.sendStatus).toHaveBeenCalledWith(500);
+  });
+
+  it('reports a user without the required role as forbidden', () => {
+    const res = createRes();
+    const err = new UnauthorizedUserError('update form definition roles', {
+      id: 'tester',
+      name: 'Tester',
+    } as never);
+
+    createErrorHandler(loggerMock)(err, req as never, res as never, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.FORBIDDEN);
+  });
+
+  it('still reports recognized errors with their own status', () => {
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(new NotFoundError('form definition', 'missing'), req as never, res as never, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.NOT_FOUND);
+  });
+
+  it('reports an unrecognized error as a server error', () => {
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(new Error('boom'), req as never, res as never, jest.fn());
+
+    expect(res.sendStatus).toHaveBeenCalledWith(500);
+  });
+
+  it('ends the response instead of setting a status when the headers are already sent', () => {
+    const res = createRes();
+    res.headersSent = true;
+
+    createErrorHandler(loggerMock)(new Error('boom'), req as never, res as never, jest.fn());
+
+    expect(res.sendStatus).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalled();
+  });
+});

--- a/libs/core-common/src/errors/handler.ts
+++ b/libs/core-common/src/errors/handler.ts
@@ -1,5 +1,6 @@
 import { AdspIdFormatError, UnauthorizedUserError, GoAError } from '@abgov/adsp-service-sdk';
 import { ErrorRequestHandler } from 'express';
+import * as HttpStatusCodes from 'http-status-codes';
 import { Logger } from 'winston';
 import { InvalidValueError } from './invalidValue';
 import { InvalidOperationError } from './invalidOperation';
@@ -14,6 +15,12 @@ const ErrorResponseHelper = (res, err: GoAError) => {
   });
 };
 
+// body-parser raises a SyntaxError carrying the raw body when it cannot parse the request, and
+// tags it with a status (400 for a malformed entity, 413 for one over the size limit). These are
+// client errors, so report them as such instead of letting them fall through to a 500.
+const isBodyParseError = (err: unknown): err is Error & { status?: number; statusCode?: number } =>
+  err instanceof SyntaxError && 'body' in err;
+
 export const createErrorHandler =
   (logger: Logger): ErrorRequestHandler =>
   (err, req, res, _next) => {
@@ -27,6 +34,10 @@ export const createErrorHandler =
       err instanceof ValidationFailedError
     ) {
       ErrorResponseHelper(res, err);
+    } else if (isBodyParseError(err)) {
+      res.status(err.status || err.statusCode || HttpStatusCodes.BAD_REQUEST).json({
+        errorMessage: `Malformed request body: ${err.message}`,
+      });
     } else {
       logger.warn(
         `Unexpected error encountered in handler for request ${req.path} ${


### PR DESCRIPTION
…teria

If you want to test for the 403 error, you will need to remove form-admin from tenant-admin role and add another benign role ie - 
urn:ads:platform:form-service form-support

when you will see there error - no code changes for that one, the other 2 have code changes
