### PR TITLE
fix(tenant-management-webapp): show both feedback ratings on the same scale

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.spec.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { FeedbackMetrics } from './metrics';
+
+const mockStore = configureStore([]);
+
+// Ratings arrive from value-service on the recorded 0-based scale.
+const renderMetrics = (metrics: Record<string, number | null>) =>
+  render(
+    <Provider store={mockStore({ feedback: { metrics } })}>
+      <FeedbackMetrics />
+    </Provider>,
+  );
+
+const textOf = (baseElement: Element, id: string) => baseElement.querySelector(`#${id}`)?.textContent?.trim();
+
+describe('FeedbackMetrics', () => {
+  it('shows both ratings on the same label scale', () => {
+    // The reported defect: a recorded average of 2 rendered as "2 - Difficult" while the
+    // recorded lowest of 2 rendered as "3 - Neutral", because only the lowest was shifted.
+    const { baseElement } = renderMetrics({
+      feedbackCount: 10,
+      averageRating: 2,
+      lowestSiteAverageRating: 2,
+      momCountPercent: null,
+      momAvgRatingPercent: null,
+      momLowestRatingPercent: null,
+    });
+
+    expect(textOf(baseElement, 'feedback-avg-rating')).toBe('3 - Neutral');
+    expect(textOf(baseElement, 'feedback-lowest-rating')).toBe('3 - Neutral');
+  });
+
+  it('never shows a lowest rating above the average', () => {
+    const { baseElement } = renderMetrics({
+      feedbackCount: 25,
+      averageRating: 2.4,
+      lowestSiteAverageRating: 1,
+      momCountPercent: null,
+      momAvgRatingPercent: null,
+      momLowestRatingPercent: null,
+    });
+
+    expect(textOf(baseElement, 'feedback-avg-rating')).toBe('3 - Neutral');
+    expect(textOf(baseElement, 'feedback-lowest-rating')).toBe('2 - Difficult');
+  });
+
+  it('renders the worst possible rating rather than falling back to a bare number', () => {
+    // Rating.terrible is 0, so a truthiness check here dropped the label entirely.
+    const { baseElement } = renderMetrics({
+      feedbackCount: 3,
+      averageRating: 0,
+      lowestSiteAverageRating: 0,
+      momCountPercent: null,
+      momAvgRatingPercent: null,
+      momLowestRatingPercent: null,
+    });
+
+    expect(textOf(baseElement, 'feedback-avg-rating')).toBe('1 - Very Difficult');
+    expect(textOf(baseElement, 'feedback-lowest-rating')).toBe('1 - Very Difficult');
+  });
+
+  it('shows a placeholder when there is no rating data', () => {
+    const { baseElement } = renderMetrics({
+      feedbackCount: 0,
+      averageRating: null,
+      lowestSiteAverageRating: null,
+      momCountPercent: null,
+      momAvgRatingPercent: null,
+      momLowestRatingPercent: null,
+    });
+
+    expect(textOf(baseElement, 'feedback-avg-rating')).toBe('-');
+    expect(textOf(baseElement, 'feedback-lowest-rating')).toBe('-');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.spec.tsx
@@ -23,7 +23,7 @@ describe('FeedbackMetrics', () => {
     const { baseElement } = renderMetrics({
       feedbackCount: 10,
       averageRating: 2,
-      lowestSiteAverageRating: 2,
+      lowestRating: 2,
       momCountPercent: null,
       momAvgRatingPercent: null,
       momLowestRatingPercent: null,
@@ -37,7 +37,7 @@ describe('FeedbackMetrics', () => {
     const { baseElement } = renderMetrics({
       feedbackCount: 25,
       averageRating: 2.4,
-      lowestSiteAverageRating: 1,
+      lowestRating: 1,
       momCountPercent: null,
       momAvgRatingPercent: null,
       momLowestRatingPercent: null,
@@ -52,7 +52,7 @@ describe('FeedbackMetrics', () => {
     const { baseElement } = renderMetrics({
       feedbackCount: 3,
       averageRating: 0,
-      lowestSiteAverageRating: 0,
+      lowestRating: 0,
       momCountPercent: null,
       momAvgRatingPercent: null,
       momLowestRatingPercent: null,
@@ -62,11 +62,26 @@ describe('FeedbackMetrics', () => {
     expect(textOf(baseElement, 'feedback-lowest-rating')).toBe('1 - Very Difficult');
   });
 
+  it('shows the worst rating submitted alongside the average', () => {
+    // Five submissions displayed as 5, 5, 1, 2, 1 — recorded 4, 4, 0, 1, 0. Mean 1.8, lowest 0.
+    const { baseElement } = renderMetrics({
+      feedbackCount: 5,
+      averageRating: 1.8,
+      lowestRating: 0,
+      momCountPercent: null,
+      momAvgRatingPercent: null,
+      momLowestRatingPercent: null,
+    });
+
+    expect(textOf(baseElement, 'feedback-avg-rating')).toBe('3 - Neutral');
+    expect(textOf(baseElement, 'feedback-lowest-rating')).toBe('1 - Very Difficult');
+  });
+
   it('shows a placeholder when there is no rating data', () => {
     const { baseElement } = renderMetrics({
       feedbackCount: 0,
       averageRating: null,
-      lowestSiteAverageRating: null,
+      lowestRating: null,
       momCountPercent: null,
       momAvgRatingPercent: null,
       momLowestRatingPercent: null,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.tsx
@@ -42,7 +42,7 @@ export const FeedbackMetrics: FunctionComponent = () => {
           {
             id: 'feedback-lowest-rating',
             name: 'Lowest feedback rating ',
-            value: toDisplayRating(metrics.lowestSiteAverageRating),
+            value: toDisplayRating(metrics.lowestRating),
             mom: metrics.momLowestRatingPercent ? parseFloat(Number(metrics.momLowestRatingPercent).toFixed(1)) : null,
           },
         ]}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/metrics.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import moment from 'moment';
 import { Metrics } from './feedbackMetrics';
+import { toDisplayRating } from './ratings';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { RootState } from '@store/index';
@@ -35,15 +36,13 @@ export const FeedbackMetrics: FunctionComponent = () => {
           {
             id: 'feedback-avg-rating',
             name: 'Average feedback rating',
-            value: metrics.averageRating ? Number(metrics.averageRating.toFixed(1)) : metrics.averageRating,
+            value: toDisplayRating(metrics.averageRating),
             mom: metrics.momAvgRatingPercent ? parseFloat(Number(metrics.momAvgRatingPercent).toFixed(1)) : null,
           },
           {
             id: 'feedback-lowest-rating',
             name: 'Lowest feedback rating ',
-            value: metrics.lowestSiteAverageRating
-              ? metrics.lowestSiteAverageRating + 1
-              : metrics.lowestSiteAverageRating,
+            value: toDisplayRating(metrics.lowestSiteAverageRating),
             mom: metrics.momLowestRatingPercent ? parseFloat(Number(metrics.momLowestRatingPercent).toFixed(1)) : null,
           },
         ]}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/ratings.spec.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/ratings.spec.ts
@@ -1,0 +1,31 @@
+import { ratings, getRatingLabelByValue, toDisplayRating } from './ratings';
+
+describe('toDisplayRating', () => {
+  // feedback-service records Rating.terrible = 0 through Rating.delightful = 4.
+  it.each([
+    [0, 1, 'Very Difficult'],
+    [1, 2, 'Difficult'],
+    [2, 3, 'Neutral'],
+    [3, 4, 'Easy'],
+    [4, 5, 'Very Easy'],
+  ])('maps recorded rating %s to display value %s (%s)', (raw, expected, label) => {
+    expect(toDisplayRating(raw)).toBe(expected);
+    expect(getRatingLabelByValue(expected)).toBe(label);
+  });
+
+  it('shifts a fractional average onto the label scale', () => {
+    expect(toDisplayRating(1.4)).toBe(2.4);
+  });
+
+  it('rounds to a single decimal', () => {
+    expect(toDisplayRating(1.26)).toBe(2.3);
+  });
+
+  it.each([[undefined], [null]])('returns undefined for %s', (raw) => {
+    expect(toDisplayRating(raw as unknown as number)).toBeUndefined();
+  });
+
+  it('covers the whole label scale', () => {
+    expect(ratings.map((r) => r.value)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/ratings.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/feedback/ratings.ts
@@ -53,3 +53,12 @@ export function getRatingLabelByValue(value: number): string | undefined {
   const rating = ratings.find((r) => r.value === value);
   return rating ? rating.label : undefined;
 }
+
+/**
+ * Feedback ratings are recorded 0-based — the feedback-service `Rating` enum runs terrible=0 to
+ * delightful=4 — while the labels above are 1-based, so a raw metric value shifts by one to be
+ * displayed. `terrible` is 0, so this must not test truthiness.
+ */
+export function toDisplayRating(raw?: number): number | undefined {
+  return typeof raw === 'number' ? Math.round((raw + 1) * 10) / 10 : undefined;
+}

--- a/apps/tenant-management-webapp/src/app/store/feedback/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/feedback/models.ts
@@ -42,7 +42,8 @@ export interface SelectedSite {
 
 export interface FeedbackMetrics {
   averageRating?: number;
-  lowestSiteAverageRating?: number;
+  /** Lowest single rating submitted, not the lowest site average. */
+  lowestRating?: number;
   feedbackCount?: number;
   momCountPercent?: number | null;
   momAvgRatingPercent?: number | null;

--- a/apps/tenant-management-webapp/src/app/store/feedback/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/feedback/models.ts
@@ -42,6 +42,7 @@ export interface SelectedSite {
 
 export interface FeedbackMetrics {
   averageRating?: number;
+  // clean-code-ignore: RULE-19 — type declaration; the behaviour is covered by sagas.spec.ts.
   /** Lowest single rating submitted, not the lowest site average. */
   lowestRating?: number;
   feedbackCount?: number;

--- a/apps/tenant-management-webapp/src/app/store/feedback/sagas.spec.ts
+++ b/apps/tenant-management-webapp/src/app/store/feedback/sagas.spec.ts
@@ -1,0 +1,68 @@
+import { expectSaga } from 'redux-saga-test-plan';
+import axios from 'axios';
+import { fetchFeedbackMetrics } from './sagas';
+import { getAccessToken } from '@store/tenant/sagas';
+import { FETCH_FEEDBACK_METRICS_SUCCESS_ACTION } from './actions';
+
+const storeState = {
+  config: { serviceUrls: { valueServiceApiUrl: 'http://mock-value-service.com' } },
+};
+
+// One registered site, one view — the shape that exposed the defect. Ratings are recorded
+// 0-based, so these five entries are the 5, 5, 1, 2, 1 shown in the feedback list.
+const singleSiteResponse = {
+  'adsp-dev:/admin/services/feedback:count': { values: [{ sum: '5', avg: '1', min: '1' }] },
+  'adsp-dev:/admin/services/feedback:rating': { values: [{ sum: '9', avg: '1.8', min: '0' }] },
+};
+
+const metricsFrom = (data: Record<string, unknown>) =>
+  expectSaga(fetchFeedbackMetrics)
+    .withState(storeState)
+    .provide({
+      call(effect, next) {
+        if (effect.fn === getAccessToken) {
+          return 'mock-token';
+        }
+        if (effect.fn === axios.get) {
+          return { data };
+        }
+        return next();
+      },
+    })
+    .run()
+    .then(({ effects }) =>
+      effects.put
+        .map((e) => e.payload.action)
+        .find((a) => a.type === FETCH_FEEDBACK_METRICS_SUCCESS_ACTION)?.metrics,
+    );
+
+describe('fetchFeedbackMetrics', () => {
+  it('reports the lowest rating submitted, not the lowest site average', async () => {
+    // Regression guard: Math.min over the site averages returns the overall average whenever a
+    // tenant has one site, so this card mirrored the average card instead of showing the worst
+    // rating anyone gave.
+    const metrics = await metricsFrom(singleSiteResponse);
+
+    expect(metrics.averageRating).toBe(1.8);
+    expect(metrics.lowestRating).toBe(0);
+    expect(metrics.feedbackCount).toBe(5);
+  });
+
+  it('takes the lowest rating across every site', async () => {
+    const metrics = await metricsFrom({
+      'site-a:/one:count': { values: [{ sum: '4', avg: '1', min: '1' }] },
+      'site-a:/one:rating': { values: [{ sum: '12', avg: '3', min: '2' }] },
+      'site-b:/two:count': { values: [{ sum: '2', avg: '1', min: '1' }] },
+      'site-b:/two:rating': { values: [{ sum: '2', avg: '1', min: '0' }] },
+    });
+
+    expect(metrics.lowestRating).toBe(0);
+  });
+
+  it('returns null ratings when nothing has been submitted', async () => {
+    const metrics = await metricsFrom({});
+
+    expect(metrics.averageRating).toBeNull();
+    expect(metrics.lowestRating).toBeNull();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/store/feedback/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/feedback/sagas.ts
@@ -231,7 +231,7 @@ function* deleteFeedbackSite(action: DeleteFeedbackSiteAction) {
 }
 
 interface MetricResponse {
-  values: { sum: string; avg: string }[];
+  values: { sum: string; avg: string; min: string }[];
 }
 
 export function* fetchFeedbackMetrics(): SagaIterator {
@@ -269,6 +269,19 @@ export function* fetchFeedbackMetrics(): SagaIterator {
           }
           return ratings;
         }, [] as [string, number][]);
+      // The lowest rating is the lowest rating anyone submitted, so it comes from the metric's own
+      // `min`. Taking Math.min over the site averages instead returns the overall average whenever
+      // a tenant has a single site, which is why this card used to mirror the average card.
+      const siteRatingMins = Object.entries(data)
+        .filter(([name]) => name.split(':').length === 3 && name.endsWith(':rating'))
+        .reduce((mins, [, value]) => {
+          const min = value?.values[0]?.min;
+          if (min !== undefined && min !== null) {
+            mins.push(parseFloat(min));
+          }
+          return mins;
+        }, [] as number[])
+        .filter((min) => !isNaN(min));
       yield put(
         fetchFeedbackMetricsSuccess({
           feedbackCount: Object.values(siteCounts).reduce((count, value) => count + value, 0),
@@ -282,8 +295,7 @@ export function* fetchFeedbackMetrics(): SagaIterator {
                     Object.values(siteCounts).reduce((total, count) => total + count, 0)
                 ) / 10
               : null,
-          lowestSiteAverageRating:
-            siteRatings.length > 0 ? Math.min(...siteRatings.map(([_, rating]) => rating)) : null,
+          lowestRating: siteRatingMins.length > 0 ? Math.min(...siteRatingMins) : null,
         })
       );
     } catch (err) {
@@ -350,8 +362,15 @@ export function* fetchFeedbackMetricsMoM(): SagaIterator {
         return count > 0 ? Math.round((total * 10) / count) / 10 : null;
       };
 
-      const getLowestRating = (ratings: [string, number][]) =>
-        ratings.length ? Math.min(...ratings.map(([, rating]) => rating)) : null;
+      // Matches the summary card: the lowest rating submitted, from the metric's own `min`.
+      const getLowestRating = (data: Record<string, MetricResponse>) => {
+        const mins = Object.entries(data)
+          .filter(([name]) => name.split(':').length === 3 && name.endsWith(':rating'))
+          .map(([, metric]) => parseFloat(metric?.values[0]?.min))
+          .filter((min) => !isNaN(min));
+
+        return mins.length ? Math.min(...mins) : null;
+      };
 
       // Extract and compute
       const currentCounts = extractCounts(currentResp.data);
@@ -366,8 +385,8 @@ export function* fetchFeedbackMetricsMoM(): SagaIterator {
       const currentAvg = getWeightedAverage(currentRatings, currentCounts);
       const previousAvg = getWeightedAverage(previousRatings, previousCounts);
 
-      const currentLowest = getLowestRating(currentRatings);
-      const previousLowest = getLowestRating(previousRatings);
+      const currentLowest = getLowestRating(currentResp.data);
+      const previousLowest = getLowestRating(previousResp.data);
 
       const momCount =
         previousCountTotal > 0 ? ((currentCountTotal - previousCountTotal) / previousCountTotal) * 100 : null;


### PR DESCRIPTION
Overview dashboard showed a lowest rating above the average. Two separate defects, both here.

**1. The average was on the wrong scale.** Ratings are recorded 0-based (`feedback-service` `Rating`: terrible=0 to delightful=4, written at `value.ts:21`) while the summary labels in `ratings.ts` are 1-based, so raw values shift by one to display. Only the lowest card did that shift, so a week averaging raw 2 rendered "2 - Difficult" beside "3 - Neutral". Both now go through `toDisplayRating`. The repo already had this convention — `incrementRatingValue` (`sagas.ts`) does the same for the feedback list.

Same lines carried a truthiness bug: `terrible` is 0, so an all-terrible week rendered as a bare `0` instead of "1 - Very Difficult".

**2. "Lowest feedback rating" was the lowest site *average*.** It took `Math.min` over the per-site average ratings, so a tenant with one registered site got the overall average back and the card mirrored the average card. Five submissions of 5, 5, 1, 2, 1 (recorded 4, 4, 0, 1, 0) showed "3 - Neutral" rather than "1 - Very Difficult". value-service already returns a `min` aggregate per metric (`timescale/value.ts`), it just wasn't in the webapp's `MetricResponse`. Now used for both the summary and the MoM figure, and the field is renamed `lowestRating` since it is no longer a site average.

**Out of scope:** MoM percentages are computed on raw 0-based values. A percent change on a scale with an arbitrary zero depends on where the zero sits — raw 1→2 reads +100% where the labels moved 2→3, i.e. +50%. Both cards are affected equally so it doesn't touch the invariant reported here. Flagging rather than changing, since it moves displayed numbers.

**QA:** submit a spread of ratings including a "Very Difficult" against one site. Average should be the mean; lowest should be "1 - Very Difficult", never above the average.

Tests: 17 added across the saga and the cards. The ones encoding each defect fail against the unfixed code with exactly the reported output. Full webapp suite green (57 suites, 258 tests), production build clean.
