### PR TITLE
feat(adsp-sdk-mcp-server): improve service registration guidance and add configuration schema tool

### DIFF
--- a/libs/adsp-cli/src/index.ts
+++ b/libs/adsp-cli/src/index.ts
@@ -4,4 +4,6 @@ export { getDirectoryServiceUrl, getServiceUrls } from './directory';
 export { getConfiguration } from './configuration';
 export { getServiceRoles, ServiceNotInDirectoryError } from './serviceRoles';
 export type { ServiceRoleEntry } from './serviceRoles';
+export { getServiceConfigurationSchemas } from './serviceConfigurations';
+export type { ServiceConfigurationSchema } from './serviceConfigurations';
 export { HttpRequestError } from './httpError';

--- a/libs/adsp-cli/src/serviceConfigurations.ts
+++ b/libs/adsp-cli/src/serviceConfigurations.ts
@@ -1,0 +1,59 @@
+import { getConfiguration } from './configuration';
+import { getServiceUrls } from './directory';
+import { ServiceNotInDirectoryError } from './serviceRoles';
+
+const CONFIGURATION_SERVICE_URN = 'urn:ads:platform:configuration-service:v2';
+
+export interface ServiceConfigurationSchema {
+  /** Key as stored in the configuration-service document (e.g. "form-service" or "platform:form-service"). */
+  key: string;
+  configurationSchema: Record<string, unknown>;
+  description?: string;
+}
+
+interface ConfigurationServiceConfiguration {
+  [key: string]: {
+    configurationSchema?: Record<string, unknown>;
+    description?: string;
+    anonymousRead?: boolean;
+  };
+}
+
+/**
+ * Reads every platform service's registered configuration schema from configuration-service's own
+ * configuration document (the same document ServiceRegistration PATCHes into at service startup).
+ * Optionally filters to the service whose name matches the last segment of the provided URN.
+ */
+export async function getServiceConfigurationSchemas(
+  accessToken: string,
+  directoryServiceUrl: string,
+  serviceId?: string
+): Promise<ServiceConfigurationSchema[]> {
+  const serviceUrls = await getServiceUrls(directoryServiceUrl);
+  const configurationServiceUrl = serviceUrls[CONFIGURATION_SERVICE_URN];
+  if (!configurationServiceUrl) {
+    throw new ServiceNotInDirectoryError(CONFIGURATION_SERVICE_URN);
+  }
+
+  const configuration = await getConfiguration<ConfigurationServiceConfiguration>(
+    accessToken,
+    configurationServiceUrl,
+    'platform',
+    'configuration-service'
+  );
+
+  const entries = Object.entries(configuration ?? {})
+    .filter(([, value]) => value?.configurationSchema != null)
+    .map(([key, value]) => ({
+      key,
+      configurationSchema: value.configurationSchema,
+      description: value.description,
+    }));
+
+  if (!serviceId) {
+    return entries;
+  }
+
+  const name = serviceId.split(':').pop();
+  return entries.filter(({ key }) => key === name || key.endsWith(`:${name}`));
+}

