### PR TITLE
fix(tenant-management-webapp): align feedback filter date error

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.spec.tsx
@@ -213,4 +213,40 @@ describe('Feedbacks Components', () => {
       expect(screen.getByText('Feedback service')).toBeInTheDocument();
     });
   });
+
+  it('should show the date range error when the start date is after the end date', () => {
+    const { baseElement } = render(
+      <Provider store={store}>
+        <FeedbacksList />
+      </Provider>
+    );
+    const dropDown = baseElement.querySelector("goa-dropdown[testId='sites-dropdown']");
+    fireEvent(dropDown, new CustomEvent('_change', { detail: { value: 'http://newsite.com' } }));
+
+    const startDate = baseElement.querySelector("goa-input[name='feedback-filter-start-date']");
+    fireEvent(startDate, new CustomEvent('_change', { detail: { value: '2099-12-31' } }));
+
+    expect(screen.getByText('Start date must be before End date.')).toBeInTheDocument();
+  });
+
+  it('should keep the error icon and message on the same horizontal level', () => {
+    // Regression guard: the badge and the message used to be bare siblings in a plain div, so they
+    // were baseline-aligned in an inline formatting context and the message compensated with
+    // line-height: 2.5rem and top: -3px. That left the icon and text on different levels.
+    const { baseElement } = render(
+      <Provider store={store}>
+        <FeedbacksList />
+      </Provider>
+    );
+    const dropDown = baseElement.querySelector("goa-dropdown[testId='sites-dropdown']");
+    fireEvent(dropDown, new CustomEvent('_change', { detail: { value: 'http://newsite.com' } }));
+
+    const startDate = baseElement.querySelector("goa-input[name='feedback-filter-start-date']");
+    fireEvent(startDate, new CustomEvent('_change', { detail: { value: '2099-12-31' } }));
+
+    const wrapper = screen.getByText('Start date must be before End date.').parentElement;
+    const styles = getComputedStyle(wrapper);
+    expect(styles.display).toBe('flex');
+    expect(styles.alignItems).toBe('center');
+  });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/feedback/feedbacks.tsx
@@ -19,7 +19,7 @@ import {
 import { LoadMoreWrapper } from '@components/styled-components';
 import { FeedbackSearchCriteria, getDefaultSearchCriteria } from '@store/feedback/models';
 import { exportFeedbacks, getFeedbackSites, getFeedbacks } from '@store/feedback/actions';
-import { ExportDates, FeedbackFilterError, ProgressWrapper } from '../styled-components';
+import { ExportDates, FeedbackFilterError, FeedbackFilterErrorWrapper, ProgressWrapper } from '../styled-components';
 import { transformedData } from '../ratings';
 import { FullScreenModalWrapper } from '../styled-components';
 import { GoabInputOnChangeDetail, GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
@@ -206,10 +206,10 @@ export const FeedbacksList = (): JSX.Element => {
           {sharedFilterForm}
 
           {showDateError && (
-            <div>
+            <FeedbackFilterErrorWrapper>
               <GoabBadge type="emergency" icon />
               <FeedbackFilterError>Start date must be before End date.</FeedbackFilterError>
-            </div>
+            </FeedbackFilterErrorWrapper>
           )}
           <GoabButtonGroup alignment="start" gap="compact">
             <GoabButton

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/styled-components.ts
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import styled from 'styled-components';
 
 export const PRE = styled.div`
@@ -124,16 +125,18 @@ export const ButtonPadding = styled.div`
 export const ExportDates = styled.div`
   display: flex;
   margin-top: var(--goa-space-l);
-  margin-bottom: var(--goa-space-l);
+  margin-bottom: var(--goa-space-xs);
   gap: var(--goa-space-m);
 `;
+export const FeedbackFilterErrorWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--goa-space-2xs);
+  margin-bottom: var(--goa-space-m);
+`;
+
 export const FeedbackFilterError = styled.span`
   color: var(--goa-color-emergency-default);
-  padding-left: 5px;
-  display: inline-flex;
-  line-height: 2.5rem;
-  position: relative;
-  top: -3px;
 `;
 
 export const NoResultsMessage = styled.div`


### PR DESCRIPTION
Feedback service → Feedback: when the start date is after the end date, the error icon and message sat on different horizontal levels. Same defect as the calendar event filter.

<img width="673" height="217" alt="image" src="https://github.com/user-attachments/assets/1adc6377-056d-4819-bbcc-9730a3c608df" />
