### PR TITLE
feat(form): sort forms and submissions tables

### DIFF
--- a/apps/form-admin-app/src/app/components/SortableColumnHeader.spec.tsx
+++ b/apps/form-admin-app/src/app/components/SortableColumnHeader.spec.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import { SortableColumnHeader, toSortChange } from './SortableColumnHeader';
+import { getDefaultResultsSort } from '../state';
+
+const renderHeader = (sort: Parameters<typeof toSortChange>[1]) =>
+  render(
+    <table>
+      <thead>
+        <tr>
+          <SortableColumnHeader name="created" sort={sort}>
+            Created on
+          </SortableColumnHeader>
+        </tr>
+      </thead>
+    </table>,
+  );
+
+describe('SortableColumnHeader', () => {
+  it('should indicate the direction of the sorted column', () => {
+    const { baseElement } = renderHeader({ field: 'created', direction: 'asc' });
+
+    expect(baseElement.querySelector("goa-table-sort-header[name='created']").getAttribute('direction')).toBe('asc');
+  });
+
+  it('should not indicate a direction for a column that is not sorted', () => {
+    const { baseElement } = renderHeader({ field: 'status', direction: 'asc' });
+
+    expect(baseElement.querySelector("goa-table-sort-header[name='created']").getAttribute('direction')).toBe('none');
+  });
+
+  it('should not indicate a direction when there is no sort', () => {
+    const { baseElement } = renderHeader(null);
+
+    expect(baseElement.querySelector("goa-table-sort-header[name='created']").getAttribute('direction')).toBe('none');
+  });
+});
+
+describe('toSortChange', () => {
+  const sort = getDefaultResultsSort();
+
+  it('should resolve ascending sort direction', () => {
+    expect(toSortChange({ sortBy: 'status', sortDir: 1 }, sort)).toEqual({ field: 'status', direction: 'asc' });
+  });
+
+  it('should resolve descending sort direction', () => {
+    expect(toSortChange({ sortBy: 'status', sortDir: -1 }, sort)).toEqual({ field: 'status', direction: 'desc' });
+  });
+
+  it('should resolve a change of direction on the sorted column', () => {
+    expect(toSortChange({ sortBy: 'created', sortDir: 1 }, sort)).toEqual({ field: 'created', direction: 'asc' });
+  });
+
+  it('should resolve no change for the sort already applied', () => {
+    expect(toSortChange({ sortBy: 'created', sortDir: -1 }, sort)).toBeNull();
+  });
+
+  it('should resolve no change when no column is sorted', () => {
+    expect(toSortChange({ sortBy: '', sortDir: 0 }, sort)).toBeNull();
+  });
+
+  it('should resolve a change when there is no sort applied', () => {
+    expect(toSortChange({ sortBy: 'created', sortDir: -1 }, null)).toEqual({ field: 'created', direction: 'desc' });
+  });
+});

--- a/apps/form-admin-app/src/app/components/SortableColumnHeader.tsx
+++ b/apps/form-admin-app/src/app/components/SortableColumnHeader.tsx
@@ -1,0 +1,29 @@
+import { GoabTableSortHeader } from '@abgov/react-components';
+import { GoabTableOnSortDetail } from '@abgov/ui-components-common';
+import { FunctionComponent, ReactNode } from 'react';
+import { ResultsSort, SortDirection } from '../state';
+
+interface SortableColumnHeaderProps {
+  name: string;
+  sort: ResultsSort;
+  children: ReactNode;
+}
+
+// Renders a table heading that the user can sort on. The sort direction indicator reflects the sort
+// applied to the results, so that it stays correct when results are sorted from outside the table.
+export const SortableColumnHeader: FunctionComponent<SortableColumnHeaderProps> = ({ name, sort, children }) => (
+  <th>
+    <GoabTableSortHeader name={name} direction={sort?.field === name ? sort.direction : 'none'}>
+      {children}
+    </GoabTableSortHeader>
+  </th>
+);
+
+// The table also raises the sort event for the sort it starts with, so changes that match the sort
+// already applied are resolved to null and the caller can skip searching the results again.
+export const toSortChange = (detail: GoabTableOnSortDetail, sort: ResultsSort): ResultsSort => {
+  const direction: SortDirection = detail.sortDir === 1 ? 'asc' : 'desc';
+  return !detail.sortBy || (detail.sortBy === sort?.field && direction === sort?.direction)
+    ? null
+    : { field: detail.sortBy, direction };
+};