--- a/libs/adsp-sdk-mcp-server/package.json
+++ b/libs/adsp-sdk-mcp-server/package.json
@@ -8,7 +8,7 @@
     "adsp-sdk-mcp-server": "./src/main.js"
   },
   "dependencies": {
-    "@abgov/adsp-cli": "^1.0.0",
+    "@abgov/adsp-cli": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "tslib": "^2.3.0",
     "zod": "^3.25.76"

--- a/libs/adsp-sdk-mcp-server/src/server.spec.ts
+++ b/libs/adsp-sdk-mcp-server/src/server.spec.ts
@@ -35,12 +35,19 @@ describe('adsp-sdk-mcp-server', () => {
     rmSync(docsRoot, { recursive: true, force: true });
   });
 
-  it('lists all four tools', async () => {
+  it('lists all tools including live-data tools', async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
 
     expect(names).toEqual(
-      expect.arrayContaining(['search_adsp_docs', 'read_adsp_doc', 'search_sdk_reference', 'get_platform_quickstart'])
+      expect.arrayContaining([
+        'search_adsp_docs',
+        'read_adsp_doc',
+        'search_sdk_reference',
+        'get_platform_quickstart',
+        'list_service_roles',
+        'get_service_configuration_schema',
+      ])
     );
   });
 

--- a/libs/adsp-sdk-mcp-server/src/server.ts
+++ b/libs/adsp-sdk-mcp-server/src/server.ts
@@ -2,6 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { join } from 'path';
 import { DocsRepository } from './docs/docsRepository';
+import { createConfigurationSchemaTools } from './tools/registerConfigurationSchemaTool';
 import { createDocsTools } from './tools/registerDocsTools';
 import { createQuickstartTool } from './tools/registerQuickstartTool';
 import { createServiceRolesTools } from './tools/registerServiceRolesTool';
@@ -22,6 +23,7 @@ export function createAdspMcpServer(options: CreateAdspMcpServerOptions = {}): S
     ...createSdkTools(),
     ...createQuickstartTool(),
     ...createServiceRolesTools(),
+    ...createConfigurationSchemaTools(),
   ];
   const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
 

--- a/libs/adsp-sdk-mcp-server/src/tools/registerConfigurationSchemaTool.spec.ts
+++ b/libs/adsp-sdk-mcp-server/src/tools/registerConfigurationSchemaTool.spec.ts
@@ -1,0 +1,153 @@
+class MockHttpRequestError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+class MockServiceNotInDirectoryError extends Error {
+  constructor(urn: string) {
+    super(`${urn} was not found in the directory for the configured environment.`);
+  }
+}
+
+jest.mock('@abgov/adsp-cli', () => ({
+  getAccessToken: jest.fn(),
+  getDirectoryServiceUrl: jest.fn(),
+  getServiceConfigurationSchemas: jest.fn(),
+  HttpRequestError: MockHttpRequestError,
+  ServiceNotInDirectoryError: MockServiceNotInDirectoryError,
+}));
+
+import {
+  getAccessToken,
+  getDirectoryServiceUrl,
+  getServiceConfigurationSchemas,
+  ServiceNotInDirectoryError,
+} from '@abgov/adsp-cli';
+import { createConfigurationSchemaTools } from './registerConfigurationSchemaTool';
+
+const mockGetAccessToken = getAccessToken as jest.Mock;
+const mockGetDirectoryServiceUrl = getDirectoryServiceUrl as jest.Mock;
+const mockGetServiceConfigurationSchemas = getServiceConfigurationSchemas as jest.Mock;
+
+const [getConfigurationSchemaTool] = createConfigurationSchemaTools();
+
+function getText(result: Awaited<ReturnType<typeof getConfigurationSchemaTool.handler>>): string {
+  return (result.content[0] as { type: 'text'; text: string }).text;
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('get_service_configuration_schema', () => {
+  it('has the correct name and an optional serviceId input schema', () => {
+    expect(getConfigurationSchemaTool.name).toBe('get_service_configuration_schema');
+    expect(getConfigurationSchemaTool.inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        serviceId: { type: 'string', description: expect.any(String) },
+      },
+    });
+  });
+
+  it('returns an actionable message when not authenticated', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'not-authenticated' });
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('npx @abgov/adsp-cli login');
+    expect(mockGetServiceConfigurationSchemas).not.toHaveBeenCalled();
+  });
+
+  it('returns all schemas when no serviceId is provided', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockResolvedValue([
+      { key: 'form-service', configurationSchema: { type: 'object' }, description: 'Form definitions.' },
+      { key: 'task-service', configurationSchema: { type: 'object' }, description: 'Task queues.' },
+    ]);
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(getText(result))).toHaveLength(2);
+    expect(mockGetServiceConfigurationSchemas).toHaveBeenCalledWith('token-abc', 'https://directory-service.example.com', undefined);
+  });
+
+  it('passes serviceId through to the helper when provided', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockResolvedValue([
+      { key: 'form-service', configurationSchema: { type: 'object' } },
+    ]);
+
+    const result = await getConfigurationSchemaTool.handler({ serviceId: 'urn:ads:platform:form-service' });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockGetServiceConfigurationSchemas).toHaveBeenCalledWith(
+      'token-abc',
+      'https://directory-service.example.com',
+      'urn:ads:platform:form-service'
+    );
+  });
+
+  it('distinguishes a 401 as a stale/invalid token', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockRejectedValue(new MockHttpRequestError(401, 'unauthorized'));
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('401');
+    expect(getText(result)).toContain('npx @abgov/adsp-cli login');
+  });
+
+  it('distinguishes a missing directory entry', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockRejectedValue(
+      new ServiceNotInDirectoryError('urn:ads:platform:configuration-service:v2')
+    );
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('was not found in the directory');
+  });
+
+  it('distinguishes a 403 as likely wrong realm/environment', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockRejectedValue(new MockHttpRequestError(403, 'forbidden'));
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('wrong tenant realm');
+  });
+
+  it('distinguishes a 5xx as a platform outage', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockRejectedValue(new MockHttpRequestError(503, 'unavailable'));
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('outage');
+  });
+
+  it('distinguishes a DNS/connection failure', async () => {
+    mockGetAccessToken.mockResolvedValue({ status: 'ok', token: 'token-abc' });
+    mockGetDirectoryServiceUrl.mockReturnValue('https://directory-service.example.com');
+    mockGetServiceConfigurationSchemas.mockRejectedValue(new TypeError('fetch failed'));
+
+    const result = await getConfigurationSchemaTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('Could not reach the ADSP platform');
+  });
+});

