### PR TITLE
fix(tenant-management-webapp): update access service code link

### DIFF
--- a/apps/tenant-management-webapp-e2e/src/integration/tenant-admin.feature
+++ b/apps/tenant-management-webapp-e2e/src/integration/tenant-admin.feature
@@ -185,7 +185,7 @@ Feature: Tenant admin
     Given a tenant admin user is on tenant admin page
     When the user selects the "Access" menu item
     Then the user views the "Access service" overview content "Access allows you to"
-    And the user views the link of See the code for "access-service"
+    And the user views the link of See the code for "keycloak/keycloak"
     And the user views the link of "Get support" under Support
 
   @TEST_CS-2501 @REQ_CS-1401 @regression

--- a/apps/tenant-management-webapp/src/app/components/AsideLinks.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/components/AsideLinks.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import AsideLinks from './AsideLinks';
+
+describe('AsideLinks', () => {
+  const mockStore = configureStore([]);
+
+  const renderAsideLinks = (props: React.ComponentProps<typeof AsideLinks>) => {
+    const store = mockStore({
+      config: { serviceUrls: { docServiceApiUrl: 'https://api-docs.adsp.alberta.ca' } },
+      tenant: { name: 'Auto Test' },
+    });
+
+    return render(
+      <Provider store={store}>
+        <AsideLinks {...props} />
+      </Provider>
+    );
+  };
+
+  it('points the access service code link at the keycloak repository', () => {
+    const { getByTestId } = renderAsideLinks({ serviceName: 'access' });
+
+    expect(getByTestId('code-link').querySelector('a')).toHaveAttribute('href', 'https://github.com/keycloak/keycloak');
+  });
+
+  it('points other service code links at the monorepo service directory', () => {
+    const { getByTestId } = renderAsideLinks({ serviceName: 'file' });
+
+    expect(getByTestId('code-link').querySelector('a')).toHaveAttribute(
+      'href',
+      'https://github.com/GovAlta/adsp-monorepo/tree/main/apps/file-service'
+    );
+  });
+
+  it('builds the docs link from the doc service url and tenant name', () => {
+    const { getByTestId } = renderAsideLinks({ serviceName: 'file' });
+
+    expect(getByTestId('docs-link').querySelector('a')).toHaveAttribute(
+      'href',
+      'https://api-docs.adsp.alberta.ca/auto-test?urls.primaryName=File service'
+    );
+  });
+
+  it('uppercases the pdf service in the docs link', () => {
+    const { getByTestId } = renderAsideLinks({ serviceName: 'pdf' });
+
+    expect(getByTestId('docs-link').querySelector('a')).toHaveAttribute(
+      'href',
+      'https://api-docs.adsp.alberta.ca/auto-test?urls.primaryName=PDF service'
+    );
+  });
+
+  it('omits the docs link when noDocsLink is set', () => {
+    const { queryByTestId } = renderAsideLinks({ serviceName: 'file', noDocsLink: true });
+
+    expect(queryByTestId('docs-link')).not.toBeInTheDocument();
+  });
+
+  it('shows the feedback tutorial link only when requested', () => {
+    const { queryByTestId, rerender } = renderAsideLinks({ serviceName: 'feedback' });
+    expect(queryByTestId('feedback-tutorial-link')).not.toBeInTheDocument();
+
+    const store = mockStore({
+      config: { serviceUrls: { docServiceApiUrl: 'https://api-docs.adsp.alberta.ca' } },
+      tenant: { name: 'Auto Test' },
+    });
+    rerender(
+      <Provider store={store}>
+        <AsideLinks serviceName="feedback" feedbackTutorialLink={true} />
+      </Provider>
+    );
+
+    expect(queryByTestId('feedback-tutorial-link')?.querySelector('a')).toHaveAttribute(
+      'href',
+      'https://govalta.github.io/adsp-monorepo/tutorials/feedback-service/collectingFeedback.html'
+    );
+  });
+});

--- a/apps/tenant-management-webapp/src/app/components/AsideLinks.tsx
+++ b/apps/tenant-management-webapp/src/app/components/AsideLinks.tsx
@@ -25,7 +25,7 @@ const AsideLinks = ({ serviceName, noDocsLink = false, feedbackTutorialLink }: A
   };
   const getSupportCodeLink = () => {
     if (serviceName.toLowerCase() === 'access') {
-      return 'https://github.com/GovAlta/access-service';
+      return 'https://github.com/keycloak/keycloak';
     }
     return `https://github.com/GovAlta/adsp-monorepo/tree/main/apps/${serviceName}-service`;
   };

--- a/docs/tutorials/access-service/themes.md
+++ b/docs/tutorials/access-service/themes.md
@@ -37,7 +37,7 @@ Keycloak uses FreeMarker files to build server-side webpages that then get serve
 Probably the easiest way to build and test a new theme is:
 
 - read the [keycloak guide](https://www.keycloak.org/docs/18.0/server_development/) for developing themes
-- clone the [access-service git repository](https://github.com/GovAlta/access-service/tree/main)
+- clone the Access service repository, and
 - follow the instructions in the repository to build, test, and deploy your new templates.
 
-If you have any questions please contact the ADSP team on slack (#adsp-connect) or email us at [ADSP Support](adsp@gov.ab.ca).
+The Access service repository is maintained by the ADSP team in a private Government of Alberta organization, so you will need to request access before you can clone it. Please contact the ADSP team on slack (#adsp-connect) or email us at [ADSP Support](adsp@gov.ab.ca) to request access, or if you have any questions.


### PR DESCRIPTION
## What changed

- Point the Access service **See the code** link at the upstream Keycloak repository.
- Update the tenant-admin regression scenario to verify the new destination.
- Drop the dead `access-service` repo link from the Keycloak themes tutorial and explain how to request access instead.
- Add `AsideLinks.spec.tsx` covering the link-building logic (addresses the Clean Code RULE-19 warning).

## Why

`GovAlta/access-service` has moved into a private, enterprise-managed GovAlta organization, so the old link 404s for everyone and the new location is not reachable by tenant admins — enterprise-managed orgs cannot host public repositories. Access service is a deployment of Keycloak (see `docs/services/access-service.md`), so upstream `keycloak/keycloak` is the closest destination the page's audience can actually open.

## Impact

Tenant administrators get a working **See the code** link. Links for all other services are unchanged. The themes tutorial no longer sends readers to a 404.

## Validation

- `jest --config apps/tenant-management-webapp/jest.config.ts` — 62 suites / 290 tests passed
- `npx nx lint tenant-management-webapp` — passed (one pre-existing warning in `TenantIDP.tsx`)
