### PR TITLE
feat(adsp-cli): add delete-tenant command; fix KC 24 adsp-cli scope mappings

### DIFF
--- a/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
@@ -34,6 +34,7 @@ describe('KeycloakRealmService', () => {
       listRoles: jest.fn(),
       del: jest.fn(),
       addOptionalClientScope: jest.fn(),
+      addClientScopeMappings: jest.fn(),
       getServiceAccountUser: jest.fn(),
     },
     clientScopes: {
@@ -75,6 +76,7 @@ describe('KeycloakRealmService', () => {
     keycloakClientMock.clients.findRole.mockReset();
     keycloakClientMock.clients.listRoles.mockReset();
     keycloakClientMock.clients.addOptionalClientScope.mockReset();
+    keycloakClientMock.clients.addClientScopeMappings.mockReset();
     keycloakClientMock.clients.getServiceAccountUser.mockReset();
 
     keycloakClientMock.clientScopes.create.mockReset();
@@ -183,6 +185,10 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
+        // grantAdspCliClientScopeMappings: adsp-cli, config-service, agent-service (not in realm → [])
+        .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
+        .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
@@ -193,6 +199,8 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce(testerRole)
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' })
+        // grantAdspCliClientScopeMappings: configuration-admin from config-service
+        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
         .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' });
@@ -253,6 +261,10 @@ describe('KeycloakRealmService', () => {
           expect.objectContaining({ name: 'manage-users' }),
         ]),
       );
+      expect(keycloakClientMock.clients.addClientScopeMappings).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'adsp-cli-client-123', client: 'config-service-client-123' }),
+        expect.arrayContaining([expect.objectContaining({ name: 'configuration-admin' })]),
+      );
 
       axiosMock.get.mockResolvedValueOnce({ data: [{ id: 'execution-123' }] });
 
@@ -303,6 +315,9 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
+        .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
+        .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
@@ -313,6 +328,7 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce(testerRole)
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' })
+        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
         .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' });
@@ -351,6 +367,9 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
+        .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
+        .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-ci-client-123' }])
         .mockResolvedValueOnce([{ id: 'config-service-client-123' }])
