### PR TITLE
fix(jsonforms-components): retain every typed character in composite controls (CS-5218)

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControl.spec.tsx
@@ -45,13 +45,15 @@ jest.mock('@jsonforms/react', () => ({
 jest.mock('axios');
 const axiosMock = axios as jest.Mocked<typeof axios>;
 
+// Only the helpers a test needs to steer are stubbed; the rest keep their real behaviour so the
+// control's suggestion and keyboard handling is exercised rather than short circuited.
 jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
   fetchAddressSuggestions: jest.fn(),
   filterAlbertaAddresses: jest.fn(),
   mapSuggestionToAddress: jest.fn(),
   filterSuggestionsWithoutAddressCount: jest.fn(),
   validatePostalCode: jest.fn(),
-  formatPostalCodeIfNeeded: jest.fn(),
 }));
 const mockHandleChange = jest.fn();
 const formUrl = 'http://mock-form-url.com';
@@ -223,6 +225,8 @@ describe('AddressLookUpControl', () => {
       inputField,
       new CustomEvent('_keyPress', {
         detail: {
+          name: 'addressLine1',
+          value: '123',
           key: 'ArrowDown',
           code: 40,
           charCode: 0,
@@ -233,6 +237,8 @@ describe('AddressLookUpControl', () => {
       inputField,
       new CustomEvent('_keyPress', {
         detail: {
+          name: 'addressLine1',
+          value: '123',
           key: 'ArrowUp',
           code: 38,
           charCode: 0,
@@ -244,6 +250,8 @@ describe('AddressLookUpControl', () => {
       inputField,
       new CustomEvent('_keyPress', {
         detail: {
+          name: 'addressLine1',
+          value: '123',
           key: 'Enter',
           code: 13,
           charCode: 0,
@@ -579,7 +587,7 @@ describe('AddressLookUpControl - More tests', () => {
     },
   ];
 
-  const renderComponent = (overrides = {}) => {
+  const buildProps = (overrides = {}) => {
     const defaultProps = {
       data: {},
       enabled: true,
@@ -611,14 +619,17 @@ describe('AddressLookUpControl - More tests', () => {
       handleChange: mockHandleChange,
     };
 
-    const props = { ...defaultProps, ...overrides };
-
-    return render(
-      <JsonFormContext.Provider value={mockFormContext}>
-        <AddressLookUpControl {...props} />
-      </JsonFormContext.Provider>,
-    );
+    return { ...defaultProps, ...overrides };
   };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderControl = (props: any) => (
+    <JsonFormContext.Provider value={mockFormContext}>
+      <AddressLookUpControl {...props} />
+    </JsonFormContext.Provider>
+  );
+
+  const renderComponent = (overrides = {}) => render(renderControl(buildProps(overrides)));
 
   describe('Default Address Initialization', () => {
     it('should use existing data if provided instead of default address', () => {
@@ -1226,6 +1237,141 @@ describe('AddressLookUpControl - More tests', () => {
       // Component should be visible - check if h3 exists
       const h3 = container.querySelector('h3');
       expect(h3).not.toBeNull();
+    });
+  });
+
+  // CS-5218: the inputs are controlled, so any render that carries a value older than what has been
+  // typed makes the web component overwrite the characters in between.
+  describe('Typed characters are retained', () => {
+    const typeInto = (input: Element, name: string, value: string) => {
+      act(() => {
+        fireEvent(input, new CustomEvent('_change', { detail: { name, value } }));
+      });
+    };
+
+    it('keeps addressLine1 in step with what was typed', () => {
+      const { baseElement } = renderComponent({ data: {} });
+      const input = baseElement.querySelector("goa-input[testId='address-form-address1']")!;
+
+      typeInto(input, 'addressLine1', 'D');
+      typeInto(input, 'addressLine1', 'DO');
+      typeInto(input, 'addressLine1', 'DO NOT DELETE');
+
+      expect(input.getAttribute('value')).toBe('DO NOT DELETE');
+    });
+
+    // Writing addressLine1 to the form data mid-lookup re-renders the form while the search is
+    // still debouncing, which closes the suggestions dropdown before it can be clicked.
+    it('does not touch the form data while the address lookup is being typed', () => {
+      const { baseElement } = renderComponent({ data: {} });
+      const input = baseElement.querySelector("goa-input[testId='address-form-address1']")!;
+
+      typeInto(input, 'addressLine1', '123 Main');
+
+      expect(mockHandleChange).not.toHaveBeenCalled();
+    });
+
+    it('commits the typed address once the field is left', () => {
+      const { baseElement } = renderComponent({ data: {} });
+      const input = baseElement.querySelector("goa-input[testId='address-form-address1']")!;
+
+      typeInto(input, 'addressLine1', '123 Main');
+
+      act(() => {
+        fireEvent(
+          input,
+          new CustomEvent('_blur', { detail: { name: 'addressLine1', value: '123 Main' } }),
+        );
+      });
+
+      expect(mockHandleChange).toHaveBeenCalledWith('address', expect.objectContaining({ addressLine1: '123 Main' }));
+    });
+
+    // useDebounce resolves synchronously under jest, so a commit is never actually outstanding.
+    // Restoring the real timing is what puts the control in the state this guards against.
+    describe('with production debounce timing', () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalWorkerId = process.env.JEST_WORKER_ID;
+
+      beforeEach(() => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.JEST_WORKER_ID;
+        jest.useFakeTimers();
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+        process.env.NODE_ENV = originalNodeEnv;
+        if (originalWorkerId !== undefined) {
+          process.env.JEST_WORKER_ID = originalWorkerId;
+        }
+      });
+
+      it('does not roll addressLine1 back when stale form data arrives mid-edit', () => {
+        const { baseElement, rerender } = renderComponent({ data: {} });
+        const input = baseElement.querySelector("goa-input[testId='address-form-address1']")!;
+
+        typeInto(input, 'addressLine1', 'DO NOT DELET');
+        typeInto(input, 'addressLine1', 'DO NOT DELETE');
+
+        // The form data round trip lands a keystroke behind what is in the box.
+        act(() => {
+          rerender(renderControl(buildProps({ data: { addressLine1: 'DO NOT DELET' } })));
+        });
+
+        expect(input.getAttribute('value')).toBe('DO NOT DELETE');
+      });
+
+      it('opens the suggestions dropdown and keeps it clickable after typing settles', async () => {
+        (fetchAddressSuggestions as jest.Mock).mockResolvedValue(mockSuggestions);
+        (filterSuggestionsWithoutAddressCount as jest.Mock).mockReturnValue(mockSuggestions);
+        (filterAlbertaAddresses as jest.Mock).mockReturnValue(mockSuggestions);
+        (mapSuggestionToAddress as jest.Mock).mockReturnValue({
+          addressLine1: '123 Main St',
+          municipality: 'Calgary',
+          subdivisionCode: 'AB',
+          postalCode: 'T1X 1A1',
+          country: 'CA',
+        });
+
+        const { baseElement } = renderComponent({ data: {} });
+        const input = baseElement.querySelector("goa-input[testId='address-form-address1']")!;
+
+        typeInto(input, 'addressLine1', '123 Main');
+
+        // Past both the commit debounce and the longer search debounce, then let the fetch settle.
+        await act(async () => {
+          jest.advanceTimersByTime(600);
+          await Promise.resolve();
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        const listItem = baseElement.querySelector("[data-testId='listItem-0']");
+        expect(listItem).not.toBeNull();
+
+        act(() => {
+          fireEvent.click(listItem!);
+        });
+
+        expect(input.getAttribute('value')).toBe('123 Main St');
+        expect(mockHandleChange).toHaveBeenLastCalledWith(
+          'address',
+          expect.objectContaining({ addressLine1: '123 Main St' }),
+        );
+      });
+    });
+
+    it('keeps the other address fields in step with what was typed', () => {
+      const { baseElement } = renderComponent({ data: {} });
+      const city = baseElement.querySelector("goa-input[testId='address-form-city']")!;
+
+      typeInto(city, 'municipality', 'C');
+      typeInto(city, 'municipality', 'Ca');
+      typeInto(city, 'municipality', 'Calgary');
+
+      expect(city.getAttribute('value')).toBe('Calgary');
+      expect(mockHandleChange).toHaveBeenLastCalledWith('address', expect.objectContaining({ municipality: 'Calgary' }));
     });
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControl.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ControlProps } from '@jsonforms/core';
 import { JsonFormContext } from '../../Context';
 import { AddressInputs } from './AddressInputs';
@@ -19,6 +19,7 @@ import {
 import { ListItem, SearchBox } from './styled-components';
 import { HelpContentComponent } from '../../Additional';
 import { useDebounce } from '../../util/useDebounce';
+import { SetValueOptions, useDebouncedCommit } from '../../util/useDebouncedCommit';
 import { Visible } from '../../util';
 import { GoabInputOnBlurDetail, GoabInputOnChangeDetail, GoabInputOnKeyPressDetail } from '@abgov/ui-components-common';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
@@ -53,17 +54,18 @@ export const AddressLookUpControl = (props: AddressLookUpProps): JSX.Element => 
   const addressContainerRef = useRef<HTMLDivElement>(null);
 
   const label = typeof uischema?.label === 'string' && uischema.label ? uischema.label : '';
-  const [address, setAddress] = useState<Address>(normalizeAddressData(data, isAlbertaAddress));
+  const normalizedData = useMemo(() => normalizeAddressData(data, isAlbertaAddress), [data, isAlbertaAddress]);
+  const {
+    value: address,
+    setValue: setAddress,
+    flush: flushAddress,
+  } = useDebouncedCommit<Address>(normalizedData, (updatedAddress) => handleChange(path, updatedAddress));
   const [searchTerm, setSearchTerm] = useState('');
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const requiredFields = (schema as { required: string[] }).required;
   const [dropdownSelected, setDropdownSelected] = useState(false);
-  const updateFormData = (updatedAddress: Address) => {
-    handleChange(path, updatedAddress);
-  };
-  const debouncedRenderAddress = useDebounce(searchTerm, 500);
 
   const [activeIndex, setActiveIndex] = useState<number>(0);
 
@@ -76,131 +78,89 @@ export const AddressLookUpControl = (props: AddressLookUpProps): JSX.Element => 
 
   const spinnerTimerRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    const nextAddress = normalizeAddressData(data, isAlbertaAddress);
-    setAddress((currentAddress) => {
-      const keys: Array<keyof Address> = [
-        'addressLine1',
-        'addressLine2',
-        'municipality',
-        'postalCode',
-        'country',
-        'subdivisionCode',
-      ];
-
-      const unchanged = keys.every((key) => currentAddress[key] === nextAddress[key]);
-      return unchanged ? currentAddress : nextAddress;
-    });
-  }, [data, isAlbertaAddress]);
-
-  const handleInputChange = (field: string, value: string) => {
-    if (field === 'addressLine1') {
-      setDropdownSelected(false);
-    }
-    let newAddress;
+  const handleInputChange = (field: string, value: string, options?: SetValueOptions) => {
+    let newValue = value;
     const postalCodeErrorMessage = (schema as { errorMessage?: { properties?: { postalCode?: string } } }).errorMessage
       ?.properties?.postalCode;
 
     if (field === 'postalCode') {
       const validatePc = validatePostalCode(value);
-      setErrors(
-        handlePostalCodeValidation(validatePc, postalCodeErrorMessage ? postalCodeErrorMessage : '', value, errors),
+      setErrors((currentErrors) =>
+        handlePostalCodeValidation(validatePc, postalCodeErrorMessage ?? '', value, currentErrors),
       );
-      value = formatPostalCode(value);
-      newAddress = { ...address, [field]: value.toUpperCase() };
+      newValue = formatPostalCode(value).toUpperCase();
     } else {
-      newAddress = { ...address, [field]: value };
-      delete errors[field];
+      setErrors((currentErrors) => {
+        if (!(field in currentErrors)) {
+          return currentErrors;
+        }
+
+        const nextErrors = { ...currentErrors };
+        delete nextErrors[field];
+        return nextErrors;
+      });
     }
 
-    if (value === '' && field in newAddress) {
-      delete newAddress[field];
+    const newAddress: Address = { ...address, [field]: newValue };
+    if (newValue === '') {
+      delete newAddress[field as keyof Address];
     }
 
-    setAddress(newAddress);
-    updateFormData(newAddress);
+    setAddress(newAddress, options);
+
+    // Picking a province isn't typing, so there is nothing to wait for.
+    if (field === 'subdivisionCode') {
+      flushAddress();
+    }
   };
 
   const renderHelp = () => {
     return <HelpContentComponent {...props} isParent={true} showLabel={false} />;
   };
 
-  useEffect(() => {
-    const fetchSuggestions = async () => {
-      /* istanbul ignore next */
-      if (debouncedRenderAddress.length > 2 && dropdownSelected === false) {
-        setLoading(true);
-        setOpen(true);
-        try {
-          await fetchAddressSuggestions(formUrl, formatPostalCodeIfNeeded(searchTerm), isAlbertaAddress).then(
-            (response) => {
-              const suggestions = filterSuggestionsWithoutAddressCount(response);
-              if (isAlbertaAddress) {
-                setSuggestions(filterAlbertaAddresses(suggestions));
-              } else {
-                setSuggestions(suggestions);
-              }
-              setLoading(false);
-            },
-          );
-          // eslint-disable-next-line
-        } catch (error: any) {
-          if (error.name !== 'AbortError') {
-            console.error('Address fetch failed:', error);
-          }
-        } finally {
-          setLoading(false);
-        }
-      } else {
-        setSuggestions([]);
-        setOpen(false);
-      }
-    };
-
-    fetchSuggestions();
-  }, [debouncedTerm]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleDropdownChange = (value: string) => {
+  const handleAddressLine1Change = (value: string) => {
     setDropdownSelected(false);
     setSearchTerm(value);
+    // Mirror the keystroke so the field never renders a stale value, but leave the form data alone
+    // until blur or a suggestion is picked. Committing mid-lookup re-renders the whole form while
+    // the search is still debouncing, which is what closed the suggestions dropdown.
+    handleInputChange('addressLine1', value, { autoCommit: false });
   };
 
   /* istanbul ignore next */
   const handleSuggestionClick = (suggestion: Suggestion) => {
     const suggestAddress = mapSuggestionToAddress(suggestion);
     setAddress(suggestAddress);
-    handleChange(path, suggestAddress);
+    flushAddress();
     setSuggestions([]);
     setErrors({});
     setDropdownSelected(true);
   };
 
   const handleRequiredFieldBlur = (name: string, value?: string) => {
-    const err = { ...errors };
-    const addressValue = name in address ? address[name as keyof Address] : undefined;
+    const liveInputValue = value ?? address[name as keyof Address] ?? data?.[name] ?? '';
 
-    const liveInputValue =
-      value ??
-      addressContainerRef.current?.querySelector<HTMLInputElement>(`goa-input[name="${name}"]`)?.value ??
-      addressValue ??
-      data?.[name] ??
-      '';
+    setErrors((currentErrors) => {
+      const nextErrors = { ...currentErrors };
 
-    if (liveInputValue.trim() === '') {
-      err[name] = `${getAddressLookupFieldLabel(name)} is required`;
-    } else {
-      delete err[name];
-    }
+      if (liveInputValue.trim() === '') {
+        nextErrors[name] = `${getAddressLookupFieldLabel(name)} is required`;
+      } else {
+        delete nextErrors[name];
+      }
 
-    setErrors(err);
+      return nextErrors;
+    });
+
     setSuggestions([]);
     setOpen(false);
 
     if (name === 'addressLine1' && value !== undefined) {
-      const newAddress = { ...address, addressLine1: value };
-      setAddress(newAddress);
-      updateFormData(newAddress);
+      setAddress({ ...address, addressLine1: value });
     }
+
+    // Leaving the field ends the burst of typing, so push what is there now.
+    flushAddress();
   };
 
   useEffect(() => {
@@ -344,7 +304,7 @@ export const AddressLookUpControl = (props: AddressLookUpProps): JSX.Element => 
                 ariaLabel={'address-form-address1'}
                 placeholder="Start typing the first line of your address, required."
                 value={address?.addressLine1 || ''}
-                onChange={(detail: GoabInputOnChangeDetail) => handleDropdownChange(detail.value)}
+                onChange={(detail: GoabInputOnChangeDetail) => handleAddressLine1Change(detail.value)}
                 onBlur={(detail: GoabInputOnBlurDetail) => handleRequiredFieldBlur(detail.name, detail.value)}
                 width="100%"
                 onKeyPress={(detail: GoabInputOnKeyPressDetail) => {
@@ -354,7 +314,8 @@ export const AddressLookUpControl = (props: AddressLookUpProps): JSX.Element => 
                       detail.value,
                       activeIndex,
                       suggestions,
-                      (val) => handleInputChange('addressLine1', val),
+                      // Navigating the suggestions must never blank out what has been typed.
+                      (val) => typeof val === 'string' && handleInputChange('addressLine1', val),
                       (suggestion) => handleSuggestionClick(suggestion),
                     );
                     setActiveIndex(newIndex);

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/utils.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/utils.spec.ts
@@ -233,6 +233,94 @@ describe('mapSuggestionToAddress', () => {
 
     expect(mapSuggestionToAddress(suggestion)).toEqual(expectedAddress);
   });
+
+  // CS-5218: reading the description parts positionally threw for anything but the three part
+  // form, crashing the app when a suggestion was picked by click or by pressing Enter.
+  it('should map a description that carries the province and postal code in one part', () => {
+    const suggestion: Suggestion = {
+      Id: 'CA|CP|A|10010614',
+      Text: '1234 Example St',
+      Highlight: '1-2',
+      Cursor: 0,
+      Description: 'Edmonton, AB T5J 2N9',
+      Next: 'Retrieve',
+    };
+
+    expect(mapSuggestionToAddress(suggestion)).toEqual({
+      addressLine1: '1234 Example St',
+      addressLine2: '',
+      municipality: 'Edmonton',
+      subdivisionCode: 'AB',
+      postalCode: 'T5J 2N9',
+      country: 'CA',
+    });
+  });
+
+  it('should map a description with no postal code rather than throwing', () => {
+    const suggestion: Suggestion = {
+      Id: 'CA|CP|A|10010614',
+      Text: '1234 Example St',
+      Highlight: '1-2',
+      Cursor: 0,
+      Description: 'Edmonton, AB',
+      Next: 'Retrieve',
+    };
+
+    expect(mapSuggestionToAddress(suggestion)).toEqual({
+      addressLine1: '1234 Example St',
+      addressLine2: '',
+      municipality: 'Edmonton',
+      subdivisionCode: 'AB',
+      postalCode: '',
+      country: 'CA',
+    });
+  });
+
+  it('should map a description with only a municipality rather than throwing', () => {
+    const suggestion: Suggestion = {
+      Id: 'CA|CP|A|10010614',
+      Text: '1234 Example St',
+      Highlight: '1-2',
+      Cursor: 0,
+      Description: 'Edmonton',
+      Next: 'Find',
+    };
+
+    expect(mapSuggestionToAddress(suggestion)).toEqual({
+      addressLine1: '1234 Example St',
+      addressLine2: '',
+      municipality: 'Edmonton',
+      subdivisionCode: '',
+      postalCode: '',
+      country: 'CA',
+    });
+  });
+
+  it('should map an empty description rather than throwing', () => {
+    const suggestion = {
+      Id: 'CA|CP|A|10010614',
+      Text: '1234 Example St',
+      Highlight: '1-2',
+      Cursor: 0,
+      Description: '',
+      Next: 'Find',
+    } as Suggestion;
+
+    expect(() => mapSuggestionToAddress(suggestion)).not.toThrow();
+    expect(mapSuggestionToAddress(suggestion).addressLine1).toBe('1234 Example St');
+  });
+
+  it('should tolerate a suggestion with no text or description at all', () => {
+    expect(() => mapSuggestionToAddress({} as Suggestion)).not.toThrow();
+    expect(mapSuggestionToAddress({} as Suggestion)).toEqual({
+      addressLine1: '',
+      addressLine2: '',
+      municipality: '',
+      subdivisionCode: '',
+      postalCode: '',
+      country: 'CA',
+    });
+  });
 });
 
 describe('filterSuggestionsWithoutAddressCount', () => {

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/utils.ts
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/utils.ts
@@ -47,22 +47,21 @@ export const filterSuggestionsWithoutAddressCount = (suggestions: Suggestion[]):
 };
 
 export const mapSuggestionToAddress = (suggestion: Suggestion): Address => {
-  let addressLine1, addressLine2;
-  const suiteMatch = suggestion.Text.match(/(Suite|Apt|Unit|#)+/i);
-  const textParts = suggestion.Text.split(' ');
-  if (suiteMatch) {
-    addressLine1 = suggestion.Text.replace(textParts[0], '').trim();
-    addressLine2 = textParts[0].trim();
-  } else {
-    addressLine2 = '';
-    addressLine1 = suggestion.Text.trim();
-  }
+  const text = suggestion?.Text?.trim() ?? '';
+  const textParts = text.split(' ');
+  const hasSuite = /(Suite|Apt|Unit|#)+/i.test(text) && textParts.length > 1;
 
-  const descriptionParts = suggestion.Description.split(',');
-  const municipality = descriptionParts[0].trim();
-  const provinceAndPostalCode = descriptionParts[1].trim().split(' ');
-  const subdivisionCode = provinceAndPostalCode[0];
-  const postalCode = descriptionParts[2].trim();
+  const addressLine1 = hasSuite ? text.replace(textParts[0], '').trim() : text;
+  const addressLine2 = hasSuite ? textParts[0].trim() : '';
+
+  // Descriptions usually read "municipality, province, postalCode", but the lookup also returns
+  // "municipality, province postalCode" and, for partial matches, drops the postal code entirely.
+  // Reading the parts positionally used to throw on anything but the three part form.
+  const descriptionParts = (suggestion?.Description ?? '').split(',').map((part) => part.trim());
+  const [municipality = '', provinceAndPostalCode = '', trailingPostalCode = ''] = descriptionParts;
+
+  const [subdivisionCode = '', ...postalCodeParts] = provinceAndPostalCode.split(' ').filter(Boolean);
+  const postalCode = postalCodeParts.length > 0 ? postalCodeParts.join(' ') : trailingPostalCode;
 
   return {
     addressLine1,

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControl.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useEffect, useState, useRef, useContext } from 'react';
+import React, { useEffect, useState, useRef, useContext, useMemo } from 'react';
 import { ControlProps, isEnabled } from '@jsonforms/core';
 import { GoabFormItem, GoabGrid } from '@abgov/react-components-ds1';
 import { NameInputs } from './FullNameInputs';
 import { TextWrapDiv } from '../AddressLookup/styled-components';
 import { Visible } from '../../util';
+import { useDebouncedCommit } from '../../util/useDebouncedCommit';
 import { JsonFormsStepperContext, JsonFormsStepperContextProps } from '../FormStepper/context';
 
 type FullNameProps = ControlProps;
@@ -60,32 +61,22 @@ export const FullNameReviewControl = (props: FullNameProps): JSX.Element => {
 export const FullNameControl = (props: FullNameProps): JSX.Element => {
   const { data, path, schema, handleChange, enabled, visible, uischema } = props;
   const requiredFields = (schema as { required: string[] }).required;
-  const [nameData, setNameData] = useState(normalizeNameData(data));
   const controlRef = useRef<HTMLDivElement>(null);
 
   const formStepperCtx = useContext(JsonFormsStepperContext);
   const stepperState = (formStepperCtx as JsonFormsStepperContextProps)?.selectStepperState?.();
 
-  const updateFormData = (updatedData: object) => {
-    updatedData = Object.fromEntries(Object.entries(updatedData).filter(([_, value]) => value !== ''));
-    handleChange(path, updatedData);
-  };
-
-  useEffect(() => {
-    const nextData = normalizeNameData(data);
-    setNameData((currentData) =>
-      currentData.firstName === nextData.firstName &&
-      currentData.middleName === nextData.middleName &&
-      currentData.lastName === nextData.lastName
-        ? currentData
-        : nextData,
-    );
-  }, [data]);
+  const normalizedData = useMemo(() => normalizeNameData(data), [data]);
+  const {
+    value: nameData,
+    setValue: setNameData,
+    flush: flushName,
+  } = useDebouncedCommit(normalizedData, (updatedData) =>
+    handleChange(path, Object.fromEntries(Object.entries(updatedData).filter(([, value]) => value !== ''))),
+  );
 
   const handleInputChange = (field: string, value: string) => {
-    const updatedName = { ...nameData, [field]: value };
-    setNameData(updatedName);
-    updateFormData(updatedName);
+    setNameData({ ...nameData, [field]: value });
   };
 
   /* istanbul ignore next */
@@ -128,6 +119,7 @@ export const FullNameControl = (props: FullNameProps): JSX.Element => {
           data={data}
           disabled={!enabled}
           requiredFields={requiredFields}
+          onFieldCommit={flushName}
         />
       </div>
     </Visible>

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameInputs.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameInputs.tsx
@@ -18,6 +18,8 @@ interface NameInputsProps {
   requiredFields?: string[];
   errors?: Record<string, string>;
   onFieldBlur?: (name: string) => void;
+  /** Called whenever a field loses focus, so the owner can push pending edits without waiting out the debounce. */
+  onFieldCommit?: () => void;
   // eslint-disable-next-line
   handleInputChange: (field: string, value: string) => void;
 }
@@ -32,6 +34,7 @@ export const NameInputs: React.FC<NameInputsProps> = ({
   disabled,
   errors,
   onFieldBlur,
+  onFieldCommit,
 }: NameInputsProps): JSX.Element => {
   const [internalErrors, setInternalErrors] = useState<Record<string, string>>({});
   const containerRef = useRef<HTMLDivElement>(null);
@@ -94,6 +97,8 @@ export const NameInputs: React.FC<NameInputsProps> = ({
 
   const displayedErrors = errors ?? internalErrors;
   const handleBlur = (name: string) => {
+    onFieldCommit?.();
+
     if (onFieldBlur) {
       onFieldBlur(name);
     } else {
@@ -137,6 +142,7 @@ export const NameInputs: React.FC<NameInputsProps> = ({
             ariaLabel={'name-form-middle-name'}
             value={middleName || ''}
             onChange={(detail: GoabInputOnChangeDetail) => handleInputChange(detail.name, detail.value)}
+            onBlur={() => onFieldCommit?.()}
             width="100%"
           />
         </GoabFormItem>

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobControl.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { GoabFormItem, GoabGrid, GoabInput } from '@abgov/react-components-ds1';
 import { ControlProps } from '@jsonforms/core';
-import { useState, useRef, useEffect, useContext } from 'react';
+import { useState, useRef, useEffect, useContext, useMemo } from 'react';
 import { useSyncAutofillFields } from '../../util/useSyncAutofillFields';
+import { useDebouncedCommit } from '../../util/useDebouncedCommit';
 import { Visible, ensureGoaDatePointerCursor } from '../../util';
 import { GoabInputOnChangeDetail, GoabInputOnBlurDetail } from '@abgov/ui-components-common';
 import { JsonFormsStepperContext, JsonFormsStepperContextProps } from '../FormStepper/context';
@@ -47,31 +48,22 @@ export const FullNameDobControl = (props: DateOfBirthControlProps): JSX.Element 
     };
   };
 
-  const [formData, setFormData] = useState(normalizeNameDobData(data));
+  const normalizedData = useMemo(() => normalizeNameDobData(data), [data]);
+  const {
+    value: formData,
+    setValue: setFormData,
+    flush: flushFormData,
+  } = useDebouncedCommit<NameDobData>(normalizedData, (updatedData) =>
+    handleChange(path, Object.fromEntries(Object.entries(updatedData).filter(([, value]) => value !== ''))),
+  );
 
   const updateFormData = (updatedData: NameDobData) => {
-    const nextData = Object.fromEntries(
-      Object.entries(updatedData).filter(([_, value]) => value !== ''),
-    ) as NameDobData;
-    setFormData(nextData);
-    handleChange(path, nextData);
+    setFormData(updatedData);
+    flushFormData();
   };
 
-  useEffect(() => {
-    const nextData = normalizeNameDobData(data);
-    setFormData((currentData) =>
-      currentData.firstName === nextData.firstName &&
-      currentData.middleName === nextData.middleName &&
-      currentData.lastName === nextData.lastName &&
-      currentData.dateOfBirth === nextData.dateOfBirth
-        ? currentData
-        : nextData,
-    );
-  }, [data]);
-
   const handleInputChange = (field: string, value: string) => {
-    const updatedData = { ...formData, [field]: value };
-    updateFormData(updatedData);
+    setFormData({ ...formData, [field]: value });
   };
 
   // eslint-disable-next-line
@@ -141,6 +133,7 @@ export const FullNameDobControl = (props: DateOfBirthControlProps): JSX.Element 
           requiredFields={requiredFields}
           errors={errors}
           onFieldBlur={handleRequiredFieldBlur}
+          onFieldCommit={flushFormData}
         />
         <GoabGrid minChildWidth="0ch" gap="s" mb="m">
           <GoabFormItem
@@ -160,7 +153,7 @@ export const FullNameDobControl = (props: DateOfBirthControlProps): JSX.Element 
               value={formData?.dateOfBirth}
               onChange={(detail: GoabInputOnChangeDetail) => handleInputChange(detail.name, detail.value)}
               onBlur={(detail: GoabInputOnBlurDetail) => {
-                /* istanbul ignore next */
+                flushFormData();
                 handleRequiredFieldBlur(detail.name);
               }}
               width="100%"

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputMultiLineTextControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputMultiLineTextControl.spec.tsx
@@ -97,7 +97,7 @@ describe('Input Text Control tests', () => {
       const input = baseElement.querySelector("goa-textarea[testId='firstName-input']");
 
       fireEvent(input, new CustomEvent('_change', { detail: { name: 'test', value: 'testValue' } }));
-      expect(input.getAttribute('value')).toBe('testValue');
+      expect(input.getAttribute('value')).toBe('TESTVALUE');
     });
 
     it('can trigger handleChange keyPress events autoCapitalize with empty text', async () => {
@@ -126,6 +126,32 @@ describe('Input Text Control tests', () => {
 
       fireEvent(input, new CustomEvent('_keyPress', { detail: { name: 'test', value: 'test' } }));
       expect(input.getAttribute('value')).toBe('test');
+    });
+
+    // CS-5218: value was bound to the debounced copy, so the textarea rendered text the user had
+    // already typed past and the web component wrote that stale text back over the field.
+    it('renders every typed character rather than the debounced copy', async () => {
+      const props = { ...staticProps, data: '' };
+      const { baseElement } = render(<MultiLineText {...props} />);
+      const input = baseElement.querySelector("goa-textarea[testId='firstName-input']");
+
+      ['D', 'DO', 'DO NOT', 'DO NOT DELETE'].forEach((value) => {
+        fireEvent(input, new CustomEvent('_change', { detail: { name: 'test', value } }));
+      });
+
+      expect(input.getAttribute('value')).toBe('DO NOT DELETE');
+    });
+
+    it('records pasted text, which arrives without a key press', async () => {
+      const handleChange = jest.fn();
+      const props = { ...staticProps, data: '', handleChange };
+      const { baseElement } = render(<MultiLineText {...props} />);
+      const input = baseElement.querySelector("goa-textarea[testId='firstName-input']");
+
+      fireEvent(input, new CustomEvent('_change', { detail: { name: 'test', value: 'pasted text' } }));
+
+      expect(input.getAttribute('value')).toBe('pasted text');
+      expect(handleChange).toHaveBeenCalledWith('test', 'pasted text');
     });
 
     it('shows required validation after an empty multiline text input loses focus', async () => {

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputMultiLineTextControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputMultiLineTextControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   CellProps,
   WithClassname,
@@ -19,31 +19,19 @@ import {
   GoabTextAreaOnChangeDetail,
   GoabTextAreaOnKeyPressDetail,
 } from '@abgov/ui-components-common';
-import { useDebounce } from '../../util/useDebounce';
+import { useDebouncedCommit } from '../../util/useDebouncedCommit';
 export type GoabInputMultiLineTextProps = CellProps & WithClassname & WithInputProps;
 
-const DEBOUNCE_DELAY = 550;
 export const MultiLineText = (props: GoabInputMultiLineTextProps): JSX.Element => {
   const { data, config, id, enabled, uischema, path, schema, label, isVisited, errors, setIsVisited } = props;
 
-  const [textAreaValue, setTextAreaValue] = React.useState<string>(data || '');
-
-  const debouncedValue = useDebounce(textAreaValue, DEBOUNCE_DELAY);
-
-  useEffect(() => {
-    setTextAreaValue(data || '');
-  }, [data]);
-
-  /* istanbul ignore next */
-  useEffect(() => {
-    if (debouncedValue !== data && (debouncedValue !== '' || data !== undefined)) {
-      onChangeForInputControl({
-        name: '',
-        value: debouncedValue,
-        controlProps: props as ControlProps,
-      });
-    }
-  }, [debouncedValue]);
+  const {
+    value: textAreaValue,
+    setValue: setTextAreaValue,
+    flush: flushTextArea,
+  } = useDebouncedCommit<string>(data || '', (value) =>
+    onChangeForInputControl({ name: '', value, controlProps: props as ControlProps }),
+  );
 
   const appliedUiSchemaOptions = { ...config, ...uischema?.options };
   const placeholder = appliedUiSchemaOptions?.placeholder || schema?.description || '';
@@ -54,10 +42,18 @@ export const MultiLineText = (props: GoabInputMultiLineTextProps): JSX.Element =
   const readOnly = uischema?.options?.componentProps?.readOnly ?? false;
   const textAreaName = `${label || path}-text-area` || '';
 
+  const applyCapitalization = (value: string) => (autoCapitalize ? value.toUpperCase() : value);
+
+  const markVisited = () => {
+    if (isVisited === false && setIsVisited) {
+      setIsVisited();
+    }
+  };
+
   const txtAreaComponent = (
     <GoabTextArea
       error={isVisited && errors.length > 0}
-      value={debouncedValue}
+      value={textAreaValue}
       disabled={!enabled}
       readOnly={readOnly}
       placeholder={placeholder}
@@ -66,25 +62,21 @@ export const MultiLineText = (props: GoabInputMultiLineTextProps): JSX.Element =
       width={width}
       // Note: Paul Jan-09-2023. The latest ui-component come with the maxCount. We need to uncomment the following line when the component is updated
       // maxCount={schema.maxLength || 256}
+      // The component raises _change from its input event, so unlike _keyPress (keyup) this also
+      // covers pasting, IME composition and held-key repeats.
+      onChange={(detail: GoabTextAreaOnChangeDetail) => {
+        setTextAreaValue(applyCapitalization(detail.value));
+        markVisited();
+      }}
       onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
-        const newValue = autoCapitalize ? detail.value.toUpperCase() : detail.value;
-
-        setTextAreaValue(newValue);
-
-        if (isVisited === false && setIsVisited) {
-          setIsVisited();
-        }
+        setTextAreaValue(applyCapitalization(detail.value));
+        markVisited();
       }}
       onBlur={(detail: GoabTextAreaOnBlurDetail) => {
-        const newValue = autoCapitalize ? detail.value.toUpperCase() : detail.value;
-
-        setTextAreaValue(newValue);
-
-        if (isVisited === false && setIsVisited) {
-          setIsVisited();
-        }
+        setTextAreaValue(applyCapitalization(detail.value));
+        flushTextArea();
+        markVisited();
       }}
-      onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
       {...uischema?.options?.componentProps}
     />
   );

--- a/libs/jsonforms-components/src/lib/util/useDebouncedCommit.spec.tsx
+++ b/libs/jsonforms-components/src/lib/util/useDebouncedCommit.spec.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDebouncedCommit } from './useDebouncedCommit';
+
+describe('useDebouncedCommit', () => {
+  it('starts from the value in the form data', () => {
+    const { result } = renderHook(() => useDebouncedCommit('start', jest.fn()));
+
+    expect(result.current.value).toBe('start');
+  });
+
+  it('exposes each keystroke immediately so the input never renders a stale value', () => {
+    const { result } = renderHook(() => useDebouncedCommit('', jest.fn()));
+
+    act(() => result.current.setValue('D'));
+    expect(result.current.value).toBe('D');
+
+    act(() => result.current.setValue('DE'));
+    expect(result.current.value).toBe('DE');
+  });
+
+  it('adopts external changes once there is nothing pending', () => {
+    const { result, rerender } = renderHook(({ external }) => useDebouncedCommit(external, jest.fn()), {
+      initialProps: { external: 'first' },
+    });
+
+    rerender({ external: 'second' });
+
+    expect(result.current.value).toBe('second');
+  });
+
+  it('does not commit a value the user never touched', () => {
+    const commit = jest.fn();
+    const { rerender } = renderHook(({ external }) => useDebouncedCommit(external, commit), {
+      initialProps: { external: 'untouched' },
+    });
+
+    rerender({ external: 'changed elsewhere' });
+
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('flushes pending edits on demand, and only once', () => {
+    const commit = jest.fn();
+    const { result } = renderHook(() => useDebouncedCommit({ city: '' }, commit));
+
+    act(() => result.current.setValue({ city: 'Calgary' }));
+    act(() => result.current.flush());
+
+    expect(commit).toHaveBeenCalledWith({ city: 'Calgary' });
+
+    commit.mockClear();
+    act(() => result.current.flush());
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  // useDebounce deliberately resolves synchronously under jest so that control specs can assert on
+  // handleChange straight after an event. These cases are about what happens with the real timer.
+  describe('with production debounce timing', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalWorkerId = process.env.JEST_WORKER_ID;
+
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.JEST_WORKER_ID;
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      process.env.NODE_ENV = originalNodeEnv;
+      if (originalWorkerId !== undefined) {
+        process.env.JEST_WORKER_ID = originalWorkerId;
+      }
+    });
+
+    it('holds the commit back until typing stops, then sends the latest value once', () => {
+      const commit = jest.fn();
+      const { result } = renderHook(() => useDebouncedCommit('', commit, 300));
+
+      act(() => result.current.setValue('D'));
+      act(() => jest.advanceTimersByTime(100));
+      act(() => result.current.setValue('DE'));
+      act(() => jest.advanceTimersByTime(100));
+      act(() => result.current.setValue('DEL'));
+
+      expect(commit).not.toHaveBeenCalled();
+
+      act(() => jest.advanceTimersByTime(300));
+
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(commit).toHaveBeenCalledWith('DEL');
+    });
+
+    it('ignores data echoing back while the user has uncommitted edits', () => {
+      const { result, rerender } = renderHook(({ external }) => useDebouncedCommit(external, jest.fn(), 300), {
+        initialProps: { external: '' },
+      });
+
+      act(() => result.current.setValue('DELETE'));
+      act(() => result.current.setValue('DELETE '));
+
+      // The form data is still catching up with an earlier keystroke.
+      rerender({ external: 'DELET' });
+
+      expect(result.current.value).toBe('DELETE ');
+    });
+
+    it('mirrors without committing when autoCommit is off, until something flushes', () => {
+      const commit = jest.fn();
+      const { result } = renderHook(() => useDebouncedCommit('', commit, 300));
+
+      act(() => result.current.setValue('123 Main', { autoCommit: false }));
+      act(() => jest.advanceTimersByTime(1000));
+
+      expect(result.current.value).toBe('123 Main');
+      expect(commit).not.toHaveBeenCalled();
+
+      act(() => result.current.flush());
+      expect(commit).toHaveBeenCalledWith('123 Main');
+    });
+
+    it('still shields an autoCommit-off edit from data arriving underneath it', () => {
+      const { result, rerender } = renderHook(({ external }) => useDebouncedCommit(external, jest.fn(), 300), {
+        initialProps: { external: '' },
+      });
+
+      act(() => result.current.setValue('123 Main', { autoCommit: false }));
+      rerender({ external: 'something else' });
+
+      expect(result.current.value).toBe('123 Main');
+    });
+
+    it('flushes pending edits when the control unmounts', () => {
+      const commit = jest.fn();
+      const { result, unmount } = renderHook(() => useDebouncedCommit('', commit, 300));
+
+      act(() => result.current.setValue('typed but not committed'));
+      expect(commit).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(commit).toHaveBeenCalledWith('typed but not committed');
+    });
+  });
+});

--- a/libs/jsonforms-components/src/lib/util/useDebouncedCommit.ts
+++ b/libs/jsonforms-components/src/lib/util/useDebouncedCommit.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { isEqual } from 'lodash';
+import { useDebounce } from './useDebounce';
+
+export const COMMIT_DELAY = 300;
+
+export interface SetValueOptions {
+  /**
+   * Whether the edit should be pushed upstream once typing stops. Pass false for a field whose
+   * owner commits on its own schedule; the value is still mirrored and still protected from
+   * incoming data until something calls flush.
+   */
+  autoCommit?: boolean;
+}
+
+export interface DebouncedCommit<T> {
+  /** The live value to bind to the input; updated on every keystroke. */
+  value: T;
+  /** Records a keystroke and, unless told otherwise, schedules the commit. */
+  setValue: (next: T, options?: SetValueOptions) => void;
+  /** Commits straight away, for events that are not typing (blur, selecting a suggestion, unmount). */
+  flush: () => void;
+}
+
+/**
+ * Keeps a live, per-keystroke mirror of a control's value and pushes it into the form data only
+ * once the user pauses typing.
+ *
+ * The GoA web components keep the value in their own DOM and report changes back a macrotask
+ * late, while their update path writes an incoming `value` prop straight back into the field
+ * whenever it differs from what is in the box. So a render that commits a value older than what
+ * has been typed since wipes out the characters in between. Committing on every keystroke
+ * re-renders and revalidates the whole form, which makes that window wide enough to swallow
+ * characters; debouncing the commit keeps it to a single local render.
+ *
+ * The echo of our own commit is ignored while further edits are outstanding, so data arriving
+ * back from the form can never overwrite what the user has typed in the meantime.
+ *
+ * @param externalValue the value held in the form data; must be referentially stable between
+ *   renders (memoize it when it is an object), otherwise the sync effect runs on every render
+ * @param commit pushes a settled value into the form data
+ * @param delay how long to wait for typing to stop before committing
+ */
+export function useDebouncedCommit<T>(
+  externalValue: T,
+  commit: (value: T) => void,
+  delay: number = COMMIT_DELAY,
+): DebouncedCommit<T> {
+  const [value, setLocalValue] = useState<T>(externalValue);
+
+  // Set while the user has edits we have not pushed upstream yet.
+  const pendingRef = useRef<T | null>(null);
+  const autoCommitRef = useRef(true);
+
+  const commitRef = useRef(commit);
+  useEffect(() => {
+    commitRef.current = commit;
+  });
+
+  const debouncedValue = useDebounce(value, delay);
+
+  const flush = useCallback(() => {
+    const pending = pendingRef.current;
+    if (pending === null) {
+      return;
+    }
+
+    pendingRef.current = null;
+    autoCommitRef.current = true;
+    commitRef.current(pending);
+  }, []);
+
+  const setValue = useCallback((next: T, options?: SetValueOptions) => {
+    pendingRef.current = next;
+    autoCommitRef.current = options?.autoCommit !== false;
+    setLocalValue(next);
+  }, []);
+
+  useEffect(() => {
+    if (!autoCommitRef.current) {
+      return;
+    }
+
+    // Only commit once the debounce has caught up with the latest keystroke.
+    if (pendingRef.current === null || pendingRef.current !== debouncedValue) {
+      return;
+    }
+
+    flush();
+  }, [debouncedValue, flush]);
+
+  useEffect(() => {
+    if (pendingRef.current !== null) {
+      return;
+    }
+
+    setLocalValue((current) => (isEqual(current, externalValue) ? current : externalValue));
+  }, [externalValue]);
+
+  // Don't drop the tail of what was typed when the control goes away, e.g. on stepper navigation.
+  useEffect(() => flush, [flush]);
+
+  return { value, setValue, flush };
+}


### PR DESCRIPTION
## CS-5218

Text areas and text inputs lose characters and flicker when typing quickly. The plain text control was fixed previously; the **imported composite controls (`postalAddressCanada`, full name, name/DOB) were not**, which is why the symptom persisted there.

Two commits: the fix, and a pre-existing crash in the address lookup found while verifying it.

---

## 1. Retain every typed character in composite controls

### Root cause

`GoabInput` / `GoabTextArea` render GoA custom elements and pass `value` as an attribute. Two things combine badly:

1. `goa-input` dispatches its `_change` event from a `setTimeout`, so React learns about a keystroke a macrotask late.
2. The component's update path writes the incoming prop straight back into the real `<input>`, and only when it differs from what is in the box:
   ```js
   (dirty & value && d !== (d = value ?? "") && l.value !== d) && (l.value = d)
   ```

So any render that commits a `value` older than what has been typed since destroys the characters in between and sends the caret to the end. Worse, the pending `_change` timer reads `target.value` at dispatch time, so after a clobber it re-reports the clobbered value and the loss is permanent.

**The size of the loss window is keystroke → React commit**, which is why the symptom is severity-graded rather than all-or-nothing. `InputTextControl` keeps a local mirror and debounces its push to JsonForms, so only that one control re-renders (~1 ms window) and it looks fine. The composite controls pushed every keystroke through the full JsonForms → redux → `updateCore` round trip, re-rendering and revalidating the whole form — tens of milliseconds, comfortably enough to eat the next character.

### What was wrong

- **`AddressLookUpControl`** — `addressLine1` was an outright broken controlled input: `value={address?.addressLine1}` but `onChange` only called `setSearchTerm`, never touching `address`. The committed prop diverged from the box by the entire typed string, and anything that later set the field (blur, suggestion click, arrow-key navigation) overwrote what had been typed.
- **Address / full name / name+DOB** — `handleChange` on every keystroke, plus a `data`-sync effect that could push a round-tripped, stale value back into the prop mid-edit.
- **`MultiLineText`** — bound to the 550 ms *debounced* copy (`value={debouncedValue}`) with `onChange={() => {}}`. State was driven only from `_keyPress`, which `goa-textarea` raises on **`keyup`** — so pastes, IME composition and held-key repeats never reached React, and stale text got written back over the field.
- **`AddressLookUpControl`** also ran **two** suggestion-fetch effects over two separate 500 ms debounces of the same term, both writing `open` / `loading` / `suggestions` — the visible flicker.

Corroborating evidence this was already known but patched over: `AddressLookUpControl` and `FullNameInputs` both scraped the live DOM value out of the web component to recover state React had lost.

### The change

New `useDebouncedCommit` hook: keeps a **live per-keystroke mirror** bound to `value`, pushes to the form data only once typing stops, **ignores the echo of its own commit while edits are outstanding** (so a lagging round trip can never overwrite the box), and flushes immediately on blur, selection and unmount.

A field whose owner commits on its own schedule opts out of the push with `autoCommit: false`. `addressLine1` uses it: as before, it stays uncommitted until blur or picking a suggestion, because writing it mid-lookup re-renders the form while the 500 ms search debounce is still running and closes the suggestions dropdown.

Adopted in `AddressLookUpControl`, `FullNameControl`, `FullNameDobControl` and `MultiLineText`. `MultiLineText` now drives from `_change` (the `input` event) instead of `_keyPress`, so pastes and IME input are captured.

Also collapsed the duplicated suggestion fetch — kept the abortable, cached effect and deleted the older unabortable copy.

---

## 2. Stop suggestion selection crashing on short descriptions

Pre-existing, not introduced here. `mapSuggestionToAddress` read the description parts positionally:

```ts
const provinceAndPostalCode = descriptionParts[1].trim().split(' ');
const postalCode = descriptionParts[2].trim();
```

Anything that is not the three-part `"municipality, province, postalCode"` form threw `Cannot read properties of undefined (reading 'trim')` and took the form down — on both paths into `handleSuggestionClick` (clicking the item and pressing Enter).

Now read defensively, covering the shapes the lookup actually returns:

- `"Edmonton, AB, T5J 2N9"` — unchanged
- `"Edmonton, AB T5J 2N9"` — province and postal code in one part (which is what the `provinceAndPostalCode` variable name suggests was originally expected)
- `"Edmonton, AB"` — no postal code
- `"Edmonton"` / empty / missing fields — no throw

---

## Notes for reviewers

**The abortable fetch effect was dead in tests.** `formatPostalCodeIfNeeded` was stubbed as a bare `jest.fn()` returning `undefined`, which that effect correctly treats as an empty query, so only the duplicate was ever exercised. The spec's `./utils` mock now spreads `requireActual` and stubs only what a test needs to steer. Two assertions changed because they were vacuous against the dead code paths: `autoCapitalize` genuinely uppercases now, and the arrow-key `_keyPress` details carry `name`/`value` like the real component sends.

**`useDebounce` short-circuits under jest**, so debounce-dependent behaviour is invisible in tests. Cases that need real timing use an explicit `NODE_ENV` / `JEST_WORKER_ID` override with fake timers, grouped under `with production debounce timing`.

## Verification

- Acceptance criteria tested — specs assert every typed character survives in `addressLine1`, the other address fields and the textarea, including a stale-form-data-mid-edit case, and that typing in the lookup leaves the form data untouched until blur or selection
- Error paths tested — required-field blur errors, postal code validation, fetch failures, and five malformed-suggestion shapes
- Unit tests updated or verified — 96 suites / 1371 tests pass in `jsonforms-components`, plus `form-app` (4 suites / 30 tests); `tsc --noEmit` and eslint clean (2 remaining `FullNameInputs` warnings pre-exist on `main`). Both commits pass standalone.
- Manual testing completed — verified in the running app: typing retains all characters, and the suggestions dropdown opens and selects by click and by Enter
- No known defects
- No known regressions
