### PR TITLE
fix(tenant-management-webapp): persist date range when switching calendar data select

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/index.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/index.tsx
@@ -62,7 +62,6 @@ export const CalendarEvents = (): JSX.Element => {
   const onCalendarSelect = (name: string, value: string) => {
     setSelectedCalendar(value);
     dispatch(FetchEventsByCalendar(value, null));
-    dispatch(UpdateSearchCalendarEventCriteria());
   };
 
   useEffect(() => {


### PR DESCRIPTION
* Previously, UpdateSearchCalendarEventCriteria() was dispatched on calendar switch, which reset the date filter to the default (current week) while the saga fetched events using the stale user-selected criteria, causing the event list and date filter to show inconsistent date ranges.