--- a/libs/adsp-sdk-mcp-server/src/tools/registerConfigurationSchemaTool.ts
+++ b/libs/adsp-sdk-mcp-server/src/tools/registerConfigurationSchemaTool.ts
@@ -1,0 +1,86 @@
+import {
+  getAccessToken,
+  getDirectoryServiceUrl,
+  getServiceConfigurationSchemas,
+  HttpRequestError,
+  ServiceNotInDirectoryError,
+} from '@abgov/adsp-cli';
+import { LiveToolDefinition } from './types';
+
+function describeError(err: unknown): string {
+  if (err instanceof ServiceNotInDirectoryError) {
+    return err.message;
+  }
+
+  if (err instanceof HttpRequestError) {
+    if (err.status === 401) {
+      return 'Access token was rejected (401). Run `npx @abgov/adsp-cli login` again to refresh it.';
+    }
+    if (err.status === 403) {
+      return (
+        'Access denied (403) reading configuration-service schemas. This is more likely the wrong tenant realm ' +
+        'or environment than a missing role — check ADSP_TENANT_REALM and ADSP_ENV.'
+      );
+    }
+    if (err.status >= 500) {
+      return `The ADSP platform returned an error (${err.status}). It may be experiencing an outage — try again shortly.`;
+    }
+    return `Request failed with status ${err.status}.`;
+  }
+
+  if (err instanceof TypeError) {
+    return `Could not reach the ADSP platform (${err.message}). Check ADSP_ENV/ADSP_DIRECTORY_SERVICE_URL and your network connection.`;
+  }
+
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function createConfigurationSchemaTools(): LiveToolDefinition[] {
+  return [
+    {
+      name: 'get_service_configuration_schema',
+      description:
+        'Returns the configuration schema(s) for ADSP platform services, read live from configuration-service. ' +
+        'Use this to determine the correct shape for `serviceConfigurations` entries in `initializeService` when ' +
+        'registering with a service that does not have a named field in `ServiceRegistration` (e.g. form-service, ' +
+        'task-service). Pass a `serviceId` URN to get one service\'s schema; omit to list all registered schemas. ' +
+        'Requires authentication: run `npx @abgov/adsp-cli login` once in a terminal (interactive), or set ' +
+        'ADSP_CLIENT_ID and ADSP_CLIENT_SECRET environment variables for non-interactive/CI use.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          serviceId: {
+            type: 'string',
+            description: 'Optional ADSP service URN to filter to (e.g. "urn:ads:platform:form-service").',
+          },
+        },
+      },
+      handler: async (args: { serviceId?: string }) => {
+        const tokenResult = await getAccessToken();
+
+        if (tokenResult.status === 'not-authenticated') {
+          return {
+            isError: true,
+            content: [
+              { type: 'text', text: 'Not authenticated. Run `npx @abgov/adsp-cli login` in a terminal, then retry.' },
+            ],
+          };
+        }
+
+        try {
+          const directoryServiceUrl = getDirectoryServiceUrl();
+          const schemas = await getServiceConfigurationSchemas(
+            tokenResult.token,
+            directoryServiceUrl,
+            args.serviceId
+          );
+          return {
+            content: [{ type: 'text', text: JSON.stringify(schemas, null, 2) }],
+          };
+        } catch (err) {
+          return { isError: true, content: [{ type: 'text', text: describeError(err) }] };
+        }
+      },
+    },
+  ];
+}

