### PR TITLE
feat(adsp-cli): improve tenant picker UX for large tenant lists

### DIFF
--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -487,7 +487,12 @@ describe('login', () => {
       expect(mockPrompt).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'autocomplete',
-          choices: [{ name: 'tenant-a', message: 'tenant-a (yours)' }, 'tenant-b', 'tenant-c'],
+          choices: [
+            { name: 'tenant-a', message: 'tenant-a (yours)' },
+            { role: 'separator', value: '─────────────────────' },
+            'tenant-b',
+            'tenant-c',
+          ],
         })
       );
     });

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -308,15 +308,9 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
     ...rest.map((t) => t.name),
   ];
   const { prompt } = await import('enquirer');
+  const promptOptions = { type: 'autocomplete', name: 'tenant', message: 'Which tenant?', hint: '(type to filter)', limit: 10, choices };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { tenant: pickedName } = await prompt<{ tenant: string }>({
-    type: 'autocomplete',
-    name: 'tenant',
-    message: 'Which tenant?',
-    hint: '(type to filter)',
-    limit: 10,
-    choices,
-  } as any);
+  const { tenant: pickedName } = await prompt<{ tenant: string }>(promptOptions as any);
 
   if (pickedName === CREATE_TENANT_CHOICE) {
     return createTenantInteractive(directoryServiceUrl, coreToken);

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -308,6 +308,7 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
     ...rest.map((t) => t.name),
   ];
   const { prompt } = await import('enquirer');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { tenant: pickedName } = await prompt<{ tenant: string }>({
     type: 'autocomplete',
     name: 'tenant',
@@ -315,7 +316,7 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
     hint: '(type to filter)',
     limit: 10,
     choices,
-  });
+  } as any);
 
   if (pickedName === CREATE_TENANT_CHOICE) {
     return createTenantInteractive(directoryServiceUrl, coreToken);

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -300,9 +300,11 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
     throw new Error('No tenants found.');
   }
 
+  const hasPinnedItems = owned.length > 0 || showCreateOption;
   const choices = [
-    ...owned.map((t) => ({ name: t.name, message: `${t.name} (yours)` })),
     ...(showCreateOption ? [{ name: CREATE_TENANT_CHOICE, message: '+ Create a new tenant' }] : []),
+    ...owned.map((t) => ({ name: t.name, message: `${t.name} (yours)` })),
+    ...(hasPinnedItems && rest.length > 0 ? [{ role: 'separator', value: '─────────────────────' }] : []),
     ...rest.map((t) => t.name),
   ];
   const { prompt } = await import('enquirer');
@@ -310,6 +312,8 @@ async function promptForTenantRealm(directoryServiceUrl: string, coreToken: stri
     type: 'autocomplete',
     name: 'tenant',
     message: 'Which tenant?',
+    hint: '(type to filter)',
+    limit: 10,
     choices,
   });
 


### PR DESCRIPTION
## Summary

- Pins **+ Create a new tenant** to the top of the list so it's always visible regardless of how many owned tenants exist
- Lists owned tenants (with `(yours)` label) immediately below the create option
- Adds a separator line between pinned items and the full tenant list
- Caps the visible rows at 10 (`limit: 10`) to prevent the list filling the terminal
- Adds `(type to filter)` hint so users know they can start typing to narrow the list

## Test plan

- [ ] Run `npx adsp login --env test` and confirm create option appears at top
- [ ] Confirm owned tenant(s) appear below create option with `(yours)` label
- [ ] Confirm separator is visible between owned/create and the full list
- [ ] Type a few characters and confirm the list filters correctly
- [ ] Confirm selecting a tenant still logs in successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)