### PR TITLE
fix(calendar-service): allow core service accounts to update calendar

### DIFF
--- a/apps/calendar-service/src/calendar/model/calendar.spec.ts
+++ b/apps/calendar-service/src/calendar/model/calendar.spec.ts
@@ -262,6 +262,42 @@ describe('CalendarEntity', () => {
 
       expect(result).toBeFalsy();
     });
+
+    it('can return true for core user with admin role', () => {
+      const entity = new CalendarEntity(repositoryMock, tenantId, {
+        name: 'test',
+        displayName: 'Test',
+        description: 'test',
+        updateRoles: ['test-updater'],
+        readRoles: ['test-reader'],
+      });
+
+      const result = entity.canUpdateEvent({
+        isCore: true,
+        id: 'test',
+        roles: [CalendarServiceRoles.Admin],
+      } as User);
+
+      expect(result).toBeTruthy();
+    });
+
+    it('can return false for core user without roles', () => {
+      const entity = new CalendarEntity(repositoryMock, tenantId, {
+        name: 'test',
+        displayName: 'Test',
+        description: 'test',
+        updateRoles: ['test-updater'],
+        readRoles: ['test-reader'],
+      });
+
+      const result = entity.canUpdateEvent({
+        isCore: true,
+        id: 'test',
+        roles: [],
+      } as User);
+
+      expect(result).toBeFalsy();
+    });
   });
 
   describe('getEvents', () => {

--- a/apps/calendar-service/src/calendar/model/calendar.ts
+++ b/apps/calendar-service/src/calendar/model/calendar.ts
@@ -50,7 +50,7 @@ export class CalendarEntity implements Calendar {
   }
 
   canUpdateEvent(user: User): boolean {
-    return isAllowedUser(user, this.tenantId, [CalendarServiceRoles.Admin, ...this.updateRoles]);
+    return isAllowedUser(user, this.tenantId, [CalendarServiceRoles.Admin, ...this.updateRoles], true);
   }
 
   createEvent(user: User, event: New<CalendarEvent>): Promise<CalendarEventEntity> {


### PR DESCRIPTION
* canUpdateEvent was using allowCore=false, preventing platform core service accounts (e.g. form-service) from patching calendar events even when they hold the calendar-admin role. Set allowCore=true to match the existing behaviour of canAccessPrivateEvent.