### PR TITLE
fix(jsonforms-components): keep validation quiet until a step is worked through

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -107,6 +107,10 @@ const createStepperContextInitData = (
       isCompleted: status === StepStatus.COMPLETED || (visited && !hasRequiredFields),
       isValid: status === StepStatus.COMPLETED || (visited && !hasRequiredFields),
       isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(status),
+      // Navigation is tracked by the reducer, which merges this value forward on every recompute.
+      // It starts false so a freshly opened form shows no validation messages until the user has
+      // actually worked through a step; deriving it here from data would defeat the point.
+      isNavigatedAway: false,
       status,
       uischema: c,
       isEnabled: isEnabled(c, data, '', ajv, undefined),

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.spec.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.spec.ts
@@ -50,6 +50,8 @@ describe('stepperReducer', () => {
       // Assert
       expect(result.activeId).toBe(1);
       expect(result.categories[0].isVisited).toBe(true);
+      expect(result.categories[0].isNavigatedAway).toBe(true);
+      expect(result.categories[1].isNavigatedAway).toBeFalsy();
       expect(result.isOnReview).toBe(false);
       expect(result.hasNextButton).toBe(true);
       expect(result.hasPrevButton).toBe(true);
@@ -80,6 +82,7 @@ describe('stepperReducer', () => {
       // Assert
       expect(result.activeId).toBe(0);
       expect(result.categories[1].isVisited).toBe(true);
+      expect(result.categories[1].isNavigatedAway).toBe(true);
       expect(result.isOnReview).toBe(false);
       expect(result.hasPrevButton).toBe(false);
     });
@@ -179,6 +182,20 @@ describe('stepperReducer', () => {
       expect(result.categories[1].isVisited).toBe(true);
       expect(result.categories[0].isVisited).toBe(false);
     });
+
+    test('marks the specified category as navigated away from', () => {
+      // This is the action RenderPages fires on Next, Previous and back to the application
+      // overview, so it is what actually opens up validation messages for a step.
+      // Arrange
+      const state = buildState();
+
+      // Act
+      const result = stepperReducer(state, { type: 'set/visited', payload: { id: 1 } });
+
+      // Assert
+      expect(result.categories[1].isNavigatedAway).toBe(true);
+      expect(result.categories[0].isNavigatedAway).toBeFalsy();
+    });
   });
 
   describe('validate/form', () => {
@@ -259,6 +276,38 @@ describe('stepperReducer', () => {
 
       // Assert
       expect(result.categories[0].isVisited).toBe(true);
+    });
+
+    test('carries a navigated category across a recompute', () => {
+      // Arrange
+      const state = buildState({
+        categories: [{ ...buildCategory(0), isNavigatedAway: true }, buildCategory(1)],
+      });
+      const newState = buildState({ categories: [buildCategory(0), buildCategory(1)] });
+
+      // Act
+      const result = stepperReducer(state, { type: 'update/uischema', payload: { state: newState } });
+
+      // Assert
+      expect(result.categories[0].isNavigatedAway).toBe(true);
+      expect(result.categories[1].isNavigatedAway).toBe(false);
+    });
+
+    test('does not let a recomputed visited category mark itself navigated (CS-5245)', () => {
+      // Entering data anywhere in a step makes the recompute report it visited. That must not
+      // promote the step to navigated, or every untouched control on it starts showing errors.
+      // Arrange
+      const state = buildState({ categories: [buildCategory(0), buildCategory(1)] });
+      const newState = buildState({
+        categories: [{ ...buildCategory(0), isVisited: true, isNavigatedAway: true }, buildCategory(1)],
+      });
+
+      // Act
+      const result = stepperReducer(state, { type: 'update/uischema', payload: { state: newState } });
+
+      // Assert
+      expect(result.categories[0].isVisited).toBe(true);
+      expect(result.categories[0].isNavigatedAway).toBe(false);
     });
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/reducer.ts
@@ -37,11 +37,15 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
       // (page/next, page/prev, or setVisited previously marked it visited).
       // Preserve any previously-tracked isVisited=true so navigation history
       // isn't lost whenever unrelated form data changes trigger this recompute.
+      // isNavigatedAway is tracked here and never recomputed, so the merge is the only thing
+      // carrying it across a recompute. Seeding it from the recomputed state instead would let
+      // data presence mark a step navigated, which is the whole thing it exists to avoid.
       const mergedCategories = newState.categories.map((newCategory) => {
         const previousCategory = categories.find((c) => c.id === newCategory.id);
         return {
           ...newCategory,
           isVisited: previousCategory?.isVisited || newCategory.isVisited,
+          isNavigatedAway: previousCategory?.isNavigatedAway === true,
         };
       });
 
@@ -51,7 +55,9 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
     case 'page/next': {
       const newActive = activeId + 1;
 
-      const newCategories = categories.map((c, idx) => (idx === activeId ? { ...c, isVisited: true } : c));
+      const newCategories = categories.map((c, idx) =>
+        idx === activeId ? { ...c, isVisited: true, isNavigatedAway: true } : c,
+      );
 
       const isOnReview = newActive === lastId + 1;
 
@@ -69,7 +75,9 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
     case 'page/prev': {
       const newActive = Math.max(0, activeId - 1);
 
-      const newCategories = categories.map((c, idx) => (idx === activeId ? { ...c, isVisited: true } : c));
+      const newCategories = categories.map((c, idx) =>
+        idx === activeId ? { ...c, isVisited: true, isNavigatedAway: true } : c,
+      );
 
       return {
         ...state,
@@ -138,6 +146,7 @@ export const stepperReducer = (state: StepperContextDataType, action: StepperAct
           ? {
               ...cat,
               isVisited: true,
+              isNavigatedAway: true,
             }
           : cat,
       );

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
@@ -3,7 +3,15 @@ import { StepStatusType } from '../../../common/Constants';
 
 export interface CategoryInternalState {
   isCompleted?: boolean;
+  // "Started": set when the step holds user entered data as well as when it is navigated through,
+  // because the task list status has to show progress on a form resumed from saved data. Do not use
+  // it to gate validation messages — entering data in one field would then raise errors on every
+  // other field of the step. Use isNavigatedAway for that.
   isVisited?: boolean;
+  // "The user has been through this step and moved on": set only by navigation (Next, Previous, or
+  // back to the application overview), never derived from data. Gates validation messages, so a
+  // step the user has not worked through yet stays quiet.
+  isNavigatedAway?: boolean;
   isValid?: boolean;
   showReviewPageLink?: boolean;
   id: number;

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/types.ts
@@ -3,6 +3,7 @@ import { StepStatusType } from '../../../common/Constants';
 
 export interface CategoryInternalState {
   isCompleted?: boolean;
+  // clean-code-ignore: RULE-19 — declarations only; nothing is emitted at runtime to unit test.
   // "Started": set when the step holds user entered data as well as when it is navigated through,
   // because the task list status has to show progress on a form resumed from saved data. Do not use
   // it to gate validation messages — entering data in one field would then raise errors on every

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseControl.spec.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ControlProps } from '@jsonforms/core';
+import { JsonFormsContext } from '@jsonforms/react';
+import { GoAInputBaseControl } from './InputBaseControl';
+import { JsonFormsStepperContext, JsonFormsStepperContextProps } from '../FormStepper/context/StepperContext';
+import { CategoryState } from '../FormStepper/context/types';
+
+const requiredError = 'Do you have vision loss is required';
+
+const schema = {
+  type: 'object',
+  properties: {
+    hasVisionLoss: { type: 'string', enum: ['yes', 'no'] },
+  },
+  required: ['hasVisionLoss'],
+};
+
+const uischema = {
+  type: 'Control',
+  scope: '#/properties/hasVisionLoss',
+  label: 'Do you have vision loss',
+  options: { format: 'radio' },
+};
+
+// Stand-in for the rendered control. The gating under test lives in the wrapping form item, so the
+// inner component only has to exist.
+const StubInput = () => <div data-testid="stub-input" />;
+
+const baseProps = {
+  uischema,
+  schema,
+  rootSchema: schema,
+  label: 'Do you have vision loss',
+  path: 'hasVisionLoss',
+  id: 'hasVisionLoss',
+  visible: true,
+  enabled: true,
+  required: true,
+  data: undefined,
+  errors: requiredError,
+  config: {},
+  renderers: [],
+  cells: [],
+  handleChange: jest.fn(),
+} as unknown as ControlProps;
+
+const renderControl = (category?: Partial<CategoryState>) => {
+  const stepperContext = category
+    ? ({
+        selectStepperState: () => ({ activeId: 0, categories: [category] }),
+      } as unknown as JsonFormsStepperContextProps)
+    : undefined;
+
+  const control = (
+    <JsonFormsContext.Provider value={{ core: { data: {}, schema, errors: [] } } as never}>
+      <GoAInputBaseControl {...baseProps} input={StubInput} />
+    </JsonFormsContext.Provider>
+  );
+
+  return render(
+    stepperContext ? (
+      <JsonFormsStepperContext.Provider value={stepperContext}>{control}</JsonFormsStepperContext.Provider>
+    ) : (
+      control
+    ),
+  );
+};
+
+const queryErrorItem = (baseElement: Element) => baseElement.querySelector(`goa-form-item[error="${requiredError}"]`);
+
+describe('GoAInputBaseControl error gating', () => {
+  it('does not show the error on a step the user has only entered data on (CS-5245)', () => {
+    // Answering one question marks the whole step visited, which must not raise errors on the
+    // questions the user has not reached yet.
+    const { baseElement } = renderControl({ id: 0, isVisited: true, isNavigatedAway: false });
+
+    expect(queryErrorItem(baseElement)).not.toBeInTheDocument();
+  });
+
+  it('does not show the error when the step is first opened', () => {
+    const { baseElement } = renderControl({ id: 0, isVisited: false, isNavigatedAway: false });
+
+    expect(queryErrorItem(baseElement)).not.toBeInTheDocument();
+  });
+
+  it('shows the error once the user has worked through the step and come back', () => {
+    const { baseElement } = renderControl({ id: 0, isVisited: true, isNavigatedAway: true });
+
+    expect(queryErrorItem(baseElement)).toBeInTheDocument();
+  });
+
+  it('does not show the error on a non stepper form before the control is touched', () => {
+    const { baseElement } = renderControl();
+
+    expect(queryErrorItem(baseElement)).not.toBeInTheDocument();
+  });
+});

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseControl.tsx
@@ -115,7 +115,7 @@ export const GoAInputBaseControl = (props: ControlProps & WithInput): JSX.Elemen
         >
           <GoabFormItem
             requirement={uischema?.options?.componentProps?.requirement ?? (requiredNow ? 'required' : undefined)}
-            error={currentCategory?.isVisited === true || isVisited || hasValue ? modifiedErrors : undefined}
+            error={currentCategory?.isNavigatedAway === true || isVisited || hasValue ? modifiedErrors : undefined}
             testId={isStepperReview === true ? `review-base-${path}` : path}
             label={getFormItemLabel(labelToUpdate, props?.noLabel)}
             helpText={typeof uischema?.options?.help === 'string' && !isStepperReview ? uischema?.options?.help : ''}

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnum.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnum.spec.tsx
@@ -92,6 +92,38 @@ describe('EnumSelect component', () => {
       expect(handleChangeMock).toHaveBeenLastCalledWith('', 'option1-value');
     });
 
+    it('marks itself visited on selection so a cleared required control can report its error', () => {
+      const setIsVisited = jest.fn();
+      const props = { ...staticProps, isVisited: false, setIsVisited, handleChange: handleChangeMock };
+      const { container } = render(<EnumSelect {...props} />);
+
+      fireEvent(
+        container.querySelector('#jsonforms--dropdown') as Element,
+        new CustomEvent('_change', {
+          detail: { name: 'jsonforms--dropdown', value: '' },
+          bubbles: true,
+        })
+      );
+
+      expect(setIsVisited).toHaveBeenCalled();
+    });
+
+    it('does not mark itself visited again once it already is', () => {
+      const setIsVisited = jest.fn();
+      const props = { ...staticProps, isVisited: true, setIsVisited, handleChange: handleChangeMock };
+      const { container } = render(<EnumSelect {...props} />);
+
+      fireEvent(
+        container.querySelector('#jsonforms--dropdown') as Element,
+        new CustomEvent('_change', {
+          detail: { name: 'jsonforms--dropdown', value: 'option1-value' },
+          bubbles: true,
+        })
+      );
+
+      expect(setIsVisited).not.toHaveBeenCalled();
+    });
+
     it('stores primitive dropdown value even when schema type is object without properties', () => {
       const props = {
         ...staticProps,

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnum.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnum.tsx
@@ -31,7 +31,7 @@ function fetchRegisterConfigFromOptions(options: Record<string, unknown> | undef
 }
 
 export const EnumSelect = (props: EnumSelectProps): JSX.Element => {
-  const { data, enabled, path, handleChange, options, uischema, schema, errors } = props;
+  const { data, enabled, path, handleChange, options, uischema, schema, errors, isVisited, setIsVisited } = props;
 
   const registerCtx = useContext(JsonFormsRegisterContext);
   const registerConfig: RegisterConfig | undefined = fetchRegisterConfigFromOptions(props.uischema?.options?.register);
@@ -97,6 +97,12 @@ export const EnumSelect = (props: EnumSelectProps): JSX.Element => {
           id={`jsonforms-${path}-dropdown`}
           filterable={autoCompletion}
           onChange={(detail: GoabDropdownOnChangeDetail) => {
+            // goa-dropdown exposes no blur event, so a selection is the only interaction available
+            // to mark visited on. This is what surfaces the error when the user picks the empty
+            // placeholder on a required control, which leaves no value to fall back on.
+            if (isVisited === false && setIsVisited) {
+              setIsVisited();
+            }
             if (expectsObjectValue(schema)) {
               handleChange(
                 path,

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumRadios.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumRadios.spec.tsx
@@ -95,6 +95,60 @@ describe('Input Boolean Radio Control', () => {
     expect(radioGroup.getAttribute('value')).toBe('two');
   });
 
+  it('marks itself visited on selection so the group can report its own error state', () => {
+    const setIsVisited = jest.fn();
+    const handleChange = jest.fn();
+    const { baseElement } = render(
+      <RadioGroup
+        data={undefined}
+        id="enum-id"
+        enabled={true}
+        schema={{ enum: ['one', 'two'] }}
+        uischema={{ type: 'Control' }}
+        path=""
+        handleChange={handleChange}
+        options={{}}
+        config={{}}
+        label="Options"
+        isVisited={false}
+        setIsVisited={setIsVisited}
+        errors={'error'}
+      />
+    );
+
+    const radioGroup = baseElement.querySelector("goa-radio-group[testId='enum-id-radio-group']");
+    fireEvent(radioGroup as Element, new CustomEvent('_change', { detail: { value: 'two' } }));
+
+    expect(setIsVisited).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalledWith('', 'two');
+  });
+
+  it('does not mark itself visited again once it already is', () => {
+    const setIsVisited = jest.fn();
+    const { baseElement } = render(
+      <RadioGroup
+        data={'one'}
+        id="enum-id"
+        enabled={true}
+        schema={{ enum: ['one', 'two'] }}
+        uischema={{ type: 'Control' }}
+        path=""
+        handleChange={jest.fn()}
+        options={{}}
+        config={{}}
+        label="Options"
+        isVisited={true}
+        setIsVisited={setIsVisited}
+        errors={''}
+      />
+    );
+
+    const radioGroup = baseElement.querySelector("goa-radio-group[testId='enum-id-radio-group']");
+    fireEvent(radioGroup as Element, new CustomEvent('_change', { detail: { value: 'two' } }));
+
+    expect(setIsVisited).not.toHaveBeenCalled();
+  });
+
   it('uses id fallback in testId when path is empty and can be disabled', () => {
     const handleChange = jest.fn();
     const { baseElement } = render(

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumRadios.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumRadios.tsx
@@ -26,7 +26,8 @@ import { GoabRadioGroupOnChangeDetail } from '@abgov/ui-components-common';
 type RadioGroupProp = EnumCellProps & WithClassname & TranslateProps & WithInputProps;
 
 export const RadioGroup = (props: RadioGroupProp): JSX.Element => {
-  const { data, id, enabled, schema, uischema, path, handleChange, config, label, isVisited, errors } = props;
+  const { data, id, enabled, schema, uischema, path, handleChange, config, label, isVisited, setIsVisited, errors } =
+    props;
   const oneOF = schema?.oneOf || [];
   const items =
     oneOF?.length > 0
@@ -52,7 +53,15 @@ export const RadioGroup = (props: RadioGroupProp): JSX.Element => {
       value={data}
       disabled={!enabled}
       {...appliedUiSchemaOptions}
-      onChange={(detail: GoabRadioGroupOnChangeDetail) => handleChange(path, detail.value)}
+      onChange={(detail: GoabRadioGroupOnChangeDetail) => {
+        // goa-radio-group exposes no blur event, so selecting an option is the only interaction we
+        // can mark visited on. Without this the group never reports its own error state, and on a
+        // non stepper form a required control the user cleared would stay silent.
+        if (isVisited === false && setIsVisited) {
+          setIsVisited();
+        }
+        handleChange(path, detail.value);
+      }}
       {...uischema?.options?.componentProps}
     >
       {items.map((item, index) => (


### PR DESCRIPTION
Resolves CS-5245.

## Problem

On a task list form, answering one question made every *other* control on that step start showing its required error — including radios and dropdowns the user had not reached yet. Reported against the Driver Medical form: select `yes` for 22.1 and 22.2's radio and dropdown immediately go red.

`isVisited` was serving two masters. `StepperContext.tsx:109` derived it from step *status*, and `getStepStatus` treats a step as started once it merely **holds data** (`util.ts:190-193`):

```ts
isVisited: [StepStatus.COMPLETED, StepStatus.IN_PROGRESS].includes(status),
```

The effect at `StepperContext.tsx:286-314` re-runs `createStepperContextInitData` on every data change (it is keyed on `JSON.stringify(StepperProps.data)`). So entering data anywhere in a step flipped the whole category to visited, and `InputBaseControl.tsx:118` gated error display on exactly that. It was then persisted to localStorage and merged back permanently.

## Change

`isVisited` keeps its "started" meaning — four consumers depend on it (task list badges via `getCategoryStatus`, the completed counter, `FormStepperControl`, the persisted visit record) and none of them change here.

Validation display moves onto a new `isNavigatedAway`, set **only** by navigation and never derived from data. `set/visited` is the live path — `RenderPages.tsx` fires it on Next, Previous, and back to the application overview — which matches the AC's "after the page has been visited". `page/next`/`page/prev` set it too, for reducer coherence.

It is carried across recomputes by the reducer merge rather than re-derived. Seeding it from `visitedIds` would have reintroduced the bug, since that set is itself built from the polluted `isVisited` (`StepperContext.tsx:298-301`).

Radio and dropdown now also mark themselves visited on selection. Neither `GoabRadioGroup` nor `GoabDropdown` exposes an `onBlur` prop — I checked the type definitions — so selection is the only interaction available. This is what surfaces the error when a user picks the empty placeholder on a required control, which leaves no value for `hasValue` to catch.

## Tests

Eleven added; `nx test jsonforms-components` is **1400 passed, 97 suites**, coverage gate satisfied.

I verified these catch the bug rather than merely passing: reverting the one-line gate in `InputBaseControl.tsx` back to `isVisited` fails **`does not show the error on a step the user has only entered data on (CS-5245)`**, and only that test.

- `InputBaseControl.spec.tsx` (new) — all four gating states, including a non-stepper form
- `reducer.spec.ts` — `isNavigatedAway` carried across a recompute, plus a guard that a recomputed `isVisited` can *not* promote a step to navigated
- `InputEnum.spec.tsx` / `InputEnumRadios.spec.tsx` — selection marks visited, and does not re-fire once already visited
