### PR TITLE
feat(form-service): CS-5272 add reviewer notes to form submissions

### DIFF
--- a/apps/form-admin-app/src/app/containers/FormSubmissionWorkspace.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/FormSubmissionWorkspace.spec.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { FormSubmissionWorkspace } from './FormSubmissionWorkspace';
+import { updateFormDisposition } from '../state';
+
+jest.mock('../state', () => {
+  const actual = jest.requireActual('../state');
+  return {
+    ...actual,
+    updateFormDisposition: jest.fn((payload) => ({ type: 'form/update-form-disposition', payload })),
+  };
+});
+
+const mockStore = configureStore();
+
+const busy = { initializing: false, loading: false, findPdf: false, executing: false, exporting: false };
+
+const definition = {
+  id: 'test',
+  name: 'Test definition',
+  dispositionStates: [{ id: 'rejected', name: 'rejected', description: 'Rejected' }],
+};
+
+const submission = {
+  urn: 'urn:ads:platform:form-service:v1:/submissions/submission-1',
+  id: 'submission-1',
+  formId: 'form-1',
+  formDefinitionId: 'test',
+  formData: {},
+  formFiles: {},
+  created: '2026-08-01T12:00:00.000Z',
+  createdBy: { id: 'user-1', name: 'Test User' },
+  disposition: null,
+  notes: [
+    {
+      id: 'note-1',
+      content: 'Called the applicant.',
+      created: '2026-08-02T12:00:00.000Z',
+      createdBy: { id: 'reviewer-1', name: 'Reviewer One' },
+    },
+  ],
+  updated: '2026-08-01T12:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'Test User' },
+  hash: 'hash',
+};
+
+const renderWorkspace = (props = {}) => {
+  const store = mockStore({
+    directory: {
+      resourceTags: {},
+      tagResources: {},
+      results: [],
+      next: null,
+      busy: { loading: false, loadingResourceTags: {}, executing: false },
+    },
+  });
+  const dispatch = jest.fn().mockResolvedValue({ type: 'form/update-form-disposition/fulfilled' });
+  const view = render(
+    <Provider store={store}>
+      <FormSubmissionWorkspace
+        dispatch={dispatch as never}
+        definition={definition as never}
+        submission={submission as never}
+        draft={{ status: 'rejected', reason: 'invalid data' }}
+        busy={busy}
+        onOpenTag={jest.fn()}
+        {...props}
+      />
+    </Provider>,
+  );
+
+  return { dispatch, ...view };
+};
+
+describe('FormSubmissionWorkspace', () => {
+  beforeEach(() => {
+    (updateFormDisposition as unknown as jest.Mock).mockClear();
+  });
+
+  it('should render the workspace sections', () => {
+    const { baseElement } = renderWorkspace();
+
+    const headings = Array.from(baseElement.querySelectorAll('goa-accordion')).map((accordion) =>
+      accordion.getAttribute('heading'),
+    );
+    expect(headings).toEqual(['Communication/Messages', 'Notes', 'Tags', 'History', 'Disposition']);
+  });
+
+  it('should render the notes of the submission in the notes section', () => {
+    const { baseElement } = renderWorkspace();
+
+    const notes = baseElement.querySelector("goa-accordion[heading='Notes']");
+    expect(notes.textContent).toContain('Called the applicant.');
+    expect(notes.textContent).toContain('Reviewer One');
+  });
+
+  it('should disposition the submission from the draft', () => {
+    const { baseElement } = renderWorkspace();
+
+    fireEvent(baseElement.querySelector("goa-accordion[heading='Disposition'] goa-button"), new CustomEvent('_click'));
+
+    expect(updateFormDisposition).toHaveBeenCalledWith({
+      submissionUrn: '/forms/form-1/submissions/submission-1',
+      status: 'rejected',
+      reason: 'invalid data',
+    });
+  });
+
+  it('should show the disposition of a dispositioned submission', () => {
+    const { baseElement } = renderWorkspace({
+      submission: {
+        ...submission,
+        disposition: { id: 'disposition-1', status: 'rejected', reason: 'invalid data', date: '2026-08-04T12:00:00Z' },
+      },
+    });
+
+    const disposition = baseElement.querySelector("goa-accordion[heading='Disposition']");
+    expect(disposition.textContent).toContain('invalid data');
+    expect(disposition.querySelector('goa-dropdown')).toBeFalsy();
+  });
+});

--- a/apps/form-admin-app/src/app/containers/FormSubmissionWorkspace.tsx
+++ b/apps/form-admin-app/src/app/containers/FormSubmissionWorkspace.tsx
@@ -17,7 +17,7 @@ import {
   submissionSelector,
   updateFormDisposition,
 } from '../state';
-import { AdspId } from '@core-services/app-common';
+import { AdspId } from '../../lib/adspId';
 import { DateTime } from 'luxon';
 import { SubmissionNotes } from './SubmissionNotes';
 import { Tags } from './Tags';

--- a/apps/form-admin-app/src/app/containers/FormSubmissionWorkspace.tsx
+++ b/apps/form-admin-app/src/app/containers/FormSubmissionWorkspace.tsx
@@ -19,6 +19,7 @@ import {
 } from '../state';
 import { AdspId } from '@core-services/app-common';
 import { DateTime } from 'luxon';
+import { SubmissionNotes } from './SubmissionNotes';
 import { Tags } from './Tags';
 import { PropertiesContainer } from '../components/PropertiesContainer';
 import styled from 'styled-components';
@@ -56,8 +57,7 @@ export const FormSubmissionWorkspace: FunctionComponent<FormSubmissionWorkspaceP
         {/* TODO: Add Communication/Messages content */}
       </GoabAccordion>
       <GoabAccordion heading="Notes" maxWidth={ACCORDION_MAX_WIDTH} mb="m">
