### PR TITLE
fix(jsonforms-components): restore black italic text in help content

### DIFF
--- a/libs/jsonforms-components/src/lib/Additional/HelpContent.css
+++ b/libs/jsonforms-components/src/lib/Additional/HelpContent.css
@@ -10,9 +10,12 @@ li > ol {
   margin-top: initial;
 }
 
-em {
-  font-size: var(--goa-typography-body-s) !important;
-  color: var(--goa-color-text-default) !important;
+/* The GoA design system styles every <em> as small grey hint text
+   (see @abgov/web-components/index.css). Markdown emphasis in help content
+   is not hint text, so keep it matching the copy around it. */
+.help-content-markdown em {
+  font-size: inherit;
+  color: inherit;
 }
 
 .help-content-markdown{

--- a/libs/jsonforms-components/src/lib/Additional/HelpContent.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/HelpContent.tsx
@@ -10,7 +10,7 @@ import { RenderLink } from './LinkControl';
 import { compileSync } from '@mdx-js/mdx';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
-import './HelpContent';
+import './HelpContent.css';
 
 interface OptionProps {
   ariaLabel?: string;


### PR DESCRIPTION
Italicized markdown in HelpContent (`***Traffic Safety Act***`) rendered light grey and undersized in form-app.

`HelpContent.css` exists to neutralize the design system's global `em { color: var(--goa-color-greyscale-200) }` rule, but #5579 changed its import to `'./HelpContent'` — a self-import of the `.tsx` — so it stopped being bundled. This restores the import, scopes the `em` rule under `.help-content-markdown` instead of overriding `em` globally with `!important`, and replaces the invalid `font-size: var(--goa-typography-body-s)` (a `font` shorthand, silently dropped) with `inherit`.

Verified: `HelpContent.spec.tsx` passes (10/10), `nx build form-app` succeeds, and the rule is present in the emitted bundle.
