### PR TITLE
fix: retain textarea input that arrives without a keystroke

### DIFF
--- a/apps/task-app/src/app/containers/details/FormSubmissionReviewTask.tsx
+++ b/apps/task-app/src/app/containers/details/FormSubmissionReviewTask.tsx
@@ -20,7 +20,7 @@ import { registerDetailsComponent } from './register';
 
 import { ReviewContent, ActionContainer, FormReviewContainer } from './styled-components';
 import { TaskCancelModal } from './TaskCancelModal';
-import { GoabTextAreaOnKeyPressDetail, GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
 
 export const FormSubmissionReviewTask: FunctionComponent<TaskDetailsProps> = ({
   user,
@@ -118,13 +118,11 @@ export const FormSubmissionReviewTask: FunctionComponent<TaskDetailsProps> = ({
             width="600px"
             testId="reason"
             aria-label="reason"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               setDispositionReason(detail.value);
               validators.remove('dispositionReason');
               validators['dispositionReason'].check(detail.value);
             }}
-            // eslint-disable-next-line
-            onChange={() => {}}
           />
         </GoabFormItem>
       </div>

--- a/apps/tenant-management-webapp/jest.config.ts
+++ b/apps/tenant-management-webapp/jest.config.ts
@@ -26,6 +26,10 @@ export default {
     '^@lib(.*)$': path.resolve(__dirname, './src/app/lib/$1'),
     '^@pages(.*)$': path.resolve(__dirname, './src/app/pages/$1'),
     '^@store(.*)$': path.resolve(__dirname, './src/app/store/$1'),
+    // clean-code-ignore: RULE-19
+    '^@form-editor-common$': path.resolve(__dirname, '../../libs/form-editor-common/src/index.ts'),
+    // clean-code-ignore: RULE-19
+    '^@form-editor-common/(.*)$': path.resolve(__dirname, '../../libs/form-editor-common/src/lib/$1'),
     '^uuid$': require.resolve('uuid'),
     // clean-code-ignore: RULE-19
     // @mdx-js/mdx, react-markdown and rehype-sanitize are ESM-only; stub them so Jest (babel-jest) can parse tests.

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/calendar/calendarModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/calendar/calendarModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { GoabButton, GoabButtonGroup, GoabModal, GoabTextArea, GoabInput, GoabFormItem } from '@abgov/react-components';
 import { CalendarItem } from '@store/calendar/models';
@@ -18,7 +19,6 @@ import { ActionState } from '@store/session/models';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
   GoabTextAreaOnChangeDetail,
-  GoabTextAreaOnKeyPressDetail,
   GoabInputOnChangeDetail,
 } from '@abgov/ui-components-common';
 
@@ -213,13 +213,11 @@ export const CalendarModal = ({
               testId={`calendar-modal-description-input`}
               aria-label="description"
               width="100%"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 validators.remove('description');
                 validators['description'].check(detail.value);
                 setCalendar({ ...calendar, description: detail.value });
               }}
-              // eslint-disable-next-line
-              onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
             />
             <HelpTextComponent
               length={calendar?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/addEditModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/calendar/events/addEditModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useEffect, useState } from 'react';
 import {
   GoabModal,
@@ -22,7 +23,6 @@ import { HelpTextComponent } from '@components/HelpTextComponent';
 import { readOnlyCalendars } from '.';
 import {
   GoabTextAreaOnChangeDetail,
-  GoabTextAreaOnKeyPressDetail,
   GoabInputOnChangeDetail,
   GoabCheckboxOnChangeDetail,
 } from '@abgov/ui-components-common';
@@ -188,13 +188,11 @@ export const EventAddEditModal = ({ calendarName }: EventAddEditModalProps): JSX
           aria-label="description"
           disabled={readOnlyCalendars.includes(calendarName)}
           width="100%"
-          onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+          onChange={(detail: GoabTextAreaOnChangeDetail) => {
             validators.remove('description');
             validators['description'].check(detail.value);
             setCalendarEvent({ ...calendarEvent, description: detail.value });
           }}
-          // eslint-disable-next-line
-          onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
         />
         <HelpTextComponent
           length={calendarEvent?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/comment/comments/addCommentModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/comment/comments/addCommentModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useState } from 'react';
 
 import { GoabButton, GoabButtonGroup, GoabFormItem, GoabModal, GoabTextArea } from '@abgov/react-components';
@@ -8,7 +9,7 @@ import { useValidators } from '@lib/validation/useValidators';
 
 import { DescriptionItem } from '../styled-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import { GoabTextAreaOnKeyPressDetail, GoabTextAreaOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail } from '@abgov/ui-components-common';
 interface TopicModalProps {
   topic: TopicItem;
   selComment: Comment;
@@ -85,13 +86,11 @@ export const AddCommentModal = ({ topic, selComment, open, type, onCancel, onSav
               width="100%"
               testId="content"
               aria-label="content"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 validators.remove('content');
                 validators['content'].check(detail.value);
                 setComment({ ...comment, content: detail.value });
               }}
-              // eslint-disable-next-line
-              onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
             />
             <HelpTextComponent
               length={comment?.content?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topics/topicModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/comment/topics/topicModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useState } from 'react';
 
 import {
@@ -26,7 +27,6 @@ import { RootState } from '@store/index';
 import { DescriptionItem } from '../styled-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
-  GoabTextAreaOnKeyPressDetail,
   GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
   GoabDropdownOnChangeDetail,
@@ -209,13 +209,11 @@ export const TopicModal: FunctionComponent<TopicModalProps> = ({
               width="100%"
               testId="description"
               aria-label="description"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 validators.remove('description');
                 validators['description'].check(detail.value);
                 setTopic({ ...topic, description: detail.value });
               }}
-              // eslint-disable-next-line
-              onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
             />
             <HelpTextComponent
               length={topic?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/configuration/definitions/addEditDefinition.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/configuration/definitions/addEditDefinition.tsx
@@ -27,7 +27,6 @@ import styled from 'styled-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import { NamespaceDropdown } from '@components/NamespaceDropdown';
 import {
-  GoabTextAreaOnKeyPressDetail,
   GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
 } from '@abgov/ui-components-common';
@@ -219,13 +218,11 @@ export const AddEditConfigDefinition: FunctionComponent<AddEditConfigDefinitionP
             testId="form-description"
             aria-label="description"
             width="100%"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               validators.remove('description');
               validators['description'].check(detail.value);
               setDefinition({ ...definition, description: detail.value });
             }}
-            // eslint-disable-next-line
-            onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
           />
           <HelpTextComponent
             length={definition?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/edit.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/edit.tsx
@@ -18,7 +18,6 @@ import { HelpTextComponent } from '@components/HelpTextComponent';
 import { NamespaceDropdown } from '@components/NamespaceDropdown';
 import styled from 'styled-components';
 import {
-  GoabTextAreaOnKeyPressDetail,
   GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
 } from '@abgov/ui-components-common';
@@ -169,13 +168,11 @@ export const EventDefinitionModalForm: FunctionComponent<EventDefinitionFormProp
             value={definition.description}
             aria-label="description"
             width="100%"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               validators.remove('description');
               validators['description'].check(detail.value);
               setDefinition({ ...definition, description: detail.value });
             }}
-            // eslint-disable-next-line
-            onChange={(detail: GoabTextAreaOnChangeDetail) => {}}
           />
           <HelpTextComponent
             length={definition?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/addEditStream/addEditStream.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/addEditStream/addEditStream.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useMemo, useState, useEffect } from 'react';
 import { GoADropdownOption, GoADropdown } from '@abgov/react-components-old';
 import { ChipsWrapper, IdField, StreamModalStyles } from '../styleComponents';
@@ -26,7 +27,7 @@ import { ResetModalState } from '@store/session/actions';
 import { selectModalStateByType } from '@store/session/selectors';
 import { selectRolesObject, constructRoleObjFromUrns, roleObjectToUrns } from '@store/sharedSelectors/roles';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface AddEditStreamProps {
   onSave: (stream: Stream) => void;
@@ -154,13 +155,11 @@ export const AddEditStream = ({ onSave, eventDefinitions, streams }: AddEditStre
             testId="stream-description"
             aria-label="stream-description"
             width="100%"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               validators.remove('description');
               validators['description'].check(detail.value);
               setStream({ ...stream, description: detail.value });
             }}
-            // eslint-disable-next-line
-            onChange={() => {}}
           />
           <HelpTextComponent
             length={stream?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/addEditFormDefinition.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/addEditFormDefinition.spec.tsx
@@ -1,0 +1,77 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { AddEditFormDefinition } from '@form-editor-common/definitions/addEditFormDefinition';
+
+const mockStore = configureStore([]);
+
+const initialState = {
+  form: {
+    definitions: {},
+    formResourceTag: { searchedTagExists: false },
+  },
+  session: { indicator: { show: false } },
+  tenant: { name: 'autotest' },
+  directory: { directory: [] },
+};
+
+const initialValue = {
+  id: '',
+  name: '',
+  description: '',
+  dataSchema: {},
+  uiSchema: {},
+  applicantRoles: [],
+  clerkRoles: [],
+  assessorRoles: [],
+  formDraftUrlTemplate: '',
+  anonymousApply: false,
+};
+
+const renderModal = (onSave = jest.fn()) =>
+  render(
+    <Provider store={mockStore(initialState)}>
+      <AddEditFormDefinition
+        open={true}
+        isEdit={false}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        initialValue={initialValue as any}
+        onClose={() => {}}
+        onSave={onSave}
+      />
+    </Provider>
+  );
+
+describe('AddEditFormDefinition description', () => {
+  it('renders the description textarea', () => {
+    const { baseElement } = renderModal();
+
+    expect(baseElement.querySelector("goa-textarea[testId='form-definition-description']")).toBeInTheDocument();
+  });
+
+  it('keeps description text that arrives without a keystroke, as a mouse paste does', async () => {
+    const { baseElement } = renderModal();
+    const description = baseElement.querySelector("goa-textarea[testId='form-definition-description']");
+
+    fireEvent(description, new CustomEvent('_change', { detail: { value: 'pasted description' } }));
+
+    await waitFor(() => {
+      expect(baseElement.querySelector("goa-textarea[testId='form-definition-description']")).toHaveAttribute(
+        'value',
+        'pasted description'
+      );
+    });
+  });
+
+  it('reflects the pasted description in the character count', async () => {
+    const { baseElement } = renderModal();
+    const description = baseElement.querySelector("goa-textarea[testId='form-definition-description']");
+
+    fireEvent(description, new CustomEvent('_change', { detail: { value: '12345' } }));
+
+    await waitFor(() => {
+      expect(baseElement.textContent).toContain('5/180');
+    });
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/dataRegister/addRegisterDataModal.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/dataRegister/addRegisterDataModal.spec.tsx
@@ -33,7 +33,7 @@ describe('AddRegisterDataModal', () => {
 
     const dataInput = baseElement.querySelector("goa-textarea[testId='data-register-add-data-input']");
     // separator is left as the default 'comma', but the data uses semicolons
-    fireEvent(dataInput, new CustomEvent('_keyPress', { detail: { value: 'Monday; Tuesday; Wednesday' } }));
+    fireEvent(dataInput, new CustomEvent('_change', { detail: { value: 'Monday; Tuesday; Wednesday' } }));
     fireEvent(dataInput, new CustomEvent('_blur', { detail: { value: 'Monday; Tuesday; Wednesday' } }));
 
     const formItem = baseElement.querySelector("goa-form-item[testId='data-register-add-data-formitem']");
@@ -50,7 +50,7 @@ describe('AddRegisterDataModal', () => {
     fireEvent(nameInput, new CustomEvent('_change', { detail: { value: 'weekdays' } }));
 
     const dataInput = baseElement.querySelector("goa-textarea[testId='data-register-add-data-input']");
-    fireEvent(dataInput, new CustomEvent('_keyPress', { detail: { value: 'Monday, Tuesday, Wednesday' } }));
+    fireEvent(dataInput, new CustomEvent('_change', { detail: { value: 'Monday, Tuesday, Wednesday' } }));
     fireEvent(dataInput, new CustomEvent('_blur', { detail: { value: 'Monday, Tuesday, Wednesday' } }));
 
     const formItem = baseElement.querySelector("goa-form-item[testId='data-register-add-data-formitem']");
@@ -68,7 +68,7 @@ describe('AddRegisterDataModal', () => {
     fireEvent(nameInput, new CustomEvent('_change', { detail: { value: 'weekdays' } }));
 
     const dataInput = baseElement.querySelector("goa-textarea[testId='data-register-add-data-input']");
-    fireEvent(dataInput, new CustomEvent('_keyPress', { detail: { value: 'Monday, Tuesday' } }));
+    fireEvent(dataInput, new CustomEvent('_change', { detail: { value: 'Monday, Tuesday' } }));
     fireEvent(dataInput, new CustomEvent('_blur', { detail: { value: 'Monday, Tuesday' } }));
 
     const saveBtn = baseElement.querySelector("goa-button[testId='data-register-add-save']");

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/form/dataRegister/addRegisterDataModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/form/dataRegister/addRegisterDataModal.tsx
@@ -12,7 +12,7 @@ import {
 import {
   GoabDropdownOnChangeDetail,
   GoabInputOnChangeDetail,
-  GoabTextAreaOnKeyPressDetail,
+  GoabTextAreaOnChangeDetail,
 } from '@abgov/ui-components-common';
 import {
   getSeparatorHelpText,
@@ -151,7 +151,7 @@ export const AddRegisterDataModal = ({ open, onCancel, onSave }: AddRegisterData
           rows={2}
           width="100%"
           testId="data-register-add-description-input"
-          onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => onDescriptionChange(detail.value)}
+          onChange={(detail: GoabTextAreaOnChangeDetail) => onDescriptionChange(detail.value)}
         />
       </GoabFormItem>
       <GoabFormItem label="Register data" mt="m" mb="m">
@@ -183,7 +183,7 @@ export const AddRegisterDataModal = ({ open, onCancel, onSave }: AddRegisterData
           value={configValue}
           width="100%"
           testId="data-register-add-data-input"
-          onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => handleDataChange(detail.value)}
+          onChange={(detail: GoabTextAreaOnChangeDetail) => handleDataChange(detail.value)}
           onBlur={() => parseAndSet(configValue, separator)}
         />
       </GoabFormItem>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/addEditNotification/addEditNotification.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/addEditNotification/addEditNotification.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { NotificationItem } from '@store/notification/models';
@@ -32,7 +33,7 @@ import { ClientRoleTable } from '@components/RoleTable';
 import { areObjectsEqual } from '@lib/objectUtil';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
-  GoabTextAreaOnKeyPressDetail,
+  GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
   GoabRadioGroupOnChangeDetail,
 } from '@abgov/ui-components-common';
@@ -255,14 +256,13 @@ export const NotificationTypeModalForm: FunctionComponent<NotificationTypeFormPr
             value={type?.description}
             aria-label="description"
             width="100%"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               if (detail.value) {
                 validators.remove('description');
                 validators['description'].check(detail.value);
                 setType({ ...type, description: detail.value });
               }
             }}
-            onChange={() => {}}
           />
           <HelpTextComponent
             length={type?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/contactInformation/edit.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/contactInformation/edit.tsx
@@ -1,9 +1,10 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import type { ContactInformation } from '@store/notification/models';
 import styled from 'styled-components';
 import { GoabTextArea, GoabInput, GoabButton, GoabButtonGroup, GoabFormItem, GoabModal } from '@abgov/react-components';
 import { isSmsValid, emailError, smsError } from '@lib/inputValidation';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface NotificationTypeFormProps {
   initialValue?: ContactInformation;
@@ -108,11 +109,9 @@ export const ContactInformationModalForm: FunctionComponent<NotificationTypeForm
               testId="form-support-instructions"
               aria-label="name"
               width="100%"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 setContactInformation({ ...contactInformation, supportInstructions: detail.value });
               }}
-              // eslint-disable-next-line
-              onChange={() => {}}
             />
           </GoabFormItem>
         </ErrorWrapper>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/subscribers/editSubscriber.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/subscribers/editSubscriber.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import type { Subscriber } from '@store/subscription/models';
 import { GoabButton, GoabButtonGroup, GoabInput, GoabTextArea, GoabModal, GoabFormItem } from '@abgov/react-components';
@@ -5,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@store/index';
 import styled from 'styled-components';
 import { emailError, smsError } from '@lib/inputValidation';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface NotificationTypeFormProps {
   initialValue?: Subscriber;
@@ -214,11 +215,9 @@ export const SubscriberModalForm: FunctionComponent<NotificationTypeFormProps> =
                 value={bot}
                 aria-label="slack"
                 width="100%"
-                onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+                onChange={(detail: GoabTextAreaOnChangeDetail) => {
                   setBot(detail.value);
                 }}
-                // eslint-disable-next-line
-                onChange={() => {}}
               />
             </GoabFormItem>
           )}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { PdfTemplate } from '@store/pdf/model';
 import { toKebabName } from '@lib/kebabName';
@@ -17,7 +18,7 @@ import {
   GoabCheckbox,
 } from '@abgov/react-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface AddEditPdfTemplateProps {
   open: boolean;
@@ -177,13 +178,11 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
             width="100%"
             testId="pdf-template-description"
             aria-label="pdf-template-description"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               validators.remove('description');
               validators['description'].check(detail.value);
               setTemplate({ ...template, description: detail.value });
             }}
-            // eslint-disable-next-line
-            onChange={() => {}}
           />
           <HelpTextComponent
             length={template?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/addScriptModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/addScriptModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useEffect, useState, useRef } from 'react';
 import {
   GoabCheckbox,
@@ -21,7 +22,7 @@ import { fetchKeycloakServiceRoles } from '@store/access/actions';
 import { FetchRealmRoles } from '@store/tenant/actions';
 import { TextGoASkeleton } from '@core-services/app-common';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface AddScriptModalProps {
   initialValue?: ScriptItem;
@@ -181,9 +182,7 @@ export const AddScriptModal = ({
             testId={`script-modal-description-input`}
             aria-label="description"
             width="100%"
-            // eslint-disable-next-line
-            onChange={() => {}}
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               const description = detail.value;
               validators.remove('description');
               validators['description'].check(description);

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import { RootState } from '@store/index';
 import { saveNotice } from '@store/notice/actions';
 import React, { useState, useEffect } from 'react';
@@ -17,7 +18,7 @@ import {
 import { getTimeFromGMT, getDateTime } from '@lib/timeUtil';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
-  GoabTextAreaOnKeyPressDetail,
+  GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
   GoabDropdownOnChangeDetail,
 } from '@abgov/ui-components-common';
@@ -168,11 +169,9 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
           name="message"
           value={message}
           width="100%"
-          onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+          onChange={(detail: GoabTextAreaOnChangeDetail) => {
             setMessage(detail.value);
           }}
-          // eslint-disable-next-line
-          onChange={() => {}}
         />
         <HelpTextComponent
           length={message.length}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookForm.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/webhooks/webhookForm.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { saveWebhook } from '@store/status/actions';
@@ -32,7 +33,7 @@ import { ResetModalState } from '@store/session/actions';
 import { PageIndicator } from '@components/Indicator';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
-  GoabTextAreaOnKeyPressDetail,
+  GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
   GoabDropdownOnChangeDetail,
   GoabCheckboxOnChangeDetail,
@@ -256,7 +257,7 @@ export const WebhookFormModal = (): JSX.Element => {
               name="description"
               value={webhook?.description}
               width="100%"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 validators.remove('description');
                 validators['description'].check(detail.value);
                 setWebhook({
@@ -264,8 +265,6 @@ export const WebhookFormModal = (): JSX.Element => {
                   description: detail.value,
                 });
               }}
-              // eslint-disable-next-line
-              onChange={() => {}}
               aria-label="description"
             />
             <HelpTextComponent

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/task/tasks/taskModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/task/tasks/taskModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useEffect, useState } from 'react';
 
 import {
@@ -18,7 +19,7 @@ import { useValidators } from '@lib/validation/useValidators';
 import { DescriptionItem } from '../styled-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
-  GoabTextAreaOnKeyPressDetail,
+  GoabTextAreaOnChangeDetail,
   GoabInputOnChangeDetail,
   GoabRadioGroupOnChangeDetail,
 } from '@abgov/ui-components-common';
@@ -153,13 +154,11 @@ export const TaskModal: FunctionComponent<TaskModalProps> = ({
               width="100%"
               testId="description"
               aria-label="description"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 validators.remove('description');
                 validators['description'].check(detail.value);
                 setTask({ ...task, description: detail.value });
               }}
-              // eslint-disable-next-line
-              onChange={() => {}}
             />
             <HelpTextComponent
               length={task?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/value/addEditDefinition.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/value/addEditDefinition.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useEffect, useState } from 'react';
 import Editor from '@monaco-editor/react';
 import {
@@ -25,7 +26,7 @@ import {
 import styled from 'styled-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import { NamespaceDropdown } from '@components/NamespaceDropdown';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface AddEditValueDefinitionProps {
   onSave: (definition: ValueDefinition) => void;
@@ -205,13 +206,11 @@ export const AddEditValueDefinition = ({
             testId="value-description"
             aria-label="description"
             width="100%"
-            onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+            onChange={(detail: GoabTextAreaOnChangeDetail) => {
               validators.remove('description');
               validators['description'].check(detail.value);
               setDefinition({ ...definition, description: detail.value });
             }}
-            // eslint-disable-next-line
-            onChange={() => {}}
           />
           <HelpTextComponent
             length={definition?.description?.length || 0}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/value/addEditDefinitions.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/value/addEditDefinitions.spec.tsx
@@ -142,3 +142,33 @@ test('shows validation errors', async () => {
     expect(formItem.getAttribute('error')).toBe('Cannot use the word platform as namespace');
   });
 });
+
+test('keeps description text that arrives without a keystroke, as a mouse paste does', async () => {
+  const store = mockStore(initialState);
+  const onSave = jest.fn();
+
+  const { baseElement } = render(
+    <Provider store={store}>
+      <AddEditValueDefinition
+        onSave={onSave}
+        initialValue={{ ...initialValue, namespace: 'ns', name: 'thing' }}
+        open={true}
+        isEdit={true}
+        onClose={() => {}}
+        values={[]}
+      />
+    </Provider>
+  );
+
+  const description = baseElement.querySelector("goa-textarea[testId='value-description']");
+  expect(description).toBeInTheDocument();
+
+  fireEvent(description, new CustomEvent('_change', { detail: { value: 'pasted description' } }));
+
+  await waitFor(() => {
+    expect(baseElement.querySelector("goa-textarea[testId='value-description']")).toHaveAttribute(
+      'value',
+      'pasted description'
+    );
+  });
+});

--- a/libs/form-editor-common/src/lib/definitions/addEditDispositionModal.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditDispositionModal.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { toKebabName } from '@lib/kebabName';
 import { useValidators } from '@lib/validation/useValidators';
@@ -5,7 +6,7 @@ import { isNotEmptyCheck, wordMaxLengthCheck, badCharsCheck, duplicateNameCheck 
 import { DispositionFormItem, DescriptionItem } from '../styled-components';
 import { GoabTextArea, GoabInput, GoabModal, GoabButtonGroup, GoabFormItem, GoabButton } from '@abgov/react-components';
 import { Disposition } from '@store/form/model';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 
 interface AddEditDispositionModalProps {
   open: boolean;
@@ -123,11 +124,9 @@ export const AddEditDispositionModal: FunctionComponent<AddEditDispositionModalP
               width="100%"
               testId="disposition-description"
               aria-label="disposition-description"
-              onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+              onChange={(detail: GoabTextAreaOnChangeDetail) => {
                 setTemplate({ ...template, description: detail.value });
               }}
-              // eslint-disable-next-line
-              onChange={() => {}}
             />
           </DescriptionItem>
         </GoabFormItem>

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinition.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinition.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19
 import React, { useState, useEffect, useMemo } from 'react';
 import { debounce as _debounce } from 'lodash';
 import { FormDefinition } from '@store/form/model';
@@ -28,7 +29,7 @@ import {
   GoabFilterChip,
 } from '@abgov/react-components';
 import { HelpTextComponent } from '@components/HelpTextComponent';
-import { GoabTextAreaOnKeyPressDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabTextAreaOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 import { fetchFormTagByTagName } from '@store/form/action';
 
 interface AddEditFormDefinitionProps {
@@ -275,12 +276,11 @@ export const AddEditFormDefinition = ({
                 width="100%"
                 testId="form-definition-description"
                 aria-label="form-definition-description"
-                onKeyPress={(detail: GoabTextAreaOnKeyPressDetail) => {
+                onChange={(detail: GoabTextAreaOnChangeDetail) => {
                   validators.remove('description');
                   validators['description'].check(detail.value);
                   setDefinition({ ...definition, description: detail.value });
                 }}
-                onChange={() => {}}
               />
               <HelpTextComponent
                 length={definition?.description?.length || 0}


### PR DESCRIPTION
Textareas across the admin app, the form editor lib, the jsonforms multiline control and the task app drove their state from `onKeyPress` and discarded `onChange`, usually via an explicit no-op.

`goa-textarea` raises `_keyPress` on **keyup** and `_change` on **input**, so text entered without a keyup never reached React state — context-menu paste, drag-and-drop, autofill and IME composition all produce input events and no keyup. The text sits in the DOM looking correct while state holds the previous value, so the field reads fine and the entry is silently dropped on save.

Ctrl+V happened to survive, because releasing V and Control each fire a keyup carrying the current value. That is why this has been so hard to reproduce and has been reopened several times.

## Reproduce

1. Form service → Definitions → **Add definition**
2. **Right-click → Paste** into Description (not Ctrl+V — that self-heals)
3. The character counter stays at `0/180` while the text is visible
4. Save — the description is empty

## Change

Drive state from `onChange` at all 22 sites. Handler bodies are unchanged; only the prop, its detail type and the redundant no-op are affected.

Left alone deliberately:
- `InputDateControl` / `InputTimeControl` also commit from keyup via `onKeyPressForDateControl`, but committing on every input event would push partially typed dates through `standardizeDate`.
- `onKeyPress` on `GoabInput` in `AddressLookUpControl` and the definitions list is genuine key handling.

## Scope

This fixes the deterministic half. The separate fast-typing race — a render carrying a stale value written back over the box — is narrowed by committing one event earlier, but not closed; it remains reproducible under CPU throttling. Closing it requires the value to stop being controlled between commits.

Not caused by the Design System 2 migration: both web component versions raise `_keyPress` on keyup and pass `value` identically.

## Tests

Guards that fire `_change` with no `_keyPress` — what a mouse paste looks like — for the form definition modal, the jsonforms multiline control and the value definition modal. Each was verified to fail without the fix.

Specs that drove components through `_keyPress` now use `_change`. One `autoCapitalize` assertion in `InputMultiLineTextControl` expected the value back unchanged, which only held because `_change` was a no-op, so the option was never exercised.

`AddEditFormDefinition` resolves `@store`, `@lib` and `@components` back into `tenant-management-webapp`, so its spec lives there; `jest.config.ts` gains the `@form-editor-common` mapping `tsconfig.base.json` already had.

Relates to CS-4770, CTA-1114.