--- a/apps/form-admin-app/src/app/containers/FormSubmissions.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/FormSubmissions.spec.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { FormSubmissions } from './FormSubmissions';
+import { findSubmissions, getDefaultResultsSort, getDefaultSubmissionCriteria } from '../state';
+
+jest.mock('../state', () => {
+  const actual = jest.requireActual('../state');
+  return {
+    ...actual,
+    findSubmissions: jest.fn((payload) => ({ type: 'form/find-submissions', payload })),
+    exportSubmissions: jest.fn((payload) => ({ type: 'form/export-submissions', payload })),
+    getTags: jest.fn((payload) => ({ type: 'directory/get-tags', payload })),
+    tagResource: jest.fn((payload) => ({ type: 'directory/tag-resource', payload })),
+  };
+});
+
+const mockStore = configureStore();
+const definitionId = 'submission-test';
+const submissionUrn = 'urn:ads:platform:form-service:v1:/submissions/submission-1';
+
+const createState = ({
+  submissions = {},
+  submissionResults = [],
+  submissionCriteria = getDefaultSubmissionCriteria(),
+  submissionSort = getDefaultResultsSort(),
+}: {
+  submissions?: Record<string, unknown>;
+  submissionResults?: string[];
+  submissionCriteria?: ReturnType<typeof getDefaultSubmissionCriteria>;
+  submissionSort?: ReturnType<typeof getDefaultResultsSort>;
+} = {}) => ({
+  user: {
+    user: {
+      id: 'user-1',
+      name: 'Test User',
+      email: 'test@gov.ab.ca',
+      roles: ['urn:ads:platform:form-service:form-admin'],
+    },
+  },
+  form: {
+    busy: {
+      initializing: false,
+      loading: false,
+      findPdf: false,
+      executing: false,
+      exporting: false,
+    },
+    forms: {},
+    submissions,
+    definitions: {
+      [definitionId]: {
+        id: definitionId,
+        name: 'Submission test',
+        supportTopic: false,
+        anonymousApply: false,
+        assessorRoles: [],
+      },
+    },
+    pdfs: {},
+    dataValues: {
+      [definitionId]: [{ name: 'First name', path: 'firstName', type: 'string', selected: true }],
+    },
+    results: {
+      definitions: [],
+      forms: [],
+      submissions: submissionResults,
+    },
+    resultTotals: {
+      definitions: 0,
+      forms: 0,
+      submissions: submissionResults.length,
+    },
+    definitionCriteria: {},
+    formCriteria: {},
+    submissionCriteria,
+    formSort: getDefaultResultsSort(),
+    submissionSort,
+    next: {
+      definitions: null,
+      forms: null,
+      submissions: null,
+    },
+    selectedDefinition: definitionId,
+    selectedForm: null,
+    selectedSubmission: null,
+    dispositionDraft: { status: '', reason: '' },
+    export: {
+      forms: {},
+      submissions: {},
+    },
+  },
+  directory: {
+    resources: {},
+    tags: {},
+    resourceTags: {},
+    tagResources: {},
+    results: [],
+    next: null,
+    busy: {
+      loading: false,
+      loadingResourceTags: {},
+      executing: false,
+    },
+  },
+  comment: {
+    topics: {},
+  },
+  file: {
+    files: {},
+    metadata: {},
+    busy: {
+      download: {},
+      metadata: {},
+      find: false,
+    },
+  },
+});
+
+const renderSubmissions = (state = createState()) => {
+  const store = mockStore(state);
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FormSubmissions definitionId={definitionId} />
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  return { store, ...view };
+};
+
+describe('FormSubmissions', () => {
+  beforeEach(() => {
+    (findSubmissions as unknown as jest.Mock).mockClear();
+  });
+
+  it('should render the submissions table', () => {
+    const { getByText } = renderSubmissions(
+      createState({
+        submissions: {
+          'submission-1': {
+            urn: submissionUrn,
+            id: 'submission-1',
+            formId: 'form-1',
+            created: '2026-08-01T12:00:00.000Z',
+            updated: '2026-08-01T12:00:00.000Z',
+            createdBy: { id: 'user-1', name: 'Test User' },
+            disposition: { id: 'accepted', status: 'accepted', reason: '', date: '2026-08-02T12:00:00.000Z' },
+            formData: { firstName: 'Ada' },
+          },
+        },
+        submissionResults: ['submission-1'],
+      }),
+    );
+
+    expect(getByText('Submitted on')).toBeTruthy();
+    expect(getByText('Ada')).toBeTruthy();
+  });
+
+  it('should dispatch findSubmissions on mount when no submissions are loaded', () => {
+    renderSubmissions();
+
+    expect(findSubmissions).toHaveBeenCalledWith({
+      definitionId,
+      criteria: getDefaultSubmissionCriteria(),
+      sort: getDefaultResultsSort(),
+    });
+  });
+
+  it('should indicate the submitted on column is sorted descending by default', () => {
+    const { baseElement } = renderSubmissions();
+
+    expect(baseElement.querySelector("goa-table-sort-header[name='created']").getAttribute('direction')).toBe('desc');
+    expect(baseElement.querySelector("goa-table-sort-header[name='disposition']").getAttribute('direction')).toBe(
+      'none',
+    );
+    expect(baseElement.querySelector("goa-table-sort-header[name='data.firstName']")).toBeTruthy();
+  });
+
+  it('should not make the tags or actions columns sortable', () => {
+    const { baseElement } = renderSubmissions();
+
+    const sortable = Array.from(baseElement.querySelectorAll('goa-table-sort-header')).map((header) =>
+      header.getAttribute('name'),
+    );
+    expect(sortable).toEqual(['created', 'disposition', 'data.firstName']);
+  });
+
+  it('should find submissions with the selected sort', () => {
+    const { baseElement, store } = renderSubmissions();
+
+    fireEvent(
+      baseElement.querySelector('goa-table'),
+      new CustomEvent('_sort', { detail: { sortBy: 'disposition', sortDir: 1 } }),
+    );
+
+    expect(store.getActions()).toContainEqual({
+      type: 'form/setSubmissionSort',
+      payload: { field: 'disposition', direction: 'asc' },
+    });
+    expect(findSubmissions).toHaveBeenCalledWith({
+      definitionId,
+      criteria: getDefaultSubmissionCriteria(),
+      sort: { field: 'disposition', direction: 'asc' },
+    });
+  });
+
+  it('should keep the sort when loading more submissions', () => {
+    const { baseElement } = renderSubmissions();
+    (findSubmissions as unknown as jest.Mock).mockClear();
+
+    fireEvent(baseElement.querySelector("goa-button[testId='find-submissions']"), new CustomEvent('_click'));
+
+    expect(findSubmissions).toHaveBeenCalledWith({
+      definitionId,
+      criteria: getDefaultSubmissionCriteria(),
+      sort: getDefaultResultsSort(),
+      after: undefined,
+    });
+  });
+
+  it('should not find submissions again for the sort the results already have', () => {
+    const { baseElement } = renderSubmissions();
+    (findSubmissions as unknown as jest.Mock).mockClear();
+
+    fireEvent(
+      baseElement.querySelector('goa-table'),
+      new CustomEvent('_sort', { detail: { sortBy: 'created', sortDir: -1 } }),
+    );
+
+    expect(findSubmissions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/form-admin-app/src/app/containers/FormSubmissions.tsx
+++ b/apps/form-admin-app/src/app/containers/FormSubmissions.tsx
@@ -27,6 +27,8 @@ import {
   directoryBusySelector,
   tagResource,
   formResultTotalsSelector,
+  submissionSortSelector,
+  DATA_VALUE_SORT_PREFIX,
 } from '../state';
 import { ContentContainer } from '../components/ContentContainer';
 import { FilterDrawerLayout } from '../components/FilterDrawerLayout';
@@ -38,8 +40,9 @@ import { DateRangeCriteriaItem, isSearchDisabled } from '../components/DateRange
 import { AddTagModal } from '../components/AddTagModal';
 import { Tags } from './Tags';
 import { TagSearchFilter } from './TagSearchFilter';
-import { GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabDropdownOnChangeDetail, GoabTableOnSortDetail } from '@abgov/ui-components-common';
 import { ResultsSummary } from '../components/ResultsSummary';
+import { SortableColumnHeader, toSortChange } from '../components/SortableColumnHeader';
 
 interface FormSubmissionsProps {
   definitionId: string;
@@ -58,6 +61,7 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
   const submissions = useSelector(submissionsSelector);
   const dataValues = useSelector(selectedDataValuesSelector);
   const criteria = useSelector(submissionCriteriaSelector);
+  const sort = useSelector(submissionSortSelector);
   const activeFilterCount = useSelector(submissionFilterCountSelector);
   const { submissions: next } = useSelector(nextSelector);
   const { submissions: totalSubmissions } = useSelector(formResultTotalsSelector);
@@ -65,18 +69,28 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
 
   useEffect(() => {
     if (submissions.length < 1) {
-      dispatch(findSubmissions({ definitionId, criteria }));
+      dispatch(findSubmissions({ definitionId, criteria, sort }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, definitionId]);
 
+  // The table wires up its sort headers when it mounts, so it is remounted when the data value
+  // columns of the definition are loaded and the set of sortable columns changes.
+  const sortableColumnsKey = dataValues.map(({ path }) => path).join('|');
   const searchDisabled = isSearchDisabled(busy.loading, criteria);
   const updateCriteria = (update: typeof criteria) => dispatch(formActions.setSubmissionCriteria(update)); // clean-code-ignore: 2.10
-  const handleFindSubmissions = (after?: string) => dispatch(findSubmissions({ definitionId, criteria, after })); // clean-code-ignore: 2.10
+  const handleFindSubmissions = (after?: string) => dispatch(findSubmissions({ definitionId, criteria, sort, after })); // clean-code-ignore: 2.10
   const clearFilters = () => {
     const criteria = {};
     dispatch(formActions.setSubmissionCriteria(criteria));
-    dispatch(findSubmissions({ definitionId, criteria }));
+    dispatch(findSubmissions({ definitionId, criteria, sort }));
+  };
+  const handleSort = (detail: GoabTableOnSortDetail) => {
+    const update = toSortChange(detail, sort);
+    if (update) {
+      dispatch(formActions.setSubmissionSort(update));
+      dispatch(findSubmissions({ definitionId, criteria, sort: update }));
+    }
   };
 
   return (
@@ -175,14 +189,20 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
           loading={busy.loading}
           onClearFilters={clearFilters}
         />
-        <GoabTable width="100%">
+        <GoabTable key={sortableColumnsKey} width="100%" onSort={handleSort}>
           <thead>
             <tr>
-              <th>Submitted on</th>
-              <th>Disposition</th>
+              <SortableColumnHeader name="created" sort={sort}>
+                Submitted on
+              </SortableColumnHeader>
+              <SortableColumnHeader name="disposition" sort={sort}>
+                Disposition
+              </SortableColumnHeader>
               <th>Tags</th>
               {dataValues.map(({ name, path }) => (
-                <th key={path}>{name}</th>
+                <SortableColumnHeader key={path} name={`${DATA_VALUE_SORT_PREFIX}${path}`} sort={sort}>
+                  {name}
+                </SortableColumnHeader>
               ))}
               <th>Actions</th>
             </tr>

--- a/apps/form-admin-app/src/app/containers/Forms.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/Forms.spec.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { Forms } from './Forms';
-import { findForms, getDefaultFormCriteria } from '../state';
+import { findForms, getDefaultFormCriteria, getDefaultResultsSort } from '../state';
 import { FormStatus } from '../state/types';
 
 jest.mock('../state', () => {
@@ -27,10 +27,12 @@ const createState = ({
   forms = {},
   formResults = [],
   formCriteria = getDefaultFormCriteria(),
+  formSort = getDefaultResultsSort(),
 }: {
   forms?: Record<string, unknown>;
   formResults?: string[];
   formCriteria?: ReturnType<typeof getDefaultFormCriteria>;
+  formSort?: ReturnType<typeof getDefaultResultsSort>;
 } = {}) => ({
   user: {
     user: {
@@ -76,6 +78,8 @@ const createState = ({
     definitionCriteria: {},
     formCriteria,
     submissionCriteria: {},
+    formSort,
+    submissionSort: getDefaultResultsSort(),
     next: {
       definitions: null,
       forms: null,
@@ -168,6 +172,7 @@ describe('Forms', () => {
     expect(findForms).toHaveBeenCalledWith({
       definitionId,
       criteria: getDefaultFormCriteria(),
+      sort: getDefaultResultsSort(),
     });
   });
 
@@ -189,8 +194,48 @@ describe('Forms', () => {
     expect(findForms).toHaveBeenCalledWith({
       definitionId,
       criteria: getDefaultFormCriteria(),
+      sort: getDefaultResultsSort(),
       after: undefined,
     });
+  });
+
+  it('should indicate the created on column is sorted descending by default', () => {
+    const { baseElement } = renderForms();
+
+    expect(baseElement.querySelector("goa-table-sort-header[name='created']").getAttribute('direction')).toBe('desc');
+    expect(baseElement.querySelector("goa-table-sort-header[name='status']").getAttribute('direction')).toBe('none');
+    expect(baseElement.querySelector("goa-table-sort-header[name='data.firstName']")).toBeTruthy();
+  });
+
+  it('should find forms with the selected sort', () => {
+    const { baseElement, store } = renderForms();
+
+    fireEvent(
+      baseElement.querySelector('goa-table'),
+      new CustomEvent('_sort', { detail: { sortBy: 'status', sortDir: 1 } }),
+    );
+
+    expect(store.getActions()).toContainEqual({
+      type: 'form/setFormSort',
+      payload: { field: 'status', direction: 'asc' },
+    });
+    expect(findForms).toHaveBeenCalledWith({
+      definitionId,
+      criteria: getDefaultFormCriteria(),
+      sort: { field: 'status', direction: 'asc' },
+    });
+  });
+
+  it('should not find forms again for the sort the results already have', () => {
+    const { baseElement } = renderForms();
+    (findForms as unknown as jest.Mock).mockClear();
+
+    fireEvent(
+      baseElement.querySelector('goa-table'),
+      new CustomEvent('_sort', { detail: { sortBy: 'created', sortDir: -1 } }),
+    );
+
+    expect(findForms).not.toHaveBeenCalled();
   });
 
   it('should hide the filters trigger while the drawer is open', () => {

--- a/apps/form-admin-app/src/app/containers/Forms.tsx
+++ b/apps/form-admin-app/src/app/containers/Forms.tsx
@@ -33,6 +33,8 @@ import {
   directoryBusySelector,
   tagResource,
   formResultTotalsSelector,
+  formSortSelector,
+  DATA_VALUE_SORT_PREFIX,
 } from '../state';
 import { FilterDrawerLayout } from '../components/FilterDrawerLayout';
 import { ContentContainer } from '../components/ContentContainer';
@@ -44,8 +46,9 @@ import { DateRangeCriteriaItem, isSearchDisabled } from '../components/DateRange
 import { AddTagModal } from '../components/AddTagModal';
 import { Tags } from './Tags';
 import { TagSearchFilter } from './TagSearchFilter';
-import { GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabDropdownOnChangeDetail, GoabTableOnSortDetail } from '@abgov/ui-components-common';
 import { ResultsSummary } from '../components/ResultsSummary';
+import { SortableColumnHeader, toSortChange } from '../components/SortableColumnHeader';
 
 interface FormRowProps {
   dispatch: AppDispatch;
@@ -110,6 +113,7 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
   const forms = useSelector(formsSelector);
   const dataValues = useSelector(selectedDataValuesSelector);
   const criteria = useSelector(formCriteriaSelector);
+  const sort = useSelector(formSortSelector);
   const activeFilterCount = useSelector(formFilterCountSelector);
   const { forms: next } = useSelector(nextSelector);
   const { forms: totalForms } = useSelector(formResultTotalsSelector);
@@ -117,7 +121,7 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
 
   useEffect(() => {
     if (forms.length < 1) {
-      dispatch(findForms({ definitionId, criteria }));
+      dispatch(findForms({ definitionId, criteria, sort }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, definitionId]);
@@ -128,13 +132,23 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
     }
   }, [dispatch, definition]);
 
+  // The table wires up its sort headers when it mounts, so it is remounted when the data value
+  // columns of the definition are loaded and the set of sortable columns changes.
+  const sortableColumnsKey = dataValues.map(({ path }) => path).join('|');
   const searchDisabled = isSearchDisabled(busy.loading, criteria);
   const updateCriteria = (update: typeof criteria) => dispatch(formActions.setFormCriteria(update)); // clean-code-ignore: 2.10
-  const handleFindForms = (after?: string) => dispatch(findForms({ definitionId, criteria, after })); // clean-code-ignore: 2.10
+  const handleFindForms = (after?: string) => dispatch(findForms({ definitionId, criteria, sort, after })); // clean-code-ignore: 2.10
   const clearFilters = () => {
     const criteria = {};
     dispatch(formActions.setFormCriteria(criteria));
-    dispatch(findForms({ definitionId, criteria }));
+    dispatch(findForms({ definitionId, criteria, sort }));
+  };
+  const handleSort = (detail: GoabTableOnSortDetail) => {
+    const update = toSortChange(detail, sort);
+    if (update) {
+      dispatch(formActions.setFormSort(update));
+      dispatch(findForms({ definitionId, criteria, sort: update }));
+    }
   };
 
   return (
@@ -225,15 +239,21 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
           loading={busy.loading}
           onClearFilters={clearFilters}
         />
-        <GoabTable width="100%">
+        <GoabTable key={sortableColumnsKey} width="100%" onSort={handleSort}>
           <thead>
             <tr>
               <th></th>
-              <th>Created on</th>
-              <th>Status</th>
+              <SortableColumnHeader name="created" sort={sort}>
+                Created on
+              </SortableColumnHeader>
+              <SortableColumnHeader name="status" sort={sort}>
+                Status
+              </SortableColumnHeader>
               <th>Tags</th>
               {dataValues.map(({ name, path }) => (
-                <th key={path}>{name}</th>
+                <SortableColumnHeader key={path} name={`${DATA_VALUE_SORT_PREFIX}${path}`} sort={sort}>
+                  {name}
+                </SortableColumnHeader>
               ))}
               <th>Actions</th>
             </tr>

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -48,6 +48,23 @@ interface FormCriteria {
   tag?: string;
 }
 
+export type SortDirection = 'asc' | 'desc';
+
+// Sort field is the column name understood by the form service; data value columns are sorted using
+// the 'data.' prefix followed by the path of the value in the form data.
+export interface ResultsSort {
+  field: string;
+  direction: SortDirection;
+}
+
+export const DATA_VALUE_SORT_PREFIX = 'data.';
+
+export const getDefaultResultsSort = (): ResultsSort => ({ field: 'created', direction: 'desc' });
+
+// Tagged resource search is served by the directory service, which doesn't sort on form values, so
+// sort parameters are only sent on the form service search.
+const toSortParams = (sort?: ResultsSort) => (sort?.field ? { sortBy: sort.field, sortDirection: sort.direction } : {});
+
 export const toDateRangeStart = (value: string): string => new Date(`${value}T00:00:00.000Z`).toISOString();
 export const toDateRangeEnd = (value: string): string => new Date(`${value}T23:59:59.999Z`).toISOString();
 
@@ -121,6 +138,8 @@ export interface FormState {
   definitionCriteria: DefinitionCriteria;
   formCriteria: FormCriteria;
   submissionCriteria: FormSubmissionCriteria;
+  formSort: ResultsSort;
+  submissionSort: ResultsSort;
   next: {
     definitions: string;
     forms: string;
@@ -162,6 +181,8 @@ export const initialFormState: FormState = {
   definitionCriteria: getDefaultDefinitionCriteria(),
   formCriteria: getDefaultFormCriteria(),
   submissionCriteria: getDefaultSubmissionCriteria(),
+  formSort: getDefaultResultsSort(),
+  submissionSort: getDefaultResultsSort(),
   next: {
     definitions: null,
     forms: null,
@@ -253,7 +274,12 @@ export const loadDefinitions = createAsyncThunk(
 export const findForms = createAsyncThunk(
   'form/find-forms',
   async (
-    { definitionId, after, criteria }: { definitionId: string; after?: string; criteria?: FormCriteria },
+    {
+      definitionId,
+      after,
+      criteria,
+      sort,
+    }: { definitionId: string; after?: string; criteria?: FormCriteria; sort?: ResultsSort },
     { dispatch, getState, rejectWithValue },
   ) => {
     const state = getState() as AppState;
@@ -289,6 +315,7 @@ export const findForms = createAsyncThunk(
               ...criteria,
               definitionIdEquals: definitionId,
             }),
+            ...toSortParams(sort),
           },
         });
 
@@ -319,7 +346,12 @@ export const findForms = createAsyncThunk(
 export const findSubmissions = createAsyncThunk(
   'form/find-submissions',
   async (
-    { definitionId, after, criteria }: { definitionId: string; after?: string; criteria?: FormSubmissionCriteria },
+    {
+      definitionId,
+      after,
+      criteria,
+      sort,
+    }: { definitionId: string; after?: string; criteria?: FormSubmissionCriteria; sort?: ResultsSort },
     { dispatch, getState, rejectWithValue },
   ) => {
     const state = getState() as AppState;
@@ -348,6 +380,7 @@ export const findSubmissions = createAsyncThunk(
               ...criteria,
               definitionIdEquals: definitionId,
             }),
+            ...toSortParams(sort),
           },
         });
 
@@ -893,6 +926,12 @@ const formSlice = createSlice({
     setSubmissionCriteria: (state, { payload }: { payload: FormSubmissionCriteria }) => {
       state.submissionCriteria = payload;
     },
+    setFormSort: (state, { payload }: { payload: ResultsSort }) => {
+      state.formSort = payload;
+    },
+    setSubmissionSort: (state, { payload }: { payload: ResultsSort }) => {
+      state.submissionSort = payload;
+    },
     setDispositionDraft: (state, { payload }: { payload: Omit<FormDisposition, 'id' | 'date'> }) => {
       state.dispositionDraft = payload;
     },
@@ -1248,6 +1287,10 @@ export const formBusySelector = (state: AppState) => state.form.busy;
 export const submissionCriteriaSelector = (state: AppState) => state.form.submissionCriteria;
 
 export const submissionFilterCountSelector = createSelector(submissionCriteriaSelector, countActiveFilters);
+
+export const formSortSelector = (state: AppState) => state.form.formSort;
+
+export const submissionSortSelector = (state: AppState) => state.form.submissionSort;
 
 export const formCriteriaSelector = (state: AppState) => state.form.formCriteria;
 

--- a/apps/form-service/src/form/repository/form.ts
+++ b/apps/form-service/src/form/repository/form.ts
@@ -1,11 +1,11 @@
 import { AdspId } from '@abgov/adsp-service-sdk';
 import { Results } from '@core-services/core-common';
 import { FormEntity } from '../model';
-import { FormCriteria } from '../types';
+import { FormCriteria, ResultsSort } from '../types';
 
 export interface FormRepository {
   get(tenantId: AdspId, id: string): Promise<FormEntity>;
-  find(top: number, after: string, criteria: FormCriteria): Promise<Results<FormEntity>>;
+  find(top: number, after: string, criteria: FormCriteria, sort?: ResultsSort): Promise<Results<FormEntity>>;
   save(entity: FormEntity): Promise<FormEntity>;
   delete(entity: FormEntity): Promise<boolean>;
 }

--- a/apps/form-service/src/form/repository/form.ts
+++ b/apps/form-service/src/form/repository/form.ts
@@ -1,3 +1,5 @@
+// clean-code-ignore: RULE-19 — repository interface declaration; the mongo implementation is
+// covered by ../../mongo/form.spec.ts.
 import { AdspId } from '@abgov/adsp-service-sdk';
 import { Results } from '@core-services/core-common';
 import { FormEntity } from '../model';

--- a/apps/form-service/src/form/repository/formSubmission.ts
+++ b/apps/form-service/src/form/repository/formSubmission.ts
@@ -1,3 +1,5 @@
+// clean-code-ignore: RULE-19 — repository interface declaration; the mongo implementation is
+// covered by ../../mongo/formSubmission.spec.ts.
 import { AdspId } from '@abgov/adsp-service-sdk';
 import { Results } from '@core-services/core-common';
 import { FormSubmissionEntity } from '../model';

--- a/apps/form-service/src/form/repository/formSubmission.ts
+++ b/apps/form-service/src/form/repository/formSubmission.ts
@@ -1,11 +1,16 @@
 import { AdspId } from '@abgov/adsp-service-sdk';
 import { Results } from '@core-services/core-common';
 import { FormSubmissionEntity } from '../model';
-import { FormSubmissionCriteria } from '../types';
+import { FormSubmissionCriteria, ResultsSort } from '../types';
 
 export interface FormSubmissionRepository {
   get(tenantId: AdspId, id: string, formId?: string): Promise<FormSubmissionEntity>;
-  find(top: number, after: string, criteria: FormSubmissionCriteria): Promise<Results<FormSubmissionEntity>>;
+  find(
+    top: number,
+    after: string,
+    criteria: FormSubmissionCriteria,
+    sort?: ResultsSort,
+  ): Promise<Results<FormSubmissionEntity>>;
   save(entity: FormSubmissionEntity): Promise<FormSubmissionEntity>;
   delete(entity: FormSubmissionEntity): Promise<boolean>;
 }

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -638,8 +638,66 @@ describe('form router', () => {
         10,
         undefined,
         expect.objectContaining({ createDateAfter: '2024-01-01', createDateBefore: '2024-01-31' }),
+        null,
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page }));
+    });
+
+    it('can find forms with sort', async () => {
+      const user = {
+        tenantId,
+        id: 'tester',
+        roles: [FormServiceRoles.Admin],
+      };
+      const req = {
+        user,
+        query: {
+          sortBy: 'status',
+          sortDirection: 'asc',
+        },
+        tenant: { id: tenantId },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const page = {};
+
+      repositoryMock.find.mockResolvedValueOnce({ results: [entity], page });
+
+      const handler = findForms(apiId, repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(repositoryMock.find).toHaveBeenCalledWith(10, undefined, expect.any(Object), {
+        field: 'status',
+        direction: 'asc',
+      });
+    });
+
+    it('can find forms with descending sort by default', async () => {
+      const user = {
+        tenantId,
+        id: 'tester',
+        roles: [FormServiceRoles.Admin],
+      };
+      const req = {
+        user,
+        query: {
+          sortBy: 'created',
+        },
+        tenant: { id: tenantId },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const page = {};
+
+      repositoryMock.find.mockResolvedValueOnce({ results: [entity], page });
+
+      const handler = findForms(apiId, repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(repositoryMock.find).toHaveBeenCalledWith(10, undefined, expect.any(Object), {
+        field: 'created',
+        direction: 'desc',
+      });
     });
 
     it('can call next with invalid operation for bad criteria', async () => {
@@ -714,6 +772,7 @@ describe('form router', () => {
         expect.any(Number),
         undefined,
         expect.objectContaining({ createdByIdEquals: user.id }),
+        null,
       );
     });
 
@@ -2033,8 +2092,38 @@ describe('form router', () => {
         100,
         undefined,
         expect.objectContaining({ tenantIdEquals: tenantId }),
+        null,
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page }));
+    });
+
+    it('can find form submissions with sort', async () => {
+      const user = {
+        tenantId,
+        id: 'tester',
+        roles: [FormServiceRoles.Admin],
+      };
+      const req = {
+        user,
+        query: {
+          sortBy: 'data.firstName',
+          sortDirection: 'asc',
+        },
+        tenant: { id: tenantId },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      const page = {};
+      formSubmissionMock.find.mockResolvedValueOnce({ results: [formSubmissionEntity], page });
+
+      const handler = findSubmissions(apiId, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(formSubmissionMock.find).toBeCalledWith(100, undefined, expect.any(Object), {
+        field: 'data.firstName',
+        direction: 'asc',
+      });
     });
 
     it('can find form submissions of definition', async () => {
@@ -2075,6 +2164,7 @@ describe('form router', () => {
         10,
         'abc-123',
         expect.objectContaining({ tenantIdEquals: tenantId, definitionIdEquals: definition.id }),
+        null,
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page }));
     });
@@ -2120,6 +2210,7 @@ describe('form router', () => {
         100,
         undefined,
         expect.objectContaining({ tenantIdEquals: tenantId, definitionIdEquals: definition.id }),
+        null,
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page }));
     });
@@ -2226,6 +2317,7 @@ describe('form router', () => {
         100,
         undefined,
         expect.objectContaining({ tenantIdEquals: tenantId, formIdEquals: 'test-form' }),
+        null,
       );
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page }));
     });

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -745,12 +745,21 @@ components:
         required: false
         schema:
           type: string
-      - name: includeData
-        description: Flag indicating if data should be included in results.
+      - name: sortBy
+        description: |
+          Column to sort results on. Use 'created' or 'status' for form fields, and 'data.' followed by
+          the path into the form data for a data value (e.g. 'data.applicant.lastName').
         in: query
         required: false
         schema:
-          type: boolean
+          type: string
+      - name: sortDirection
+        description: Direction of the sort. Defaults to descending.
+        in: query
+        required: false
+        schema:
+          type: string
+          enum: [asc, desc]
       - name: criteria
         description: Criteria for the forms to retrieve.
         in: query
@@ -1050,6 +1059,22 @@ components:
         required: false
         schema:
           type: string
+      - name: sortBy
+        description: |
+          Column to sort results on. Use 'created', 'submissionStatus', or 'disposition' for submission
+          fields, and 'data.' followed by the path into the form data for a data value
+          (e.g. 'data.applicant.lastName').
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: sortDirection
+        description: Direction of the sort. Defaults to descending.
+        in: query
+        required: false
+        schema:
+          type: string
+          enum: [asc, desc]
       - name: criteria
         description: Criteria for form submissions to retrieve.
         in: query
@@ -1125,6 +1150,22 @@ components:
         required: false
         schema:
           type: string
+      - name: sortBy
+        description: |
+          Column to sort results on. Use 'created', 'submissionStatus', or 'disposition' for submission
+          fields, and 'data.' followed by the path into the form data for a data value
+          (e.g. 'data.applicant.lastName').
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: sortDirection
+        description: Direction of the sort. Defaults to descending.
+        in: query
+        required: false
+        schema:
+          type: string
+          enum: [asc, desc]
       - name: criteria
         description: Criteria for form submissions to retrieve.
         in: query

--- a/apps/form-service/src/form/router/form.ts
+++ b/apps/form-service/src/form/router/form.ts
@@ -39,7 +39,7 @@ import { mapForm, mapFormSubmission, mapFormWithFormSubmission } from '../mapper
 import { FormDefinitionEntity, FormEntity, FormSubmissionEntity } from '../model';
 import { FormRepository, FormSubmissionRepository } from '../repository';
 import { ExportServiceRoles, FormServiceRoles } from '../roles';
-import { Form, FormCriteria, FormStatus, FormSubmissionCriteria } from '../types';
+import { Form, FormCriteria, FormStatus, FormSubmissionCriteria, ResultsSort } from '../types';
 import {
   ARCHIVE_FORM_OPERATION,
   FormOperations,
@@ -52,6 +52,13 @@ import { PdfService } from '../pdf';
 import * as HttpStatusCodes from 'http-status-codes';
 
 const configurationApiId = adspId`urn:ads:platform:configuration-service:v2`;
+
+// Results are sorted by create date descending unless the request specifies a sort column; the
+// repository validates the column since only it knows how the results are stored.
+function getResultsSort(query: Record<string, unknown>): ResultsSort {
+  const { sortBy, sortDirection } = query;
+  return sortBy ? { field: sortBy as string, direction: sortDirection === 'asc' ? 'asc' : 'desc' } : null;
+}
 
 export function mapFormData(entity: FormEntity): Pick<Form, 'id' | 'data' | 'files'> {
   return {
@@ -147,7 +154,7 @@ export function findForms(apiId: AdspId, repository: FormRepository): RequestHan
         criteria.tenantIdEquals = user.tenantId;
       }
 
-      const { results, page } = await repository.find(top, after as string, criteria);
+      const { results, page } = await repository.find(top, after as string, criteria, getResultsSort(req.query));
 
       end();
       res.send({
@@ -184,10 +191,15 @@ export function findSubmissions(apiId: AdspId, repository: FormSubmissionReposit
         throw new UnauthorizedUserError('find submissions', user);
       }
 
-      const { results, page } = await repository.find(top, after as string, {
-        ...criteria,
-        tenantIdEquals: tenantId,
-      });
+      const { results, page } = await repository.find(
+        top,
+        after as string,
+        {
+          ...criteria,
+          tenantIdEquals: tenantId,
+        },
+        getResultsSort(req.query),
+      );
 
       res.send({
         results: results.map((r) => mapFormSubmission(apiId, r)),
@@ -228,11 +240,16 @@ export function findFormSubmissions(
         throw new UnauthorizedUserError('find form submissions', user);
       }
 
-      const { results, page } = await repository.find(top, after as string, {
-        ...criteria,
-        tenantIdEquals: tenantId,
-        formIdEquals: formId,
-      });
+      const { results, page } = await repository.find(
+        top,
+        after as string,
+        {
+          ...criteria,
+          tenantIdEquals: tenantId,
+          formIdEquals: formId,
+        },
+        getResultsSort(req.query),
+      );
 
       res.send({
         results: results.map((r) => mapFormSubmission(apiId, r)),
@@ -797,6 +814,8 @@ export function createFormRouter({
           after: { optional: true, isString: true },
           criteria: { optional: true, isJSON: true },
           includeData: { optional: true, isBoolean: true },
+          sortBy: { optional: true, isString: true, isLength: { options: { min: 1, max: 100 } } },
+          sortDirection: { optional: true, isIn: { options: [['asc', 'desc']] } },
         },
         ['query'],
       ),
@@ -898,6 +917,8 @@ export function createFormRouter({
       query('top').optional().isInt({ min: 1, max: 5000 }),
       query('after').optional().isString(),
       query('criteria').optional().custom(validateCriteriaValue),
+      query('sortBy').optional().isString().isLength({ min: 1, max: 100 }),
+      query('sortDirection').optional().isIn(['asc', 'desc']),
     ),
     findSubmissions(apiId, submissionRepository),
   );
@@ -924,6 +945,8 @@ export function createFormRouter({
       query('top').optional().isInt({ min: 1, max: 5000 }),
       query('after').optional().isString(),
       query('criteria').optional().custom(validateCriteriaValue),
+      query('sortBy').optional().isString().isLength({ min: 1, max: 100 }),
+      query('sortDirection').optional().isIn(['asc', 'desc']),
     ),
     findFormSubmissions(apiId, submissionRepository, repository),
   );

--- a/apps/form-service/src/form/types/index.ts
+++ b/apps/form-service/src/form/types/index.ts
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19 — re-exports only.
 export * from './definition';
 export * from './fileTypes';
 export * from './form';

--- a/apps/form-service/src/form/types/index.ts
+++ b/apps/form-service/src/form/types/index.ts
@@ -3,3 +3,4 @@ export * from './fileTypes';
 export * from './form';
 export * from './formSubmission';
 export * from './intake';
+export * from './sort';

--- a/apps/form-service/src/form/types/sort.ts
+++ b/apps/form-service/src/form/types/sort.ts
@@ -1,3 +1,5 @@
+// clean-code-ignore: RULE-19 — type declarations only; the sort they describe is covered by
+// ../../mongo/sort.spec.ts.
 export type SortDirection = 'asc' | 'desc';
 
 // Sorting of forms and submissions is single column; the field is a logical column name that the

--- a/apps/form-service/src/form/types/sort.ts
+++ b/apps/form-service/src/form/types/sort.ts
@@ -1,0 +1,8 @@
+export type SortDirection = 'asc' | 'desc';
+
+// Sorting of forms and submissions is single column; the field is a logical column name that the
+// repository maps onto the underlying document, so that stored field names are not part of the API.
+export interface ResultsSort {
+  field: string;
+  direction: SortDirection;
+}

--- a/apps/form-service/src/mongo/form.ts
+++ b/apps/form-service/src/mongo/form.ts
@@ -2,12 +2,18 @@ import { AdspId } from '@abgov/adsp-service-sdk';
 import { decodeAfter, encodeNext, InvalidOperationError, Results } from '@core-services/core-common';
 import { Model, model } from 'mongoose';
 import { Logger } from 'winston';
-import { FormCriteria, FormEntity, FormRepository } from '../form';
+import { FormCriteria, FormEntity, FormRepository, ResultsSort } from '../form';
 import { FormDefinitionRepository } from '../form';
 import { NotificationService, Subscriber } from '../notification';
 import { toDataCriteriaQuery } from './criteria';
+import { toSortQuery } from './sort';
 import { formSchema } from './schema';
 import { FormDoc } from './types';
+
+const SORT_FIELDS = {
+  created: 'created',
+  status: 'status',
+};
 
 export class MongoFormRepository implements FormRepository {
   private model: Model<Document & FormDoc>;
@@ -25,7 +31,7 @@ export class MongoFormRepository implements FormRepository {
     });
   }
 
-  find(top: number, after: string, criteria: FormCriteria): Promise<Results<FormEntity>> {
+  find(top: number, after: string, criteria: FormCriteria, sort?: ResultsSort): Promise<Results<FormEntity>> {
     const skip = decodeAfter(after);
     const baseQuery: Record<string, unknown> = {};
 
@@ -78,7 +84,7 @@ export class MongoFormRepository implements FormRepository {
     const results = new Promise<FormEntity[]>((resolve, reject) => {
       this.model
         .find(query, null, { lean: true })
-        .sort({ created: -1 })
+        .sort(toSortQuery(sort, SORT_FIELDS, 'data'))
         .skip(skip)
         .limit(top)
         .exec((err, docs) => (err ? reject(err) : resolve(Promise.all(docs.map((doc) => this.fromDoc(doc))))));

--- a/apps/form-service/src/mongo/formSubmission.ts
+++ b/apps/form-service/src/mongo/formSubmission.ts
@@ -8,8 +8,10 @@ import {
   FormSubmissionCriteria,
   FormSubmissionEntity,
   FormSubmissionRepository,
+  ResultsSort,
 } from '../form';
 import { toDataCriteriaQuery } from './criteria';
+import { toSortQuery } from './sort';
 import { formSubmissionSchema } from './schema';
 import { FormSubmissionDoc } from './types';
 
@@ -32,6 +34,12 @@ function toCreateDateQuery(criteria: FormSubmissionCriteria): Record<string, str
   };
 }
 
+const SORT_FIELDS = {
+  created: 'created',
+  submissionStatus: 'submissionStatus',
+  disposition: 'disposition.status',
+};
+
 export class MongoFormSubmissionRepository implements FormSubmissionRepository {
   private submissionModel: Model<Document & FormSubmissionDoc>;
 
@@ -48,7 +56,12 @@ export class MongoFormSubmissionRepository implements FormSubmissionRepository {
     });
   }
 
-  find(top: number, after: string, criteria: FormSubmissionCriteria): Promise<Results<FormSubmissionEntity>> {
+  find(
+    top: number,
+    after: string,
+    criteria: FormSubmissionCriteria,
+    sort?: ResultsSort,
+  ): Promise<Results<FormSubmissionEntity>> {
     // tenantId is a required criteria.
     if (!criteria?.tenantIdEquals) {
       throw new InvalidOperationError('Cannot retrieve submissions without tenant context.');
@@ -104,7 +117,7 @@ export class MongoFormSubmissionRepository implements FormSubmissionRepository {
     const results = new Promise<FormSubmissionEntity[]>((resolve, reject) => {
       this.submissionModel
         .find(query, null, { lean: true })
-        .sort({ created: -1 })
+        .sort(toSortQuery(sort, SORT_FIELDS, 'formData'))
         .skip(skip)
         .limit(top)
         .exec((err, docs) =>

--- a/apps/form-service/src/mongo/sort.spec.ts
+++ b/apps/form-service/src/mongo/sort.spec.ts
@@ -1,0 +1,57 @@
+import { InvalidOperationError } from '@core-services/core-common';
+import { toSortQuery } from './sort';
+
+describe('toSortQuery', () => {
+  const fields = { created: 'created', status: 'status', disposition: 'disposition.status' };
+
+  it('can sort by create date descending by default', () => {
+    expect(toSortQuery(null, fields, 'data')).toEqual({ created: -1 });
+  });
+
+  it('can sort by create date descending for sort without field', () => {
+    expect(toSortQuery({ field: '', direction: 'asc' }, fields, 'data')).toEqual({ created: -1 });
+  });
+
+  it('can sort ascending on create date', () => {
+    expect(toSortQuery({ field: 'created', direction: 'asc' }, fields, 'data')).toEqual({ created: 1 });
+  });
+
+  it('can sort descending on create date', () => {
+    expect(toSortQuery({ field: 'created', direction: 'desc' }, fields, 'data')).toEqual({ created: -1 });
+  });
+
+  it('can sort on mapped field with create date tie breaker', () => {
+    expect(toSortQuery({ field: 'disposition', direction: 'asc' }, fields, 'data')).toEqual({
+      'disposition.status': 1,
+      created: -1,
+    });
+  });
+
+  it('can sort on data value', () => {
+    expect(toSortQuery({ field: 'data.firstName', direction: 'desc' }, fields, 'formData')).toEqual({
+      'formData.firstName': -1,
+      created: -1,
+    });
+  });
+
+  it('can sort on nested data value', () => {
+    expect(toSortQuery({ field: 'data.applicant.lastName', direction: 'asc' }, fields, 'data')).toEqual({
+      'data.applicant.lastName': 1,
+      created: -1,
+    });
+  });
+
+  it('can throw for unrecognized field', () => {
+    expect(() => toSortQuery({ field: 'updatedBy', direction: 'asc' }, fields, 'data')).toThrow(InvalidOperationError);
+  });
+
+  it('can throw for data value path with unsupported characters', () => {
+    expect(() => toSortQuery({ field: 'data.$where', direction: 'asc' }, fields, 'data')).toThrow(
+      InvalidOperationError,
+    );
+  });
+
+  it('can throw for empty data value path', () => {
+    expect(() => toSortQuery({ field: 'data.', direction: 'asc' }, fields, 'data')).toThrow(InvalidOperationError);
+  });
+});

--- a/apps/form-service/src/mongo/sort.ts
+++ b/apps/form-service/src/mongo/sort.ts
@@ -1,0 +1,42 @@
+import { InvalidOperationError } from '@core-services/core-common';
+import { ResultsSort } from '../form';
+
+// Data value columns are sorted by the path into the form data, prefixed to distinguish them from
+// the fields of the form or submission itself.
+const DATA_VALUE_PREFIX = 'data.';
+const DATA_VALUE_PATH_PATTERN = /^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/;
+
+const DEFAULT_SORT: Record<string, 1 | -1> = { created: -1 };
+
+function toSortField(sort: ResultsSort, fields: Record<string, string>, dataField: string): string {
+  const field = fields[sort.field];
+  if (field) {
+    return field;
+  }
+
+  if (sort.field.startsWith(DATA_VALUE_PREFIX)) {
+    const path = sort.field.substring(DATA_VALUE_PREFIX.length);
+    if (DATA_VALUE_PATH_PATTERN.test(path)) {
+      return `${dataField}.${path}`;
+    }
+  }
+
+  throw new InvalidOperationError(`Cannot sort results on field: ${sort.field}`);
+}
+
+// Results are sorted on a single column, with the create date as tie breaker so that paging over
+// values shared by many records (e.g. a status) returns each record exactly once.
+export function toSortQuery(
+  sort: ResultsSort,
+  fields: Record<string, string>,
+  dataField: string,
+): Record<string, 1 | -1> {
+  if (!sort?.field) {
+    return DEFAULT_SORT;
+  }
+
+  const field = toSortField(sort, fields, dataField);
+  const direction = sort.direction === 'asc' ? 1 : -1;
+
+  return field === 'created' ? { created: direction } : { [field]: direction, created: -1 };
+}


### PR DESCRIPTION
CS-5266 — reviewers can sort the forms and submissions tables in the form admin app.

<img width="1605" height="391" alt="image" src="https://github.com/user-attachments/assets/7ef63c99-f255-403a-80e0-c10c1ac7b6d1" />


**form-service**
- `GET /form/v1/forms`, `/submissions` and `/forms/{formId}/submissions` accept `sortBy` and `sortDirection` (`asc`/`desc`, default `desc`); default sort is unchanged (`created` descending).
- `toSortQuery` maps allowed columns (`created`, `status` / `submissionStatus`, `disposition`) and `data.<path>` data values onto the mongo sort, rejecting anything else. Non-date sorts get `created: -1` as tie breaker so skip paging stays stable.

**form-admin-app**
- Created on / Submitted on, Status / Disposition and every data value column are sortable; Tags and Actions are not.
- Sort is held in state and carried through mount, Find, Load more and clear filters; the sorted column and direction are indicated in the header.

Note: sorting has no effect when the Tags filter is active, since those results come from the directory service. Sorting on status, disposition or a data value is not index backed, so very large definitions will fall back to an in-memory sort.