### PR TITLE
fix(tenant-management-api): add missing Keycloak fields to adsp-cli-ci client config

### DIFF
--- a/apps/tenant-management-api/src/keycloak/configuration.ts
+++ b/apps/tenant-management-api/src/keycloak/configuration.ts
@@ -175,22 +175,21 @@ export const ADSP_CLI_CI_CLIENT_SCOPE_MAPPINGS = [
 ];
 
 /**
- * Confidential client for CI environments — client credentials grant only. Bootstrapped disabled
- * so tenants must consciously enable it and set a secret before it can be used. Service account
- * roles (configuration-admin, see ADSP_CLI_CI_CLIENT_SCOPE_MAPPINGS) are granted separately in
- * keycloak.ts's grantCiClientServiceAccountRoles after realm creation.
+ * Confidential client for CI environments — client credentials grant only. Bootstrapped disabled;
+ * service account roles (configuration-admin) granted separately in grantCiClientServiceAccountRoles.
  */
 export const createAdspCliCiClientConfig = (id: string): ClientRepresentation => ({
   id,
   clientId: ADSP_CLI_CI_CLIENT_ID,
   enabled: false,
   publicClient: false,
+  bearerOnly: false,
   standardFlowEnabled: false,
   implicitFlowEnabled: false,
   directAccessGrantsEnabled: false,
   serviceAccountsEnabled: true,
+  authorizationServicesEnabled: false,
   fullScopeAllowed: false,
-  description:
-    'Confidential client for @abgov/adsp-cli CI use (client credentials grant). ' +
-    'Bootstrapped disabled — enable and configure a secret via the tenant admin console to use.',
+  redirectUris: [],
+  description: 'Confidential client for @abgov/adsp-cli CI use (client credentials grant).',
 });


### PR DESCRIPTION
## Summary
- Adds `bearerOnly: false`, `authorizationServicesEnabled: false`, and `redirectUris: []` to `createAdspCliCiClientConfig`
- Without these fields Keycloak rejects the client creation request with a generic error, causing silent failure during tenant provisioning
- Also trims the client description to a single concise line

## Test plan
- [ ] Verified fields resolve the import error by successfully importing the client JSON into an existing tenant via Keycloak admin console
- [ ] Create a new tenant and confirm `adsp-cli-ci` client is created without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)