@@ -361,6 +380,7 @@ describe('KeycloakRealmService', () => {
         .mockResolvedValueOnce(testerRole)
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' })
+        .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
         .mockResolvedValueOnce({ id: 'config-admin-role-123', name: 'configuration-admin' })
         .mockResolvedValueOnce({ id: 'manage-clients-role-123', name: 'manage-clients' })
         .mockResolvedValueOnce({ id: 'manage-users-role-123', name: 'manage-users' });

--- a/apps/tenant-management-api/src/keycloak/keycloak.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.ts
@@ -210,6 +210,38 @@ export class KeycloakRealmServiceImpl implements RealmService {
   }
 
   /**
+   * Explicitly adds the ADSP_CLI_CLIENT_SCOPE_MAPPINGS role restrictions to the adsp-cli client via
+   * the scope-mappings API. The clientScopeMappings key in the realm creation JSON sets the same
+   * restriction declaratively but KC 24 does not apply it — same pattern as the addOptionalClientScope
+   * regression fixed in createAdspCliAdminScope. Source clients absent from the realm are skipped so
+   * a not-yet-registered optional service does not break realm creation.
+   */
+  private async grantAdspCliClientScopeMappings(client: KeycloakAdminClient, realm: string): Promise<void> {
+    this.logger.debug(`Granting client scope mappings to 'adsp-cli' in realm '${realm}'...`, LOG_CONTEXT);
+
+    const adspCliClient = (await client.clients.find({ realm, clientId: 'adsp-cli' }))[0];
+
+    for (const mapping of ADSP_CLI_CLIENT_SCOPE_MAPPINGS) {
+      const sourceClient = (await client.clients.find({ realm, clientId: mapping.client }))[0];
+      if (!sourceClient) {
+        this.logger.debug(`Client '${mapping.client}' not found in realm '${realm}' — skipping scope mapping.`, LOG_CONTEXT);
+        continue;
+      }
+
+      const roles = await Promise.all(
+        mapping.roles.map((roleName) => client.clients.findRole({ realm, id: sourceClient.id, roleName }))
+      );
+
+      await client.clients.addClientScopeMappings(
+        { realm, id: adspCliClient.id, client: sourceClient.id },
+        roles.map((r) => ({ id: r.id, name: r.name }))
+      );
+    }
+
+    this.logger.info(`Granted client scope mappings to 'adsp-cli' in realm '${realm}'.`, LOG_CONTEXT);
+  }
+
+  /**
    * Grants the CI client's service account (created automatically by Keycloak when
    * serviceAccountsEnabled: true) the roles in ADSP_CLI_CI_CLIENT_SCOPE_MAPPINGS. Combined with
    * fullScopeAllowed: false, its tokens will carry exactly those roles and nothing else.
@@ -481,6 +513,7 @@ export class KeycloakRealmServiceImpl implements RealmService {
     await this.createAdspCliAdminScope(client, realm);
     await this.createTenantAdminComposite(client, serviceClients, realm, tenantAdminRole);
     await this.grantAdspCliAdminScopeMapping(client, realm);
+    await this.grantAdspCliClientScopeMappings(client, realm);
 
     const flowAlias = await this.createAuthenticationFlow(client, realm);
     await this.createCoreIdentityProvider(client, brokerClientSecret, brokerClient, flowAlias, realm);

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -284,7 +284,7 @@ function getCoreRealmRoles(token: string): string[] {
   }
 }
 
-function isTenantServiceAdmin(token: string): boolean {
+export function isTenantServiceAdmin(token: string): boolean {
   return getCoreRealmRoles(token).includes('tenant-service-admin');
 }
 

--- a/libs/adsp-cli/src/main.ts
+++ b/libs/adsp-cli/src/main.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 import { getDirectoryServiceUrl } from './directory';
 import { EnvironmentName, resolveEnvironmentUrls } from './environments';
-import { CORE_REALM, getAccessToken, getCachedOrRefreshedToken, getStatus, loginInteractive, loginWithClientCredentials, logout } from './login';
+import { CORE_REALM, getAccessToken, getCachedOrRefreshedToken, getStatus, isTenantServiceAdmin, loginInteractive, loginWithClientCredentials, logout } from './login';
 import { getServiceRoles } from './serviceRoles';
-import { findTenantByName, listTenants } from './tenants';
+import { deleteTenantById, findTenantByName, listTenants, Tenant } from './tenants';
 
 const USAGE =
   'Usage: adsp <login [--realm <realm> | --tenant <name>] [--scope <name>]... [--env <dev|test|prod>] | ' +
   'login --ci --tenant <name> [--client-id <id>] [--client-secret <secret>] [--env <dev|test|prod>] | ' +
-  'status | logout | token | tenants [name] | service-roles>';
+  'status | logout | token | tenants [name] | service-roles | delete-tenant <name>>';
 
 const HELP_TEXT = `adsp-cli — CLI and client library for authenticating against ADSP and calling its live APIs.
 
@@ -35,6 +35,9 @@ Commands:
                           a cached core-realm session from a prior no-args login).
   service-roles           Print every platform service's registered RBAC role, read live from
                           tenant-service configuration.
+  delete-tenant <name>    Permanently delete a tenant and its Keycloak realm. Requires a cached
+                          core-realm session with the tenant-service-admin role. Prompts for
+                          confirmation before deleting.
   help, --help, -h        Show this help.
 
 Flags (login only):
@@ -186,6 +189,85 @@ async function runToken(): Promise<void> {
   console.log(tokenResult.token);
 }
 
+async function pickTenantInteractive(directoryServiceUrl: string, coreToken: string): Promise<Tenant> {
+  const tenants = await listTenants(directoryServiceUrl, coreToken);
+  if (tenants.length === 0) {
+    throw new Error('No tenants found.');
+  }
+
+  const { prompt } = await import('enquirer');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { name } = await (prompt as any)({
+    type: 'autocomplete',
+    name: 'name',
+    message: 'Which tenant?',
+    hint: '(type to filter)',
+    limit: 10,
+    choices: tenants.map((t) => t.name),
+  });
+
+  const picked = tenants.find((t) => t.name === name);
+  if (!picked) {
+    throw new Error(`Tenant '${name}' not found.`);
+  }
+  return picked;
+}
+
+async function runDeleteTenant(argv: string[]): Promise<void> {
+  const { accessServiceUrl, directoryServiceUrl } = resolveEnvironmentUrls();
+
+  const coreToken = await getCachedOrRefreshedToken(accessServiceUrl, CORE_REALM);
+  if (!coreToken) {
+    throw new Error("No core-realm session. Run 'adsp login' (no args) to establish a core-realm session first.");
+  }
+
+  if (!isTenantServiceAdmin(coreToken)) {
+    throw new Error("Your account doesn't have the 'tenant-service-admin' role required to delete tenants.");
+  }
+
+  const tenant = argv[0]
+    ? await (async () => {
+        const found = await findTenantByName(directoryServiceUrl, argv[0]);
+        if (!found) throw new Error(`Tenant '${argv[0]}' not found.`);
+        return found;
+      })()
+    : await pickTenantInteractive(directoryServiceUrl, coreToken);
+
+  // eslint-disable-next-line no-console
+  console.log(`\nTenant:  ${tenant.name}`);
+  // eslint-disable-next-line no-console
+  console.log(`Realm:   ${tenant.realm}`);
+  // eslint-disable-next-line no-console
+  console.log(`Admin:   ${tenant.adminEmail ?? '(unknown)'}`);
+  // eslint-disable-next-line no-console
+  console.log('\nThis will permanently delete the tenant and its Keycloak realm. This cannot be undone.\n');
+
+  const { prompt } = await import('enquirer');
+  const { confirmation } = await prompt<{ confirmation: string }>({
+    type: 'input',
+    name: 'confirmation',
+    message: 'Type the tenant name to confirm deletion:',
+  });
+
+  if (confirmation !== tenant.name) {
+    throw new Error('Deletion cancelled — confirmation did not match the tenant name.');
+  }
+
+  const id = tenant.id ?? '';
+  const rawId = id.substring(id.lastIndexOf('/') + 1);
+  if (!rawId) {
+    throw new Error(`Could not determine the ID for tenant '${tenant.name}'.`);
+  }
+
+  const result = await deleteTenantById(directoryServiceUrl, coreToken, rawId);
+  // eslint-disable-next-line no-console
+  console.log(
+    result.success
+      ? `Tenant '${tenant.name}' deleted successfully.`
+      : `Tenant '${tenant.name}' was partially deleted (realm removed: ${result.deletedRealm}, record removed: ${result.deletedTenant}).`
+  );
+}
+
 async function runServiceRoles(): Promise<void> {
   const tokenResult = await getAccessToken();
   if (tokenResult.status === 'not-authenticated') {
@@ -225,6 +307,9 @@ async function main(): Promise<void> {
         break;
       case 'service-roles':
         await runServiceRoles();
+        break;
+      case 'delete-tenant':
+        await runDeleteTenant(rest);
         break;
       default:
         // eslint-disable-next-line no-console

--- a/libs/adsp-cli/src/tenants.spec.ts
+++ b/libs/adsp-cli/src/tenants.spec.ts
@@ -4,7 +4,7 @@ jest.mock('./directory', () => ({
 
 import { getServiceUrls } from './directory';
 import { HttpRequestError } from './httpError';
-import { createTenant, findTenantByName, findTenantByRealm, getTenantById, listTenants, waitForTenantActive } from './tenants';
+import { createTenant, deleteTenantById, findTenantByName, findTenantByRealm, getTenantById, listTenants, waitForTenantActive } from './tenants';
 
 const mockGetServiceUrls = getServiceUrls as jest.Mock;
 
@@ -228,6 +228,56 @@ describe('getTenantById', () => {
     await expect(
       getTenantById('https://directory-service.example.com', 'core-token', 'tenant-a')
     ).rejects.toBeInstanceOf(HttpRequestError);
+  });
+});
+
+describe('deleteTenantById', () => {
+  it('DELETEs by id with a bearer token and returns the result', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ deletedRealm: true, deletedTenant: true, success: true }),
+    });
+    global.fetch = fetchMock as never;
+
+    const result = await deleteTenantById('https://directory-service.example.com', 'core-token', 'tenant-abc');
+
+    expect(result).toEqual({ deletedRealm: true, deletedTenant: true, success: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${TENANT_SERVICE_URL}/v2/tenants/tenant-abc`);
+    expect(init.method).toBe('DELETE');
+    expect(init.headers.Authorization).toBe('Bearer core-token');
+  });
+
+  it('throws a tenant-service-admin message on a 401', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }) as never;
+
+    await expect(
+      deleteTenantById('https://directory-service.example.com', 'core-token', 'tenant-abc')
+    ).rejects.toMatchObject({ status: 401, message: expect.stringContaining('tenant-service-admin') });
+  });
+
+  it('surfaces the server-provided errorMessage on other non-ok responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ errorMessage: 'Cannot delete active tenant.' }),
+    }) as never;
+
+    await expect(
+      deleteTenantById('https://directory-service.example.com', 'core-token', 'tenant-abc')
+    ).rejects.toMatchObject({ status: 400, message: 'Cannot delete active tenant.' });
+  });
+
+  it('falls back to a generic message when the error body is not JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => { throw new Error('no body'); },
+    }) as never;
+
+    await expect(
+      deleteTenantById('https://directory-service.example.com', 'core-token', 'tenant-abc')
+    ).rejects.toMatchObject({ status: 500, message: 'Tenant service request failed with status 500.' });
   });
 });
 

--- a/libs/adsp-cli/src/tenants.ts
+++ b/libs/adsp-cli/src/tenants.ts
@@ -79,6 +79,49 @@ export async function listTenants(directoryServiceUrl: string, accessToken: stri
   return data.results ?? [];
 }
 
+export interface DeleteTenantResult {
+  deletedRealm: boolean;
+  deletedTenant: boolean;
+  success: boolean;
+}
+
+/**
+ * Deletes a tenant and its Keycloak realm — requires a core-realm token with the
+ * tenant-service-admin role. The id argument is the raw tenant id (not the full URN).
+ */
+export async function deleteTenantById(
+  directoryServiceUrl: string,
+  accessToken: string,
+  id: string
+): Promise<DeleteTenantResult> {
+  const tenantServiceUrl = await resolveTenantServiceUrl(directoryServiceUrl);
+  const url = new URL(`v2/tenants/${encodeURIComponent(id)}`, tenantServiceUrl);
+
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new HttpRequestError(
+        response.status,
+        "Your account doesn't have the 'tenant-service-admin' role required to delete tenants."
+      );
+    }
+    let message = `Tenant service request failed with status ${response.status}.`;
+    try {
+      const body = (await response.json()) as { errorMessage?: string };
+      if (body.errorMessage) message = body.errorMessage;
+    } catch {
+      // non-JSON body — use the fallback message
+    }
+    throw new HttpRequestError(response.status, message);
+  }
+
+  return (await response.json()) as DeleteTenantResult;
+}
+
 /**
  * tenant-service's role guard (`requireBetaTesterOrAdmin`) rejects a caller lacking the
  * beta-tester/tenant-service-admin role with a bare 401 and no body, so that case needs its own


### PR DESCRIPTION
## Summary

- **KC 24 scope fix**: Realm creation in KC 24 silently ignores `clientScopeMappings` from the realm JSON, so `adsp-cli` tokens were issued with no `resource_access` claim at all (no `configuration-admin`, no `agent-user`). Added `grantAdspCliClientScopeMappings` as an explicit post-creation step in `keycloak.ts` using the stable `clients.addClientScopeMappings` endpoint (POST `/{id}/scope-mappings/clients/{client}`), which is not affected by the KC 24 regression. Agent-service client is gracefully skipped if not present in the realm at creation time.
- **`adsp delete-tenant` command**: New CLI command for core users with the `tenant-service-admin` role. Pre-flights the role check from the cached core token before any network calls or prompts, then resolves the target tenant either by name arg or an interactive autocomplete picker. Requires the user to type the exact tenant name to confirm before calling `DELETE /v2/tenants/:id`.

## Changed files

| File | Change |
|---|---|
| `apps/tenant-management-api/src/keycloak/keycloak.ts` | Add `grantAdspCliClientScopeMappings`, call it in `createRealm` |
| `apps/tenant-management-api/src/keycloak/keycloak.spec.ts` | Update mock sequences for the three `createRealm` tests; assert new scope mapping call |
| `libs/adsp-cli/src/tenants.ts` | Add `deleteTenantById` + `DeleteTenantResult` |
| `libs/adsp-cli/src/login.ts` | Export `isTenantServiceAdmin` |
| `libs/adsp-cli/src/main.ts` | Add `pickTenantInteractive` + `runDeleteTenant`; wire into `main()` switch; update USAGE and HELP_TEXT |
| `libs/adsp-cli/src/tenants.spec.ts` | Add 4 tests for `deleteTenantById` |

## Test plan

- [ ] All existing `adsp-cli` and `tenant-management-api` keycloak tests pass (138 / 58 respectively)
- [ ] Provision a new tenant and confirm `adsp login` produces a token with `configuration-admin` in `resource_access`
- [ ] `adsp delete-tenant` with a non-admin account fails immediately with a role error (before any tenant lookup)
- [ ] `adsp delete-tenant` with no arg shows an autocomplete picker
- [ ] `adsp delete-tenant <name>` skips the picker and goes straight to the confirmation prompt
- [ ] Mistyped confirmation cancels without deleting
- [ ] Correct confirmation deletes and reports `success: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)