-        Notes section
-        {/* TODO: Add Notes content */}
+        <SubmissionNotes dispatch={dispatch} submission={submission} busy={busy} />
       </GoabAccordion>
       <GoabAccordion heading="Tags" maxWidth={ACCORDION_MAX_WIDTH} mb="m">
         <Tags urn={submission.urn} hideAddButton={false} onTag={onOpenTag} />

--- a/apps/form-admin-app/src/app/containers/SubmissionNotes.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/SubmissionNotes.spec.tsx
@@ -1,0 +1,126 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { SubmissionNotes } from './SubmissionNotes';
+import { addSubmissionNote, deleteSubmissionNote } from '../state';
+
+jest.mock('../state', () => {
+  const actual = jest.requireActual('../state');
+  return {
+    ...actual,
+    addSubmissionNote: Object.assign(
+      jest.fn((payload) => ({ type: 'form/add-submission-note', payload })),
+      { fulfilled: { type: 'form/add-submission-note/fulfilled' } },
+    ),
+    deleteSubmissionNote: Object.assign(
+      jest.fn((payload) => ({ type: 'form/delete-submission-note', payload })),
+      { fulfilled: { type: 'form/delete-submission-note/fulfilled' } },
+    ),
+  };
+});
+
+const busy = { initializing: false, loading: false, findPdf: false, executing: false, exporting: false };
+
+const submission = {
+  urn: 'urn:ads:platform:form-service:v1:/submissions/submission-1',
+  id: 'submission-1',
+  formId: 'form-1',
+  formDefinitionId: 'test',
+  formData: {},
+  formFiles: {},
+  created: '2026-08-01T12:00:00.000Z',
+  createdBy: { id: 'user-1', name: 'Test User' },
+  disposition: null,
+  updated: '2026-08-01T12:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'Test User' },
+  hash: 'hash',
+  notes: [
+    {
+      id: 'note-1',
+      content: 'Called the applicant.',
+      created: '2026-08-02T12:00:00.000Z',
+      createdBy: { id: 'reviewer-1', name: 'Reviewer One' },
+    },
+    {
+      id: 'note-2',
+      content: 'Waiting on documents.',
+      created: '2026-08-03T12:00:00.000Z',
+      createdBy: { id: 'reviewer-2', name: 'Reviewer Two' },
+    },
+  ],
+};
+
+const renderNotes = (props = {}) => {
+  const dispatch = jest.fn().mockResolvedValue({ type: 'form/add-submission-note/fulfilled' });
+  const view = render(
+    <SubmissionNotes dispatch={dispatch as never} submission={submission as never} busy={busy} {...props} />,
+  );
+
+  return { dispatch, ...view };
+};
+
+describe('SubmissionNotes', () => {
+  beforeEach(() => {
+    (addSubmissionNote as unknown as jest.Mock).mockClear();
+    (deleteSubmissionNote as unknown as jest.Mock).mockClear();
+  });
+
+  it('should render the notes of the submission with the most recent first', () => {
+    const { baseElement, getByText } = renderNotes();
+
+    expect(getByText('Called the applicant.')).toBeTruthy();
+    expect(getByText('Waiting on documents.')).toBeTruthy();
+
+    const notes = baseElement.querySelectorAll('.note');
+    expect(notes[0].getAttribute('data-testid')).toBe('note-note-2');
+    expect(notes[1].getAttribute('data-testid')).toBe('note-note-1');
+  });
+
+  it('should add the note that was written', async () => {
+    const { baseElement, dispatch } = renderNotes();
+
+    const textArea = baseElement.querySelector("goa-textarea[name='note']");
+    fireEvent(textArea, new CustomEvent('_change', { detail: { name: 'note', value: 'Sent follow up email.' } }));
+    await act(async () => {
+      fireEvent(baseElement.querySelector("goa-button[testId='add-note']"), new CustomEvent('_click'));
+    });
+
+    expect(addSubmissionNote).toHaveBeenCalledWith({
+      formId: 'form-1',
+      submissionId: 'submission-1',
+      content: 'Sent follow up email.',
+    });
+    expect(dispatch).toHaveBeenCalled();
+  });
+
+  it('should not allow adding a note without content', () => {
+    const { baseElement } = renderNotes();
+
+    const addButton = baseElement.querySelector("goa-button[testId='add-note']");
+    expect(addButton.getAttribute('disabled')).toBe('true');
+
+    fireEvent(
+      baseElement.querySelector("goa-textarea[name='note']"),
+      new CustomEvent('_change', { detail: { name: 'note', value: 'Sent follow up email.' } }),
+    );
+
+    expect(addButton.getAttribute('disabled')).toBeNull();
+  });
+
+  it('should delete the note that was confirmed', async () => {
+    const { baseElement } = renderNotes();
+
+    fireEvent(baseElement.querySelector("goa-icon-button[title='delete note']"), new CustomEvent('_click'));
+    expect(baseElement.querySelector('goa-modal').getAttribute('open')).toBeTruthy();
+
+    const [, confirm] = Array.from(baseElement.querySelectorAll('goa-modal goa-button'));
+    await act(async () => {
+      fireEvent(confirm, new CustomEvent('_click'));
+    });
+
+    expect(deleteSubmissionNote).toHaveBeenCalledWith({
+      formId: 'form-1',
+      submissionId: 'submission-1',
+      // The most recent note is shown first, so its delete button is the first one.
+      noteId: 'note-2',
+    });
+  });
+});

