### PR TITLE
feat: implement resizable split pane for notification template editor

### DIFF
--- a/apps/tenant-management-webapp/src/app/components/Tabs.tsx
+++ b/apps/tenant-management-webapp/src/app/components/Tabs.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 interface TabsProps {
   activeIndex?: number;
   children: ReactNode;
+  actions?: ReactNode;
   style?: React.CSSProperties;
   changeTabCallback?: (index: number) => void;
 }
@@ -54,6 +55,7 @@ function Tabs(props: TabsProps): JSX.Element {
             );
           })
         }
+        {props.actions && <SCTabActions>{props.actions}</SCTabActions>}
       </SCTabs>
       {
         // eslint-disable-next-line
@@ -123,6 +125,14 @@ const SCTabs = styled.div`
   display: flex;
   border-bottom: 1px solid #ccc;
   overflow-x: auto;
+`;
+
+const SCTabActions = styled.div`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  padding: 0 var(--goa-space-xs);
 `;
 
 const SCTab = styled.div`

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationType/notificationTypes.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationType/notificationTypes.spec.tsx
@@ -9,10 +9,14 @@ import { DELETE_NOTIFICATION_TYPE, UPDATE_NOTIFICATION_TYPE } from '@store/notif
 
 jest.mock('../previewEditor/TemplateEditor', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TemplateEditor: ({ saveAndReset, resetToSavedAction }: any) => (
+  TemplateEditor: ({ saveAndReset, resetToSavedAction, previewVisible, onTogglePreview }: any) => (
     <div data-testid="template-editor-mock">
       <div data-testid="templated-editor-title" />
       <div data-testid="templated-editor-subtitle" />
+      <span data-testid="preview-visible-state">{String(previewVisible)}</span>
+      <button data-testid="preview-toggle-mock" onClick={onTogglePreview}>
+        Toggle preview
+      </button>
       <goa-button testId="template-form-close" onClick={() => resetToSavedAction?.()}>
         Cancel
       </goa-button>
@@ -154,7 +158,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const addDefButton = baseElement.querySelector("goa-button[testId='add-notification']");
     expect(addDefButton).not.toBeNull();
@@ -164,7 +168,7 @@ describe('NotificationTypes Page', () => {
     const { queryByTestId, baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const addDefButton = baseElement.querySelector("goa-button[testId='add-notification']");
     fireEvent.click(addDefButton);
@@ -178,7 +182,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
 
     const deleteBtn = baseElement.querySelectorAll("goa-icon-button[testId='delete-notification-type']")[0];
@@ -199,7 +203,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
 
     const deleteBtn = baseElement.querySelectorAll("goa-icon-button[testId='delete-notification-type']")[0];
@@ -215,7 +219,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const editBtn = baseElement.querySelectorAll("goa-icon-button[testId='edit-notification-type']")[0];
     await waitFor(() => {
@@ -237,13 +241,13 @@ describe('NotificationTypes Page', () => {
       description,
       new CustomEvent('_change', {
         detail: { value: 'the updated description' },
-      })
+      }),
     );
     fireEvent(
       name,
       new CustomEvent('_change', {
         detail: { value: 'the updated name' },
-      })
+      }),
     );
 
     fireEvent(saveBtn, new CustomEvent('_click'));
@@ -258,7 +262,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
 
     await waitFor(() => {
@@ -279,7 +283,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const addBtn = baseElement.querySelector("goa-button[testId='add-notification']");
     fireEvent.click(addBtn);
@@ -301,7 +305,7 @@ describe('NotificationTypes Page', () => {
       description,
       new CustomEvent('_change', {
         detail: { value: 'description' },
-      })
+      }),
     );
     fireEvent.click(saveBtn);
 
@@ -316,7 +320,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const addBtn = baseElement.querySelectorAll("goa-button[testId='add-event']")[1];
     await waitFor(() => {
@@ -339,7 +343,7 @@ describe('NotificationTypes Page', () => {
       el,
       new CustomEvent('_change', {
         detail: { name: 'foo:bar', value: 'foo:bar' },
-      })
+      }),
     );
 
     fireEvent.click(saveBtn);
@@ -354,7 +358,7 @@ describe('NotificationTypes Page', () => {
     const { getAllByTestId, baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const editBtn = getAllByTestId('edit-event')[0];
     await waitFor(() => {
@@ -376,11 +380,26 @@ describe('NotificationTypes Page', () => {
     const saveAction = actions.find((action) => action.type === UPDATE_NOTIFICATION_TYPE);
     expect(saveAction).toBeTruthy();
   });
+
+  it('shows preview on open and lets the editor toggle it', async () => {
+    const { getAllByTestId, getByTestId } = render(
+      <Provider store={store}>
+        <NotificationTypes />
+      </Provider>,
+    );
+
+    fireEvent.click(getAllByTestId('edit-event')[0]);
+    await waitFor(() => expect(getByTestId('preview-visible-state')).toHaveTextContent('true'));
+
+    fireEvent.click(getByTestId('preview-toggle-mock'));
+    expect(getByTestId('preview-visible-state')).toHaveTextContent('false');
+  });
+
   it('edit notification type should have title and subtitle field', async () => {
     const { getAllByTestId, queryByTestId, queryAllByText, baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
 
     const editBtn = getAllByTestId('edit-event')[0];
@@ -398,7 +417,7 @@ describe('NotificationTypes Page', () => {
     const { baseElement } = render(
       <Provider store={store}>
         <NotificationTypes />
-      </Provider>
+      </Provider>,
     );
     const deleteBtn = baseElement.querySelectorAll("goa-icon-button[testId='delete-event']")[0];
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationType/notificationTypes.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/notificationType/notificationTypes.tsx
@@ -10,6 +10,7 @@ import { DeleteModal } from '@components/DeleteModal';
 import { generateMessage } from '@lib/handlebarHelper';
 import { getTemplateBody } from '@core-services/notification-shared';
 import { checkForProhibitedTags } from '@lib/EmailTemplateValidator';
+import { ResizableSplitPane } from '@core-services/app-common';
 import { ReactComponent as Mail } from '@assets/icons/mail.svg';
 import { ReactComponent as Slack } from '@assets/icons/slack.svg';
 import { ReactComponent as Chat } from '@assets/icons/chat.svg';
@@ -83,6 +84,8 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
   const [showEventDeleteConfirmation, setShowEventDeleteConfirmation] = useState(false);
   const [coreEvent, setCoreEvent] = useState(false);
   const [showTemplateForm, setShowTemplateForm] = useState(false);
+  const [previewVisible, setPreviewVisible] = useState(true);
+  const [splitResetKey, setSplitResetKey] = useState(0);
   const templateDefaultError = {
     subject: '',
     title: '',
@@ -147,6 +150,14 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
   useEffect(() => {
     document.body.style.overflow = 'auto';
   }, []);
+
+  useEffect(() => {
+    if (showTemplateForm) {
+      setPreviewVisible(true);
+      setSplitResetKey((current) => current + 1);
+    }
+  }, [showTemplateForm]);
+
   useEffect(() => {
     // if an event is selected for editing
     if (selectedEvent) {
@@ -375,7 +386,8 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
         </p>
       </div>
       <Buttons>
-        <GoabButton size="compact"
+        <GoabButton
+          size="compact"
           testId="add-notification"
           onClick={() => {
             setSelectedType(emptyNotificationType);
@@ -528,7 +540,8 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
 
                   <NotificationBorder className="padding">
                     <EventButtonWrapper>
-                      <GoabButton size="compact"
+                      <GoabButton
+                        size="compact"
                         type="secondary"
                         testId="add-event"
                         onClick={() => {
@@ -769,122 +782,138 @@ export const NotificationTypes: FunctionComponent<ParentCompProps> = ({ activeEd
         <BodyGlobalStyles hideOverflow={showTemplateForm} />
         <ModalContent>
           <NotificationTemplateEditorContainer>
-            <TemplateEditor
-              modelOpen={showTemplateForm}
-              mainTitle={eventTemplateFormState.mainTitle}
-              templates={templates}
-              initialChannel={currentChannel}
-              validChannels={selectedType.sortedChannels}
-              serviceName={serviceName}
-              notificationTypeId={selectedType.id}
-              onSubjectChange={(value, channel) => {
-                setTemplates((prev) => {
-                  const newTemplates = structuredClone(prev);
-                  if (newTemplates[channel]) {
-                    newTemplates[channel].subject = value;
-                  } else {
-                    newTemplates[channel] = { subject: value };
-                  }
-                  return newTemplates;
-                });
-                setSubject(value);
-              }}
-              onTitleChange={(value, channel) => {
-                setTemplates((prev) => {
-                  const newTemplates = structuredClone(prev);
-                  if (newTemplates[channel]) {
-                    newTemplates[channel].title = value;
-                  } else {
-                    newTemplates[channel] = { title: value };
-                  }
-                  return newTemplates;
-                });
-                setTitle(value);
-              }}
-              onSubtitleChange={(value, channel) => {
-                setTemplates((prev) => {
-                  const newTemplates = structuredClone(prev);
-                  if (newTemplates[channel]) {
-                    newTemplates[channel].subtitle = value;
-                  } else {
-                    newTemplates[channel] = { subtitle: value };
-                  }
-                  return newTemplates;
-                });
-                setSubtitle(value);
-              }}
-              onBodyChange={(value, channel) => {
-                setTemplates((prev) => {
-                  const newTemplates = structuredClone(prev);
-                  if (newTemplates[channel]) {
-                    newTemplates[channel].body = value;
-                  } else {
-                    newTemplates[channel] = { body: value };
-                  }
-                  return newTemplates;
-                });
-                setBody(value);
-              }}
-              setPreview={(channel) => {
-                if (templates && templates[channel] && templates[channel]?.additionalStyles) {
-                  const combinedPreview = ('<style>' + templates[channel]?.additionalStyles + '</style>').concat(
-                    templates[channel]?.body,
-                  );
-                  setBodyPreview(
-                    generateMessage(
-                      getTemplateBody(combinedPreview, channel, { ...htmlPayload, ...{ title, subtitle } }),
-                      { ...htmlPayload, ...{ title, subtitle } },
-                    ),
-                  );
-                  setSubjectPreview(generateMessage(templates[channel]?.subject, htmlPayload));
-                  setTitlePreview(generateMessage(templates[channel]?.title, htmlPayload));
-                  setSubTitlePreview(generateMessage(templates[channel]?.subtitle, htmlPayload));
-                } else {
-                  setBodyPreview(
-                    generateMessage(
-                      getTemplateBody(templates[channel]?.body, channel, { ...htmlPayload, ...{ title, subtitle } }),
-                      { ...htmlPayload, ...{ title, subtitle } },
-                    ),
-                  );
-                  setSubjectPreview(generateMessage(templates[channel]?.subject, htmlPayload));
-                  setTitlePreview(generateMessage(templates[channel]?.title, htmlPayload));
-                  setSubTitlePreview(generateMessage(templates[channel]?.subtitle, htmlPayload));
-                }
-                setCurrentChannel(channel);
-              }}
-              errors={templateEditErrors}
-              saveCurrentTemplate={() => saveOrAddEventTemplate()}
-              resetToSavedAction={() => {
-                setTemplates(JSON.parse(JSON.stringify(savedTemplates)));
-                reset(true);
-              }}
-              saveAndReset={saveAndReset}
-              validateEventTemplateFields={() => validateEventTemplateFields()}
-              eventSuggestion={getEventSuggestion()}
-              savedTemplates={savedTemplates}
-              eventTemplateFormState={eventTemplateFormState}
-              onAISaved={(proposal) => {
-                setSavedTemplates((prev) => {
-                  const updated = structuredClone(prev);
-                  if (!updated.email) updated.email = { subject: '', body: '' };
-                  if (proposal.subject !== undefined) updated.email.subject = proposal.subject;
-                  if (proposal.title !== undefined) updated.email.title = proposal.title;
-                  if (proposal.subtitle !== undefined) updated.email.subtitle = proposal.subtitle;
-                  if (proposal.body !== undefined) updated.email.body = proposal.body;
-                  return updated;
-                });
-                // Refresh Redux store so reopening the modal loads the saved data.
-                dispatch(FetchNotificationConfigurationService());
-              }}
+            <ResizableSplitPane
+              initialLeftPercent={48}
+              minPaneWidth={300}
+              resetKey={splitResetKey}
+              rightHidden={!previewVisible}
+              testId="notification-template-split"
+              left={
+                <TemplateEditor
+                  modelOpen={showTemplateForm}
+                  mainTitle={eventTemplateFormState.mainTitle}
+                  templates={templates}
+                  initialChannel={currentChannel}
+                  validChannels={selectedType.sortedChannels}
+                  serviceName={serviceName}
+                  notificationTypeId={selectedType.id}
+                  onSubjectChange={(value, channel) => {
+                    setTemplates((prev) => {
+                      const newTemplates = structuredClone(prev);
+                      if (newTemplates[channel]) {
+                        newTemplates[channel].subject = value;
+                      } else {
+                        newTemplates[channel] = { subject: value };
+                      }
+                      return newTemplates;
+                    });
+                    setSubject(value);
+                  }}
+                  onTitleChange={(value, channel) => {
+                    setTemplates((prev) => {
+                      const newTemplates = structuredClone(prev);
+                      if (newTemplates[channel]) {
+                        newTemplates[channel].title = value;
+                      } else {
+                        newTemplates[channel] = { title: value };
+                      }
+                      return newTemplates;
+                    });
+                    setTitle(value);
+                  }}
+                  onSubtitleChange={(value, channel) => {
+                    setTemplates((prev) => {
+                      const newTemplates = structuredClone(prev);
+                      if (newTemplates[channel]) {
+                        newTemplates[channel].subtitle = value;
+                      } else {
+                        newTemplates[channel] = { subtitle: value };
+                      }
+                      return newTemplates;
+                    });
+                    setSubtitle(value);
+                  }}
+                  onBodyChange={(value, channel) => {
+                    setTemplates((prev) => {
+                      const newTemplates = structuredClone(prev);
+                      if (newTemplates[channel]) {
+                        newTemplates[channel].body = value;
+                      } else {
+                        newTemplates[channel] = { body: value };
+                      }
+                      return newTemplates;
+                    });
+                    setBody(value);
+                  }}
+                  setPreview={(channel) => {
+                    if (templates && templates[channel] && templates[channel]?.additionalStyles) {
+                      const combinedPreview = ('<style>' + templates[channel]?.additionalStyles + '</style>').concat(
+                        templates[channel]?.body,
+                      );
+                      setBodyPreview(
+                        generateMessage(
+                          getTemplateBody(combinedPreview, channel, { ...htmlPayload, ...{ title, subtitle } }),
+                          { ...htmlPayload, ...{ title, subtitle } },
+                        ),
+                      );
+                      setSubjectPreview(generateMessage(templates[channel]?.subject, htmlPayload));
+                      setTitlePreview(generateMessage(templates[channel]?.title, htmlPayload));
+                      setSubTitlePreview(generateMessage(templates[channel]?.subtitle, htmlPayload));
+                    } else {
+                      setBodyPreview(
+                        generateMessage(
+                          getTemplateBody(templates[channel]?.body, channel, {
+                            ...htmlPayload,
+                            ...{ title, subtitle },
+                          }),
+                          { ...htmlPayload, ...{ title, subtitle } },
+                        ),
+                      );
+                      setSubjectPreview(generateMessage(templates[channel]?.subject, htmlPayload));
+                      setTitlePreview(generateMessage(templates[channel]?.title, htmlPayload));
+                      setSubTitlePreview(generateMessage(templates[channel]?.subtitle, htmlPayload));
+                    }
+                    setCurrentChannel(channel);
+                  }}
+                  errors={templateEditErrors}
+                  saveCurrentTemplate={() => saveOrAddEventTemplate()}
+                  resetToSavedAction={() => {
+                    setTemplates(JSON.parse(JSON.stringify(savedTemplates)));
+                    reset(true);
+                  }}
+                  saveAndReset={saveAndReset}
+                  validateEventTemplateFields={() => validateEventTemplateFields()}
+                  eventSuggestion={getEventSuggestion()}
+                  savedTemplates={savedTemplates}
+                  eventTemplateFormState={eventTemplateFormState}
+                  previewVisible={previewVisible}
+                  onTogglePreview={() => setPreviewVisible((visible) => !visible)}
+                  onAISaved={(proposal) => {
+                    setSavedTemplates((prev) => {
+                      const updated = structuredClone(prev);
+                      if (!updated.email) updated.email = { subject: '', body: '' };
+                      if (proposal.subject !== undefined) updated.email.subject = proposal.subject;
+                      if (proposal.title !== undefined) updated.email.title = proposal.title;
+                      if (proposal.subtitle !== undefined) updated.email.subtitle = proposal.subtitle;
+                      if (proposal.body !== undefined) updated.email.body = proposal.body;
+                      return updated;
+                    });
+                    // Refresh Redux store so reopening the modal loads the saved data.
+                    dispatch(FetchNotificationConfigurationService());
+                  }}
+                />
+              }
+              right={
+                <PreviewTemplateContainer>
+                  <PreviewTemplate
+                    channel={channelNames[currentChannel]}
+                    subjectPreviewContent={subjectPreview}
+                    bodyPreviewContent={bodyPreview}
+                    contactPhoneNumber={contact?.phoneNumber}
+                  />
+                </PreviewTemplateContainer>
+              }
             />
-            <PreviewTemplateContainer>
-              <PreviewTemplate
-                channel={channelNames[currentChannel]}
-                subjectPreviewContent={subjectPreview}
-                bodyPreviewContent={bodyPreview}
-                contactPhoneNumber={contact?.phoneNumber}
-              />
-            </PreviewTemplateContainer>
           </NotificationTemplateEditorContainer>
         </ModalContent>
       </Modal>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.spec.tsx
@@ -34,8 +34,8 @@ jest.mock('@store/file/actions', () => ({
 }));
 
 const ACCORDION_SELECTOR = "goa-accordion[testid='email-template-properties']";
-const EDIT_BUTTON_SELECTOR = "goa-button[testid='email-template-properties-edit']";
 const ERROR_BADGE_SELECTOR = "goa-badge[testid='email-template-properties-error']";
+const PREVIEW_BUTTON_SELECTOR = "goa-button[testid='toggle-email-preview']";
 
 const mockStore = configureStore([]);
 
@@ -86,18 +86,24 @@ function renderEditor(props: Record<string, any> = {}) {
   );
 }
 
+function collapseProperties(baseElement: HTMLElement) {
+  const accordion = baseElement.querySelector(ACCORDION_SELECTOR);
+  fireEvent(accordion, new CustomEvent('_change', { detail: { open: false } }));
+}
+
 describe('TemplateEditor properties section', () => {
-  it('renders the properties accordion collapsed by default', () => {
+  it('renders the properties accordion expanded by default', () => {
     const { baseElement } = renderEditor();
 
     const accordion = baseElement.querySelector(ACCORDION_SELECTOR);
 
     expect(accordion).toBeInTheDocument();
-    expect(accordion).not.toHaveAttribute('open');
+    expect(accordion).toHaveAttribute('open', 'true');
   });
 
   it('summarizes the current property values, marking blank fields as empty', () => {
-    const { getByTestId } = renderEditor();
+    const { baseElement, getByTestId } = renderEditor();
+    collapseProperties(baseElement);
 
     const summary = getByTestId('email-template-properties-values');
 
@@ -107,32 +113,54 @@ describe('TemplateEditor properties section', () => {
   });
 
   it('keeps the subject, title and subtitle editors mounted while collapsed', () => {
-    const { getByTestId } = renderEditor();
+    const { baseElement, getByTestId } = renderEditor();
+    collapseProperties(baseElement);
 
     expect(getByTestId('templated-editor-subject')).toBeInTheDocument();
     expect(getByTestId('templated-editor-title')).toBeInTheDocument();
     expect(getByTestId('templated-editor-subtitle')).toBeInTheDocument();
   });
 
-  it('opens the accordion and hides the summary when Edit is clicked', () => {
-    const { baseElement, queryByTestId } = renderEditor();
+  it('shows the summary when the properties are collapsed', () => {
+    const { baseElement, getByTestId } = renderEditor();
+    collapseProperties(baseElement);
 
-    const editButton = baseElement.querySelector(EDIT_BUTTON_SELECTOR);
-    fireEvent(editButton, new CustomEvent('_click'));
-
-    expect(baseElement.querySelector(ACCORDION_SELECTOR)).toHaveAttribute('open', 'true');
-    expect(queryByTestId('email-template-properties-values')).not.toBeInTheDocument();
+    expect(baseElement.querySelector(ACCORDION_SELECTOR)).not.toHaveAttribute('open');
+    expect(getByTestId('email-template-properties-values')).toBeInTheDocument();
   });
 
   it('flags a collapsed section that hides a property error', () => {
     const { baseElement } = renderEditor({ errors: { subject: 'Invalid handlebar syntax' } });
+    collapseProperties(baseElement);
 
     expect(baseElement.querySelector(ERROR_BADGE_SELECTOR)).toBeInTheDocument();
   });
 
   it('does not flag an error when only the body is invalid', () => {
     const { baseElement } = renderEditor({ errors: { body: 'Invalid handlebar syntax' } });
+    collapseProperties(baseElement);
 
     expect(baseElement.querySelector(ERROR_BADGE_SELECTOR)).not.toBeInTheDocument();
+  });
+
+  it('groups the property fields and keeps the default template option outside the accordion', () => {
+    const { baseElement, getByTestId } = renderEditor();
+
+    expect(getByTestId('template-properties-grid')).toBeInTheDocument();
+    const checkbox = getByTestId('default-template-checkbox');
+    expect(checkbox.closest('goa-accordion')).toBeNull();
+
+    collapseProperties(baseElement);
+    expect(getByTestId('default-template-checkbox')).toBeInTheDocument();
+  });
+
+  it('toggles the preview from the tab bar action', () => {
+    const onTogglePreview = jest.fn();
+    const { baseElement, getByText } = renderEditor({ onTogglePreview, previewVisible: true });
+
+    expect(getByText('Hide preview')).toBeInTheDocument();
+    fireEvent(baseElement.querySelector(PREVIEW_BUTTON_SELECTOR), new CustomEvent('_click'));
+
+    expect(onTogglePreview).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -9,7 +9,9 @@ import {
   MonacoDivBody,
   TemplateEditorTitle,
   TemplatePropertiesActions,
+  TemplatePropertiesGrid,
   TemplatePropertiesSummary,
+  BodyEditorFooter,
 } from './styled-components';
 import { AppDispatch, RootState } from '@store/index';
 import { connectAgent, disconnectAgent, startThread } from '@store/agent/actions';
@@ -72,6 +74,8 @@ interface TemplateEditorProps {
   serviceName?: string;
   notificationTypeId?: string;
   onAISaved?: (proposal: EmailTemplateProposal) => void;
+  previewVisible?: boolean;
+  onTogglePreview?: () => void;
   // eslint-disable-next-line
   eventSuggestion?: any;
 }
@@ -98,6 +102,8 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   notificationTypeId,
   onAISaved,
   eventSuggestion,
+  previewVisible = true,
+  onTogglePreview,
 }) => {
   const [aiThreadId, setAiThreadId] = useState<string>(uuid());
   const agentName = 'notificationEmailTemplateAgent';
@@ -144,14 +150,14 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   const [activeIndex, setActiveIndex] = useState(0);
   const [saveModal, setSaveModal] = useState(false);
   const [useDefaultTemplate, setUseDefaultTemplate] = useState(false);
-  const [propertiesOpen, setPropertiesOpen] = useState(false);
+  const [propertiesOpen, setPropertiesOpen] = useState(true);
 
   const hasPropertyErrors = !!(errors?.['subject'] || errors?.['title'] || errors?.['subtitle']);
 
-  // Start collapsed every time the modal opens so the body editor gets the most room by default.
+  // Make the metadata fields immediately available each time the modal opens.
   // Keyed on modelOpen only - keying on templates would re-collapse the section on every keystroke.
   useEffect(() => {
-    setPropertiesOpen(false);
+    setPropertiesOpen(true);
   }, [modelOpen]);
 
   useEffect(() => {
@@ -268,6 +274,19 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
       <GoabFormItem label="">
         <Tabs
           activeIndex={activeIndex}
+          actions={
+            onTogglePreview && (
+              <GoabButton
+                type="tertiary"
+                size="compact"
+                leadingIcon={previewVisible ? 'eye-off' : 'eye'}
+                testId="toggle-email-preview"
+                onClick={onTogglePreview}
+              >
+                {previewVisible ? 'Hide preview' : 'Preview email'}
+              </GoabButton>
+            )
+          }
           changeTabCallback={(index: number) => {
             if (index < validChannels.length) {
               switchTabPreview(validChannels[index]);
@@ -360,78 +379,49 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                     )
                   }
                 >
-                  <GoabFormItem error={errors['subject'] ?? ''} label="Subject" mb="s">
-                    <MonacoDiv data-testid="templated-editor-subject">
-                      <MonacoEditor
-                        language={item.name === 'slack' ? 'markdown' : 'handlebars'}
-                        data-testid="templated-editor-subject"
-                        onChange={(value) => {
-                          onSubjectChange(value, item.name);
-                        }}
-                        value={templates[item.name]?.subject}
-                        {...subjectEditorConfig}
-                      />
-                    </MonacoDiv>
-                  </GoabFormItem>
+                  <TemplatePropertiesGrid data-testid="template-properties-grid">
+                    <GoabFormItem error={errors['subject'] ?? ''} label="Subject" mb="s">
+                      <MonacoDiv data-testid="templated-editor-subject">
+                        <MonacoEditor
+                          language={item.name === 'slack' ? 'markdown' : 'handlebars'}
+                          data-testid="templated-editor-subject"
+                          onChange={(value) => {
+                            onSubjectChange(value, item.name);
+                          }}
+                          value={templates[item.name]?.subject}
+                          {...subjectEditorConfig}
+                        />
+                      </MonacoDiv>
+                    </GoabFormItem>
 
-                  <GoabFormItem error={errors['title'] ?? ''} label="Title" mb="s">
-                    <MonacoDiv data-testid="templated-editor-title">
-                      <MonacoEditor
-                        language={item.name === 'slack' ? 'markdown' : 'handlebars'}
-                        data-testid="templated-editor-title"
-                        onChange={(value) => {
-                          onTitleChange(value, item.name);
-                        }}
-                        value={templates[item.name]?.title}
-                        {...subjectEditorConfig}
-                      />
-                    </MonacoDiv>
-                  </GoabFormItem>
+                    <GoabFormItem error={errors['title'] ?? ''} label="Title" mb="s">
+                      <MonacoDiv data-testid="templated-editor-title">
+                        <MonacoEditor
+                          language={item.name === 'slack' ? 'markdown' : 'handlebars'}
+                          data-testid="templated-editor-title"
+                          onChange={(value) => {
+                            onTitleChange(value, item.name);
+                          }}
+                          value={templates[item.name]?.title}
+                          {...subjectEditorConfig}
+                        />
+                      </MonacoDiv>
+                    </GoabFormItem>
 
-                  <GoabFormItem error={errors['subtitle'] ?? ''} label="Subtitle" mb="s">
-                    <MonacoDiv data-testid="templated-editor-subtitle">
-                      <MonacoEditor
-                        language={item.name === 'slack' ? 'markdown' : 'handlebars'}
-                        data-testid="templated-editor-subtitle"
-                        onChange={(value) => {
-                          onSubtitleChange(value, item.name);
-                        }}
-                        value={templates[item.name]?.subtitle}
-                        {...subjectEditorConfig}
-                      />
-                    </MonacoDiv>
-                  </GoabFormItem>
-
-                  {item.name === 'email' &&
-                    (() => {
-                      const emailBody = templates[item.name]?.body ?? '';
-                      const isDefaultTemplate = emailBody.trim() === emailWrapper.trim();
-                      const isBodyNotEmpty = emailBody.trim().length > 0 && !isDefaultTemplate;
-
-                      return (
-                        <GoabFormItem label="" mb="none" helpText={bodyEditorHintText}>
-                          <GoabCheckbox
-                            size="compact"
-                            name={`use-default-template`}
-                            checked={useDefaultTemplate}
-                            data-testid="default-template-checkbox"
-                            description={
-                              isBodyNotEmpty ? 'Clear the current body in order to use the default template.' : ''
-                            }
-                            onChange={(detail: GoabCheckboxOnChangeDetail) => {
-                              setUseDefaultTemplate(detail.checked);
-                              if (detail.value) {
-                                onBodyChange(emailWrapper, item.name);
-                              } else {
-                                onBodyChange('', item.name);
-                              }
-                            }}
-                            text={'Use default template to edit header and footer'}
-                            disabled={isBodyNotEmpty}
-                          ></GoabCheckbox>
-                        </GoabFormItem>
-                      );
-                    })()}
+                    <GoabFormItem error={errors['subtitle'] ?? ''} label="Subtitle" mb="s">
+                      <MonacoDiv data-testid="templated-editor-subtitle">
+                        <MonacoEditor
+                          language={item.name === 'slack' ? 'markdown' : 'handlebars'}
+                          data-testid="templated-editor-subtitle"
+                          onChange={(value) => {
+                            onSubtitleChange(value, item.name);
+                          }}
+                          value={templates[item.name]?.subtitle}
+                          {...subjectEditorConfig}
+                        />
+                      </MonacoDiv>
+                    </GoabFormItem>
+                  </TemplatePropertiesGrid>
                 </GoabAccordion>
 
                 <GoabFormItem error={errors['body'] ?? ''} mb={'s'} label="Body">
@@ -446,6 +436,34 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                     />
                   </MonacoDivBody>
                 </GoabFormItem>
+
+                {item.name === 'email' &&
+                  (() => {
+                    const emailBody = templates[item.name]?.body ?? '';
+                    const isDefaultTemplate = emailBody.trim() === emailWrapper.trim();
+                    const isBodyNotEmpty = emailBody.trim().length > 0 && !isDefaultTemplate;
+
+                    return (
+                      <BodyEditorFooter>
+                        <span>{bodyEditorHintText}</span>
+                        <GoabCheckbox
+                          size="compact"
+                          name="use-default-template"
+                          checked={useDefaultTemplate}
+                          data-testid="default-template-checkbox"
+                          description={
+                            isBodyNotEmpty ? 'Clear the current body in order to use the default template.' : ''
+                          }
+                          onChange={(detail: GoabCheckboxOnChangeDetail) => {
+                            setUseDefaultTemplate(detail.checked);
+                            onBodyChange(detail.checked ? emailWrapper : '', item.name);
+                          }}
+                          text="Use default template to edit header and footer"
+                          disabled={isBodyNotEmpty}
+                        />
+                      </BodyEditorFooter>
+                    );
+                  })()}
               </>
             </Tab>
           ))}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.ts
@@ -7,11 +7,13 @@ import { SmsPreviewPortal } from './smsPreviewPortal';
 export const TemplateEditorContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 48%;
-  min-height: calc(100vh - 4rem);
+  flex: 1;
+  height: calc(100% - 2rem);
+  min-width: 0;
   padding-right: 0.5rem;
   margin-top: 2rem;
   overflow: hidden;
+  container: template-editor / inline-size;
 
   &:hover {
     overflow: auto;
@@ -46,27 +48,45 @@ export const TemplateEditorContainer = styled.div`
 
 export const MonacoDiv = styled.div`
   display: flex;
+  min-width: 0;
   border: 1px solid var(--color-gray-700);
   border-radius: 3px;
   padding: 0.15rem 0.15rem;
 `;
-// The height budget subtracted below accounts for the fixed chrome above the body editor.
-// When the properties section is collapsed its accordion header (~52px) replaces the three
-// subject-style form items (~91px each) plus the default-template checkbox and body hint,
-// freeing ~290px for the body editor.
 export const MonacoDivBody = styled.div<{ $compact?: boolean }>`
   display: flex;
   border: 1px solid var(--color-gray-700);
   border-radius: 3px;
   padding: 0.15rem 0.15rem;
-  height: ${({ $compact }) => ($compact ? 'calc(100vh - 285px)' : 'calc(100vh - 645px)')};
-  min-height: 65px;
+  height: ${({ $compact }) => ($compact ? 'max(200px, calc(100vh - 340px))' : 'max(200px, calc(100vh - 450px))')};
+  min-height: 200px;
+`;
 
-  @media (max-width: 1420px) {
-    height: ${({ $compact }) => ($compact ? 'calc(100vh - 195px)' : 'calc(100vh - 555px)')};
+export const TemplatePropertiesGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--goa-space-s);
+
+  @container template-editor (max-width: 720px) {
+    grid-template-columns: minmax(0, 1fr);
   }
-  @media (max-height: 920px) {
-    height: ${({ $compact }) => ($compact ? 'calc(100vh - 310px)' : 'calc(100vh - 670px)')};
+`;
+
+export const BodyEditorFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--goa-space-m);
+  margin-bottom: var(--goa-space-s);
+  font: var(--goa-typography-body-s);
+  color: var(--goa-color-text-secondary);
+
+  > span {
+    flex: 1;
+  }
+
+  @container template-editor (max-width: 720px) {
+    flex-direction: column;
   }
 `;
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/styled-components.ts
@@ -189,7 +189,10 @@ export const NotificationStyles = styled.div`
 `;
 
 export const PreviewTemplateContainer = styled.div`
-  width: 52%;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  box-sizing: border-box;
   margin-left: 1rem;
   padding-top: 2rem;
   padding-left: 1rem;

--- a/libs/app-common/src/components/resizable/ResizableSplitPane.spec.tsx
+++ b/libs/app-common/src/components/resizable/ResizableSplitPane.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ResizableSplitPane } from './ResizableSplitPane';
+
+let observedWidth = 1000;
+
+class ResizeObserverMock {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  observe = () => {
+    this.callback(
+      [{ contentRect: { width: observedWidth } } as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    );
+  };
+
+  disconnect = jest.fn();
+  unobserve = jest.fn();
+}
+
+describe('ResizableSplitPane', () => {
+  beforeAll(() => {
+    global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+  });
+
+  beforeEach(() => {
+    observedWidth = 1000;
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: observedWidth,
+      top: 0,
+      width: observedWidth,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('renders both panes with an accessible separator', () => {
+    const { getByRole, getByText } = render(
+      <ResizableSplitPane left={<div>Editor</div>} right={<div>Preview</div>} initialLeftPercent={48} />,
+    );
+
+    expect(getByText('Editor')).toBeInTheDocument();
+    expect(getByText('Preview')).toBeInTheDocument();
+    expect(getByRole('separator')).toHaveAttribute('aria-valuenow', '480');
+    expect(getByRole('separator')).toHaveAttribute('aria-valuemin', '300');
+    expect(getByRole('separator')).toHaveAttribute('aria-valuemax', '691');
+  });
+
+  it('supports keyboard resizing and clamps both pane minimums', () => {
+    const { getByRole } = render(<ResizableSplitPane left={<div />} right={<div />} />);
+    const separator = getByRole('separator');
+
+    fireEvent.keyDown(separator, { key: 'ArrowRight' });
+    expect(separator).toHaveAttribute('aria-valuenow', '516');
+
+    fireEvent.keyDown(separator, { key: 'Home' });
+    expect(separator).toHaveAttribute('aria-valuenow', '300');
+
+    fireEvent.keyDown(separator, { key: 'End' });
+    expect(separator).toHaveAttribute('aria-valuenow', '691');
+  });
+
+  it('renders only the editor when the right pane is hidden', () => {
+    const { getByText, queryByRole, queryByText } = render(
+      <ResizableSplitPane left={<div>Editor</div>} right={<div>Preview</div>} rightHidden />,
+    );
+
+    expect(getByText('Editor')).toBeInTheDocument();
+    expect(queryByText('Preview')).not.toBeInTheDocument();
+    expect(queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the editor when the container cannot fit both minimum widths', () => {
+    observedWidth = 600;
+    const { getByText, queryByRole, queryByText } = render(
+      <ResizableSplitPane left={<div>Editor</div>} right={<div>Preview</div>} />,
+    );
+
+    expect(getByText('Editor')).toBeInTheDocument();
+    expect(queryByText('Preview')).not.toBeInTheDocument();
+    expect(queryByRole('separator')).not.toBeInTheDocument();
+  });
+});

--- a/libs/app-common/src/components/resizable/ResizableSplitPane.tsx
+++ b/libs/app-common/src/components/resizable/ResizableSplitPane.tsx
@@ -1,0 +1,139 @@
+import React, { FunctionComponent, KeyboardEvent, PointerEvent, ReactNode, useEffect, useRef, useState } from 'react';
+import { DIVIDER_WIDTH, SplitPaneContainer, SplitPaneDivider, SplitPanePanel } from './styled-components';
+
+const KEYBOARD_STEP = 16;
+const LARGE_KEYBOARD_STEP = 64;
+
+interface ResizableSplitPaneProps {
+  left: ReactNode;
+  right: ReactNode;
+  initialLeftPercent?: number;
+  minPaneWidth?: number;
+  rightHidden?: boolean;
+  resetKey?: unknown;
+  testId?: string;
+  ariaLabel?: string;
+}
+
+const clamp = (value: number, minimum: number, maximum: number) => Math.min(Math.max(value, minimum), maximum);
+
+export const ResizableSplitPane: FunctionComponent<ResizableSplitPaneProps> = ({
+  left,
+  right,
+  initialLeftPercent = 50,
+  minPaneWidth = 300,
+  rightHidden = false,
+  resetKey,
+  testId = 'resizable-split-pane',
+  ariaLabel = 'Resize editor and preview panes',
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const maximumLeftWidth = containerWidth - minPaneWidth - DIVIDER_WIDTH;
+  const canSplit = !rightHidden && containerWidth >= minPaneWidth * 2 + DIVIDER_WIDTH;
+
+  const updateLeftWidth = (width: number) => {
+    if (canSplit) {
+      setLeftWidth(clamp(width, minPaneWidth, maximumLeftWidth));
+    }
+  };
+
+  const resetLeftWidth = () => {
+    if (containerWidth > 0) {
+      updateLeftWidth((containerWidth * initialLeftPercent) / 100);
+    }
+  };
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateContainerWidth = (width: number) => {
+      setContainerWidth(width);
+      if (width >= minPaneWidth * 2 + DIVIDER_WIDTH) {
+        const maximum = width - minPaneWidth - DIVIDER_WIDTH;
+        setLeftWidth((current) =>
+          current === null
+            ? clamp((width * initialLeftPercent) / 100, minPaneWidth, maximum)
+            : clamp(current, minPaneWidth, maximum),
+        );
+      }
+    };
+
+    updateContainerWidth(container.getBoundingClientRect().width);
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => updateContainerWidth(entries[0].contentRect.width));
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [initialLeftPercent, minPaneWidth]);
+
+  useEffect(() => {
+    resetLeftWidth();
+    // Reset is intentionally controlled by the host rather than persisted between modal sessions.
+  }, [resetKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!dragging || !containerRef.current) return;
+    updateLeftWidth(event.clientX - containerRef.current.getBoundingClientRect().left);
+  };
+
+  const stopDragging = (event: PointerEvent<HTMLDivElement>) => {
+    setDragging(false);
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (leftWidth === null) return;
+
+    const step = event.shiftKey ? LARGE_KEYBOARD_STEP : KEYBOARD_STEP;
+    let nextWidth: number | null = null;
+
+    if (event.key === 'ArrowLeft') nextWidth = leftWidth - step;
+    if (event.key === 'ArrowRight') nextWidth = leftWidth + step;
+    if (event.key === 'Home') nextWidth = minPaneWidth;
+    if (event.key === 'End') nextWidth = maximumLeftWidth;
+
+    if (nextWidth !== null) {
+      event.preventDefault();
+      updateLeftWidth(nextWidth);
+    }
+  };
+
+  const showSplit = canSplit && leftWidth !== null;
+
+  return (
+    <SplitPaneContainer ref={containerRef} $dragging={dragging} data-testid={testId}>
+      <SplitPanePanel $width={showSplit ? leftWidth : undefined}>{left}</SplitPanePanel>
+      {showSplit && (
+        <>
+          <SplitPaneDivider
+            role="separator"
+            aria-label={ariaLabel}
+            aria-orientation="vertical"
+            aria-valuemin={minPaneWidth}
+            aria-valuemax={Math.round(maximumLeftWidth)}
+            aria-valuenow={Math.round(leftWidth)}
+            tabIndex={0}
+            $dragging={dragging}
+            onDoubleClick={resetLeftWidth}
+            onKeyDown={handleKeyDown}
+            onPointerDown={(event) => {
+              setDragging(true);
+              event.currentTarget.setPointerCapture?.(event.pointerId);
+            }}
+            onPointerMove={handlePointerMove}
+            onPointerUp={stopDragging}
+            onPointerCancel={stopDragging}
+          />
+          <SplitPanePanel $fill>{right}</SplitPanePanel>
+        </>
+      )}
+    </SplitPaneContainer>
+  );
+};

--- a/libs/app-common/src/components/resizable/index.ts
+++ b/libs/app-common/src/components/resizable/index.ts
@@ -1,0 +1,1 @@
+export * from './ResizableSplitPane';

--- a/libs/app-common/src/components/resizable/styled-components.ts
+++ b/libs/app-common/src/components/resizable/styled-components.ts
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+
+export const DIVIDER_WIDTH = 9;
+
+export const SplitPaneContainer = styled.div<{ $dragging: boolean }>`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  user-select: ${({ $dragging }) => ($dragging ? 'none' : 'auto')};
+`;
+
+export const SplitPanePanel = styled.div<{ $fill?: boolean; $width?: number }>`
+  display: flex;
+  flex: ${({ $fill, $width }) => ($fill ? '1 1 0' : $width === undefined ? '1 1 100%' : `0 0 ${$width}px`)};
+  width: ${({ $width }) => ($width === undefined ? '100%' : `${$width}px`)};
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+export const SplitPaneDivider = styled.div<{ $dragging: boolean }>`
+  position: relative;
+  flex: 0 0 ${DIVIDER_WIDTH}px;
+  width: ${DIVIDER_WIDTH}px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+  outline: none;
+
+  &::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 4px;
+    width: ${({ $dragging }) => ($dragging ? '2px' : '1px')};
+    background: ${({ $dragging }) =>
+      $dragging ? 'var(--goa-color-interactive-default)' : 'var(--goa-color-greyscale-200)'};
+    content: '';
+  }
+
+  &:hover::before {
+    width: 2px;
+    background: var(--goa-color-interactive-default);
+  }
+
+  &:focus-visible::before {
+    width: 3px;
+    background: var(--goa-color-interactive-default);
+    box-shadow: 0 0 0 2px var(--goa-color-greyscale-white);
+  }
+`;

--- a/libs/app-common/src/index.ts
+++ b/libs/app-common/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/Recaptcha';
 export * from './components/RowSkeleton';
 export * from './components/RowLoadMore';
 export * from './components/AgentChat';
+export * from './components/resizable';
 
 export * from './types/agent';
 export * from './utils';


### PR DESCRIPTION

- Added ResizableSplitPane component to allow dynamic resizing of editor and preview panes.
- Integrated ResizableSplitPane into NotificationTypes page for improved UI/UX.
- Updated TemplateEditor to support preview visibility toggle and enhanced layout.
- Refactored notification type tests to include preview functionality.
- Adjusted styled-components for better responsiveness and layout management.
- Added tests for ResizableSplitPane to ensure proper functionality and accessibility.

https://github.com/user-attachments/assets/7baee632-45a4-418b-815d-47843d2014ee

