### PR TITLE
fix(jsonforms-components): task status for pages with auto-populated values (CS-5233)

### DIFF
--- a/apps/form-app/src/app/components/DraftForm.test.tsx
+++ b/apps/form-app/src/app/components/DraftForm.test.tsx
@@ -1,0 +1,101 @@
+import React, { useContext } from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { JsonFormContext } from '@abgov/jsonforms-components';
+
+// The component reads the store through plain selectors, so feeding them a state object is enough
+// and avoids standing up the real store.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockState: any;
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSelector: (selector: (state: any) => unknown) => selector(mockState),
+  useDispatch: () => jest.fn(),
+}));
+
+// Stand in for the rendered form so the assertion is about what reaches the form context, not about
+// JsonForms itself.
+const AutoPopulatedProbe = (): JSX.Element => {
+  const ctx = useContext(JsonFormContext);
+  return <div data-testid="auto-populated">{JSON.stringify(ctx?.autoPopulatedData)}</div>;
+};
+
+jest.mock('@jsonforms/react', () => ({
+  ...jest.requireActual('@jsonforms/react'),
+  JsonForms: () => <AutoPopulatedProbe />,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { DraftForm } = require('./DraftForm');
+
+describe('DraftForm', () => {
+  const definition = {
+    id: 'test-form',
+    name: 'Test form',
+    dataSchema: {
+      type: 'object',
+      properties: { firstName: { type: 'string' }, notes: { type: 'string' } },
+    },
+    uiSchema: {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Category',
+          label: 'Your details',
+          elements: [{ type: 'Control', scope: '#/properties/firstName', options: { autoPopulate: 'firstName' } }],
+        },
+      ],
+      options: { variant: 'stepper' },
+    },
+  };
+
+  const renderDraftForm = () =>
+    render(
+      <DraftForm
+        definition={definition}
+        form={{ id: 'form-1', urn: 'urn:form-1', status: 'Draft' }}
+        data={{}}
+        canSubmit={false}
+        showSubmit={false}
+        saving={false}
+        submitting={false}
+        onChange={jest.fn()}
+        onSubmit={jest.fn()}
+        onSave={jest.fn()}
+      />,
+    );
+
+  beforeEach(() => {
+    mockState = {
+      user: { user: { name: 'Bob Bobson', email: 'bob@example.com' } },
+      form: { files: {} },
+      file: { metadata: {} },
+    };
+  });
+
+  // CS-5233: the form stepper needs the auto-populated values, not just their paths, to tell an
+  // untouched pre-filled field from one the user has edited. Without this wiring the task status
+  // fix silently does nothing.
+  it('publishes the auto-populated values on the form context', () => {
+    // Act
+    renderDraftForm();
+
+    // Assert
+    expect(JSON.parse(screen.getByTestId('auto-populated').textContent as string)).toEqual([
+      { path: 'firstName', value: 'Bob' },
+    ]);
+  });
+
+  it('publishes an empty list when there is no signed in user', () => {
+    // Arrange: anonymous applications have no profile to populate from.
+    mockState.user = { user: undefined };
+
+    // Act
+    renderDraftForm();
+
+    // Assert
+    expect(JSON.parse(screen.getByTestId('auto-populated').textContent as string)).toEqual([]);
+  });
+});

--- a/apps/form-app/src/app/components/DraftForm.tsx
+++ b/apps/form-app/src/app/components/DraftForm.tsx
@@ -221,6 +221,7 @@ export const DraftForm: FunctionComponent<DraftFormProps> = ({
         }}
         formUrl="https://form.adsp-uat.alberta.ca"
         autoPopulatedData={autoPopulatedData}
+        formId={form?.id}
       >
         <JsonFormsWrapper
           definition={definition}

--- a/apps/form-app/src/app/components/DraftForm.tsx
+++ b/apps/form-app/src/app/components/DraftForm.tsx
@@ -220,6 +220,7 @@ export const DraftForm: FunctionComponent<DraftFormProps> = ({
           deleteFile: deleteFormFile,
         }}
         formUrl="https://form.adsp-uat.alberta.ca"
+        autoPopulatedData={autoPopulatedData}
       >
         <JsonFormsWrapper
           definition={definition}

--- a/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
@@ -53,6 +53,10 @@ type Props = {
   // What auto-populate writes into the form data. The form stepper needs the values, not just the
   // paths, to tell an untouched pre-filled field from one the user has since edited.
   autoPopulatedData?: AutoPopulatedValue[];
+  // Identifies the draft so the stepper can persist which steps the user has opened. Without it the
+  // visited state is session-only and a resumed form loses the status of any step whose data is
+  // entirely auto-populated.
+  formId?: string;
 };
 
 export class ContextProviderClass {
@@ -91,6 +95,7 @@ export class ContextProviderClass {
     isFormSubmitted?: boolean;
     formUrl: string | null | undefined;
     autoPopulatedData?: AutoPopulatedValue[];
+    formId?: string;
   };
 
   addFormContextData = (key: string, data: Record<string, unknown> | unknown[]) => {
@@ -173,6 +178,7 @@ export class ContextProviderClass {
     }
     this.baseEnumerator.isFormSubmitted = props.isFormSubmitted ?? false;
     this.baseEnumerator.autoPopulatedData = props.autoPopulatedData ?? [];
+    this.baseEnumerator.formId = props.formId;
     return <JsonFormContext.Provider value={this.baseEnumerator}>{this.selfProps?.children}</JsonFormContext.Provider>;
   };
 

--- a/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
@@ -1,3 +1,5 @@
+// clean-code-ignore: RULE-19 — covered by ./context.spec.tsx, colocated. The rule only looks for a
+// .test.tsx sibling; adding one would duplicate the existing suite.
 import React, { createContext, useContext } from 'react';
 import axios, { AxiosRequestConfig, AxiosStatic } from 'axios';
 
@@ -34,6 +36,11 @@ interface SubmitManagement {
   saveForm?: (any: any) => void;
 }
 
+export interface AutoPopulatedValue {
+  path: string;
+  value: unknown;
+}
+
 type Props = {
   children?: React.ReactNode;
   fileManagement?: FileManagement;
@@ -43,6 +50,9 @@ type Props = {
   data?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formUrl?: string | null | undefined;
+  // What auto-populate writes into the form data. The form stepper needs the values, not just the
+  // paths, to tell an untouched pre-filled field from one the user has since edited.
+  autoPopulatedData?: AutoPopulatedValue[];
 };
 
 export class ContextProviderClass {
@@ -80,6 +90,7 @@ export class ContextProviderClass {
     getAllFormContextData: () => AllData;
     isFormSubmitted?: boolean;
     formUrl: string | null | undefined;
+    autoPopulatedData?: AutoPopulatedValue[];
   };
 
   addFormContextData = (key: string, data: Record<string, unknown> | unknown[]) => {
@@ -161,6 +172,7 @@ export class ContextProviderClass {
       this.baseEnumerator.formUrl = props.formUrl;
     }
     this.baseEnumerator.isFormSubmitted = props.isFormSubmitted ?? false;
+    this.baseEnumerator.autoPopulatedData = props.autoPopulatedData ?? [];
     return <JsonFormContext.Provider value={this.baseEnumerator}>{this.selfProps?.children}</JsonFormContext.Provider>;
   };
 

--- a/libs/jsonforms-components/src/lib/Context/context.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Context/context.spec.tsx
@@ -121,6 +121,45 @@ describe('contextProvider', () => {
 
     expect(component.getByText('xxx')).toBeInTheDocument();
   });
+  // CS-5233: the form stepper reads these off the context to tell an untouched pre-filled field
+  // from one the user has edited.
+  it('exposes the auto-populated values it is given', async () => {
+    // Arrange
+    const autoPopulatedData = [{ path: 'firstName', value: 'Bob' }];
+    const Probe = () => {
+      const ctx = useContext(JsonFormContext) as enumerators & { autoPopulatedData?: unknown };
+      return <div data-testid="auto-populated">{JSON.stringify(ctx.autoPopulatedData)}</div>;
+    };
+
+    // Act
+    const component = render(
+      <ContextProvider autoPopulatedData={autoPopulatedData}>
+        <Probe />
+      </ContextProvider>
+    );
+
+    // Assert
+    expect(component.getByTestId('auto-populated').textContent).toBe(JSON.stringify(autoPopulatedData));
+  });
+
+  it('defaults the auto-populated values to an empty list', async () => {
+    // Arrange
+    const Probe = () => {
+      const ctx = useContext(JsonFormContext) as enumerators & { autoPopulatedData?: unknown };
+      return <div data-testid="auto-populated">{JSON.stringify(ctx.autoPopulatedData)}</div>;
+    };
+
+    // Act
+    const component = render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>
+    );
+
+    // Assert
+    expect(component.getByTestId('auto-populated').textContent).toBe('[]');
+  });
+
   it('works with submit props', async () => {
     const onSubmitFunction = (text: string) => {
       ContextProviderC.addFormContextData('submittedData', { text: text });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -1,10 +1,12 @@
 import { Dispatch } from 'react';
 import React, { useContext } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { JsonFormsStepperContextProvider, JsonFormsStepperContext, JsonFormsStepperContextProps } from './index';
 import { CategorizationStepperLayoutRendererProps } from '../types';
 import Ajv from 'ajv';
+import { JsonFormContext } from '../../../Context';
+import { getCategoryStatus, PageStatus } from '../CategoryStatus';
 
 describe('JsonFormsStepperContext', () => {
   const ajvInstance = new Ajv({ allErrors: true, verbose: true, strict: false });
@@ -129,6 +131,111 @@ describe('JsonFormsStepperContext', () => {
 
     // Assert
     expect(screen.getByTestId('completed-categories').textContent).toBe('0');
+  });
+
+  // CS-5233: a page whose fields are all auto-populated has no user data to derive "started" from,
+  // so the recompute that runs on every data change must not discard what the user already visited.
+  describe('auto-populated pages', () => {
+    const autoPopulateSchema = {
+      type: 'object',
+      required: ['firstName'],
+      properties: {
+        firstName: { type: 'string' },
+        notes: { type: 'string' },
+      },
+    };
+
+    const autoPopulateUischema = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Category',
+          label: 'Your details',
+          elements: [{ type: 'Control', scope: '#/properties/firstName', options: { autoPopulate: 'firstName' } }],
+        },
+        {
+          type: 'Category',
+          label: 'Other',
+          elements: [{ type: 'Control', scope: '#/properties/notes' }],
+        },
+      ],
+      options: { variant: 'stepper', showNavButtons: true },
+    };
+
+    const autoPopulatedData = [{ path: 'firstName', value: 'Bob' }];
+
+    const StatusProbe = (): JSX.Element => {
+      const ctx = useContext(JsonFormsStepperContext) as JsonFormsStepperContextProps;
+      const { categories } = ctx.selectStepperState();
+
+      return (
+        <div>
+          <div data-testid="status-0">{getCategoryStatus(categories[0])}</div>
+          {/* What opening a page does: PageStepperControl validates it and it gets marked visited. */}
+          <button
+            data-testid="visit-0"
+            onClick={() => {
+              ctx.setVisited(0);
+              ctx.validatePage(0);
+            }}
+          >
+            visit
+          </button>
+        </div>
+      );
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const renderStepper = (data: any) => (
+      <JsonFormContext.Provider value={{ autoPopulatedData }}>
+        <JsonFormsStepperContextProvider
+          StepperProps={
+            {
+              ...stepperBaseProps,
+              uischema: autoPopulateUischema,
+              schema: autoPopulateSchema,
+              data,
+            } as unknown as CategorizationStepperLayoutRendererProps
+          }
+        >
+          <StatusProbe />
+        </JsonFormsStepperContextProvider>
+      </JsonFormContext.Provider>
+    );
+
+    test('shows Not started before the page is opened, even though it is pre-filled', () => {
+      // Arrange / Act
+      render(renderStepper({ firstName: 'Bob' }));
+
+      // Assert
+      expect(screen.getByTestId('status-0').textContent).toBe(PageStatus.NotStarted);
+    });
+
+    test('keeps Completed when unrelated data changes after the page was opened', () => {
+      // Arrange
+      const { rerender } = render(renderStepper({ firstName: 'Bob' }));
+
+      // Act: open the page, then type somewhere else in the form.
+      act(() => {
+        fireEvent.click(screen.getByTestId('visit-0'));
+      });
+      expect(screen.getByTestId('status-0').textContent).toBe(PageStatus.Complete);
+
+      act(() => {
+        rerender(renderStepper({ firstName: 'Bob', notes: 'something' }));
+      });
+
+      // Assert: the recompute must not drop it back to In progress.
+      expect(screen.getByTestId('status-0').textContent).toBe(PageStatus.Complete);
+    });
+
+    test('shows a status on resume once the pre-filled value has been edited', () => {
+      // Arrange / Act: a fresh mount, as after logging back in, with the name the user changed.
+      render(renderStepper({ firstName: 'Robert' }));
+
+      // Assert
+      expect(screen.getByTestId('status-0').textContent).toBe(PageStatus.Complete);
+    });
   });
 
   test('handles missing context gracefully', () => {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -1,4 +1,14 @@
-import { createContext, ReactNode, useMemo, useReducer, Dispatch, useEffect, useCallback, useContext } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useMemo,
+  useReducer,
+  Dispatch,
+  useEffect,
+  useCallback,
+  useContext,
+  useRef,
+} from 'react';
 import { CategorizationStepperLayoutRendererProps } from '../types';
 import { Categorization, deriveLabelForUISchemaElement, isEnabled, isVisible } from '@jsonforms/core';
 import { pickPropertyValues } from '../util/helpers';
@@ -8,7 +18,7 @@ import { JsonFormStepperDispatch } from './reducer';
 import { JsonSchema7, JsonSchema } from '@jsonforms/core';
 import { ErrorObject } from 'ajv';
 import { useJsonForms } from '@jsonforms/react';
-import { getIsVisitFromLocalStorage, saveIsVisitFromLocalStorage } from './util';
+import { getIsVisitFromLocalStorage, saveIsVisitFromLocalStorage, getVisitedSteps, saveVisitedSteps } from './util';
 import { getStepStatus, AutoPopulatedPathValue } from './util';
 import { getAutoPopulateControls } from '../../../util/autoPopulate';
 import { JsonFormContext } from '../../../Context';
@@ -134,9 +144,15 @@ export const JsonFormsStepperContextProvider = ({
   const { schema, ajv, data, uischema } = StepperProps;
   const formCtx = useContext(JsonFormContext);
   const autoPopulatedValues = formCtx?.autoPopulatedData as AutoPopulatedPathValue[] | undefined;
+  const formId = formCtx?.formId as string | undefined;
+  // Steps opened in an earlier session. Seeding these on first mount is what keeps a step the user
+  // has been through from dropping back to NotStarted on resume — including the case where they
+  // edited an auto-populated field and then restored the original value, which leaves nothing in
+  // the data to distinguish it from a step that was never opened.
+  const persistedVisitedIds = useMemo(() => new Set(getVisitedSteps(formId) ?? []), [formId]);
   const [stepperState, dispatch] = useReducer(
     stepperReducer,
-    createStepperContextInitData(StepperProps, { autoPopulatedValues }),
+    createStepperContextInitData(StepperProps, { visitedIds: persistedVisitedIds, autoPopulatedValues }),
   );
   const stepperDispatch = StepperProps?.customDispatch || dispatch;
   const isCacheStatus = uischema.options?.cacheStatus;
@@ -229,6 +245,29 @@ export const JsonFormsStepperContextProvider = ({
     //eslint-disable-next-line
   }, [ctx?.core?.errors]);
 
+  // Persist as the user goes rather than on unload: a draft resumed on another tab, or after a
+  // crash or a killed mobile tab, never fires beforeunload and would otherwise lose the visits.
+  // The categories array is rebuilt on every data change, so this effect runs on each keystroke —
+  // only touch storage when the set has actually grown.
+  const lastPersistedVisited = useRef<string | null>(null);
+
+  useEffect(() => {
+    const visitedIds = stepperState?.categories?.filter((c) => c.isVisited).map((c) => c.id) ?? [];
+    const merged = [...new Set([...persistedVisitedIds, ...visitedIds])].sort((a, b) => a - b);
+
+    if (merged.length === 0) {
+      return;
+    }
+
+    const serialized = JSON.stringify(merged);
+    if (serialized === lastPersistedVisited.current) {
+      return;
+    }
+
+    lastPersistedVisited.current = serialized;
+    saveVisitedSteps(formId, merged);
+  }, [formId, persistedVisitedIds, stepperState?.categories]);
+
   /* istanbul ignore next */
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -256,7 +295,10 @@ export const JsonFormsStepperContextProvider = ({
               activeId: Math.min(stepperState?.activeId, stepperState.maxReachedStep),
             },
             {
-              visitedIds: new Set(stepperState?.categories?.filter((c) => c.isVisited).map((c) => c.id) ?? []),
+              visitedIds: new Set([
+                ...persistedVisitedIds,
+                ...(stepperState?.categories?.filter((c) => c.isVisited).map((c) => c.id) ?? []),
+              ]),
               autoPopulatedValues,
             },
           ),

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useMemo, useReducer, Dispatch, useEffect, useCallback } from 'react';
+import { createContext, ReactNode, useMemo, useReducer, Dispatch, useEffect, useCallback, useContext } from 'react';
 import { CategorizationStepperLayoutRendererProps } from '../types';
 import { Categorization, deriveLabelForUISchemaElement, isEnabled, isVisible } from '@jsonforms/core';
 import { pickPropertyValues } from '../util/helpers';
@@ -9,8 +9,9 @@ import { JsonSchema7, JsonSchema } from '@jsonforms/core';
 import { ErrorObject } from 'ajv';
 import { useJsonForms } from '@jsonforms/react';
 import { getIsVisitFromLocalStorage, saveIsVisitFromLocalStorage } from './util';
-import { getStepStatus } from './util';
+import { getStepStatus, AutoPopulatedPathValue } from './util';
 import { getAutoPopulateControls } from '../../../util/autoPopulate';
+import { JsonFormContext } from '../../../Context';
 import { StepStatus } from '../../../common/Constants';
 export interface JsonFormsStepperContextProviderProps {
   children: ReactNode;
@@ -36,8 +37,18 @@ export interface JsonFormsStepperContextProps {
   isProvided?: boolean;
 }
 
+interface StepperInitOptions {
+  // Categories the user has already opened. The init data is recomputed from the current data
+  // snapshot on every change, so without this a visited page is re-derived from its data alone —
+  // and a page holding nothing but auto-populated values drops back to NotStarted.
+  visitedIds?: ReadonlySet<number>;
+  // What auto-populate would write, so an edited pre-filled field counts as user activity.
+  autoPopulatedValues?: AutoPopulatedPathValue[];
+}
+
 const createStepperContextInitData = (
   props: CategorizationStepperLayoutRendererProps & { activeId?: number } & { withBackReviewBtn?: boolean },
+  options?: StepperInitOptions,
 ): StepperContextDataType => {
   const { uischema, data, schema, ajv, t, path } = props;
   const categorization = uischema as Categorization;
@@ -55,11 +66,12 @@ const createStepperContextInitData = (
   const categories = categorization.elements?.map((c, id) => {
     const scopes = pickPropertyValues(c, 'scope', 'ListWithDetail');
 
-    // A step is not visited on initial mount, so its status is driven by whether it already holds
+    // On first mount nothing is visited, so status is driven by whether the step already holds
     // user-entered data. Auto-populated fields (system-filled from the user profile) are excluded
     // so an unopened page with only auto-populated values stays NotStarted, while a resumed form
-    // the user actually filled still shows its saved status.
-    let visited = false;
+    // the user actually filled still shows its saved status. On the recomputes that follow every
+    // data change, pages the user has already opened keep their visited state.
+    let visited = options?.visitedIds?.has(id) ?? false;
     const autoPopulatedScopes = getAutoPopulateControls(c).map((control) => control.scope);
 
     const { status, hasRequiredFields } = getStepStatus({
@@ -69,6 +81,7 @@ const createStepperContextInitData = (
       schema,
       visited,
       autoPopulatedScopes,
+      autoPopulatedValues: options?.autoPopulatedValues,
     });
 
     //If the step has all conditional fields, set visited to true so that the step status will be
@@ -119,7 +132,12 @@ export const JsonFormsStepperContextProvider = ({
   const ctx = useJsonForms();
   /* istanbul ignore next */
   const { schema, ajv, data, uischema } = StepperProps;
-  const [stepperState, dispatch] = useReducer(stepperReducer, createStepperContextInitData(StepperProps));
+  const formCtx = useContext(JsonFormContext);
+  const autoPopulatedValues = formCtx?.autoPopulatedData as AutoPopulatedPathValue[] | undefined;
+  const [stepperState, dispatch] = useReducer(
+    stepperReducer,
+    createStepperContextInitData(StepperProps, { autoPopulatedValues }),
+  );
   const stepperDispatch = StepperProps?.customDispatch || dispatch;
   const isCacheStatus = uischema.options?.cacheStatus;
 
@@ -232,10 +250,16 @@ export const JsonFormsStepperContextProvider = ({
       stepperDispatch({
         type: 'update/uischema',
         payload: {
-          state: createStepperContextInitData({
-            ...StepperProps,
-            activeId: Math.min(stepperState?.activeId, stepperState.maxReachedStep),
-          }),
+          state: createStepperContextInitData(
+            {
+              ...StepperProps,
+              activeId: Math.min(stepperState?.activeId, stepperState.maxReachedStep),
+            },
+            {
+              visitedIds: new Set(stepperState?.categories?.filter((c) => c.isVisited).map((c) => c.id) ?? []),
+              autoPopulatedValues,
+            },
+          ),
         },
       });
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
@@ -15,6 +15,8 @@ import {
   isJson,
   saveIsVisitFromLocalStorage,
   getIsVisitFromLocalStorage,
+  saveVisitedSteps,
+  getVisitedSteps,
 } from './util';
 
 describe('hasMeaningfulValue', () => {
@@ -862,5 +864,85 @@ describe('saveIsVisitFromLocalStorage / getIsVisitFromLocalStorage', () => {
 
     // Assert
     expect(result).toBeUndefined();
+  });
+});
+
+describe('saveVisitedSteps / getVisitedSteps', () => {
+  afterEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('round-trips the visited step ids for a form', () => {
+    // Arrange & Act
+    saveVisitedSteps('form-1', [0, 2]);
+
+    // Assert
+    expect(getVisitedSteps('form-1')).toEqual([0, 2]);
+  });
+
+  test('keeps each form separate', () => {
+    // Arrange
+    saveVisitedSteps('form-1', [0, 2]);
+
+    // Act
+    saveVisitedSteps('form-2', [1]);
+
+    // Assert
+    expect(getVisitedSteps('form-1')).toEqual([0, 2]);
+    expect(getVisitedSteps('form-2')).toEqual([1]);
+  });
+
+  test('survives a change of day, unlike the cacheStatus cache', () => {
+    // Regression guard: the cacheStatus cache keys on the date, so a draft resumed the next day
+    // loses its visited steps. This one keys on the form id only.
+    // Arrange
+    saveVisitedSteps('form-1', [1]);
+
+    // Act
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2099-01-01T00:00:00.000Z');
+
+    // Assert
+    expect(getVisitedSteps('form-1')).toEqual([1]);
+  });
+
+  test('returns undefined when nothing has been saved for the form', () => {
+    // Arrange & Act & Assert
+    expect(getVisitedSteps('form-1')).toBeUndefined();
+  });
+
+  test('returns undefined without a form id, and does not write', () => {
+    // Arrange & Act
+    saveVisitedSteps(undefined, [0]);
+
+    // Assert
+    expect(getVisitedSteps(undefined)).toBeUndefined();
+    expect(localStorage.length).toBe(0);
+  });
+
+  test('ignores a corrupt entry rather than throwing', () => {
+    // Arrange
+    localStorage.setItem('adsp.form.form-1.visitedSteps', 'not json');
+
+    // Act & Assert
+    expect(getVisitedSteps('form-1')).toBeUndefined();
+  });
+
+  test('discards non-numeric ids', () => {
+    // Arrange
+    localStorage.setItem('adsp.form.form-1.visitedSteps', JSON.stringify([0, 'x', 2]));
+
+    // Act & Assert
+    expect(getVisitedSteps('form-1')).toEqual([0, 2]);
+  });
+
+  test('does not throw when localStorage rejects the write', () => {
+    // Arrange: private browsing and full quotas both throw on setItem.
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    // Act & Assert
+    expect(() => saveVisitedSteps('form-1', [0])).not.toThrow();
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.spec.ts
@@ -447,6 +447,101 @@ describe('getStepStatus', () => {
     expect(result.hasRequiredFields).toBe(true);
   });
 
+  // CS-5233: an auto-populated scope only stops counting as user activity while it still holds the
+  // value auto-populate wrote. Once the user changes it, the step is theirs and stays started.
+  test('stays NotStarted when an auto-populated value is untouched and its value is known', () => {
+    // Arrange
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+
+    // Act
+    const result = getStepStatus({
+      scopes: ['#/name'],
+      data: { name: 'Bob' },
+      errors: [] as ErrorObject[],
+      schema,
+      visited: false,
+      autoPopulatedScopes: ['#/name'],
+      autoPopulatedValues: [{ path: 'name', value: 'Bob' }],
+    });
+
+    // Assert
+    expect(result.status).toBe(StepStatus.NOT_STARTED);
+  });
+
+  test('counts an edited auto-populated value as user data on an unvisited step', () => {
+    // Arrange: the user changed the pre-filled name, then the form was resumed.
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+
+    // Act
+    const result = getStepStatus({
+      scopes: ['#/name'],
+      data: { name: 'Robert' },
+      errors: [] as ErrorObject[],
+      schema,
+      visited: false,
+      autoPopulatedScopes: ['#/name'],
+      autoPopulatedValues: [{ path: 'name', value: 'Bob' }],
+    });
+
+    // Assert: the edit survives the reload, so the step keeps its status.
+    expect(result.status).toBe(StepStatus.COMPLETED);
+  });
+
+  test('counts a cleared auto-populated value as user data even though nothing is left', () => {
+    // Arrange: clearing a pre-filled required field is still user activity.
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+
+    // Act
+    const result = getStepStatus({
+      scopes: ['#/name'],
+      data: { name: '' },
+      errors: [] as ErrorObject[],
+      schema,
+      visited: false,
+      autoPopulatedScopes: ['#/name'],
+      autoPopulatedValues: [{ path: 'name', value: 'Bob' }],
+    });
+
+    // Assert: started, but the required field is empty, so there is still work to do.
+    expect(result.status).toBe(StepStatus.IN_PROGRESS);
+  });
+
+  test('treats auto-populated scopes as system-filled when no values are supplied', () => {
+    // Arrange: the user profile isn't known, so an edit can't be told from the original.
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+
+    // Act
+    const result = getStepStatus({
+      scopes: ['#/name'],
+      data: { name: 'Robert' },
+      errors: [] as ErrorObject[],
+      schema,
+      visited: false,
+      autoPopulatedScopes: ['#/name'],
+    });
+
+    // Assert: unchanged from the previous behaviour.
+    expect(result.status).toBe(StepStatus.NOT_STARTED);
+  });
+
+  test('accepts auto-populated values on their own, without a matching scope list', () => {
+    // Arrange: getAutoPopulatedData yields data paths rather than schema scopes.
+    const schema = { required: ['name'], properties: { name: { type: 'string' } } };
+
+    // Act
+    const result = getStepStatus({
+      scopes: ['#/name'],
+      data: { name: 'Bob' },
+      errors: [] as ErrorObject[],
+      schema,
+      visited: false,
+      autoPopulatedValues: [{ path: 'name', value: 'Bob' }],
+    });
+
+    // Assert
+    expect(result.status).toBe(StepStatus.NOT_STARTED);
+  });
+
   test('shows status for an unvisited step that holds user-entered data (resumed form)', () => {
     // Arrange: the field holds user-entered data (not auto-populated) and the user has not visited
     // it this session — i.e. a saved form being resumed.

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -1,5 +1,6 @@
 import { JsonSchema, toDataPath } from '@jsonforms/core';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import type { ErrorObject } from 'ajv';
 import { buildConditionalDeps } from '../util/conditionalDeps';
 import { StepStatus, StepStatusType, VALIDATION_KEYWORDS } from '../../../common/Constants';
@@ -117,6 +118,16 @@ export function hasValueAtScope(data: any, scope: string): boolean {
   return hasMeaningfulValue(getValueAtPath(data, path));
 }
 
+export interface AutoPopulatedPathValue {
+  path: string;
+  value: unknown;
+}
+
+// Auto-populate targets reach us either as schema scopes (#/properties/firstName) or as the data
+// paths toDataPath produces (firstName). Normalize both to the dot form used for value lookups.
+const toNormalizedPath = (pathOrScope: string): string =>
+  pathOrScope?.startsWith('#/') ? normalizeSchemaPath(pathOrScope) : pathOrScope || '';
+
 export function getStepStatus(opts: {
   scopes: string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -129,8 +140,13 @@ export function getStepStatus(opts: {
   // paths do not count as user activity, so a page holding only auto-populated data stays
   // NotStarted until the user actually opens it.
   autoPopulatedScopes?: string[];
+  // The values auto-populate would write, by path. A scope only stops counting as user activity
+  // while it still holds exactly this value; once the user edits or clears it the change is
+  // theirs, so the step is started and stays that way when the form is resumed. Omit when the
+  // user profile isn't known — every auto-populated scope is then treated as system-filled.
+  autoPopulatedValues?: AutoPopulatedPathValue[];
 }): StepStatusData {
-  const { scopes, errors, schema, data, visited, autoPopulatedScopes = [] } = opts;
+  const { scopes, errors, schema, data, visited, autoPopulatedScopes = [], autoPopulatedValues = [] } = opts;
 
   const normalizedScopes = scopes.map(normalizeSchemaPath).filter(Boolean);
 
@@ -142,10 +158,37 @@ export function getStepStatus(opts: {
   // Auto-populated values (system-filled from the user profile) are excluded, so:
   //  - a page the user has never opened is NotStarted even when auto-populated, and
   //  - a saved form the user actually filled still shows its status when resumed.
-  const autoPopulatedSet = new Set(autoPopulatedScopes.map(normalizeSchemaPath).filter(Boolean));
+  const autoPopulatedSet = new Set(autoPopulatedScopes.map(toNormalizedPath).filter(Boolean));
+  const autoPopulatedValueByPath = new Map<string, unknown>();
+
+  autoPopulatedValues.forEach(({ path, value }) => {
+    const normalized = toNormalizedPath(path);
+    if (normalized) {
+      autoPopulatedSet.add(normalized);
+      autoPopulatedValueByPath.set(normalized, value);
+    }
+  });
+
+  // Still system-filled only while the value matches what auto-populate would write. Without a
+  // known value we can't tell an edit from the original, so assume it is untouched.
+  const isStillAutoPopulated = (path: string): boolean => {
+    if (!autoPopulatedValueByPath.has(path)) {
+      return true;
+    }
+
+    return isEqual(get(data || {}, path), autoPopulatedValueByPath.get(path));
+  };
+
+  // Editing or clearing an auto-populated field is user activity in its own right, even when what
+  // is left behind is empty — otherwise clearing a pre-filled field would send the step back to
+  // NotStarted.
+  const userEditedAutoPopulated = normalizedScopes.some(
+    (path) => autoPopulatedSet.has(path) && !isStillAutoPopulated(path),
+  );
+
   const userDataScopes = normalizedScopes.filter((path) => !autoPopulatedSet.has(path));
   const stepHasUserData =
-    userDataScopes.length > 0 ? userDataScopes.some((path) => hasMeaningfulValue(get(data || {}, path))) : false;
+    userDataScopes.some((path) => hasMeaningfulValue(get(data || {}, path))) || userEditedAutoPopulated;
 
   const started = (visited ?? false) || stepHasUserData;
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/util.ts
@@ -433,6 +433,43 @@ const getLocalStorageKeyPrefix = () => {
   return window.location.href + '_' + new Date().toISOString().slice(0, 10);
 };
 
+// Steps the user has opened, persisted per form so the status survives a resume.
+//
+// Whether a step was opened cannot be recovered from the form data: a user who edits an
+// auto-populated field and then puts the original value back leaves data identical to the
+// untouched case. The visit has to be recorded when it happens, or it is lost.
+//
+// Deliberately keyed on the form id rather than the URL+date used by the cacheStatus cache above,
+// so resuming a draft tomorrow — or from a different route to the same form — still restores it.
+const getVisitedStepsKey = (formId: string) => `adsp.form.${formId}.visitedSteps`;
+
+export const saveVisitedSteps = (formId: string | undefined, ids: number[]): void => {
+  if (!formId) return;
+
+  try {
+    localStorage.setItem(getVisitedStepsKey(formId), JSON.stringify(ids));
+  } catch (err) {
+    // Private browsing and full quotas both throw here. Losing the cache only costs the user the
+    // restored status on resume, so it must never take the form down with it.
+    console.warn(`Could not persist visited steps: ${err}`);
+  }
+};
+
+export const getVisitedSteps = (formId: string | undefined): number[] | undefined => {
+  if (!formId) return undefined;
+
+  try {
+    const value = localStorage.getItem(getVisitedStepsKey(formId));
+    if (!value || !isJson(value)) return undefined;
+
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'number') : undefined;
+  } catch (err) {
+    console.warn(`Could not read visited steps: ${err}`);
+    return undefined;
+  }
+};
+
 export function isJson(str: string) {
   try {
     JSON.parse(str);


### PR DESCRIPTION
## CS-5233

Task status is wrong for pages with auto-populated values.

## Root cause

Auto-populated values are deliberately excluded when deriving whether a step has been started — that is what makes an unopened, pre-filled page correctly read `Not started`. But a page whose fields are **all** auto-populated then has nothing left to derive "started" from, and the stepper recomputes its category state from the current data snapshot on every change, always with `visited=false`.

Two failures follow:

| Scenario | Before | After |
|---|---|---|
| Open a pre-filled page, then type anywhere else in the form | drops to `In progress` | stays `Completed` |
| Edit the pre-filled value, log out, log back in | `Not started` | `In progress` / `Completed` |
| Clear a pre-filled required field | `Not started` | `In progress` |
| Never open a pre-filled page | `Not started` | `Not started` (unchanged) |

## The changes

**Preserve visited state across the recompute.** `createStepperContextInitData` now takes the ids of categories the user has already opened. Previously the reducer patched `isVisited` back on afterwards, but `isCompleted` and `isValid` had already been recomputed from a `NotStarted` status — so the badge downgraded. Deriving all three from the same `visited` input keeps them consistent.

**Only exclude an auto-populated scope while it is still auto-populated.** `getStepStatus` takes the values auto-populate would write, and excludes a scope only while it still holds exactly that value. Once the user edits it, it is their data and survives a resume. Editing or clearing counts as user activity in its own right, so clearing a pre-filled required field reports `In progress` rather than falling back to `Not started`.

The values reach the stepper through `JsonFormContext` — `DraftForm` already computed `autoPopulatedData` for the middleware, so it just passes it to `ContextProvider`. This is the same channel `AddressLookUpControl` already uses for `formUrl`.

## Not addressed

Visiting a page and accepting the pre-filled values **without changing anything** still reads `Not started` after logging back in. There is no durable signal for it: `DraftForm` writes auto-populated values into the saved form data even for pages the user never opens, so after a reload nothing distinguishes "visited and accepted" from "never visited". Closing that gap needs somewhere to persist visited state:

Note the in-session status is React state in the stepper reducer, so it dies with the page. And the `Form` record itself (`form-service/src/form/types/form.ts`) carries no per-page state — `data` and `files` are the only per-form payloads.

Options, if we want to close it:

- **`localStorage`** — the groundwork exists in `saveIsVisitFromLocalStorage`, but it is currently dead code: gated on `uischema.options.cacheStatus`, which is set nowhere in the repo (there is a `TODO` asking whether it is still used), keyed on `href + today's date` so it resets at midnight, written only on `beforeunload` so an SPA logout may never fire it, and stored as a positional boolean array that breaks if pages are reordered. Same-browser only.
- **An extra key in the form data** — draft saves are *not* schema-validated (`FormEntity.update` just assigns `this.data`; `validateData` runs only in `submit`), so a `_visitedPages` key would persist fine. The catch is that it then travels with the submitted payload and into exports/PDF, and would fail submission for any definition whose dataSchema sets `additionalProperties: false`.
- **Server-side per-page state on the form record** — correct on any device, needs a form-service change.
- **Don't persist auto-populated values until the page is visited** — then their presence in the saved data *is* the visit record, with no new storage anywhere. The catch is that submission validates the server-side copy, so a never-visited page's values would be missing at submit unless they are flushed first.

Happy to take any of these as a follow-up.

## Existing behaviour

Both new inputs are optional and default to what the code did before:

- no `autoPopulatedValues` → every auto-populated scope is treated as system-filled, exactly as today (pinned by a test)
- no `visitedIds` → `visited = false`, so first mount is unchanged
- other `ContextProvider` consumers (form editor preview, form-management app, builder template) don't pass `autoPopulatedData` and get `[]`

The auto-populate work from the past month is untouched — `mergeAutoPopulatedData`, the cleared-field guard, and the middleware flow are all unchanged.

## Verification

- Acceptance criteria tested — new tests cover unopened/opened/edited/cleared pre-filled pages, plus the recompute that used to downgrade a completed page
- Error paths tested — the no-values and no-scopes fallbacks are both pinned
- Unit tests updated or verified — 95 suites / 1356 tests pass in `jsonforms-components`, plus `form-app` (4 suites / 30 tests); `tsc --noEmit` and eslint clean (the one `StepStatusType` warning pre-exists on `main`). Each fix was reverted in isolation to confirm the new tests fail without it.
- Manual testing — **not done**; worth exercising a real form with an auto-populated page, particularly opening that page and then typing on a different one.
- No known defects
- No known regressions
