### PR TITLE
fix(form-service): match form data filters case insensitively

### DIFF
--- a/apps/form-service/src/mongo/criteria.ts
+++ b/apps/form-service/src/mongo/criteria.ts
@@ -1,0 +1,18 @@
+const REGEX_SPECIAL_CHARACTERS = /[.*+?^${}()|[\]\\]/g;
+
+function toCaseInsensitiveContains(value: string): Record<string, string> {
+  return { $regex: value.replace(REGEX_SPECIAL_CHARACTERS, '\\$&'), $options: 'i' };
+}
+
+// Data criteria come from user entered filter values, so text is matched as a case insensitive substring;
+// the user filtering forms or submissions knows neither the casing nor the full value in the stored data.
+// Non-text values (e.g. the number and integer filters) remain exact matches.
+export function toDataCriteriaQuery(dataCriteria: Record<string, unknown>, path: string): Record<string, unknown> {
+  return Object.entries(dataCriteria).reduce(
+    (query, [property, value]) => {
+      query[`${path}.${property}`] = typeof value === 'string' ? toCaseInsensitiveContains(value) : value;
+      return query;
+    },
+    {} as Record<string, unknown>,
+  );
+}

--- a/apps/form-service/src/mongo/form.spec.ts
+++ b/apps/form-service/src/mongo/form.spec.ts
@@ -231,6 +231,41 @@ describe('MongoFormRepository', () => {
       expect(results.results).toHaveLength(1);
       expect(results.results[0].id).toBe('form-1');
     });
+
+    it.each(['Value1', 'VALUE1', 'value1'])(
+      'should find forms by data criteria regardless of case (%s)',
+      async (value) => {
+        await saveForms({ id: 'form-1', data: { field1: 'Value1' } }, { id: 'form-2', data: { field1: 'value2' } });
+
+        const results = await repo.find(10, null, {
+          tenantIdEquals: tenantId,
+          dataCriteria: { field1: value },
+        });
+        expect(results.results).toHaveLength(1);
+        expect(results.results[0].id).toBe('form-1');
+      },
+    );
+
+    it.each(['alue1', 'UE1', '1'])('should find forms on a partial data criteria value (%s)', async (value) => {
+      await saveForms({ id: 'form-1', data: { field1: 'Value1' } }, { id: 'form-2', data: { field1: 'value2' } });
+
+      const results = await repo.find(10, null, {
+        tenantIdEquals: tenantId,
+        dataCriteria: { field1: value },
+      });
+      expect(results.results).toHaveLength(1);
+      expect(results.results[0].id).toBe('form-1');
+    });
+
+    it('should not find forms on a data criteria value that is not a substring', async () => {
+      await saveForms({ id: 'form-1', data: { field1: 'value1' } }, { id: 'form-2', data: { field1: 'value2' } });
+
+      const results = await repo.find(10, null, {
+        tenantIdEquals: tenantId,
+        dataCriteria: { field1: 'value12' },
+      });
+      expect(results.results).toHaveLength(0);
+    });
   });
 
   describe('get', () => {
@@ -259,7 +294,7 @@ describe('MongoFormRepository', () => {
             'supporting.document': adspId`urn:ads:platform:file-service:v1:/files/file-1`,
             missing: null,
           },
-        })
+        }),
       );
 
       const result = await repo.get(tenantId, 'form-1');

--- a/apps/form-service/src/mongo/form.ts
+++ b/apps/form-service/src/mongo/form.ts
@@ -5,6 +5,7 @@ import { Logger } from 'winston';
 import { FormCriteria, FormEntity, FormRepository } from '../form';
 import { FormDefinitionRepository } from '../form';
 import { NotificationService, Subscriber } from '../notification';
+import { toDataCriteriaQuery } from './criteria';
 import { formSchema } from './schema';
 import { FormDoc } from './types';
 
@@ -71,9 +72,7 @@ export class MongoFormRepository implements FormRepository {
     }
 
     if (criteria?.dataCriteria) {
-      Object.entries(criteria.dataCriteria).forEach(([property, value]) => {
-        query[`data.${property}`] = value;
-      });
+      Object.assign(query, toDataCriteriaQuery(criteria.dataCriteria, 'data'));
     }
 
     const results = new Promise<FormEntity[]>((resolve, reject) => {

--- a/apps/form-service/src/mongo/formSubmission.spec.ts
+++ b/apps/form-service/src/mongo/formSubmission.spec.ts
@@ -257,7 +257,7 @@ describe('MongoFormSubmissionRepository', () => {
           tenantIdEquals: tenantId,
           formIdEquals: testFormId,
           createDateAfter: 'not-a-date' as never,
-        })
+        }),
       ).toThrow(/valid date/);
     });
 
@@ -319,6 +319,86 @@ describe('MongoFormSubmissionRepository', () => {
       });
       expect(results.results).toHaveLength(1);
       expect(results.results[0].id).toBe('sub-1');
