### PR TITLE
fix(pdf-service): restore the previous additionalStyles rendering

### DIFF
--- a/apps/form-service/src/form/pdf.spec.ts
+++ b/apps/form-service/src/form/pdf.spec.ts
@@ -2,12 +2,13 @@ import { SubmittedFormPdfTemplate } from './pdf';
 
 describe('SubmittedFormPdfTemplate', () => {
   describe('additionalStyles', () => {
-    it('is raw css with no style element wrapper', () => {
-      // Regression guard: pdf-service wraps additionalStyles in <style> when it renders. Shipping
-      // an already wrapped value produced <style><style>…</style></style>, and the parser closes
-      // the style element at the first </style> — CSS error recovery then consumed the leading
-      // token along with the first rule in the file.
-      expect(SubmittedFormPdfTemplate.additionalStyles).not.toMatch(/<\/?style/i);
+    it('keeps its own style element wrapper', () => {
+      // Deliberate. pdf-service wraps additionalStyles again at render time, and the submitted-form
+      // PDF has always rendered with the resulting double wrapper. Removing it here would shift the
+      // layout of every submitted form. See wrapAdditionalStyles in
+      // apps/pdf-service/src/pdf/model/template.ts.
+      expect(SubmittedFormPdfTemplate.additionalStyles.trimStart()).toMatch(/^<style>/i);
+      expect(SubmittedFormPdfTemplate.additionalStyles.trimEnd()).toMatch(/<\/style>$/i);
     });
 
     it('does not set white-space: nowrap on .body', () => {

--- a/apps/form-service/src/form/pdf.ts
+++ b/apps/form-service/src/form/pdf.ts
@@ -40,8 +40,11 @@ const template = `
 
 `;
 
-// Raw CSS only — pdf-service wraps additionalStyles in a <style> element when it renders.
+// Carries its own <style> wrapper, which pdf-service wraps again. See wrapAdditionalStyles in
+// pdf-service: the submitted-form PDF has always rendered with that double wrapper, so removing it
+// here would shift the layout of every submitted form.
 const additionalStyles = `
+<style>
 /*
  * The CSS tab is useful for CSS that applies throughout your template i.e. to the header, footer,
  * and body segments. Define your default, common styles for fonts, margins, padding, colours, etc.
@@ -202,6 +205,8 @@ html {
 .content img {
   width: 100%;
 }
+</style>
+
 `;
 
 const header = `

--- a/apps/pdf-service/src/pdf/model/template.spec.ts
+++ b/apps/pdf-service/src/pdf/model/template.spec.ts
@@ -107,7 +107,7 @@ describe('PdfTemplateEntity', () => {
     expect(entity.additionalStyles).toBe('.pb20 { padding-bottom: 20px; }');
   });
 
-  it('wraps additionalStyles in a single style element when generating', () => {
+  it('wraps additionalStyles in a style element when generating', () => {
     const entity = new PdfTemplateEntity(templateServiceMock, pdfServiceMock, {
       tenantId,
       id: 'test-template',
@@ -140,17 +140,11 @@ describe('PdfTemplateEntity', () => {
       expect(wrapAdditionalStyles('.a { color: red; }')).toBe('<style>.a { color: red; }</style>');
     });
 
-    it('does not double wrap css that already carries a style element', () => {
+    it('wraps css that already carries a style element, preserving the established output', () => {
+      // Deliberate: existing templates were authored against this double wrapper, and unwrapping
+      // would change the layout of already-published PDFs. See wrapAdditionalStyles for why.
       expect(wrapAdditionalStyles('<style>\n.a { color: red; }\n</style>')).toBe(
-        '<style>\n.a { color: red; }\n</style>',
-      );
-    });
-
-    it('wraps css that only partially resembles a style element', () => {
-      // Only a wrapper spanning the whole value is unwrapped; anything else is passed through
-      // as-is rather than guessing where the author meant the css to end.
-      expect(wrapAdditionalStyles('<style>.a { color: red; }</style>.b { color: blue; }')).toBe(
-        '<style><style>.a { color: red; }</style>.b { color: blue; }</style>',
+        '<style><style>\n.a { color: red; }\n</style></style>',
       );
     });
 

--- a/apps/pdf-service/src/pdf/model/template.ts
+++ b/apps/pdf-service/src/pdf/model/template.ts
@@ -3,24 +3,25 @@ import { Readable } from 'stream';
 import { PdfService, PdfTemplate, TemplateService } from '../types';
 import { Logger } from 'winston';
 
-const STYLE_ELEMENT = /^\s*<style[^>]*>([\s\S]*)<\/style>\s*$/i;
-
-// Templates seeded from the ADSP defaults were saved with their own <style> wrapper. Strip it so
-// the caller can apply exactly one. A wrapper that does not span the whole value is left alone
-// rather than guessing where the author meant the css to end.
-function unwrapStyleElement(styles: string): string {
-  const wrapped = STYLE_ELEMENT.exec(styles);
-  return wrapped ? wrapped[1] : styles;
-}
-
-// additionalStyles is stored as raw CSS. Wrapping an already wrapped value yields
-// <style><style>…</style></style>: the parser closes the style element at the first </style>, so
-// the CSS text starts with a literal <style> token, and CSS error recovery consumes it — along
-// with the first rule in the file. Normalize to exactly one wrapper, and to no style element at
-// all when there are no styles.
+// additionalStyles is wrapped verbatim, without unwrapping a <style> element the stored value may
+// already carry.
+//
+// That double wrapping is not accidental. Tenants authored their templates against it: the parser
+// closes the style element at the first </style>, so CSS error recovery consumes the leading
+// <style> token together with the first rule in the file, and the trailing </style> lands in the
+// body as text. Normalizing to a single wrapper made that first rule start applying, which changed
+// the layout of every already-published PDF whose CSS tab holds the ADSP default. Correct in
+// isolation, but not a change to make underneath live documents.
+//
+// The only departure from the original is that an unset value yields no style element rather than
+// <style>undefined</style>. Both render identically — `undefined` is not valid CSS and is
+// discarded — so this costs nothing and keeps the literal out of the output.
+//
+// If the double wrapping is ever to be undone, it needs a migration that rewrites stored
+// additionalStyles, not a change to how they are rendered.
 export function wrapAdditionalStyles(additionalStyles?: string): string {
   const styles = additionalStyles?.trim();
-  return styles ? `<style>${unwrapStyleElement(styles)}</style>` : '';
+  return styles ? `<style>${styles}</style>` : '';
 }
 
 export class PdfTemplateEntity implements PdfTemplate {

--- a/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.spec.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.spec.ts
@@ -1,15 +1,17 @@
 import { defaultTemplateCss } from './css';
 
 describe('defaultTemplateCss', () => {
-  it('is raw css with no style element wrapper', () => {
-    // Regression guard: pdf-service wraps additionalStyles in <style> when it renders. Seeding the
-    // CSS tab with an already wrapped value produced <style><style>…</style></style>, and the
-    // parser closes the style element at the first </style> — CSS error recovery then consumed the
-    // leading token along with the first rule in the file.
-    expect(defaultTemplateCss).not.toMatch(/<\/?style/i);
+  it('keeps its own style element wrapper', () => {
+    // Deliberate. pdf-service wraps additionalStyles again at render time, and every existing
+    // template renders with the resulting double wrapper. Seeding new templates without it would
+    // give them a different layout from the ones already published. See wrapAdditionalStyles in
+    // apps/pdf-service/src/pdf/model/template.ts.
+    expect(defaultTemplateCss.trimStart()).toMatch(/^<style>/i);
+    expect(defaultTemplateCss.trimEnd()).toMatch(/<\/style>$/i);
   });
 
-  it('keeps the rule that was previously swallowed by the double wrapper', () => {
+  it('still defines the shared resets the CSS tab is seeded with', () => {
     expect(defaultTemplateCss).toMatch(/div,\s*p\s*\{[^}]*margin:/s);
+    expect(defaultTemplateCss).toMatch(/\.clear\s*\{[^}]*clear:\s*both/s);
   });
 });

--- a/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/defaultTemplates/css.ts
@@ -1,5 +1,8 @@
-// Raw CSS only — pdf-service wraps additionalStyles in a <style> element when it renders.
-export const defaultTemplateCss = `/*
+// Ships with its own <style> wrapper, which pdf-service then wraps again. See wrapAdditionalStyles
+// in pdf-service — the resulting double wrapper is what every existing template renders with, so
+// the seed has to keep producing it for new templates to match.
+export const defaultTemplateCss = `<style>
+/*
  * The CSS tab is useful for CSS that applies throughout your template i.e. to the header, footer,
  * and body segments. Define your default, common styles for fonts, margins, padding, colours, etc.
  * here.
@@ -32,4 +35,5 @@ html {
 .clear {
   clear: both;
 }
+</style>
 `;


### PR DESCRIPTION
## Summary

Restores PDF output to how it rendered before CS-5230, while keeping that ticket's actual fix.

**Design Systems 2.0 is not involved.** `72583e60c` touched only React components in tenant-management-webapp and builder-app plus one sample `.scss`. It changed nothing in `libs/notification-shared/src/templates/`, `apps/pdf-service/src/`, or `apps/form-service/src/form/pdf.ts`, and the PDF pipeline references no webapp stylesheet — Puppeteer gets a self-contained document via `setContent`, with JS disabled and external requests blocked.

The change came from CS-5230 (#5672). `wrapAdditionalStyles` normalized `additionalStyles` to a single `<style>` wrapper. Correct in isolation, but the double wrapper it removed was load-bearing: the parser closes the style element at the first `</style>`, so CSS error recovery consumed the leading `<style>` token **together with the first rule in the file**. For every template seeded from the ADSP default that rule is:

```css
div, p { margin: 0 0 0 0; padding: 0 0 0 0; }
```

Restoring it collapsed margins and padding on every `div` and `p`, which shifts spacing throughout an already-published document.

## Restored

- `wrapAdditionalStyles` wraps verbatim again, without unwrapping a `<style>` element the stored value already carries
- The tenant-management-webapp seed (`defaultTemplateCss`) and the form-service submitted-form template ship their own `<style>` wrapper again, so newly created templates render like existing ones

The one intentional departure: an unset value yields no style element rather than `<style>undefined</style>`. Both render identically — `undefined` is not valid CSS and is discarded — so this costs nothing and keeps the literal out of the output.

## Kept from CS-5230

None of these affect rendering:

- `PdfTemplateEntity` assigns `this.additionalStyles`. It never did, so `mapFormDefinition`'s counterpart read `undefined` off the entity and `GET /pdf/v1/templates` omitted the field entirely — the CSS tab showed blank even though the stored CSS was applied to every generated PDF. **That was the actual defect in the ticket.**
- The editor treats `undefined` and `''` as equal in its dirty check, and seeds `tmpTemplate` with `{}` rather than `''`.

## Note for whoever picks this up later

The double wrapper is still a bug — it silently eats the first rule of every template's CSS. Undoing it needs a migration that rewrites stored `additionalStyles`, not a change to how they are rendered. Doing it at render time is what changed live documents.

## Testing

| Project | Suites | Tests |
|---|---|---|
| pdf-service | 5/5 | 79 |
| form-service | 17/17 | 376 |
| tenant-management-webapp | 50/50 | 220 |

ESLint clean on all six changed files. The specs that pinned the single-wrapper behaviour now pin the restored behaviour, with comments explaining why it is deliberate.
