### PR TITLE
feat(form-service): add PUT method for form schedule intakes

### DIFF
--- a/apps/form-service/src/calendar.spec.ts
+++ b/apps/form-service/src/calendar.spec.ts
@@ -11,6 +11,7 @@ const axiosMock = axios as jest.Mocked<typeof axios>;
 
 describe('calendar', () => {
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+  const definitionId = 'test-definition-id';
   const loggerMock = {
     debug: jest.fn(),
     info: jest.fn(),
@@ -375,6 +376,7 @@ describe('calendar', () => {
           calendarEventId: '123',
           start,
           end,
+          definitionId,
         });
 
         // Assert
@@ -404,6 +406,7 @@ describe('calendar', () => {
           calendarEventId: '123',
           start,
           end,
+          definitionId,
         });
 
         // Assert
@@ -431,6 +434,7 @@ describe('calendar', () => {
           calendarEventId: 'missing-event',
           start: new Date(),
           end: new Date(),
+          definitionId,
         });
 
         // Assert
@@ -454,6 +458,7 @@ describe('calendar', () => {
           calendarEventId: '123',
           start: new Date(),
           end: new Date(),
+          definitionId,
         });
 
         // Assert
@@ -480,6 +485,7 @@ describe('calendar', () => {
           calendarEventId: '123',
           start: new Date(),
           end: new Date(),
+          definitionId,
         });
 
         // Assert
@@ -503,6 +509,7 @@ describe('calendar', () => {
           calendarEventId: '123',
           start: new Date(),
           end: new Date(),
+          definitionId,
         });
 
         // Assert

--- a/apps/form-service/src/calendar.spec.ts
+++ b/apps/form-service/src/calendar.spec.ts
@@ -34,6 +34,7 @@ describe('calendar', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const cacheMock = {
@@ -62,8 +63,10 @@ describe('calendar', () => {
     directoryMock.getServiceUrl.mockClear();
     directoryMock.getResourceUrl.mockClear();
     axiosMock.get.mockReset();
+    axiosMock.patch.mockReset();
     axiosMock.isAxiosError.mockReset();
     cacheMock.get.mockReset();
+    cacheMock.set.mockReset();
   });
 
   it('can create service', () => {
@@ -72,9 +75,28 @@ describe('calendar', () => {
       directoryMock,
       tokenProviderMock,
       INTAKE_CALENDAR_NAME,
-      cacheMock as unknown as NodeCache
+      cacheMock as unknown as NodeCache,
     );
     expect(service).toBeTruthy();
+  });
+
+  it('resolves the calendar service url from the directory', async () => {
+    // Arrange
+    directoryMock.getServiceUrl.mockClear();
+
+    // Act
+    await createCalendarService(
+      loggerMock,
+      directoryMock,
+      tokenProviderMock,
+      INTAKE_CALENDAR_NAME,
+      cacheMock as unknown as NodeCache,
+    );
+
+    // Assert
+    expect(directoryMock.getServiceUrl).toHaveBeenCalledTimes(1);
+    const calls = directoryMock.getServiceUrl.mock.calls as unknown as unknown[][];
+    expect(String(calls[0][0])).toBe(adspId`urn:ads:platform:calendar-service:v1`.toString());
   });
 
   describe('CalendarService', () => {
@@ -85,7 +107,7 @@ describe('calendar', () => {
           directoryMock,
           tokenProviderMock,
           INTAKE_CALENDAR_NAME,
-          cacheMock as unknown as NodeCache
+          cacheMock as unknown as NodeCache,
         );
 
         axiosMock.get.mockResolvedValueOnce({
@@ -104,7 +126,7 @@ describe('calendar', () => {
           directoryMock,
           tokenProviderMock,
           INTAKE_CALENDAR_NAME,
-          cacheMock as unknown as NodeCache
+          cacheMock as unknown as NodeCache,
         );
 
         axiosMock.get.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({
@@ -123,7 +145,7 @@ describe('calendar', () => {
           directoryMock,
           tokenProviderMock,
           INTAKE_CALENDAR_NAME,
-          cacheMock as unknown as NodeCache
+          cacheMock as unknown as NodeCache,
         );
 
         axiosMock.get.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({
@@ -139,7 +161,7 @@ describe('calendar', () => {
           directoryMock,
           tokenProviderMock,
           INTAKE_CALENDAR_NAME,
-          cacheMock as unknown as NodeCache
+          cacheMock as unknown as NodeCache,
         );
 
         axiosMock.get.mockRejectedValueOnce(new Error('oh noes!'));
@@ -153,7 +175,7 @@ describe('calendar', () => {
           directoryMock,
           tokenProviderMock,
           INTAKE_CALENDAR_NAME,
-          cacheMock as unknown as NodeCache
+          cacheMock as unknown as NodeCache,
         );
 
         const error = new Error('oh noes!');
@@ -171,7 +193,7 @@ describe('calendar', () => {
           directoryMock,
           tokenProviderMock,
           INTAKE_CALENDAR_NAME,
-          cacheMock as unknown as NodeCache
+          cacheMock as unknown as NodeCache,
         );
 
         const error = new Error('oh noes!');
@@ -180,6 +202,310 @@ describe('calendar', () => {
         axiosMock.isAxiosError.mockReturnValueOnce(true);
 
         const intake = await service.getScheduledIntake(definition);
+        expect(intake).toBeUndefined();
+      });
+      it('maps all intake fields from the calendar event response', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        const start = new Date().toISOString();
+        const end = new Date().toISOString();
+        axiosMock.get.mockResolvedValueOnce({
+          data: {
+            results: [
+              {
+                urn: 'urn:ads:platform:calendar-service:v1:/calendars/form-intake/events/123',
+                name: 'Test',
+                description: 'Intake window for test form',
+                start,
+                end,
+                isAllDay: false,
+              },
+            ],
+          },
+        });
+
+        // Act
+        const intake = await service.getScheduledIntake(definition);
+
+        // Assert
+        expect(intake.urn).toBe('urn:ads:platform:calendar-service:v1:/calendars/form-intake/events/123');
+        expect(intake.description).toBe('Intake window for test form');
+        expect(intake.isAllDay).toBe(false);
+      });
+
+      it('maps intake with undefined end when response has no end date', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        axiosMock.get.mockResolvedValueOnce({
+          data: { results: [{ name: 'Test', start: new Date().toISOString(), end: null }] },
+        });
+
+        // Act
+        const intake = await service.getScheduledIntake(definition);
+
+        // Assert
+        expect(intake.end).toBeFalsy();
+      });
+
+      it('returns the cached intake without calling the calendar service', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        const cachedIntake = {
+          name: 'Cached intake',
+          start: new Date(),
+          end: new Date(),
+          isUpcoming: false,
+        };
+        cacheMock.get.mockReturnValueOnce(cachedIntake);
+
+        // Act
+        const intake = await service.getScheduledIntake(definition);
+
+        // Assert
+        expect(intake).toBe(cachedIntake);
+        expect(axiosMock.get).not.toHaveBeenCalled();
+      });
+
+      it('returns undefined without calling the calendar service when no intake was previously cached', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        cacheMock.get.mockReturnValueOnce(null);
+
+        // Act
+        const intake = await service.getScheduledIntake(definition);
+
+        // Assert
+        expect(intake).toBeNull();
+        expect(axiosMock.get).not.toHaveBeenCalled();
+      });
+
+      it('caches the resolved intake after a calendar service lookup', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        axiosMock.get.mockResolvedValueOnce({
+          data: { results: [{ name: 'Test', start: new Date().toISOString(), end: new Date().toISOString() }] },
+        });
+
+        // Act
+        await service.getScheduledIntake(definition);
+
+        // Assert
+        expect(cacheMock.set).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'Test' }));
+      });
+
+      it('caches null when no active or upcoming intake is found', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        axiosMock.get.mockResolvedValueOnce({ data: { results: [] } }).mockResolvedValueOnce({
+          data: { results: [] },
+        });
+
+        // Act
+        await service.getScheduledIntake(definition);
+
+        // Assert
+        expect(cacheMock.set).toHaveBeenCalledWith(expect.any(String), null);
+      });
+    });
+
+    describe('updateScheduleIntake', () => {
+      it('can update a scheduled intake', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        const start = new Date();
+        const end = new Date();
+        axiosMock.patch.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            urn: 'urn:ads:platform:calendar-service:v1:/calendars/form-intake/events/123',
+            name: 'Updated intake',
+            description: 'Rescheduled intake window',
+            start: start.toISOString(),
+            end: end.toISOString(),
+            isAllDay: false,
+            isUpcoming: true,
+          },
+        });
+
+        // Act
+        const intake = await service.updateScheduleIntake(tenantId.toString(), {
+          name: 'Updated intake',
+          calendarEventId: '123',
+          start,
+          end,
+        });
+
+        // Assert
+        expect(intake.name).toBe('Updated intake');
+        expect(intake.isUpcoming).toBe(true);
+      });
+
+      it('sends the updated start, end, and name to the calendar service', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        const start = new Date();
+        const end = new Date();
+        axiosMock.patch.mockResolvedValueOnce({
+          status: 200,
+          data: { name: 'Updated intake', start: start.toISOString(), end: end.toISOString() },
+        });
+
+        // Act
+        await service.updateScheduleIntake(tenantId.toString(), {
+          name: 'Updated intake',
+          calendarEventId: '123',
+          start,
+          end,
+        });
+
+        // Assert
+        expect(axiosMock.patch).toHaveBeenCalledWith(
+          expect.stringContaining('/calendars/form-intake/events/123'),
+          expect.objectContaining({ name: 'Updated intake', start, end }),
+          expect.any(Object),
+        );
+      });
+
+      it('returns undefined when the calendar service reports the event as not found', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        axiosMock.patch.mockResolvedValueOnce({ status: 404, data: null });
+
+        // Act
+        const intake = await service.updateScheduleIntake(tenantId.toString(), {
+          name: 'Updated intake',
+          calendarEventId: 'missing-event',
+          start: new Date(),
+          end: new Date(),
+        });
+
+        // Assert
+        expect(intake).toBeUndefined();
+      });
+
+      it('returns undefined when the calendar service responds with no data', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        axiosMock.patch.mockResolvedValueOnce({ status: 200, data: null });
+
+        // Act
+        const intake = await service.updateScheduleIntake(tenantId.toString(), {
+          name: 'Updated intake',
+          calendarEventId: '123',
+          start: new Date(),
+          end: new Date(),
+        });
+
+        // Assert
+        expect(intake).toBeUndefined();
+      });
+
+      it('returns undefined and logs an error on axios error', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        const error = new Error('oh noes!');
+        error['response'] = { data: { errorMessage: 'Something went wrong!' } };
+        axiosMock.patch.mockRejectedValueOnce(error);
+        axiosMock.isAxiosError.mockReturnValueOnce(true);
+
+        // Act
+        const intake = await service.updateScheduleIntake(tenantId.toString(), {
+          name: 'Updated intake',
+          calendarEventId: '123',
+          start: new Date(),
+          end: new Date(),
+        });
+
+        // Assert
+        expect(intake).toBeUndefined();
+      });
+
+      it('returns undefined and logs an error on unexpected error', async () => {
+        // Arrange
+        const service = await createCalendarService(
+          loggerMock,
+          directoryMock,
+          tokenProviderMock,
+          INTAKE_CALENDAR_NAME,
+          cacheMock as unknown as NodeCache,
+        );
+        axiosMock.patch.mockRejectedValueOnce(new Error('oh noes!'));
+
+        // Act
+        const intake = await service.updateScheduleIntake(tenantId.toString(), {
+          name: 'Updated intake',
+          calendarEventId: '123',
+          start: new Date(),
+          end: new Date(),
+        });
+
+        // Assert
         expect(intake).toBeUndefined();
       });
     });

--- a/apps/form-service/src/calendar.ts
+++ b/apps/form-service/src/calendar.ts
@@ -18,7 +18,7 @@ class CalendarServiceImpl implements CalendarService {
     private calendarEventCache: NodeCache,
   ) {}
 
-  async updateSchdeduleIntake(
+  async updateScheduleIntake(
     tenantId: string,
     intakeParameters: { name: string; calendarEventId: string; start: Date; end: Date },
   ): Promise<Intake> {

--- a/apps/form-service/src/calendar.ts
+++ b/apps/form-service/src/calendar.ts
@@ -3,6 +3,8 @@ import axios, { isAxiosError } from 'axios';
 import * as NodeCache from 'node-cache';
 import { Logger } from 'winston';
 import { CalendarService, FormDefinitionEntity, Intake } from './form';
+import { NotFoundError } from '@core-services/core-common';
+import * as HttpStatusCodes from 'http-status-codes';
 
 type IntakeResponse = Omit<Intake, 'isUpcoming' | 'start' | 'end'> & { start: string; end?: string };
 
@@ -13,14 +15,61 @@ class CalendarServiceImpl implements CalendarService {
     private tokenProvider: TokenProvider,
     private calendarApiUrl: URL,
     private calendar: string,
-    private calendarEventCache: NodeCache
+    private calendarEventCache: NodeCache,
   ) {}
+
+  async updateSchdeduleIntake(
+    tenantId: string,
+    intakeParameters: { name: string; calendarEventId: string; start: Date; end: Date },
+  ): Promise<Intake> {
+    const { start, end, name, calendarEventId } = intakeParameters;
+    try {
+      this.logger.debug(`Updating scheduled intake for definition ${tenantId}...`, {
+        context: 'CalendarService',
+        tenantId: tenantId.toString(),
+      });
+      const token = await this.tokenProvider.getAccessToken();
+
+      const url = new URL(`calendar/v1/calendars/form-intake/events/${calendarEventId}`, this.calendarApiUrl).href;
+      const response = await axios.patch(
+        new URL(url).href,
+        {
+          start: start,
+          end: end,
+          name: name,
+        },
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          params: { tenantId: tenantId.toString() },
+        },
+      );
+
+      if (response.status === HttpStatusCodes.NOT_FOUND || !response.data) {
+        throw new NotFoundError('Update intake schedule ', calendarEventId);
+      }
+
+      const mapped = this.mapIntake(response.data, response.data.isUpcoming);
+
+      return mapped;
+    } catch (err) {
+      this.logger.error(
+        `Error encountered updating scheduled intake for definition ${tenantId}: ${
+          isAxiosError(err) ? err.response?.data?.errorMessage || err.message : err
+        }`,
+        {
+          context: 'CalendarService',
+          tenantId: tenantId.toString(),
+        },
+      );
+      return;
+    }
+  }
 
   @LimitToOne(
     (propertyKey: string, definition: FormDefinitionEntity) =>
-      `${propertyKey}-${definition.tenantId.resource}-${definition.id}`
+      `${propertyKey}-${definition.tenantId.resource}-${definition.id}`,
   )
-  async getScheduledIntake(definition: FormDefinitionEntity): Promise<Intake> {
+  async getScheduledIntake(definition: FormDefinitionEntity, token?: string): Promise<Intake> {
     try {
       this.logger.debug(`Retrieving scheduled intake for definition ${definition.id}...`, {
         context: 'CalendarService',
@@ -87,7 +136,7 @@ class CalendarServiceImpl implements CalendarService {
           {
             context: 'CalendarService',
             tenantId: definition.tenantId.toString(),
-          }
+          },
         );
       }
       return intake;
@@ -99,7 +148,7 @@ class CalendarServiceImpl implements CalendarService {
         {
           context: 'CalendarService',
           tenantId: definition.tenantId.toString(),
-        }
+        },
       );
       return;
     }
@@ -127,7 +176,7 @@ export async function createCalendarService(
   directory: ServiceDirectory,
   tokenProvider: TokenProvider,
   calendar: string,
-  calendarEventCache = new NodeCache({ stdTTL: 30, useClones: false })
+  calendarEventCache = new NodeCache({ stdTTL: 30, useClones: false }),
 ) {
   const calendarApiUrl = await directory.getServiceUrl(adspId`urn:ads:platform:calendar-service:v1`);
   return new CalendarServiceImpl(logger, tokenProvider, calendarApiUrl, calendar, calendarEventCache);

--- a/apps/form-service/src/calendar.ts
+++ b/apps/form-service/src/calendar.ts
@@ -20,11 +20,11 @@ class CalendarServiceImpl implements CalendarService {
 
   async updateScheduleIntake(
     tenantId: string,
-    intakeParameters: { name: string; calendarEventId: string; start: Date; end: Date },
+    intakeParameters: { definitionId: string; name: string; calendarEventId: string; start: Date; end: Date },
   ): Promise<Intake> {
-    const { start, end, name, calendarEventId } = intakeParameters;
+    const { start, end, name, calendarEventId, definitionId } = intakeParameters;
     try {
-      this.logger.debug(`Updating scheduled intake for definition ${tenantId}...`, {
+      this.logger.debug(`Updating scheduled intake for definition ${definitionId}...`, {
         context: 'CalendarService',
         tenantId: tenantId.toString(),
       });

--- a/apps/form-service/src/comment.spec.ts
+++ b/apps/form-service/src/comment.spec.ts
@@ -33,6 +33,7 @@ describe('comment', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const repositoryMock = {
@@ -89,7 +90,7 @@ describe('comment', () => {
       loggerMock,
       directoryMock,
       tokenProviderMock,
-      SUPPORT_COMMENT_TOPIC_TYPE_ID
+      SUPPORT_COMMENT_TOPIC_TYPE_ID,
     );
     expect(service).toBeTruthy();
   });
@@ -101,7 +102,7 @@ describe('comment', () => {
           loggerMock,
           directoryMock,
           tokenProviderMock,
-          SUPPORT_COMMENT_TOPIC_TYPE_ID
+          SUPPORT_COMMENT_TOPIC_TYPE_ID,
         );
 
         axiosMock.post.mockResolvedValueOnce({ data: { urn: 'urn:ads:platform:comment-service:v1:/topics/2' } });
@@ -111,7 +112,7 @@ describe('comment', () => {
         expect(axiosMock.post).toHaveBeenCalledWith(
           'https://comment-service/comment/v1/topics',
           expect.objectContaining({ resourceId: formUrn }),
-          expect.objectContaining({ params: expect.objectContaining({ tenantId: tenantId.toString() }) })
+          expect.objectContaining({ params: expect.objectContaining({ tenantId: tenantId.toString() }) }),
         );
       });
 
@@ -120,7 +121,7 @@ describe('comment', () => {
           loggerMock,
           directoryMock,
           tokenProviderMock,
-          SUPPORT_COMMENT_TOPIC_TYPE_ID
+          SUPPORT_COMMENT_TOPIC_TYPE_ID,
         );
 
         axiosMock.post.mockRejectedValueOnce(new Error('oh noes!'));
@@ -134,7 +135,7 @@ describe('comment', () => {
           loggerMock,
           directoryMock,
           tokenProviderMock,
-          SUPPORT_COMMENT_TOPIC_TYPE_ID
+          SUPPORT_COMMENT_TOPIC_TYPE_ID,
         );
 
         const error = new Error('oh noes!');
@@ -151,7 +152,7 @@ describe('comment', () => {
           loggerMock,
           directoryMock,
           tokenProviderMock,
-          SUPPORT_COMMENT_TOPIC_TYPE_ID
+          SUPPORT_COMMENT_TOPIC_TYPE_ID,
         );
 
         const error = new Error('oh noes!');

--- a/apps/form-service/src/form/calendar.ts
+++ b/apps/form-service/src/form/calendar.ts
@@ -4,5 +4,15 @@ import { Intake } from './types';
 export const INTAKE_CALENDAR_NAME = 'form-intake';
 
 export interface CalendarService {
-  getScheduledIntake(definition: FormDefinitionEntity): Promise<Intake>;
+  getScheduledIntake(definition: FormDefinitionEntity, token?: string): Promise<Intake>;
+  updateSchdeduleIntake(
+    tenantId: string,
+    intakeParameters: {
+      name: string;
+      calendarEventId: string;
+      start: Date;
+      end: Date;
+    },
+    token?: string,
+  ): Promise<Intake>;
 }

--- a/apps/form-service/src/form/calendar.ts
+++ b/apps/form-service/src/form/calendar.ts
@@ -5,7 +5,7 @@ export const INTAKE_CALENDAR_NAME = 'form-intake';
 
 export interface CalendarService {
   getScheduledIntake(definition: FormDefinitionEntity, token?: string): Promise<Intake>;
-  updateSchdeduleIntake(
+  updateScheduleIntake(
     tenantId: string,
     intakeParameters: {
       name: string;

--- a/apps/form-service/src/form/calendar.ts
+++ b/apps/form-service/src/form/calendar.ts
@@ -8,6 +8,7 @@ export interface CalendarService {
   updateScheduleIntake(
     tenantId: string,
     intakeParameters: {
+      definitionId: string;
       name: string;
       calendarEventId: string;
       start: Date;

--- a/apps/form-service/src/form/jobs/delete.spec.ts
+++ b/apps/form-service/src/form/jobs/delete.spec.ts
@@ -47,6 +47,7 @@ describe('delete', () => {
 
   const calendarService: CalendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const subscriberId = adspId`urn:ads:platform:notification-service:v1:/subscribers/test`;
@@ -97,7 +98,7 @@ describe('delete', () => {
       lastAccessed: new Date(),
       status: FormStatus.Draft,
       dryRun: false,
-    }
+    },
   );
 
   beforeEach(() => {

--- a/apps/form-service/src/form/jobs/lock.spec.ts
+++ b/apps/form-service/src/form/jobs/lock.spec.ts
@@ -43,6 +43,7 @@ describe('lock', () => {
 
   const calendarService: CalendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const subscriberId = adspId`urn:ads:platform:notification-service:v1:/subscribers/test`;
@@ -94,7 +95,7 @@ describe('lock', () => {
       lastAccessed: new Date(),
       status: FormStatus.Draft,
       dryRun: false,
-    }
+    },
   );
 
   beforeEach(() => {
@@ -134,7 +135,7 @@ describe('lock', () => {
       expect.objectContaining({
         statusEquals: FormStatus.Draft,
         anonymousApplicantEquals: true,
-      })
+      }),
     );
     expect(repositoryMock.save).toHaveBeenCalledTimes(1);
   });

--- a/apps/form-service/src/form/model/definition.spec.ts
+++ b/apps/form-service/src/form/model/definition.spec.ts
@@ -12,6 +12,7 @@ describe('FormDefinitionEntity', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   beforeEach(() => {
@@ -282,7 +283,7 @@ describe('FormDefinitionEntity', () => {
       expect(validationService.validate).toHaveBeenCalledWith(
         expect.any(String),
         `${tenantId.resource}:${entity.id}`,
-        data
+        data,
       );
     });
   });
@@ -407,7 +408,7 @@ describe('FormDefinitionEntity', () => {
         repositoryMock,
         notificationMock,
         true,
-        subscriber
+        subscriber,
       );
       expect(form).toBeTruthy();
       expect(notificationMock.subscribe).toHaveBeenCalledWith(entity.tenantId, entity, expect.any(String), subscriber);
@@ -421,7 +422,7 @@ describe('FormDefinitionEntity', () => {
         entity.tenantId,
         entity,
         expect.any(String),
-        expect.objectContaining({ userId: user.id })
+        expect.objectContaining({ userId: user.id }),
       );
     });
 
@@ -474,7 +475,7 @@ describe('FormDefinitionEntity', () => {
         entity.tenantId,
         entity,
         expect.any(String),
-        expect.objectContaining({ userId: user.id })
+        expect.objectContaining({ userId: user.id }),
       );
     });
   });

--- a/apps/form-service/src/form/model/form.spec.ts
+++ b/apps/form-service/src/form/model/form.spec.ts
@@ -14,6 +14,7 @@ describe('FormEntity', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const definition = new FormDefinitionEntity(validationService, calendarService, tenantId, {
@@ -134,7 +135,7 @@ describe('FormEntity', () => {
         definition,
         'test-form',
         'https://my-form/test-form',
-        subscriber
+        subscriber,
       );
       expect(entity).toBeTruthy();
       expect(entity.anonymousApplicant).toBeFalsy();
@@ -149,7 +150,7 @@ describe('FormEntity', () => {
       } as User;
 
       await expect(
-        FormEntity.create(user, repositoryMock, definition, 'test-form', 'https://my-form/test-form', subscriber)
+        FormEntity.create(user, repositoryMock, definition, 'test-form', 'https://my-form/test-form', subscriber),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -166,7 +167,7 @@ describe('FormEntity', () => {
         definition,
         'test-form',
         'https://my-form/test-form',
-        subscriber
+        subscriber,
       );
       expect(entity).toBeTruthy();
       expect(entity.anonymousApplicant).toBeTruthy();
@@ -200,7 +201,7 @@ describe('FormEntity', () => {
     it('can throw for not intake application', async () => {
       notificationMock.sendCode.mockResolvedValueOnce(null);
       await expect(entity.sendCode({ tenantId, id: 'tester', roles: [] } as User, notificationMock)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
   });
@@ -291,7 +292,7 @@ describe('FormEntity', () => {
       const result = await entity.accessByCode(
         { tenantId, id: 'tester', roles: ['intake-application'] } as User,
         notificationMock,
-        code
+        code,
       );
       expect(notificationMock.verifyCode).toHaveBeenCalledWith(tenantId, subscriber, code);
       expect(result.lastAccessed.valueOf()).toBeGreaterThanOrEqual(before.valueOf());
@@ -307,7 +308,7 @@ describe('FormEntity', () => {
       const result = await nonDraft.accessByCode(
         { tenantId, id: 'tester', roles: ['intake-application'] } as User,
         notificationMock,
-        code
+        code,
       );
       expect(notificationMock.verifyCode).toHaveBeenCalledWith(tenantId, subscriber, code);
       expect(result.lastAccessed.valueOf()).toBeGreaterThanOrEqual(before.valueOf());
@@ -317,7 +318,7 @@ describe('FormEntity', () => {
     it('can throw for non-intake application', async () => {
       const code = '123';
       await expect(
-        entity.accessByCode({ tenantId, id: 'tester', roles: [] } as User, notificationMock, code)
+        entity.accessByCode({ tenantId, id: 'tester', roles: [] } as User, notificationMock, code),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -325,7 +326,7 @@ describe('FormEntity', () => {
       const code = '123';
       notificationMock.verifyCode.mockResolvedValueOnce(false);
       await expect(
-        entity.accessByCode({ tenantId, id: 'tester', roles: ['intake-application'] } as User, notificationMock, code)
+        entity.accessByCode({ tenantId, id: 'tester', roles: ['intake-application'] } as User, notificationMock, code),
       ).rejects.toThrow(UnauthorizedError);
     });
   });
@@ -356,13 +357,13 @@ describe('FormEntity', () => {
 
     it('can throw for user without role on draft form', async () => {
       await expect(entity.accessByUser({ tenantId, id: 'tester', roles: [] } as User)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
 
     it('can throw for user not matching creator on draft form', async () => {
       await expect(
-        entity.accessByUser({ tenantId, id: 'tester-2', roles: ['test-applicant'] } as User)
+        entity.accessByUser({ tenantId, id: 'tester-2', roles: ['test-applicant'] } as User),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -375,7 +376,7 @@ describe('FormEntity', () => {
 
     it('can throw for intake application role on draft form', async () => {
       await expect(
-        entity.accessByUser({ tenantId, id: 'tester', roles: [FormServiceRoles.IntakeApp] } as User)
+        entity.accessByUser({ tenantId, id: 'tester', roles: [FormServiceRoles.IntakeApp] } as User),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -411,7 +412,7 @@ describe('FormEntity', () => {
       submitted.status = FormStatus.Submitted;
 
       await expect(submitted.accessByUser({ tenantId, id: 'tester', roles: [] } as User)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
 
@@ -420,7 +421,7 @@ describe('FormEntity', () => {
       submitted.status = FormStatus.Archived;
 
       await expect(submitted.accessByUser({ tenantId, id: 'tester', roles: [] } as User)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
 
@@ -429,7 +430,7 @@ describe('FormEntity', () => {
       locked.status = FormStatus.Locked;
 
       await expect(locked.accessByUser({ tenantId, id: 'tester', roles: ['test-applicant'] } as User)).rejects.toThrow(
-        InvalidOperationError
+        InvalidOperationError,
       );
     });
   });
@@ -460,7 +461,11 @@ describe('FormEntity', () => {
       const data = {
         attachment: 'urn:ads:platform:file-service:v1:/files/test',
       };
-      const updated = await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data);
+      const updated = await entity.update(
+        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
+        fileMock,
+        data,
+      );
       expect(updated.data).toBe(data);
       expect(updated.files.attachment?.toString()).toBe('urn:ads:platform:file-service:v1:/files/test');
       expect(repositoryMock.save).toHaveBeenCalledWith(entity);
@@ -472,10 +477,8 @@ describe('FormEntity', () => {
 
       const data = {};
       await expect(
-        locked.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data)
-      ).rejects.toThrow(
-        InvalidOperationError
-      );
+        locked.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data),
+      ).rejects.toThrow(InvalidOperationError);
     });
 
     it('ignores provided files and resolves from schema-declared data fields', async () => {
@@ -484,7 +487,11 @@ describe('FormEntity', () => {
         support: adspId`urn:ads:platform:file-service`,
       };
 
-      const updated = await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data);
+      const updated = await entity.update(
+        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
+        fileMock,
+        data,
+      );
       expect(updated.files).toEqual({});
       expect(files.support?.toString()).toBe('urn:ads:platform:file-service');
     });
@@ -492,7 +499,7 @@ describe('FormEntity', () => {
     it('can throw for different user', async () => {
       const data = {};
       await expect(
-        entity.update({ tenantId, id: 'tester-2', roles: ['test-applicant'] } as User, fileMock, data)
+        entity.update({ tenantId, id: 'tester-2', roles: ['test-applicant'] } as User, fileMock, data),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -512,40 +519,34 @@ describe('FormEntity', () => {
         nested: { evidence: 'urn:ads:platform:file-service:v1:/files/test' },
       };
 
-      const updated = await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data);
+      const updated = await entity.update(
+        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
+        fileMock,
+        data,
+      );
       expect(updated.files.attachment?.toString()).toBe('urn:ads:platform:file-service:v1:/files/test');
       expect(updated.files['nested.evidence']?.toString()).toBe('urn:ads:platform:file-service:v1:/files/test');
     });
 
     it('rebuilds files from current data so removed references are dropped', async () => {
-      await entity.update(
-        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
-        fileMock,
-        { attachment: 'urn:ads:platform:file-service:v1:/files/test' }
-      );
+      await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, {
+        attachment: 'urn:ads:platform:file-service:v1:/files/test',
+      });
 
       const updated = await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, {});
       expect(updated.files).toEqual({});
     });
 
     it('deletes orphaned files when references are replaced or removed', async () => {
-      await entity.update(
-        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
-        fileMock,
-        {
-          attachment: 'urn:ads:platform:file-service:v1:/files/old',
-          nested: { evidence: 'urn:ads:platform:file-service:v1:/files/still-referenced' },
-        }
-      );
+      await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, {
+        attachment: 'urn:ads:platform:file-service:v1:/files/old',
+        nested: { evidence: 'urn:ads:platform:file-service:v1:/files/still-referenced' },
+      });
 
-      await entity.update(
-        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
-        fileMock,
-        {
-          attachment: 'urn:ads:platform:file-service:v1:/files/new',
-          nested: { evidence: 'urn:ads:platform:file-service:v1:/files/still-referenced' },
-        }
-      );
+      await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, {
+        attachment: 'urn:ads:platform:file-service:v1:/files/new',
+        nested: { evidence: 'urn:ads:platform:file-service:v1:/files/still-referenced' },
+      });
 
       expect(fileMock.delete).toHaveBeenCalledTimes(1);
       expect(fileMock.delete.mock.calls[0][0]).toBe(tenantId);
@@ -553,22 +554,14 @@ describe('FormEntity', () => {
     });
 
     it('does not delete files that remain referenced at another path', async () => {
-      await entity.update(
-        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
-        fileMock,
-        {
-          attachment: 'urn:ads:platform:file-service:v1:/files/shared',
-          nested: { evidence: 'urn:ads:platform:file-service:v1:/files/shared' },
-        }
-      );
+      await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, {
+        attachment: 'urn:ads:platform:file-service:v1:/files/shared',
+        nested: { evidence: 'urn:ads:platform:file-service:v1:/files/shared' },
+      });
 
-      await entity.update(
-        { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
-        fileMock,
-        {
-          nested: { evidence: 'urn:ads:platform:file-service:v1:/files/shared' },
-        }
-      );
+      await entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, {
+        nested: { evidence: 'urn:ads:platform:file-service:v1:/files/shared' },
+      });
 
       expect(fileMock.delete).not.toHaveBeenCalled();
     });
@@ -576,7 +569,7 @@ describe('FormEntity', () => {
     it('can throw for user without applicant role', async () => {
       const data = {};
       await expect(entity.update({ tenantId, id: 'tester', roles: [] } as User, fileMock, data)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
 
@@ -585,7 +578,7 @@ describe('FormEntity', () => {
       const data = {};
       const entity = new FormEntity(repositoryMock, tenantId, null, subscriber, formInfo);
       await expect(
-        entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data)
+        entity.update({ tenantId, id: 'tester', roles: ['test-applicant'] } as User, fileMock, data),
       ).rejects.toThrow(UnauthorizedUserError);
       expect(repositoryMock.save).not.toHaveBeenCalled();
     });
@@ -623,7 +616,7 @@ describe('FormEntity', () => {
       const submitted = new FormEntity(repositoryMock, tenantId, definition, subscriber, formInfo);
       submitted.status = FormStatus.Submitted;
       await expect(entity.lock({ tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User)).rejects.toThrow(
-        InvalidOperationError
+        InvalidOperationError,
       );
     });
   });
@@ -660,7 +653,7 @@ describe('FormEntity', () => {
       const draft = new FormEntity(repositoryMock, tenantId, definition, subscriber, formInfo);
       draft.status = FormStatus.Draft;
       await expect(draft.unlock({ tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User)).rejects.toThrow(
-        InvalidOperationError
+        InvalidOperationError,
       );
     });
   });
@@ -693,7 +686,7 @@ describe('FormEntity', () => {
         { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
         queueTaskServiceMock,
         repositoryMock,
-        pdfServiceMock
+        pdfServiceMock,
       );
       expect(submitted.status).toBe(FormStatus.Submitted);
       expect(submitted.submitted).toBeTruthy();
@@ -726,7 +719,7 @@ describe('FormEntity', () => {
         { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
         queueTaskServiceMock,
         repositoryMock,
-        pdfServiceMock
+        pdfServiceMock,
       );
       expect(submitted.status).toBe(FormStatus.Submitted);
       expect(submitted.submitted).toBeTruthy();
@@ -741,8 +734,8 @@ describe('FormEntity', () => {
           { tenantId, id: 'tester-2', roles: ['test-applicant'] } as User,
           queueTaskServiceMock,
           repositoryMock,
-          pdfServiceMock
-        )
+          pdfServiceMock,
+        ),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -752,7 +745,7 @@ describe('FormEntity', () => {
         { tenantId, id: 'tester-2', roles: ['test-clerk'] } as User,
         queueTaskServiceMock,
         repositoryMock,
-        pdfServiceMock
+        pdfServiceMock,
       );
       expect(submitted.status).toBe(FormStatus.Submitted);
       expect(submitted.submitted).toBeTruthy();
@@ -767,8 +760,8 @@ describe('FormEntity', () => {
           { tenantId, id: 'tester', roles: [] } as User,
           queueTaskServiceMock,
           repositoryMock,
-          pdfServiceMock
-        )
+          pdfServiceMock,
+        ),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -782,8 +775,8 @@ describe('FormEntity', () => {
           { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
           queueTaskServiceMock,
           repositoryMock,
-          pdfServiceMock
-        )
+          pdfServiceMock,
+        ),
       ).rejects.toThrow(InvalidOperationError);
     });
 
@@ -800,8 +793,8 @@ describe('FormEntity', () => {
           { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
           queueTaskServiceMock,
           repositoryMock,
-          pdfServiceMock
-        )
+          pdfServiceMock,
+        ),
       ).rejects.toThrow(InvalidOperationError);
       expect(repositoryMock.save).not.toHaveBeenCalled();
     });
@@ -820,8 +813,8 @@ describe('FormEntity', () => {
           { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
           queueTaskServiceMock,
           repositoryMock,
-          pdfServiceMock
-        )
+          pdfServiceMock,
+        ),
       ).rejects.toThrow(UnauthorizedUserError);
       expect(repositoryMock.save).not.toHaveBeenCalled();
     });
@@ -860,13 +853,13 @@ describe('FormEntity', () => {
           data: {},
           files: {},
           dryRun: false,
-        }
+        },
       );
       const [submitted] = await entity.submit(
         { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
         queueTaskServiceMock,
         repositoryMock,
-        pdfServiceMock
+        pdfServiceMock,
       );
       expect(submitted.status).toBe(FormStatus.Submitted);
       expect(submitted.submitted).toBeTruthy();
@@ -906,7 +899,7 @@ describe('FormEntity', () => {
         status: FormStatus.Submitted,
       });
       await expect(entity.setToDraft({ tenantId, id: 'tester', roles: ['abc'] } as User)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
 
@@ -916,7 +909,7 @@ describe('FormEntity', () => {
         status: FormStatus.Draft,
       });
       await expect(
-        entity.setToDraft({ tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User)
+        entity.setToDraft({ tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User),
       ).rejects.toThrow(InvalidOperationError);
     });
   });
@@ -941,7 +934,7 @@ describe('FormEntity', () => {
     it('can archive form', async () => {
       const archived = await entity.archive(
         { tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User,
-        notificationMock
+        notificationMock,
       );
       expect(archived.status).toBe(FormStatus.Archived);
       expect(repositoryMock.save).toHaveBeenCalledWith(entity);
@@ -950,7 +943,7 @@ describe('FormEntity', () => {
 
     it('can throw for non admin user', async () => {
       await expect(entity.archive({ tenantId, id: 'tester', roles: [] } as User, notificationMock)).rejects.toThrow(
-        UnauthorizedUserError
+        UnauthorizedUserError,
       );
     });
   });
@@ -980,7 +973,7 @@ describe('FormEntity', () => {
       const deleted = await entity.delete(
         { tenantId, id: 'tester', roles: [FormServiceRoles.Admin] } as User,
         fileMock,
-        notificationMock
+        notificationMock,
       );
       expect(deleted).toBe(true);
       expect(fileMock.delete).toHaveBeenCalled();
@@ -990,7 +983,7 @@ describe('FormEntity', () => {
 
     it('can throw for non admin user', async () => {
       await expect(
-        entity.delete({ tenantId, id: 'tester', roles: [] } as User, fileMock, notificationMock)
+        entity.delete({ tenantId, id: 'tester', roles: [] } as User, fileMock, notificationMock),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -1004,7 +997,7 @@ describe('FormEntity', () => {
       const deleted = await entity.delete(
         { tenantId, id: 'tester', roles: ['test-applicant'] } as User,
         fileMock,
-        notificationMock
+        notificationMock,
       );
       expect(deleted).toBe(true);
       expect(fileMock.delete).toHaveBeenCalled();
@@ -1018,7 +1011,7 @@ describe('FormEntity', () => {
         status: FormStatus.Draft,
       });
       await expect(
-        entity.delete({ tenantId, id: 'tester-2', roles: ['test-applicant'] } as User, fileMock, notificationMock)
+        entity.delete({ tenantId, id: 'tester-2', roles: ['test-applicant'] } as User, fileMock, notificationMock),
       ).rejects.toThrow(UnauthorizedUserError);
     });
 
@@ -1032,7 +1025,7 @@ describe('FormEntity', () => {
       const deleted = await entity.delete(
         { tenantId, id: 'tester', roles: ['test-clerk'] } as User,
         fileMock,
-        notificationMock
+        notificationMock,
       );
       expect(deleted).toBe(true);
       expect(fileMock.delete).toHaveBeenCalled();

--- a/apps/form-service/src/form/model/formSubmission.spec.ts
+++ b/apps/form-service/src/form/model/formSubmission.spec.ts
@@ -15,6 +15,7 @@ describe('FormSubmission', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const aDefinition = new FormDefinitionEntity(validationService, calendarService, tenantId, {

--- a/apps/form-service/src/form/router/definition.spec.ts
+++ b/apps/form-service/src/form/router/definition.spec.ts
@@ -32,6 +32,7 @@ describe('definition router', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const definition = new FormDefinitionEntity(validationService, calendarService, tenantId, {
@@ -1885,4 +1886,5 @@ describe('definition router', () => {
 
 const calendarServiceMock = {
   getScheduledIntake: jest.fn(),
+  updateScheduleIntake: jest.fn(),
 };

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -562,18 +562,16 @@ export function updateIntakeSchedule(calendarService: CalendarService): RequestH
       }
 
       // Calendar service doesn't have a PUT method, so we need to use PATCH instead.
-      const response = await calendarService.updateScheduleIntake(tenantId.toString(), {
+      const intake = await calendarService.updateScheduleIntake(tenantId.toString(), {
         start,
         end,
-        calendarEventId: calendarEventId,
+        calendarEventId,
         name,
       });
 
-      const mapped = mapFormDefinition(definition, definition.revision, response);
+      const mapped = mapFormDefinition(definition, definition.revision, intake);
 
       res.status(HttpStatusCodes.OK).send(mapped);
-
-      next();
     } catch (err) {
       //Anything that is caught here is considered a Bad request
       next(err);

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -562,7 +562,7 @@ export function updateIntakeSchedule(calendarService: CalendarService): RequestH
       }
 
       // Calendar service doesn't have a PUT method, so we need to use PATCH instead.
-      const response = await calendarService.updateSchdeduleIntake(tenantId.toString(), {
+      const response = await calendarService.updateScheduleIntake(tenantId.toString(), {
         start,
         end,
         calendarEventId: calendarEventId,

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -564,6 +564,7 @@ export function updateIntakeSchedule(calendarService: CalendarService): RequestH
 
       // Calendar service doesn't have a PUT method, so we need to use PATCH instead.
       const intake = await calendarService.updateScheduleIntake(tenantId.toString(), {
+        definitionId,
         start,
         end,
         calendarEventId,

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -544,6 +544,43 @@ function parseTaskQueue(value: string): { queueNameSpace: string; queueName: str
   return { queueNameSpace, queueName };
 }
 
+export function updateIntakeSchedule(calendarService: CalendarService): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const user = req.user;
+      const tenantId = req.tenant?.id;
+      const { start, end, name, calendarEventId } = req.body;
+      const { definitionId } = req.params;
+
+      if (!isAllowedUser(user, tenantId, FormServiceRoles.Admin, true)) {
+        throw new UnauthorizedUserError('update schedule intake', user);
+      }
+
+      const [definition] = await req.getServiceConfiguration<FormDefinitionEntity>(definitionId, req.tenant.id);
+      if (!definition) {
+        throw new InvalidOperationError(`Form definition not found`);
+      }
+
+      // Calendar service doesn't have a PUT method, so we need to use PATCH instead.
+      const response = await calendarService.updateSchdeduleIntake(tenantId.toString(), {
+        start,
+        end,
+        calendarEventId: calendarEventId,
+        name,
+      });
+
+      const mapped = mapFormDefinition(definition, definition.revision, response);
+
+      res.status(HttpStatusCodes.OK).send(mapped);
+
+      next();
+    } catch (err) {
+      //Anything that is caught here is considered a Bad request
+      next(err);
+    }
+  };
+}
+
 export function patchFormDefinitionSubmissionActions(
   directory: ServiceDirectory,
   tokenProvider: TokenProvider,
@@ -782,5 +819,16 @@ export function createFormDefinitionRouter({
     patchFormDefinitionSubmissionActions(directory, tokenProvider),
   );
 
+  router.put(
+    '/definitions/:definitionId/schedule',
+    assertAuthenticatedHandler,
+    createValidationHandler(
+      body('name').isString().withMessage('name is required'),
+      body('calendarEventId').isInt().withMessage('calendarEventId'),
+      body('start').isISO8601().withMessage('start date is required'),
+      body('end').isISO8601().withMessage('end date is required'),
+    ),
+    updateIntakeSchedule(calendarService),
+  );
   return router;
 }

--- a/apps/form-service/src/form/router/definition.ts
+++ b/apps/form-service/src/form/router/definition.ts
@@ -38,6 +38,7 @@ const allowedSubmissionActionProperties = [
   'dispositionStates',
 ];
 const defaultSubmissionPdfTemplate = 'submitted-form';
+const DEFINITION_ID_REGEX = /^[a-zA-Z0-9-]+$/;
 
 // The configuration service answers /latest with 200 and an empty object when the definition has
 // never been written (see getConfiguration's `configuration.latest?.configuration || {}`), so an
@@ -573,7 +574,6 @@ export function updateIntakeSchedule(calendarService: CalendarService): RequestH
 
       res.status(HttpStatusCodes.OK).send(mapped);
     } catch (err) {
-      //Anything that is caught here is considered a Bad request
       next(err);
     }
   };
@@ -673,10 +673,7 @@ export function createFormDefinitionRouter({
   router.get(
     '/definitions/:definitionId',
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
     ),
     getFormDefinition(tenantService, calendarService),
   );
@@ -684,10 +681,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       body('formDraftUrlTemplate')
         .optional()
         .isString()
@@ -701,10 +695,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       body('name').optional().isString().isLength({ min: 1 }),
       body('description').optional().isString(),
       body('dataSchema').optional().isObject(),
@@ -722,10 +713,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
     ),
     deleteFormDefinition(directory, tokenProvider),
   );
@@ -734,10 +722,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId/schemas',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       body('data-schema').optional().isObject(),
       body('ui-schema').optional().isObject(),
     ),
@@ -748,10 +733,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId/roles',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       ...allowedRoleProperties.flatMap((field) => [body(field).optional().isArray(), body(`${field}.*`).isString()]),
       body().custom((value) => {
         const extra = Object.keys(value ?? {}).filter((key) => !allowedRoleProperties.includes(key));
@@ -768,10 +750,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId/lifecycle',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       body('allowAnonymousApplication').optional().isBoolean(),
       body('allowMultipleFormsPerApplicant').optional().isBoolean(),
       body('createSupportTopic').optional().isBoolean(),
@@ -787,10 +766,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId/submission-actions',
     assertAuthenticatedHandler,
     createValidationHandler(
-      param('definitionId')
-        .isString()
-        .isLength({ min: 1, max: 50 })
-        .matches(/^[a-zA-Z0-9-]+$/),
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       body('createPDF').optional().isBoolean(),
       body('createSubmissionRecords').optional().isBoolean(),
       body('event')
@@ -821,6 +797,7 @@ export function createFormDefinitionRouter({
     '/definitions/:definitionId/schedule',
     assertAuthenticatedHandler,
     createValidationHandler(
+      param('definitionId').isString().isLength({ min: 1, max: 50 }).matches(DEFINITION_ID_REGEX),
       body('name').isString().withMessage('name is required'),
       body('calendarEventId').isInt().withMessage('calendarEventId'),
       body('start').isISO8601().withMessage('start date is required'),

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -42,6 +42,7 @@ describe('form router', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const definition = new FormDefinitionEntity(validationService, calendarService, tenantId, {
@@ -187,6 +188,7 @@ describe('form router', () => {
 
   const calendarServiceMock = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const formInfo = {

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -1166,3 +1166,24 @@ components:
               properties:
                 deleted:
                   type: boolean
+/form/v1/definitions/{definitionId}/schedule:
+  put:
+    tags:
+      - Form schedules
+    description: Form schedule intakes.
+    responses:
+      200:
+        description: Successful form schedule intake update.
+        content:
+          schema:
+            $ref: '#/components/schemas/FormDefinition'
+          example:
+            name: My Application Form
+      400:
+        description: Validation failed  for JSON object
+      401:
+        description: User is not authorized to create form definitions.
+      403:
+        description: User is not authorized to create form definitions.
+      404:
+        description: Schedule intake not found.

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -68,11 +68,13 @@ components:
           type: string
         scheduledIntakes:
           type: boolean
+          description: Allow this form definition to accept schedule intakes
         supportTopic:
           type: boolean
         securityClassification:
           type: string
           enum: [public, 'protected a', 'protected b', 'protected c']
+          description: The security classification for the form definition
         queueTaskToProcess:
           type: object
           properties:
@@ -91,6 +93,32 @@ components:
           type: boolean
         dryRun:
           type: boolean
+        intake:
+          type: object
+          properties:
+            urn:
+              type: string
+              description: The urn of the form schedule intake
+            name:
+              type: string
+              description: The description of the form schedule intake
+            description:
+              type: string
+              description: The description of the form schedule intake
+            start:
+              type: string
+              format: date-time
+              description: The start date time of the form schedule intake
+            end:
+              type: string
+              format: date-time
+              description: The end date time of the form schedule intake
+            isAllDay:
+              type: boolean
+              description: Is form schedule intake all day
+            isUpcoming:
+              type: boolean
+              description: Is the form schedule intake upcoming
     FormDefinitionCreate:
       type: object
       description: Payload for creating a new form definition. Only name and description are accepted; all other fields are set to defaults.
@@ -276,6 +304,25 @@ components:
         operation:
           type: string
           enum: [to-draft]
+    PutIntakeParameters:
+      type: object
+      description: Payload for updating schedule intake
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        calendarEventId:
+          type: string
 
 /form/v1/definitions:
   get:
@@ -1171,6 +1218,19 @@ components:
     tags:
       - Form schedules
     description: Form schedule intakes.
+    parameters:
+      - name: definitionId
+        description: ID of the form definition.
+        required: true
+        in: path
+        schema:
+          type: string
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PutIntakeParameters'
+    required: true
     responses:
       200:
         description: Successful form schedule intake update.

--- a/apps/form-service/src/notification.spec.ts
+++ b/apps/form-service/src/notification.spec.ts
@@ -35,6 +35,7 @@ describe('notification', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const cacheMock = {
@@ -58,7 +59,7 @@ describe('notification', () => {
       loggerMock,
       directoryMock,
       tokenProviderMock,
-      cacheMock as unknown as NodeCache
+      cacheMock as unknown as NodeCache,
     );
     expect(service).toBeTruthy();
   });
@@ -69,7 +70,7 @@ describe('notification', () => {
       loggerMock,
       directoryMock,
       tokenProviderMock,
-      cacheMock as unknown as NodeCache
+      cacheMock as unknown as NodeCache,
     );
     const subscriberId = adspId`urn:ads:platform:notification-service:v1:/subscribers/test`;
     const subscriberUrl = new URL('https://notification-service/notification/v1/subscribers/test');
@@ -99,7 +100,7 @@ describe('notification', () => {
           subscriberUrl.href,
           expect.objectContaining({
             params: expect.objectContaining({ tenantId: tenantId.toString() }),
-          })
+          }),
         );
       });
 
@@ -123,7 +124,7 @@ describe('notification', () => {
           subscriberUrl.href,
           expect.objectContaining({
             params: expect.objectContaining({ tenantId: tenantId.toString() }),
-          })
+          }),
         );
       });
 
@@ -166,7 +167,7 @@ describe('notification', () => {
           expect.objectContaining({
             criteria: expect.objectContaining({ correlationId: `${apiId}:/forms/form-1` }),
           }),
-          expect.any(Object)
+          expect.any(Object),
         );
       });
 
@@ -197,7 +198,7 @@ describe('notification', () => {
             params: expect.objectContaining({
               criteria: JSON.stringify({ correlationId: `${apiId}:/forms/test` }),
             }),
-          })
+          }),
         );
       });
 
@@ -228,14 +229,14 @@ describe('notification', () => {
             address: subscriber.channels[0].address,
             reason: 'Enter this code to access your form.',
           }),
-          expect.any(Object)
+          expect.any(Object),
         );
       });
 
       it('can throw for no subscriber channel', async () => {
         directoryMock.getResourceUrl.mockResolvedValueOnce(subscriberUrl);
         await expect(service.sendCode(tenantId, { ...subscriber, channels: [], urn: subscriberId })).rejects.toThrow(
-          InvalidOperationError
+          InvalidOperationError,
         );
       });
 
@@ -264,7 +265,7 @@ describe('notification', () => {
             address: subscriber.channels[0].address,
             code: 'test',
           }),
-          expect.any(Object)
+          expect.any(Object),
         );
       });
 

--- a/apps/form-service/src/pdf.spec.ts
+++ b/apps/form-service/src/pdf.spec.ts
@@ -32,6 +32,7 @@ describe('pdf', () => {
 
   const calendarService = {
     getScheduledIntake: jest.fn(),
+    updateScheduleIntake: jest.fn(),
   };
 
   const repositoryMock = {
@@ -137,7 +138,7 @@ describe('pdf', () => {
         }),
         expect.objectContaining({
           params: expect.objectContaining({ tenantId: tenantId.toString() }),
-        })
+        }),
       );
     });
 
@@ -158,7 +159,7 @@ describe('pdf', () => {
         }),
         expect.objectContaining({
           params: expect.objectContaining({ tenantId: tenantId.toString() }),
-        })
+        }),
       );
     });
 


### PR DESCRIPTION
- Adding new api endpoint `/form/v1/definitions/{definitionId}/schedule`
- updating unit tests
- updating swagger documentation