### PR TITLE
fix(tenant-management-api): grant manage-clients/manage-users directly to adsp-cli-ci service account

### DIFF
--- a/apps/tenant-management-api/src/keycloak/configuration.ts
+++ b/apps/tenant-management-api/src/keycloak/configuration.ts
@@ -164,14 +164,15 @@ export const ADSP_CLI_CLIENT_SCOPE_MAPPINGS = [
 export const ADSP_CLI_CI_CLIENT_ID = 'adsp-cli-ci';
 
 /**
- * Roles granted to the adsp-cli-ci service account — configuration-admin only. agent-user is
- * intentionally omitted: agent-service is for interactive (human-in-the-loop) use and has no
- * value in a non-interactive CI pipeline. The adsp-cli-admin optional scope (manage-clients +
- * manage-users) is attached separately in keycloak.ts's createAdspCliAdminScope so it is
- * available if a tenant admin enables it for automated provisioning workflows.
+ * Roles granted to the adsp-cli-ci service account. agent-user is intentionally omitted:
+ * agent-service is for interactive (human-in-the-loop) use and has no value in a non-interactive
+ * CI pipeline. manage-clients and manage-users (from realm-management) are included so the service
+ * account can perform automated provisioning workflows (registering Keycloak clients, assigning
+ * roles) when the tenant enables this client.
  */
 export const ADSP_CLI_CI_CLIENT_SCOPE_MAPPINGS = [
   { client: 'urn:ads:platform:configuration-service', roles: ['configuration-admin'] },
+  { client: 'realm-management', roles: ['manage-clients', 'manage-users'] },
 ];
 
 /**

--- a/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
@@ -180,27 +180,27 @@ describe('KeycloakRealmService', () => {
       keycloakClientMock.clients.find
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
-        .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
+        .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'my-tenant-broker-client-123' }]);
       keycloakClientMock.clients.findRole
         .mockResolvedValueOnce({ id: 'tenant-admin-role-123', name: 'tenant-admin' })
         .mockResolvedValueOnce(testerRole)
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' })
-        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' });
+        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
+        .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
+        .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' });
 
       keycloakClientMock.clientScopes.create.mockResolvedValueOnce({});
       keycloakClientMock.clientScopes.findOneByName
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' })
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' });
-      keycloakClientMock.clients.addOptionalClientScope
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined);
+      keycloakClientMock.clients.addOptionalClientScope.mockResolvedValueOnce(undefined);
       keycloakClientMock.clients.getServiceAccountUser.mockResolvedValueOnce({ id: 'ci-service-account-user-123' });
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });
@@ -301,27 +301,27 @@ describe('KeycloakRealmService', () => {
       keycloakClientMock.clients.find
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
-        .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
+        .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([]);
       keycloakClientMock.clients.findRole
         .mockResolvedValueOnce({ id: 'tenant-admin-role-123', name: 'tenant-admin' })
         .mockResolvedValueOnce(testerRole)
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' })
-        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' });
+        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
+        .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
+        .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' });
 
       keycloakClientMock.clientScopes.create.mockResolvedValueOnce({});
       keycloakClientMock.clientScopes.findOneByName
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' })
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' });
-      keycloakClientMock.clients.addOptionalClientScope
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined);
+      keycloakClientMock.clients.addOptionalClientScope.mockResolvedValueOnce(undefined);
       keycloakClientMock.clients.getServiceAccountUser.mockResolvedValueOnce({ id: 'ci-service-account-user-123' });
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });
@@ -350,27 +350,27 @@ describe('KeycloakRealmService', () => {
       keycloakClientMock.clients.find
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
-        .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
+        .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'my-tenant-broker-client-123' }]);
       keycloakClientMock.clients.findRole
         .mockResolvedValueOnce({ id: 'tenant-admin-role-123', name: 'tenant-admin' })
         .mockResolvedValueOnce(testerRole)
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' })
-        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' });
+        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
+        .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
+        .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' });
 
       keycloakClientMock.clientScopes.create.mockResolvedValueOnce({});
       keycloakClientMock.clientScopes.findOneByName
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' })
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' });
-      keycloakClientMock.clients.addOptionalClientScope
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined);
+      keycloakClientMock.clients.addOptionalClientScope.mockResolvedValueOnce(undefined);
       keycloakClientMock.clients.getServiceAccountUser.mockResolvedValueOnce({ id: 'ci-service-account-user-123' });
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });

--- a/apps/tenant-management-api/src/keycloak/keycloak.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.ts
@@ -231,18 +231,16 @@ export class KeycloakRealmServiceImpl implements RealmService {
     await client.clientScopes.create({ realm, ...createAdspCliAdminClientScopeConfig() });
 
     const adminScope = await client.clientScopes.findOneByName({ realm, name: ADSP_CLI_ADMIN_CLIENT_SCOPE_NAME });
+    const adspCliClient = (await client.clients.find({ realm, clientId: 'adsp-cli' }))[0];
 
-    for (const clientId of ['adsp-cli', ADSP_CLI_CI_CLIENT_ID]) {
-      const adspClient = (await client.clients.find({ realm, clientId }))[0];
-      await client.clients.addOptionalClientScope({
-        realm,
-        id: adspClient.id,
-        clientScopeId: adminScope.id,
-      });
-    }
+    await client.clients.addOptionalClientScope({
+      realm,
+      id: adspCliClient.id,
+      clientScopeId: adminScope.id,
+    });
 
     this.logger.debug(
-      `Created '${ADSP_CLI_ADMIN_CLIENT_SCOPE_NAME}' client scope and assigned to adsp-cli and ${ADSP_CLI_CI_CLIENT_ID} as optional.`,
+      `Created '${ADSP_CLI_ADMIN_CLIENT_SCOPE_NAME}' client scope and assigned to adsp-cli as optional.`,
       LOG_CONTEXT,
     );
   }


### PR DESCRIPTION
## Summary

- Fixes tenant creation failure in UAT introduced by the `adsp-cli-ci` CI client feature
- `addOptionalClientScope` fails on Keycloak 24 for `adsp-cli-ci` because optional scopes apply to user-interactive flows; `adsp-cli-ci` is a client-credentials-only client with no consent screen
- Removes `adsp-cli-ci` from `addOptionalClientScope` in `createAdspCliAdminScope`
- Adds `manage-clients` and `manage-users` (from `realm-management`) to `ADSP_CLI_CI_CLIENT_SCOPE_MAPPINGS` so `grantCiClientServiceAccountRoles` grants them directly to the service account and the `clientScopeMappings` scope filter passes them through `fullScopeAllowed: false`

## Test plan

- [ ] All existing `keycloak.spec.ts` tests pass (13/13)
- [ ] Create a new tenant in UAT and verify it provisions successfully end-to-end
- [ ] Verify the `adsp-cli-ci` service account in the new realm has `manage-clients` and `manage-users` roles granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)