+    });
+
+    it.each(['Support', 'SUPPORT', 'support'])(
+      'should find submissions by formData criteria regardless of case (%s)',
+      async (value) => {
+        const results = await repo.find(10, null, {
+          tenantIdEquals: tenantId,
+          formIdEquals: testFormId,
+          dataCriteria: { category: value },
+        });
+        expect(results.results).toHaveLength(1);
+        expect(results.results[0].id).toBe('sub-1');
+      },
+    );
+
+    it.each(['supp', 'ORT', 'ppo'])(
+      'should find submissions on a partial formData criteria value (%s)',
+      async (value) => {
+        const results = await repo.find(10, null, {
+          tenantIdEquals: tenantId,
+          formIdEquals: testFormId,
+          dataCriteria: { category: value },
+        });
+        expect(results.results).toHaveLength(1);
+        expect(results.results[0].id).toBe('sub-1');
+      },
+    );
+
+    it('should not find submissions on a formData criteria value that is not a substring', async () => {
+      const results = await repo.find(10, null, {
+        tenantIdEquals: tenantId,
+        formIdEquals: testFormId,
+        dataCriteria: { category: 'supports' },
+      });
+      expect(results.results).toHaveLength(0);
+    });
+
+    it('should treat regex characters in a formData criteria value as literals', async () => {
+      await repo.save(
+        createSubmission({
+          id: 'sub-5',
+          formId: testFormId,
+          formDefinitionId: 'def-1',
+          formData: { category: 'sup.ort' },
+        }),
+      );
+
+      const literal = await repo.find(10, null, {
+        tenantIdEquals: tenantId,
+        formIdEquals: testFormId,
+        dataCriteria: { category: 'SUP.ORT' },
+      });
+      expect(literal.results).toHaveLength(1);
+      expect(literal.results[0].id).toBe('sub-5');
+
+      const wildcard = await repo.find(10, null, {
+        tenantIdEquals: tenantId,
+        formIdEquals: testFormId,
+        dataCriteria: { category: 'supp.rt' },
+      });
+      expect(wildcard.results).toHaveLength(0);
+    });
+
+    it('should find submissions on a non-string formData criteria value', async () => {
+      await repo.save(
+        createSubmission({
+          id: 'sub-6',
+          formId: testFormId,
+          formDefinitionId: 'def-1',
+          formData: { category: 'support', count: 3 },
+        }),
+      );
+
+      const results = await repo.find(10, null, {
+        tenantIdEquals: tenantId,
+        formIdEquals: testFormId,
+        dataCriteria: { count: 3 },
+      });
+      expect(results.results).toHaveLength(1);
+      expect(results.results[0].id).toBe('sub-6');
     });
 
     it('should find submissions with multiple formData criteria', async () => {

--- a/apps/form-service/src/mongo/formSubmission.ts
+++ b/apps/form-service/src/mongo/formSubmission.ts
@@ -9,6 +9,7 @@ import {
   FormSubmissionEntity,
   FormSubmissionRepository,
 } from '../form';
+import { toDataCriteriaQuery } from './criteria';
 import { formSubmissionSchema } from './schema';
 import { FormSubmissionDoc } from './types';
 
@@ -97,9 +98,7 @@ export class MongoFormSubmissionRepository implements FormSubmissionRepository {
     }
 
     if (criteria?.dataCriteria) {
-      Object.entries(criteria.dataCriteria).forEach(([property, value]) => {
-        query[`formData.${property}`] = value;
-      });
+      Object.assign(query, toDataCriteriaQuery(criteria.dataCriteria, 'formData'));
     }
 
     const results = new Promise<FormSubmissionEntity[]>((resolve, reject) => {


### PR DESCRIPTION
Resolves CS-5219.

## Problem

Text filters on the Submission Search page required an exact, case sensitive match. Searching `auto` against a stored `Auto` returned `Showing 0 of 10 submissions`, which reads to users as missing records.

Both mongo repositories assigned the raw filter value straight into the query:

```ts
query[`formData.${property}`] = value;   // formSubmission.ts
query[`data.${property}`] = value;       // form.ts
```

## Change

New `apps/form-service/src/mongo/criteria.ts` builds the data criteria query fragment, shared by both repositories (`formData` for submissions, `data` for forms):

- **Text values** match as a case insensitive substring, so `auto` finds `Auto`, `Autotest` and `RENAULT_AUTO`.
- **Regex characters are escaped** so they match literally. This matters more with substring matching than it did with equality: unescaped, a filter value of `supp.rt` would match a stored `support`.
- **Non-text values** pass through as exact matches, so the number and integer filters (which `DataValueCriteriaItem` sends through `parseInt`/`parseFloat`) are unchanged.

The Forms search page is fixed alongside Submissions because it had the identical bug from the identical line, and the *Export to file* flow on both pages runs through the same `repository.find`.

## Tests

Sixteen cases added across `form.spec.ts` and `formSubmission.spec.ts`. These run against a real Mongo via `mongodb-memory-server`, so query behaviour is genuinely exercised rather than asserted against a mock:

- `Auto` / `auto` / `AUTO` style trios return the same record, per the acceptance criteria
- prefix, suffix and mid-string partials all match (`supp`, `ORT`, `ppo`)
- negative cases (`supports`, `value12`) confirm the filter is not matching everything
- regex characters are treated literally — this test fails loudly if escaping regresses
- numeric criteria still match exactly

`nx test form-service` — 401 passed, 17 suites, coverage gate satisfied, `criteria.ts` at 100%.

## Notes for review

- **Performance.** An unanchored regex cannot use an index, so a data criteria filter is a scan over the tenant/form scoped subset. Those queries are already narrowed by `tenantId` plus `formId`/`definitionId`, so this should be fine, but it is worth a thought for tenants with high submission volume.
- **Pre-existing, not addressed here.** `criteria` arrives as raw `JSON.parse` output with no whitelist on `dataCriteria` values (`form/router/form.ts:127`, `:173`), so a caller can pass `{"$ne": null}` and have it land in the query untouched. Escaping means this PR does not add to that surface, but it may deserve a follow-up.