### PR TITLE
fix(tenant-management-webapp): scroll to top when a side menu item is selected

### DIFF
--- a/apps/tenant-management-webapp/src/app/app.tsx
+++ b/apps/tenant-management-webapp/src/app/app.tsx
@@ -26,6 +26,7 @@ import '@abgov/web-components/index.css';
 import '@abgov/design-tokens/dist/tokens.css';
 import { useScripts } from '@core-services/app-common';
 import { SelectTenant } from '@pages/public/SelectTenant';
+// clean-code-ignore: RULE-19
 import { APP_SCROLL_CONTAINER_ID } from '@lib/scrollAppToTop';
 
 const AppRouters = () => {

--- a/apps/tenant-management-webapp/src/app/app.tsx
+++ b/apps/tenant-management-webapp/src/app/app.tsx
@@ -26,6 +26,7 @@ import '@abgov/web-components/index.css';
 import '@abgov/design-tokens/dist/tokens.css';
 import { useScripts } from '@core-services/app-common';
 import { SelectTenant } from '@pages/public/SelectTenant';
+import { APP_SCROLL_CONTAINER_ID } from '@lib/scrollAppToTop';
 
 const AppRouters = () => {
   return (
@@ -71,7 +72,7 @@ const AppDiv = styled.div`
 
 export const App = (): JSX.Element => {
   return (
-    <AppDiv>
+    <AppDiv id={APP_SCROLL_CONTAINER_ID}>
       <ThemeProvider theme={theme}>
         <Provider store={store}>
           <AppWithAuthContext />

--- a/apps/tenant-management-webapp/src/app/lib/scrollAppToTop.spec.ts
+++ b/apps/tenant-management-webapp/src/app/lib/scrollAppToTop.spec.ts
@@ -1,0 +1,63 @@
+import { APP_SCROLL_CONTAINER_ID, scrollAppToTop } from './scrollAppToTop';
+
+// jsdom has no layout, so a real element's scrollTop always reads back as 0.
+// Back it with a stored value so the reset is actually observable.
+const addScrollContainer = (startingScrollTop: number) => {
+  const container = document.createElement('div');
+  container.id = APP_SCROLL_CONTAINER_ID;
+  let scrollTop = startingScrollTop;
+  Object.defineProperty(container, 'scrollTop', {
+    get: () => scrollTop,
+    set: (value) => {
+      scrollTop = value;
+    },
+    configurable: true,
+  });
+  document.body.appendChild(container);
+  return container;
+};
+
+describe('scrollAppToTop', () => {
+  afterEach(() => {
+    document.getElementById(APP_SCROLL_CONTAINER_ID)?.remove();
+  });
+
+  it('resets the app scroll container to the top', () => {
+    const container = addScrollContainer(1200);
+
+    scrollAppToTop();
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('leaves an already-topped container alone', () => {
+    const container = addScrollContainer(0);
+
+    scrollAppToTop();
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('does nothing when the container is not mounted', () => {
+    expect(() => scrollAppToTop()).not.toThrow();
+  });
+
+  it('ignores elements that are not the app scroll container', () => {
+    const other = document.createElement('div');
+    other.id = 'some-other-container';
+    let scrollTop = 500;
+    Object.defineProperty(other, 'scrollTop', {
+      get: () => scrollTop,
+      set: (value) => {
+        scrollTop = value;
+      },
+      configurable: true,
+    });
+    document.body.appendChild(other);
+
+    scrollAppToTop();
+
+    expect(other.scrollTop).toBe(500);
+    other.remove();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/lib/scrollAppToTop.ts
+++ b/apps/tenant-management-webapp/src/app/lib/scrollAppToTop.ts
@@ -1,0 +1,10 @@
+// The admin content scrolls inside AppDiv (app.tsx), which is absolutely positioned with
+// `overflow: auto`, rather than the document. window.scrollTo therefore does nothing here.
+export const APP_SCROLL_CONTAINER_ID = 'app-scroll-container';
+
+export const scrollAppToTop = (): void => {
+  const container = document.getElementById(APP_SCROLL_CONTAINER_ID);
+  if (container) {
+    container.scrollTop = 0;
+  }
+};

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import Sidebar from './sidebar';
+import { APP_SCROLL_CONTAINER_ID } from '@lib/scrollAppToTop';
+
+const mockStore = configureStore([]);
+const initialState = {
+  tenant: { name: 'test-tenant' },
+  // Task is off in defaultFeaturesVisible; the ticket's environment has it enabled.
+  config: { featureFlags: { Task: true } },
+  session: {
+    authenticated: true,
+    realm: 'test',
+    resourceAccess: { 'urn:ads:platform:tenant-service': { roles: ['tenant-admin'] } },
+  },
+};
+
+// jsdom has no layout, so a real element's scrollTop always reads back as 0.
+// Back it with a stored value so the reset is actually observable.
+const addScrollContainer = (startingScrollTop: number) => {
+  const container = document.createElement('div');
+  container.id = APP_SCROLL_CONTAINER_ID;
+  let scrollTop = startingScrollTop;
+  Object.defineProperty(container, 'scrollTop', {
+    get: () => scrollTop,
+    set: (value) => {
+      scrollTop = value;
+    },
+    configurable: true,
+  });
+  document.body.appendChild(container);
+  return container;
+};
+
+describe('Sidebar', () => {
+  afterEach(() => {
+    document.getElementById(APP_SCROLL_CONTAINER_ID)?.remove();
+  });
+
+  const renderSidebar = () =>
+    render(
+      <Provider store={mockStore(initialState)}>
+        <MemoryRouter>
+          <Sidebar type="desktop" />
+        </MemoryRouter>
+      </Provider>,
+    );
+
+  it.each([
+    ['menu-task', 'a service'],
+    ['menu-value', 'a second service'],
+    ['menu-dashboard', 'the dashboard'],
+    ['menu-eventLog', 'the event log'],
+  ])('scrolls the app container back to the top when %s is clicked', (testId) => {
+    const container = addScrollContainer(800);
+    const { getByTestId } = renderSidebar();
+
+    fireEvent.click(getByTestId(testId));
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('does not throw when the scroll container is absent', () => {
+    const { getByTestId } = renderSidebar();
+
+    expect(() => fireEvent.click(getByTestId('menu-task'))).not.toThrow();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
@@ -7,6 +7,8 @@ import BetaBadge from '@icons/beta-badge.svg';
 import { RootState } from '@store/index';
 import { FetchTenant } from '@store/tenant/actions';
 
+import { scrollAppToTop } from '@lib/scrollAppToTop';
+
 import { serviceVariables } from '../../../featureFlag';
 import { GoabSideMenu, GoabSideMenuHeading } from '@abgov/react-components';
 
@@ -55,6 +57,7 @@ const Sidebar = ({ type }: SidebarProps) => {
               <NavLink
                 to="/admin"
                 end
+                onClick={scrollAppToTop}
                 className={({ isActive }) => `menu-section-link${isActive ? ' current' : ''}`}
                 title="Dashboard"
                 data-testid="menu-dashboard"
@@ -65,6 +68,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                 <>
                   <NavLink
                     to="event-log"
+                    onClick={scrollAppToTop}
                     className={({ isActive }) => (isActive ? 'current' : '')}
                     title="Event log"
                     data-testid="menu-eventLog"
@@ -73,6 +77,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                   </NavLink>
                   <NavLink
                     to="service-metrics"
+                    onClick={scrollAppToTop}
                     className={({ isActive }) => (isActive ? 'current' : '')}
                     title="Service metrics"
                     data-testid="menu-service-metrics"
@@ -82,6 +87,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                   <NavLink
                     to="/admin"
                     end
+                    onClick={scrollAppToTop}
                     className={({ isActive }) => `menu-section-link${isActive ? ' current' : ''}`}
                     title="Services"
                     data-testid="sidebar-service"
@@ -98,6 +104,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                   <NavLink
                     key={index}
                     to={service.link}
+                    onClick={scrollAppToTop}
                     className={({ isActive }) => (isActive ? 'current' : '')}
                     title={service.name}
                     data-testid={`menu-${service.name.toLowerCase()}`}


### PR DESCRIPTION
CS-5240

The admin content scrolls inside `AppDiv` (`app.tsx`, absolutely positioned with `overflow: auto`), not the document, and react-router leaves that container's `scrollTop` alone across navigation. Landing on a short page such as Task or Value clamps it to that page's own maximum scroll, parking the user at the bottom with only a button in view and the tab bar off screen above. The side menu links now reset the container.

Note `window.scrollTo(0, 0)` would be a no-op here — the document is not what scrolls.

**Scope:** side menu clicks only, as scoped on the ticket. Reaching a service by browser back/forward or by opening its URL directly still lands wherever the container was.

**QA:** scroll to the bottom of a long service page, then click Task or Value in the side menu — the tab bar should be in view.

Tests: 5 specs added; the 4 scroll assertions fail without the change. Full webapp suite green (54 suites, 242 tests), production build clean.
