### PR TITLE
chore: remove 13 stale/redundant npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,28 +344,16 @@
     "yaml": "^1.10.3"
   },
   "overrides": {
-    "@nx/angular": "23.1.1",
-    "@nx/devkit": "23.1.1",
     "@opentelemetry/api": "1.9.0",
-    "ai": "^5.0.0",
     "nx": {
-      "axios": "1.18.0",
-      "form-data": "4.0.6"
+      "axios": "1.18.0"
     },
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "rxjs": "7.8.2",
     "fast-uri": "4.1.1",
     "picomatch": "4.0.5",
-    "idna": "3.15",
     "hono": "4.12.32",
-    "urllib3": "2.7.0",
     "serialize-javascript": "7.0.5",
     "systeminformation": "5.33.1",
-    "tmp": "0.2.7",
     "ws": "8.21.1",
-    "webpack-dev-server": "5.2.6",
-    "koa": "3.1.2",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "@hapi/wreck": "18.1.2",
     "ip-address": "10.1.1",
@@ -380,7 +368,6 @@
     "undici": "7.28.0",
     "svgo": "4.0.2",
     "engine.io": "6.6.9",
-    "adm-zip": "0.6.0",
     "websocket-driver": "0.7.5",
     "http-proxy-middleware": "3.0.7",
     "piscina": "5.3.0",


### PR DESCRIPTION
## Summary

Removes 13 `overrides` entries from `package.json` that either do nothing or duplicate existing constraints. Verified that `package-lock.json` is identical before and after — none of these entries affected dependency resolution.

| Entry | Reason for removal |
|---|---|
| `idna: 3.15` | Python package — npm overrides ignore it |
| `urllib3: 2.7.0` | Python package — npm overrides ignore it |
| `koa: 3.1.2` | Not present anywhere in the dependency tree |
| `adm-zip: 0.6.0` | Not present anywhere in the dependency tree |
| `ai: ^5.0.0` | `ai` is not installed; range also conflicts with its consumer's peer dep |
| `@nx/angular: 23.1.1` | Listed as an optional peer dep by `@abgov/nx-adsp`; never installed |
| `react: 18.3.1` | Root `devDependencies` already pins exactly `18.3.1` |
| `react-dom: 18.3.1` | Root `devDependencies` already pins exactly `18.3.1` |
| `rxjs: 7.8.2` | Root `devDependencies` already pins exactly `7.8.2` |
| `webpack-dev-server: 5.2.6` | Root `devDependencies` already pins exactly `5.2.6` |
| `tmp: 0.2.7` | `nx@23.1.1` pins `tmp@0.2.7` exactly; no transitive consumer resolves differently |
| `@nx/devkit: 23.1.1` | Every `@nx/*@23.1.1` package pins this exact version already |
| `nx.form-data: 4.0.6` | `nx@23.1.1` already pins `form-data@4.0.6` in its own deps |

## Test plan

- [ ] CI passes
- [ ] `npm install` on a clean checkout produces an identical `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)