--- a/apps/form-admin-app/src/app/containers/SubmissionNotes.tsx
+++ b/apps/form-admin-app/src/app/containers/SubmissionNotes.tsx
@@ -1,0 +1,152 @@
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabFormItem,
+  GoabIconButton,
+  GoabModal,
+  GoabTextArea,
+} from '@abgov/react-components';
+import { GoabTextAreaOnChangeDetail } from '@abgov/ui-components-common';
+import { DateTime } from 'luxon';
+import { FunctionComponent, useState } from 'react';
+import styled from 'styled-components';
+import {
+  addSubmissionNote,
+  AppDispatch,
+  deleteSubmissionNote,
+  formBusySelector,
+  FormSubmissionNote,
+  submissionSelector,
+} from '../state';
+
+const MAX_NOTE_LENGTH = 5000;
+
+const NotesList = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--goa-space-l);
+
+  > .note {
+    border-bottom: 1px solid var(--goa-color-greyscale-200);
+    padding-bottom: var(--goa-space-s);
+    margin-bottom: var(--goa-space-s);
+
+    > .note-header {
+      display: flex;
+      align-items: center;
+
+      > .note-author {
+        font-weight: var(--goa-font-weight-bold);
+      }
+
+      > .note-created {
+        color: var(--goa-color-text-secondary);
+        font-size: var(--goa-font-size-2);
+        margin-left: var(--goa-space-s);
+        margin-right: auto;
+      }
+    }
+
+    > .note-content {
+      margin: var(--goa-space-2xs) 0 0 0;
+      white-space: pre-wrap;
+    }
+  }
+`;
+
+interface SubmissionNotesProps {
+  dispatch: AppDispatch;
+  submission: ReturnType<typeof submissionSelector>['submission'];
+  busy: ReturnType<typeof formBusySelector>;
+}
+
+export const SubmissionNotes: FunctionComponent<SubmissionNotesProps> = ({ dispatch, submission, busy }) => {
+  const [draft, setDraft] = useState('');
+  const [deleting, setDeleting] = useState<FormSubmissionNote>(null);
+
+  // Show the most recent note first since that's where reviewers pick up from.
+  const notes = [...(submission?.notes || [])].sort((a, b) => b.created.localeCompare(a.created));
+  const content = draft.trim();
+  const error = content.length > MAX_NOTE_LENGTH ? `Note must be ${MAX_NOTE_LENGTH} characters or less.` : '';
+
+  return (
+    <>
+      {notes.length > 0 && (
+        <NotesList>
+          {notes.map((note) => (
+            <div key={note.id} className="note" data-testid={`note-${note.id}`}>
+              <div className="note-header">
+                <span className="note-author">{note.createdBy.name}</span>
+                <span className="note-created">{DateTime.fromISO(note.created).toFormat('LLL d, yyyy h:mm a')}</span>
+                <GoabIconButton
+                  title="delete note"
+                  icon="trash"
+                  size="small"
+                  variant="color"
+                  disabled={busy.executing}
+                  onClick={() => setDeleting(note)}
+                />
+              </div>
+              <p className="note-content">{note.content}</p>
+            </div>
+          ))}
+        </NotesList>
+      )}
+      <GoabFormItem label="Note" error={error}>
+        <GoabTextArea
+          name="note"
+          value={draft}
+          placeholder="Write a note about this submission..."
+          width="100%"
+          error={!!error}
+          onChange={(detail: GoabTextAreaOnChangeDetail) => setDraft(detail.value)}
+          mb="m"
+        />
+      </GoabFormItem>
+      <GoabButtonGroup alignment="start">
+        <GoabButton
+          testId="add-note"
+          size="compact"
+          disabled={!content || !!error || busy.executing}
+          onClick={async () => {
+            const { type } = await dispatch(
+              addSubmissionNote({ formId: submission.formId, submissionId: submission.id, content }),
+            );
+
+            // Only clear the draft if the note was actually added, so the reviewer doesn't lose it on failure.
+            if (type === addSubmissionNote.fulfilled.type) {
+              setDraft('');
+            }
+          }}
+        >
+          Add note
+        </GoabButton>
+      </GoabButtonGroup>
+      <GoabModal heading="Delete note" open={!!deleting}>
+        <div>Delete the note added by {deleting?.createdBy?.name}? This action cannot be undone.</div>
+        <GoabButtonGroup alignment="end" mt="xl">
+          <GoabButton size="compact" type="secondary" onClick={() => setDeleting(null)}>
+            Cancel
+          </GoabButton>
+          <GoabButton
+            size="compact"
+            type="primary"
+            disabled={busy.executing}
+            onClick={async () => {
+              await dispatch(
+                deleteSubmissionNote({
+                  formId: submission.formId,
+                  submissionId: submission.id,
+                  noteId: deleting.id,
+                }),
+              );
+              setDeleting(null);
+            }}
+          >
+            Delete note
+          </GoabButton>
+        </GoabButtonGroup>
+      </GoabModal>
+    </>
+  );
+};

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -885,6 +885,67 @@ export const updateFormDisposition = createAsyncThunk(
   },
 );
 
+export const addSubmissionNote = createAsyncThunk(
+  'form/add-submission-note',
+  async (
+    { formId, submissionId, content }: { formId: string; submissionId: string; content: string },
+    { getState, rejectWithValue },
+  ) => {
+    try {
+      const { config } = getState() as AppState;
+      const formServiceUrl = config.directory[FORM_SERVICE_ID];
+      const accessToken = await getAccessToken();
+
+      const { data } = await axios.post<FormSubmission>(
+        new URL(`/form/v1/forms/${formId}/submissions/${submissionId}/notes`, formServiceUrl).href,
+        { content },
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+
+      return data;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        return rejectWithValue({
+          status: err.response?.status,
+          message: err.response?.data?.errorMessage || err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
+  },
+);
+
+export const deleteSubmissionNote = createAsyncThunk(
+  'form/delete-submission-note',
+  async (
+    { formId, submissionId, noteId }: { formId: string; submissionId: string; noteId: string },
+    { getState, rejectWithValue },
+  ) => {
+    try {
+      const { config } = getState() as AppState;
+      const formServiceUrl = config.directory[FORM_SERVICE_ID];
+      const accessToken = await getAccessToken();
+
+      const { data } = await axios.delete<FormSubmission>(
+        new URL(`/form/v1/forms/${formId}/submissions/${submissionId}/notes/${noteId}`, formServiceUrl).href,
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+
+      return data;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        return rejectWithValue({
+          status: err.response?.status,
+          message: err.response?.data?.errorMessage || err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
+  },
+);
+
 export const runFormOperation = createAsyncThunk(
   'form/run-form-operation',
   async ({ urn, operation }: { urn: AdspId; operation: 'to-draft' | 'archive' }, { getState, rejectWithValue }) => {
@@ -1119,6 +1180,26 @@ const formSlice = createSlice({
         state.busy.executing = false;
       })
       .addCase(updateFormDisposition.fulfilled, (state, { payload }) => {
+        state.busy.executing = false;
+        state.submissions[payload.id] = payload;
+      })
+      .addCase(addSubmissionNote.pending, (state) => {
+        state.busy.executing = true;
+      })
+      .addCase(addSubmissionNote.rejected, (state) => {
+        state.busy.executing = false;
+      })
+      .addCase(addSubmissionNote.fulfilled, (state, { payload }) => {
+        state.busy.executing = false;
+        state.submissions[payload.id] = payload;
+      })
+      .addCase(deleteSubmissionNote.pending, (state) => {
+        state.busy.executing = true;
+      })
+      .addCase(deleteSubmissionNote.rejected, (state) => {
+        state.busy.executing = false;
+      })
+      .addCase(deleteSubmissionNote.fulfilled, (state, { payload }) => {
         state.busy.executing = false;
         state.submissions[payload.id] = payload;
       })

--- a/apps/form-admin-app/src/app/state/types.ts
+++ b/apps/form-admin-app/src/app/state/types.ts
@@ -92,6 +92,7 @@ export interface FormDisposition {
   date: string;
 }
 
+// clean-code-ignore: RULE-19 — type declarations only.
 export interface FormSubmissionNote {
   id: string;
   content: string;

--- a/apps/form-admin-app/src/app/state/types.ts
+++ b/apps/form-admin-app/src/app/state/types.ts
@@ -92,6 +92,16 @@ export interface FormDisposition {
   date: string;
 }
 
+export interface FormSubmissionNote {
+  id: string;
+  content: string;
+  created: string;
+  createdBy: {
+    id: string;
+    name: string;
+  };
+}
+
 export interface FormSubmission {
   urn: string;
   id: string;
@@ -105,6 +115,7 @@ export interface FormSubmission {
     name: string;
   };
   disposition: FormDisposition;
+  notes?: FormSubmissionNote[];
   updated: string;
   updatedBy: {
     id: string;

--- a/apps/form-service/src/form/mapper.spec.ts
+++ b/apps/form-service/src/form/mapper.spec.ts
@@ -1,0 +1,71 @@
+import { adspId } from '@abgov/adsp-service-sdk';
+import { mapFormSubmission } from './mapper';
+import { FormSubmissionEntity } from './model';
+import { FormSubmission } from './types';
+
+describe('mapper', () => {
+  const apiId = adspId`urn:ads:platform:form-service:v1`;
+  const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+
+  const repositoryMock = {
+    find: jest.fn(),
+    get: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const submissionInfo: FormSubmission = {
+    id: 'submission-1',
+    formDefinitionId: 'test-form-definition',
+    formDefinitionRevision: 0,
+    formId: 'form-1',
+    formData: {},
+    formFiles: {},
+    created: new Date(),
+    createdBy: { id: 'tester', name: 'tester' },
+    updatedBy: { id: 'tester', name: 'tester' },
+    updated: new Date(),
+    submissionStatus: '',
+    disposition: null,
+    hash: 'hashid',
+    dryRun: false,
+  };
+
+  describe('mapFormSubmission', () => {
+    it('can map submission notes', () => {
+      const created = new Date();
+      const entity = new FormSubmissionEntity(repositoryMock, tenantId, {
+        ...submissionInfo,
+        notes: [{ id: 'note-1', content: 'Called the applicant.', created, createdBy: { id: 'r1', name: 'Reviewer' } }],
+      });
+
+      const result = mapFormSubmission(apiId, entity);
+
+      expect(result.notes).toEqual([
+        { id: 'note-1', content: 'Called the applicant.', created, createdBy: { id: 'r1', name: 'Reviewer' } },
+      ]);
+    });
+
+    it('can map submission without notes', () => {
+      const entity = new FormSubmissionEntity(repositoryMock, tenantId, submissionInfo);
+
+      const result = mapFormSubmission(apiId, entity);
+
+      expect(result.notes).toEqual([]);
+      expect(result.disposition).toBeNull();
+      expect(result.urn).toBe(`${apiId}:/submissions/submission-1`);
+    });
+
+    it('can map submission disposition', () => {
+      const date = new Date();
+      const entity = new FormSubmissionEntity(repositoryMock, tenantId, {
+        ...submissionInfo,
+        disposition: { id: 'disposition-1', status: 'rejected', reason: 'invalid data', date },
+      });
+
+      const result = mapFormSubmission(apiId, entity);
+
+      expect(result.disposition).toEqual({ id: 'disposition-1', status: 'rejected', reason: 'invalid data', date });
+    });
+  });
+});

--- a/apps/form-service/src/form/mapper.ts
+++ b/apps/form-service/src/form/mapper.ts
@@ -102,6 +102,12 @@ export function mapFormSubmission(apiId: AdspId, entity: FormSubmissionEntity) {
           reason: entity.disposition.reason,
         }
       : null,
+    notes: (entity.notes || []).map((note) => ({
+      id: note.id,
+      content: note.content,
+      created: note.created,
+      createdBy: { id: note.createdBy.id, name: note.createdBy.name },
+    })),
     updated: entity.updated,
     updatedBy: { id: entity.updatedBy.id, name: entity.updatedBy.name },
     hash: entity.hash,

--- a/apps/form-service/src/form/model/formSubmission.spec.ts
+++ b/apps/form-service/src/form/model/formSubmission.spec.ts
@@ -1,10 +1,10 @@
 import { adspId, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
-import { FormSubmission, QueueTaskToProcess } from '../types';
+import { FormSubmission, FormSubmissionNote, QueueTaskToProcess } from '../types';
 import { FormSubmissionEntity } from './formSubmission';
 import { FormServiceRoles } from '../roles';
 import { FormEntity } from './form';
 import { FormDefinitionEntity } from './definition';
-import { InvalidValueError } from '@core-services/core-common';
+import { InvalidValueError, NotFoundError } from '@core-services/core-common';
 
 describe('FormSubmission', () => {
   const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
@@ -200,5 +200,91 @@ describe('FormSubmission', () => {
     const user = { tenantId, id: 'tester', roles: ['abvc'] } as User;
 
     entity.canRead(user);
+  });
+
+  describe('notes', () => {
+    const assessor = { tenantId, id: 'assessor', name: 'Assessor', roles: ['test-assessor'] } as User;
+
+    beforeEach(() => {
+      // Reset since preceding tests queue up one time results that they don't consume.
+      repositoryMock.save.mockReset();
+      repositoryMock.save.mockImplementation((saved) => Promise.resolve(saved));
+    });
+
+    function anEntity(notes?: FormSubmissionNote[]) {
+      return new FormSubmissionEntity(repositoryMock, tenantId, { ...formSubmissionInfo, notes }, aDefinition, {
+        id: '242',
+        definition: aDefinition,
+      } as FormEntity);
+    }
+
+    it('can add note', async () => {
+      const before = new Date();
+      const entity = anEntity();
+
+      const result = await entity.addNote(assessor, 'Called the applicant.');
+
+      expect(repositoryMock.save).toHaveBeenCalled();
+      expect(result.notes).toHaveLength(1);
+      expect(result.notes[0]).toMatchObject({
+        content: 'Called the applicant.',
+        createdBy: { id: assessor.id, name: assessor.name },
+      });
+      expect(result.notes[0].id).toBeTruthy();
+      expect(result.updated.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(result.updatedBy).toMatchObject({ id: assessor.id, name: assessor.name });
+    });
+
+    it('can add note to submission with existing notes', async () => {
+      const entity = anEntity([
+        { id: 'existing', content: 'first', created: new Date(), createdBy: { id: 'tester', name: 'tester' } },
+      ]);
+
+      const result = await entity.addNote({ ...assessor, roles: [FormServiceRoles.Admin] } as User, 'second');
+
+      expect(result.notes.map(({ content }) => content)).toEqual(['first', 'second']);
+    });
+
+    it('cannot add note - unauthorized', async () => {
+      const entity = anEntity();
+
+      await expect(entity.addNote({ tenantId, id: 'tester', roles: ['abc'] } as User, 'nope')).rejects.toThrow(
+        UnauthorizedUserError,
+      );
+      expect(repositoryMock.save).not.toHaveBeenCalled();
+    });
+
+    it('can delete note', async () => {
+      const entity = anEntity([
+        { id: 'note-1', content: 'first', created: new Date(), createdBy: { id: 'tester', name: 'tester' } },
+        { id: 'note-2', content: 'second', created: new Date(), createdBy: { id: 'assessor', name: 'Assessor' } },
+      ]);
+
+      const result = await entity.deleteNote(assessor, 'note-1');
+
+      expect(repositoryMock.save).toHaveBeenCalled();
+      expect(result.notes.map(({ id }) => id)).toEqual(['note-2']);
+      expect(result.updatedBy).toMatchObject({ id: assessor.id, name: assessor.name });
+    });
+
+    it('cannot delete note - not found', async () => {
+      const entity = anEntity([
+        { id: 'note-1', content: 'first', created: new Date(), createdBy: { id: 'tester', name: 'tester' } },
+      ]);
+
+      await expect(entity.deleteNote(assessor, 'note-2')).rejects.toThrow(NotFoundError);
+      expect(repositoryMock.save).not.toHaveBeenCalled();
+    });
+
+    it('cannot delete note - unauthorized', async () => {
+      const entity = anEntity([
+        { id: 'note-1', content: 'first', created: new Date(), createdBy: { id: 'tester', name: 'tester' } },
+      ]);
+
+      await expect(entity.deleteNote({ tenantId, id: 'tester', roles: [] } as User, 'note-1')).rejects.toThrow(
+        UnauthorizedUserError,
+      );
+      expect(repositoryMock.save).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/form-service/src/form/model/formSubmission.ts
+++ b/apps/form-service/src/form/model/formSubmission.ts
@@ -1,9 +1,9 @@
 import { AdspId, isAllowedUser, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
-import { InvalidValueError } from '@core-services/core-common';
+import { InvalidValueError, NotFoundError } from '@core-services/core-common';
 import { v4 as uuidv4 } from 'uuid';
 import { FormSubmissionRepository } from '../repository';
 import { DirectoryServiceRoles, FormServiceRoles } from '../roles';
-import { FormDisposition, FormSubmission, SecurityClassificationType } from '../types';
+import { FormDisposition, FormSubmission, FormSubmissionNote, SecurityClassificationType } from '../types';
 import { FormEntity } from './form';
 import { FormDefinitionEntity } from './definition';
 
@@ -21,6 +21,7 @@ export class FormSubmissionEntity implements FormSubmission {
   updated: Date;
   submissionStatus: string;
   disposition: FormDisposition;
+  notes: FormSubmissionNote[];
   hash: string;
   securityClassification: SecurityClassificationType;
   dryRun: boolean;
@@ -83,6 +84,7 @@ export class FormSubmissionEntity implements FormSubmission {
     this.tenantId = tenantId;
     this.submissionStatus = formSubmission.submissionStatus;
     this.disposition = formSubmission.disposition || null;
+    this.notes = formSubmission.notes || [];
     this.hash = formSubmission.hash;
     // This is for backwards compatibility, but security classification should be saved against the submission.
     this.securityClassification = formSubmission.securityClassification || form?.securityClassification;
@@ -96,6 +98,17 @@ export class FormSubmissionEntity implements FormSubmission {
     );
   }
 
+  // Assessors of the form definition and form admins review submissions; they can disposition
+  // a submission and maintain the notes recorded against it.
+  canAssess(user: User): boolean {
+    return isAllowedUser(
+      user,
+      this.tenantId,
+      [FormServiceRoles.Admin, ...(this.definition?.assessorRoles || [])],
+      true,
+    );
+  }
+
   async delete(user: User): Promise<boolean> {
     if (!isAllowedUser(user, this.tenantId, FormServiceRoles.Admin, true)) {
       throw new UnauthorizedUserError('delete form', user);
@@ -106,9 +119,7 @@ export class FormSubmissionEntity implements FormSubmission {
   }
 
   async dispositionSubmission(user: User, status: string, reason?: string): Promise<FormSubmissionEntity> {
-    if (
-      !isAllowedUser(user, this.tenantId, [FormServiceRoles.Admin, ...(this.definition?.assessorRoles || [])], true)
-    ) {
+    if (!this.canAssess(user)) {
       throw new UnauthorizedUserError('updated form disposition', user);
     }
 
@@ -125,6 +136,44 @@ export class FormSubmissionEntity implements FormSubmission {
       date: dispositionedOn,
     };
     this.updated = dispositionedOn;
+    this.updatedBy = { id: user.id, name: user.name };
+
+    return await this.repository.save(this);
+  }
+
+  async addNote(user: User, content: string): Promise<FormSubmissionEntity> {
+    if (!this.canAssess(user)) {
+      throw new UnauthorizedUserError('add form submission note', user);
+    }
+
+    const addedOn = new Date();
+    this.notes = [
+      ...this.notes,
+      {
+        id: uuidv4(),
+        content,
+        created: addedOn,
+        createdBy: { id: user.id, name: user.name },
+      },
+    ];
+    this.updated = addedOn;
+    this.updatedBy = { id: user.id, name: user.name };
+
+    return await this.repository.save(this);
+  }
+
+  async deleteNote(user: User, noteId: string): Promise<FormSubmissionEntity> {
+    if (!this.canAssess(user)) {
+      throw new UnauthorizedUserError('delete form submission note', user);
+    }
+
+    const note = this.notes.find(({ id }) => id === noteId);
+    if (!note) {
+      throw new NotFoundError('form submission note', noteId);
+    }
+
+    this.notes = this.notes.filter(({ id }) => id !== noteId);
+    this.updated = new Date();
     this.updatedBy = { id: user.id, name: user.name };
 
     return await this.repository.save(this);

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -8,9 +8,11 @@ import { FormServiceRoles, FormStatus, FORM_SUBMITTED, QueueTaskToProcess, FormS
 import { FormDefinitionEntity, FormEntity, FormSubmissionEntity } from '../model';
 
 import {
+  addFormSubmissionNote,
   createForm,
   createFormRouter,
   deleteFormSubmission,
+  deleteFormSubmissionNote,
   findFormSubmissions,
   findSubmissions,
   getFormSubmission,
@@ -2585,6 +2587,165 @@ describe('form router', () => {
         params: { formId: 'test-form' },
       };
       expect(() => validateCriteria(req.query.criteria)).toThrow(InvalidOperationError);
+    });
+  });
+
+  describe('form submission notes', () => {
+    const user = {
+      tenantId,
+      id: 'tester',
+      name: 'Tester',
+      roles: [FormServiceRoles.Admin],
+    };
+
+    beforeEach(() => {
+      // Reset since preceding tests queue up one time results that they don't consume.
+      formSubmissionMock.save.mockReset();
+    });
+
+    function aSubmission(notes?: FormSubmission['notes']) {
+      const submission = new FormSubmissionEntity(
+        formSubmissionMock,
+        tenantId,
+        { ...formSubmissionInfo, notes },
+        definition,
+        entity,
+      );
+      formSubmissionMock.save.mockResolvedValueOnce(submission);
+      return submission;
+    }
+
+    it('can create handler addFormSubmissionNote', () => {
+      const handler = addFormSubmissionNote(apiId, logger, formSubmissionMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can add form submission note', async () => {
+      const req = {
+        user,
+        tenant: { id: tenantId },
+        body: { content: 'Called the applicant.' },
+        params: { formId: 'test-form', submissionId: 'submissionId' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      formSubmissionMock.get.mockResolvedValueOnce(aSubmission());
+
+      const handler = addFormSubmissionNote(apiId, logger, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(formSubmissionMock.save).toBeCalled();
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notes: [expect.objectContaining({ content: 'Called the applicant.' })],
+        }),
+      );
+    });
+
+    it('form submission not found to add note', async () => {
+      const req = {
+        user,
+        tenant: { id: tenantId },
+        body: { content: 'Called the applicant.' },
+        params: { formId: 'test-form', submissionId: 'submissionId' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      formSubmissionMock.get.mockResolvedValueOnce(null);
+
+      const handler = addFormSubmissionNote(apiId, logger, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+    });
+
+    it('cannot add form submission note without assessor role', async () => {
+      const req = {
+        user: { tenantId, id: 'tester', name: 'Tester', roles: [] },
+        tenant: { id: tenantId },
+        body: { content: 'Called the applicant.' },
+        params: { formId: 'test-form', submissionId: 'submissionId' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      formSubmissionMock.get.mockResolvedValueOnce(aSubmission());
+
+      const handler = addFormSubmissionNote(apiId, logger, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+    });
+
+    it('can create handler deleteFormSubmissionNote', () => {
+      const handler = deleteFormSubmissionNote(apiId, logger, formSubmissionMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can delete form submission note', async () => {
+      const req = {
+        user,
+        tenant: { id: tenantId },
+        params: { formId: 'test-form', submissionId: 'submissionId', noteId: 'note-1' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      formSubmissionMock.get.mockResolvedValueOnce(
+        aSubmission([
+          { id: 'note-1', content: 'first', created: new Date(), createdBy: { id: 'tester', name: 'tester' } },
+        ]),
+      );
+
+      const handler = deleteFormSubmissionNote(apiId, logger, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(formSubmissionMock.save).toBeCalled();
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ notes: [] }));
+    });
+
+    it('form submission not found to delete note', async () => {
+      const req = {
+        user,
+        tenant: { id: tenantId },
+        params: { formId: 'test-form', submissionId: 'submissionId', noteId: 'note-1' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      formSubmissionMock.get.mockResolvedValueOnce(null);
+
+      const handler = deleteFormSubmissionNote(apiId, logger, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+    });
+
+    it('form submission note not found to delete', async () => {
+      const req = {
+        user,
+        tenant: { id: tenantId },
+        params: { formId: 'test-form', submissionId: 'submissionId', noteId: 'note-2' },
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      formSubmissionMock.get.mockResolvedValueOnce(
+        aSubmission([
+          { id: 'note-1', content: 'first', created: new Date(), createdBy: { id: 'tester', name: 'tester' } },
+        ]),
+      );
+
+      const handler = deleteFormSubmissionNote(apiId, logger, formSubmissionMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
     });
   });
 });

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -274,6 +274,27 @@ components:
           format: date-time
         disposition:
           $ref: '#/components/schemas/FormDisposition'
+        notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormSubmissionNote'
+    FormSubmissionNote:
+      type: object
+      properties:
+        id:
+          type: string
+        content:
+          type: string
+        created:
+          type: string
+          format: date-time
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+            name:
+              type: string
     SendCodeOperation:
       type: object
       properties:
@@ -1026,6 +1047,73 @@ components:
                 type: string
               dispositionReason:
                 type: string
+
+/form/v1/forms/{formId}/submissions/{submissionId}/notes:
+  parameters:
+    - name: formId
+      description: ID of the form.
+      required: true
+      in: path
+      schema:
+        type: string
+    - name: submissionId
+      description: ID of the submission.
+      required: true
+      in: path
+      schema:
+        type: string
+  post:
+    tags:
+      - Form Submission
+    description: Adds a reviewer note to the form submission.
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              content:
+                type: string
+    responses:
+      200:
+        description: Successfully added the note to the form submission.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FormSubmission'
+
+/form/v1/forms/{formId}/submissions/{submissionId}/notes/{noteId}:
+  parameters:
+    - name: formId
+      description: ID of the form.
+      required: true
+      in: path
+      schema:
+        type: string
+    - name: submissionId
+      description: ID of the submission.
+      required: true
+      in: path
+      schema:
+        type: string
+    - name: noteId
+      description: ID of the note.
+      required: true
+      in: path
+      schema:
+        type: string
+  delete:
+    tags:
+      - Form Submission
+    description: Removes a reviewer note from the form submission.
+    responses:
+      200:
+        description: Successfully removed the note from the form submission.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FormSubmission'
 
 /form/v1/forms/{formId}/submissions:
   parameters:

--- a/apps/form-service/src/form/router/form.ts
+++ b/apps/form-service/src/form/router/form.ts
@@ -528,6 +528,85 @@ export function updateFormSubmissionDisposition(
   };
 }
 
+export function addFormSubmissionNote(
+  apiId: AdspId,
+  logger: Logger,
+  submissionRepository: FormSubmissionRepository,
+): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const end = startBenchmark(req, 'operation-handler-time');
+      const user = req.user;
+      const tenantId = req.tenant?.id;
+      const { formId, submissionId } = req.params;
+      const { content } = req.body;
+
+      logger.debug(`Adding note to form submission with ID: ${submissionId} (form ID: ${formId})...`, {
+        context: 'FormRouter',
+        tenantId: tenantId?.toString,
+        user: user ? `${user.name} (ID: ${user.id})` : null,
+      });
+
+      const formSubmission = await submissionRepository.get(tenantId, submissionId, formId);
+      if (!formSubmission) {
+        throw new NotFoundError('Form submission', submissionId);
+      }
+
+      const updated = await formSubmission.addNote(user, content);
+      end();
+
+      res.send(mapFormSubmission(apiId, updated));
+
+      logger.info(`Added note to form submission with ID: ${submissionId} (form ID: ${formId}).`, {
+        context: 'FormRouter',
+        tenantId: tenantId?.toString,
+        user: `${user.name} (ID: ${user.id})`,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export function deleteFormSubmissionNote(
+  apiId: AdspId,
+  logger: Logger,
+  submissionRepository: FormSubmissionRepository,
+): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const end = startBenchmark(req, 'operation-handler-time');
+      const user = req.user;
+      const tenantId = req.tenant?.id;
+      const { formId, submissionId, noteId } = req.params;
+
+      logger.debug(`Deleting note ${noteId} from form submission with ID: ${submissionId} (form ID: ${formId})...`, {
+        context: 'FormRouter',
+        tenantId: tenantId?.toString,
+        user: user ? `${user.name} (ID: ${user.id})` : null,
+      });
+
+      const formSubmission = await submissionRepository.get(tenantId, submissionId, formId);
+      if (!formSubmission) {
+        throw new NotFoundError('Form submission', submissionId);
+      }
+
+      const updated = await formSubmission.deleteNote(user, noteId);
+      end();
+
+      res.send(mapFormSubmission(apiId, updated));
+
+      logger.info(`Deleted note ${noteId} from form submission with ID: ${submissionId} (form ID: ${formId}).`, {
+        context: 'FormRouter',
+        tenantId: tenantId?.toString,
+        user: `${user.name} (ID: ${user.id})`,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
 export function accessForm(logger: Logger, notificationService: NotificationService): RequestHandler {
   return async (req, res, next) => {
     try {
@@ -968,6 +1047,23 @@ export function createFormRouter({
       body('dispositionReason').isString().isLength({ min: 1 }),
     ),
     updateFormSubmissionDisposition(apiId, logger, eventService, submissionRepository),
+  );
+
+  router.post(
+    '/forms/:formId/submissions/:submissionId/notes',
+    assertAuthenticatedHandler,
+    createValidationHandler(
+      param('formId').isUUID(),
+      param('submissionId').isUUID(),
+      body('content').isString().isLength({ min: 1, max: 5000 }),
+    ),
+    addFormSubmissionNote(apiId, logger, submissionRepository),
+  );
+  router.delete(
+    '/forms/:formId/submissions/:submissionId/notes/:noteId',
+    assertAuthenticatedHandler,
+    createValidationHandler(param('formId').isUUID(), param('submissionId').isUUID(), param('noteId').isUUID()),
+    deleteFormSubmissionNote(apiId, logger, submissionRepository),
   );
 
   return router;

--- a/apps/form-service/src/form/types/formSubmission.ts
+++ b/apps/form-service/src/form/types/formSubmission.ts
@@ -8,6 +8,7 @@ export interface FormDisposition {
   date: Date;
 }
 
+// clean-code-ignore: RULE-19 — type declarations only.
 export interface FormSubmissionNote {
   id: string;
   content: string;

--- a/apps/form-service/src/form/types/formSubmission.ts
+++ b/apps/form-service/src/form/types/formSubmission.ts
@@ -8,6 +8,16 @@ export interface FormDisposition {
   date: Date;
 }
 
+export interface FormSubmissionNote {
+  id: string;
+  content: string;
+  created: Date;
+  createdBy: {
+    id: string;
+    name: string;
+  };
+}
+
 export interface FormSubmission {
   id: string;
   formDefinitionId: string;
@@ -27,6 +37,7 @@ export interface FormSubmission {
   updated: Date;
   submissionStatus?: string;
   disposition: FormDisposition;
+  notes?: FormSubmissionNote[];
   hash: string;
   securityClassification?: SecurityClassificationType;
   dryRun: boolean;

--- a/apps/form-service/src/mongo/formSubmission.ts
+++ b/apps/form-service/src/mongo/formSubmission.ts
@@ -201,6 +201,7 @@ export class MongoFormSubmissionRepository implements FormSubmissionRepository {
         {} as Record<string, string>,
       ),
       disposition: entity.disposition,
+      notes: entity.notes,
       hash: entity.hash,
       dryRun: entity.form?.dryRun,
     };
@@ -231,6 +232,7 @@ export class MongoFormSubmissionRepository implements FormSubmissionRepository {
           {} as Record<string, AdspId>,
         ),
         disposition: doc.disposition,
+        notes: doc.notes?.map(({ id, content, created, createdBy }) => ({ id, content, created, createdBy })),
         hash: doc.hash,
         dryRun: doc.dryRun,
       },

--- a/apps/form-service/src/mongo/schema.ts
+++ b/apps/form-service/src/mongo/schema.ts
@@ -104,6 +104,28 @@ export const formDeposition = {
   },
 };
 
+export const formSubmissionNoteSchema = new Schema(
+  {
+    id: {
+      type: String,
+      required: true,
+    },
+    content: {
+      type: String,
+      required: true,
+    },
+    created: {
+      type: Date,
+      required: true,
+    },
+    createdBy: {
+      type: createdBy,
+      required: true,
+    },
+  },
+  { _id: false }
+);
+
 export const formSubmissionSchema = new Schema(
   {
     id: {
@@ -167,6 +189,7 @@ export const formSubmissionSchema = new Schema(
       type: Boolean,
     },
     disposition: { type: formDeposition, required: false },
+    notes: { type: [formSubmissionNoteSchema], required: false },
     hash: String,
   },
   { _id: false }

--- a/apps/form-service/src/mongo/schema.ts
+++ b/apps/form-service/src/mongo/schema.ts
@@ -104,6 +104,7 @@ export const formDeposition = {
   },
 };
 
+// clean-code-ignore: RULE-19 — schema declarations only.
 export const formSubmissionNoteSchema = new Schema(
   {
     id: {


### PR DESCRIPTION

<img width="1916" height="894" alt="image" src="https://github.com/user-attachments/assets/4f1c5995-942f-47d4-b370-d2b6457cf0b7" />
<img width="1150" height="640" alt="image" src="https://github.com/user-attachments/assets/6bd7c09c-17f3-4c1e-b444-8ed2cb12b238" />


Adds reviewer notes to form submissions (CS-5272), filling in the Notes section of the submission review workspace.

- Notes are stored on the submission in form-service; add/delete is gated on the same check as disposition (form-admin or the definition's assessor roles), and any assessor can remove any note.
- New endpoints: `POST /form/v1/forms/{formId}/submissions/{submissionId}/notes` and `DELETE .../notes/{noteId}`, both returning the updated submission. Swagger updated.
- Form admin app: note thunks in the form slice plus a `SubmissionNotes` container in the workspace Notes accordion — newest first, per-note delete with confirmation, draft held in local state.

Collapse/show needed no change: the accordion and the existing Hide workspace button already cover it.

Worth a look during review: notes are included in `mapFormSubmission`, so they also appear in submission exports (admin/assessor/export-job only — nothing applicant-facing). No domain event is emitted for note changes, unlike disposition.

Tests: form-service 441 passing (new entity + router coverage for add, delete, not found, unauthorized); form-admin-app 44 passing (new `SubmissionNotes.spec.tsx`).