--- a/libs/adsp-sdk-mcp-server/src/tools/registerQuickstartTool.ts
+++ b/libs/adsp-sdk-mcp-server/src/tools/registerQuickstartTool.ts
@@ -61,17 +61,83 @@ many tenants and needs to resolve which one a request belongs to.)
 
 ## 3. Registering what your service needs
 
-Pass \`roles\`, \`events\`, \`configuration\`, \`eventStreams\`, \`fileTypes\`, \`notifications\`, and/or \`values\` on the options
-object (see the \`ServiceRegistration\` SDK reference entry) and the SDK registers them with the relevant platform
-services (configuration-service, event-service, tenant-service, push-service, file-service, notification-service,
-value-service) automatically on startup.
+The \`ServiceRegistration\` fields in the options object tell the SDK what to declare at startup.
 
-## 4. Next steps
+**Registration is how platform services learn about your service's resources.** Most ADSP services store
+their resource definitions (file types, event types, form definitions, task queues, etc.) as configuration in
+configuration-service. Registering them at startup is what creates those resources — without registration
+they do not exist, and API calls to those services will fail regardless of whether Keycloak roles are
+correctly assigned. Always register the definitions for every ADSP service your code depends on.
+
+| Service you call | Registration field | What the SDK registers |
+|---|---|---|
+| configuration-service | \`configuration\` (configurationSchema) | Your config schema; enables \`req.getConfiguration()\` |
+| event-service | \`events\` | Event definitions; events appear in the event log and can be subscribed to |
+| file-service | \`fileTypes\` | File type definitions controlling storage, access, and scan rules |
+| notification-service | \`notifications\` | Notification type definitions triggered by events |
+| push-service | \`eventStreams\` | Event stream definitions for WebSocket delivery to clients |
+| value-service | \`values\` | Value definitions for time-series data |
+| tenant-service | \`roles\` | RBAC roles users can be assigned; roles appear in \`req.user.roles\` |
+| any other service | \`serviceConfigurations\` | Generic: posts a configuration object to that service's namespace |
+
+All fields are optional — only include the ones your service actually uses. Every named field above is a
+convenience wrapper around the same underlying mechanism: the SDK PATCHes configuration-service under the
+target service's namespace. \`serviceConfigurations\` exposes that mechanism directly for any service not
+covered by a named field:
+
+\`\`\`typescript
+serviceConfigurations: [
+  {
+    serviceId: AdspId.parse('urn:ads:platform:<target-service>'),
+    // Plain object when the service uses a single configuration document:
+    configuration: { /* shape matching the target service's configuration schema */ },
+    // — OR — NamedConfiguration[] when the service uses namespace mode
+    // (one named document per resource definition, e.g. one entry per form):
+    // configuration: [{ name: '<resource-id>', configuration: { /* schema shape */ } }],
+  },
+]
+\`\`\`
+
+To find the correct \`configuration\` shape for a service: call \`get_service_configuration_schema\` with
+the service's URN (e.g. \`urn:ads:platform:form-service\`) — it returns the live JSON Schema registered by
+that service, which is exactly the shape required here. Use \`search_sdk_reference\` for the full
+\`ServiceRegistration\` type and the \`NamedConfiguration\` variant.
+
+## 4. Keycloak setup for service-to-service calls
+
+When your service makes HTTP requests to another ADSP service (e.g. uploads files via file-service, sends
+notifications via notification-service), **two Keycloak changes are required on your service's client** — one
+is NOT enough:
+
+### Step 1 — Add an audience mapper
+
+Every ADSP service validates that its own URN appears in the \`aud\` (audience) claim of the incoming token.
+Your service's token will not carry that URN by default, so every call will be rejected with 401 unless you
+add an audience mapper.
+
+In Keycloak admin console: **Clients → {your-client-id} → Client Scopes → {your-client-id}-dedicated →
+Add mapper → By configuration → Audience** → set "Included Client Audience" to the target service's URN
+(e.g. \`urn:ads:platform:file-service\`). Repeat for each service you call.
+
+### Step 2 — Assign the service account role
+
+Your service's token must also carry the role the target service requires for the operation. Use
+\`list_service_roles\` to find the least-privileged role, then assign it.
+
+In Keycloak admin console: **Clients → {your-client-id} → Service Account Roles → Client Roles** → select
+the target service's URN from the dropdown → assign the role (e.g. \`file-service-user\`). Repeat for each
+service you call.
+
+Both steps are always required. The audience mapper makes your token acceptable to the target service; the
+role controls what that service will permit your service account to do.
+
+## 5. Next steps
 
 - Use \`search_adsp_docs\` for platform concepts (multi-tenancy, service discovery, configuration, domain events) and
   service-specific docs.
 - Use \`search_sdk_reference\` for details on any specific SDK symbol (e.g. \`EventService\`, \`ConfigurationService\`,
   \`authorize\`).
+- Use \`list_service_roles\` to find the exact role name to assign in Step 2 above.
 - Read the full getting-started guide with \`read_adsp_doc\` on path \`getting-started.md\`, the Node SDK page at
   \`platform/platform-node-sdk.md\`, and the architecture overview at \`architecture.md\`.
 `;

