### PR TITLE
fix(pdf-service): restore fonts-liberation in the container image

### DIFF
--- a/apps/pdf-service/Dockerfile
+++ b/apps/pdf-service/Dockerfile
@@ -7,8 +7,13 @@ COPY . .
 
 # Install Chrome system library dependencies and unzip for reliable extraction.
 # Fonts and libs required by Chrome for Testing (bundled via puppeteer browsers install).
+# fonts-liberation is metric-compatible with Arial/Helvetica/Times and must be installed
+# explicitly: it used to arrive as a hard dependency of the google-chrome-stable package, which
+# this image no longer installs. Without it Arial falls back to DejaVu Sans, which is ~15% wider
+# and renders every template larger than it does in environments that still have Liberation.
 RUN apt-get update \
   && apt-get install -y \
+    fonts-liberation \
     fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
     libasound2 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 \
     libdrm2 libgbm1 libglib2.0-0 libnss3 libnspr4 libpango-1.0-0 \


### PR DESCRIPTION
## Problem

PDFs render noticeably larger in dev and uat than in production — roughly 15% wider text, wrapping earlier, across every template. Production is unaffected because it has not been deployed since before the change that caused this.

## Cause

The 2026-05-27 rewrite of `apps/pdf-service/Dockerfile` (#5450–#5454) replaced the `google-chrome-stable` apt package with a Chrome for Testing download via `puppeteer browsers install chrome`.

`fonts-liberation` was a hard `Depends` of `google-chrome-stable`, so it was previously installed as a side effect. Dropping that package silently dropped the font, and nothing in the remaining font list (`fonts-ipafont-gothic`, `fonts-wqy-zenhei`, `fonts-thai-tlwg`, `fonts-kacst`, `fonts-freefont-ttf`) replaces it.

Liberation Sans is metric-compatible with Arial/Helvetica. Without it, templates that name those fonts fall back to DejaVu Sans, which is roughly 15% wider with a larger x-height:

```
prod  $ fc-match Arial
      LiberationSans-Regular.ttf: "Liberation Sans" "Regular"

uat   $ fc-match Arial
      DejaVuSans.ttf: "DejaVu Sans" "Book"
```

`fc-match sans-serif` returns DejaVu Sans in both environments, which is why only templates naming Arial or Helvetica are affected.

## Change

Install `fonts-liberation` explicitly rather than relying on it arriving as a transitive dependency.

## Verification

After rebuild and redeploy, in a dev pdf-service pod:

```
fc-match Arial       # expect LiberationSans-Regular.ttf "Liberation Sans"
fc-match sans-serif  # expect DejaVu Sans — unchanged, matches prod
```

Then regenerate a PDF and compare line breaks against the prod output.

## Notes

- Image-only change: no configuration update, no service restart, no cache invalidation required.
- Affects every PDF template rendered in dev and uat, not one specific template.


