### PR TITLE
fix(tenant-management-webapp): stop the add PDF template modal writing to the shared default

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.spec.tsx
@@ -1,0 +1,82 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { AddEditPdfTemplate } from './addEditPdfTemplates';
+import { defaultPdfTemplate } from '@store/pdf/model';
+
+const mockStore = configureStore([]);
+const initialState = {
+  session: { indicator: { show: false } },
+  pdf: { pdfTemplates: {}, corePdfTemplates: {} },
+};
+
+describe('AddEditPdfTemplate', () => {
+  const renderModal = (store, open: boolean) => (
+    <Provider store={store}>
+      <AddEditPdfTemplate
+        open={open}
+        isEdit={false}
+        initialValue={defaultPdfTemplate}
+        onClose={() => {}}
+        onSave={() => {}}
+      />
+    </Provider>
+  );
+
+  it('clears entered values when the modal is closed and opened again', () => {
+    const store = mockStore(initialState);
+    const { baseElement, rerender } = render(renderModal(store, true));
+
+    fireEvent(
+      baseElement.querySelector("goa-input[testId='pdf-template-name']"),
+      new CustomEvent('_change', { detail: { value: 'Draft Template' } }),
+    );
+    fireEvent(
+      baseElement.querySelector("goa-textarea[testId='pdf-template-description']"),
+      new CustomEvent('_change', { detail: { value: 'draft description' } }),
+    );
+
+    expect(baseElement.querySelector("goa-input[testId='pdf-template-name']")).toHaveAttribute('value', 'Draft Template');
+    expect(baseElement.querySelector("goa-input[testId='pdf-template-id']")).toHaveAttribute('value', 'draft-template');
+    expect(baseElement.querySelector("goa-textarea[testId='pdf-template-description']")).toHaveAttribute(
+      'value',
+      'draft description',
+    );
+
+    // cancel, then open again
+    rerender(renderModal(store, false));
+    rerender(renderModal(store, true));
+
+    expect(baseElement.querySelector("goa-input[testId='pdf-template-name']")).toHaveAttribute('value', '');
+    expect(baseElement.querySelector("goa-input[testId='pdf-template-id']")).toHaveAttribute('value', '');
+    expect(baseElement.querySelector("goa-textarea[testId='pdf-template-description']")).toHaveAttribute('value', '');
+  });
+
+  it('does not write the populate-template toggle back into the shared default template', () => {
+    const store = mockStore(initialState);
+    const pristine = { ...defaultPdfTemplate };
+    const { baseElement } = render(renderModal(store, true));
+
+    // Unticking used to mutate `template` in place, which on a fresh open is
+    // defaultPdfTemplate itself, blanking the default html for the whole session.
+    fireEvent(
+      baseElement.querySelector("goa-checkbox[testId='populate-template']"),
+      new CustomEvent('_change', { detail: { checked: false } }),
+    );
+
+    expect(defaultPdfTemplate).toEqual(pristine);
+  });
+
+  it('reflects the populate-template toggle in the checkbox', () => {
+    const store = mockStore(initialState);
+    const { baseElement } = render(renderModal(store, true));
+    const checkbox = () => baseElement.querySelector("goa-checkbox[testId='populate-template']");
+
+    expect(checkbox()).toHaveAttribute('checked', 'true');
+
+    fireEvent(checkbox(), new CustomEvent('_change', { detail: { checked: false } }));
+
+    expect(checkbox()).not.toHaveAttribute('checked', 'true');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/addEditPdfTemplates.tsx
@@ -35,7 +35,8 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
   open,
   onSave,
 }) => {
-  const [template, setTemplate] = useState<PdfTemplate>(initialValue);
+  // Copy: initialValue is the shared defaultPdfTemplate, and editing must not write through to it.
+  const [template, setTemplate] = useState<PdfTemplate>({ ...initialValue });
   const [spinner, setSpinner] = useState<boolean>(false);
 
   const templates = useSelector((state: RootState) => {
@@ -66,7 +67,7 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
   }, [templates]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    setTemplate(initialValue);
+    setTemplate({ ...initialValue });
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { errors, validators } = useValidators(
@@ -202,20 +203,16 @@ export const AddEditPdfTemplate: FunctionComponent<AddEditPdfTemplateProps> = ({
             testId={'populate-template'}
             mt="m"
             onChange={() => {
-              template.startWithDefault = !template.startWithDefault;
-              if (template.startWithDefault) {
-                template.footer = initialValue.footer;
-                template.header = initialValue.header;
-                template.additionalStyles = initialValue.additionalStyles;
-                template.template = initialValue.template;
-                template.variables = initialValue.variables;
-              } else {
-                template.footer = '';
-                template.header = '';
-                template.additionalStyles = '';
-                template.template = '';
-                template.variables = '';
-              }
+              const startWithDefault = !template.startWithDefault;
+              setTemplate({
+                ...template,
+                startWithDefault,
+                footer: startWithDefault ? initialValue.footer : '',
+                header: startWithDefault ? initialValue.header : '',
+                additionalStyles: startWithDefault ? initialValue.additionalStyles : '',
+                template: startWithDefault ? initialValue.template : '',
+                variables: startWithDefault ? initialValue.variables : '',
+              });
             }}
           >
             Populate template with ADSP default html


### PR DESCRIPTION
CS-5244

The reported symptom — a description surviving cancel and reopen — was already fixed by #5705, which moved `goa-textarea` off the keyup-driven `onKeyPress` onto `onChange`. It is not reproducible on main.

This PR fixes a second leak with the same effect. On a fresh open `template` is the very object passed as `initialValue`, which `templates.tsx:97` supplies as the module-level `defaultPdfTemplate`. The populate-template checkbox mutated it in place, so unticking it once blanked the shared default's header, footer, body and styles for the rest of the session, left the checkbox stuck on reopen, and made any template created afterwards come out with empty HTML. The handler now builds a new object, and state is seeded from a copy on mount and on reset.

**QA:** verify via the checkbox, not the original steps. Add template → untick "Populate template with ADSP default html" → Cancel → Add template again. The box should be ticked and the default HTML intact.

Tests: 3 specs added; the two checkbox ones fail without the fix. Full webapp suite green (54 suites, 240 tests).