--- a/libs/adsp-sdk-mcp-server/src/tools/registerServiceRolesTool.spec.ts
+++ b/libs/adsp-sdk-mcp-server/src/tools/registerServiceRolesTool.spec.ts
@@ -61,7 +61,9 @@ describe('list_service_roles', () => {
     const result = await listServiceRolesTool.handler({});
 
     expect(result.isError).toBeUndefined();
-    expect(JSON.parse(getText(result))).toEqual([
+    const text = getText(result);
+    // Response is preamble + JSON; parse starting from the first '['.
+    expect(JSON.parse(text.slice(text.indexOf('[')))).toEqual([
       { serviceId: 'urn:ads:platform:event-service', serviceName: 'event-service', role: 'event-sender', description: 'Sender role.' },
     ]);
     expect(mockGetServiceRoles).toHaveBeenCalledWith('token-abc', 'https://directory-service.example.com');

--- a/libs/adsp-sdk-mcp-server/src/tools/registerServiceRolesTool.ts
+++ b/libs/adsp-sdk-mcp-server/src/tools/registerServiceRolesTool.ts
@@ -35,15 +35,40 @@ function describeError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+const SERVICE_ROLES_PREAMBLE = `## How to use these roles
+
+This list covers every ADSP platform service. For each service your service needs to call, complete
+**both** of the following Keycloak steps — one without the other is not enough:
+
+1. **Add an audience mapper** on your service's client so its tokens carry the target service's URN in the
+   \`aud\` claim (target services reject tokens that don't include their URN):
+   Keycloak admin → Clients → {your-client-id} → Client Scopes → {your-client-id}-dedicated →
+   Add mapper → By configuration → Audience → set "Included Client Audience" to the \`serviceId\`
+   (e.g. \`urn:ads:platform:file-service\`).
+
+2. **Assign the role** to your service account:
+   Keycloak admin → Clients → {your-client-id} → Service Account Roles → Client Roles →
+   select \`serviceId\` from the dropdown → assign the role.
+
+Roles where \`inTenantAdmin: true\` are automatically granted to tenant admin users, but service accounts
+always need explicit assignment regardless of that flag.
+
+---
+
+`;
+
 export function createServiceRolesTools(): LiveToolDefinition[] {
   return [
     {
       name: 'list_service_roles',
       description:
-        'List every ADSP platform service\'s registered RBAC role (role name, description, whether it is part of ' +
-        'the tenant-admin composite role), read live from tenant-service configuration. Use this to pick the ' +
-        'least-privileged role for a service account or user, rather than defaulting to an admin role. Requires ' +
-        'login: run `npx @abgov/adsp-cli login` once in a terminal first (no other setup needed).',
+        'List every ADSP platform service\'s registered RBAC role (role name, description, whether it is ' +
+        'part of the tenant-admin composite role), read live from tenant-service configuration. Use this to ' +
+        'identify the least-privileged role when your service needs to call another ADSP service. After ' +
+        'identifying the role, two Keycloak steps are required: (1) add an audience mapper for the service\'s ' +
+        'URN on your client, and (2) assign the role to your service account — both are needed. Requires ' +
+        'authentication: run `npx @abgov/adsp-cli login` once in a terminal (interactive), or set ' +
+        'ADSP_CLIENT_ID and ADSP_CLIENT_SECRET environment variables for non-interactive/CI use.',
       inputSchema: { type: 'object', properties: {} },
       handler: async () => {
         const tokenResult = await getAccessToken();
@@ -60,7 +85,9 @@ export function createServiceRolesTools(): LiveToolDefinition[] {
         try {
           const directoryServiceUrl = getDirectoryServiceUrl();
           const roles = await getServiceRoles(tokenResult.token, directoryServiceUrl);
-          return { content: [{ type: 'text', text: JSON.stringify(roles, null, 2) }] };
+          return {
+            content: [{ type: 'text', text: SERVICE_ROLES_PREAMBLE + JSON.stringify(roles, null, 2) }],
+          };
         } catch (err) {
           return { isError: true, content: [{ type: 'text', text: describeError(err) }] };
         }


### PR DESCRIPTION
## Summary

- Adds `get_service_configuration_schema` MCP tool — fetches live configuration schemas from configuration-service so agents know the exact `serviceConfigurations` shape for any platform service (e.g. form-service, task-service) without needing docs lookups
- Adds `getServiceConfigurationSchemas` helper to `@abgov/adsp-cli`, parallel to the existing `getServiceRoles` pattern
- Updates `get_platform_quickstart` Section 3 to make clear that registration *creates* resources (not just declares intent), and that missing it causes API call failures even with correct Keycloak roles
- Updates tool descriptions to document `ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET` env vars as the CI/non-interactive authentication path (picks up the `adsp-cli-ci` client credentials feature)

## Test plan

- [ ] `npx nx test adsp-cli` — all tests pass
- [ ] `npx nx test adsp-sdk-mcp-server` — all tests pass, branch coverage ≥ 80%
- [ ] Call `get_service_configuration_schema` with `urn:ads:platform:form-service` in a logged-in MCP session and verify the form definition JSON Schema is returned
- [ ] Verify `list_service_roles` and `get_service_configuration_schema` work in a CI environment with `ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET` set (no interactive login required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)