### PR TITLE
fix(tenant-management-webapp): align calendar event filter date error

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/eventListFilter.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/eventListFilter.tsx
@@ -5,7 +5,7 @@ import { UpdateSearchCriteriaAndFetchEvents } from '@store/calendar/actions';
 import { CalendarEventSearchCriteria } from '@store/calendar/models';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@store/index';
-import { CalendarEventFilterError } from './styled-components';
+import { CalendarEventFilterError, CalendarEventFilterErrorWrapper } from './styled-components';
 import { GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface EventListFilterProps {
@@ -92,10 +92,10 @@ export const EventListFilter = ({ calenderName }: EventListFilterProps): JSX.Ele
         </GoabFormItem>
       </GoabGrid>
       {showDateError && (
-        <>
+        <CalendarEventFilterErrorWrapper>
           <GoabBadge type="emergency" icon />
           <CalendarEventFilterError>Start date must be before end date.</CalendarEventFilterError>
-        </>
+        </CalendarEventFilterErrorWrapper>
       )}
     </EventFilterWrapper>
   );

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/styled-components.ts
@@ -97,13 +97,15 @@ export const EventFilterButtonWrapper = styled.div`
   margin-bottom: var(--goa-space-xl);
 `;
 
+export const CalendarEventFilterErrorWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--goa-space-2xs);
+  margin-top: var(--goa-space-xs);
+`;
+
 export const CalendarEventFilterError = styled.span`
   color: var(--goa-color-emergency-default);
-  padding-left: 5px;
-  display: inline-flex;
-  line-height: 2.5rem;
-  position: relative;
-  top: -3px;
 `;
 
 export const CalendarDropdownWrapper = styled.div`


### PR DESCRIPTION
Calendar service → Events: when the start date is after the end date, the error icon and message sat on different horizontal levels.

The badge and message were bare siblings in a fragment, so they were baseline-aligned, and the message compensated with `line-height: 2.5rem` and `top: -3px`.

Wrapped them in a flex container with `align-items: center` and dropped the offsets. Added `margin-top` so the error clears the date input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192adyAwEfqBRLi1ENAUiLk
