### PR TITLE
fix(notification): move template hint text to tooltip and improve notification editor button spaces

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -12,6 +12,8 @@ import {
   TemplatePropertiesGrid,
   TemplatePropertiesSummary,
   BodyEditorFooter,
+  CheckboxRow,
+  CheckboxHint,
 } from './styled-components';
 import { AppDispatch, RootState } from '@store/index';
 import { connectAgent, disconnectAgent, startThread } from '@store/agent/actions';
@@ -35,6 +37,8 @@ import {
   GoabBadge,
   GoabFormItem,
   GoabCheckbox,
+  GoabIcon,
+  GoabTooltip,
 } from '@abgov/react-components';
 import { areObjectsEqual } from '@lib/objectUtil';
 import emailWrapper from './templates/email-wrapper.hbs';
@@ -112,7 +116,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   const editorHeight = height - 200;
   const monaco = useMonaco();
   const bodyEditorHintText =
-    "*GOA default header and footer wrapper is applied if the template doesn't include proper <html> opening and closing tags";
+    "GOA default header and footer wrapper is applied if the template doesn't include proper <html> opening and closing tags";
 
   const agentConnected = useSelector(agentConnectedSelector);
   const notificationEmailAIEnabled = useSelector(
@@ -157,6 +161,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
     setPropertiesOpenMap((prev) => ({ ...prev, [channel]: open }));
   };
 
+  const anyPropertiesOpen = Object.values(propertiesOpenMap).some(Boolean);
   const hasPropertyErrors = !!(errors?.['subject'] || errors?.['title'] || errors?.['subtitle']);
 
   // Make the metadata fields immediately available each time the modal opens.
@@ -276,7 +281,7 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
   } else return null;
 
   return (
-    <TemplateEditorContainer>
+    <TemplateEditorContainer $propertiesOpen={anyPropertiesOpen}>
       <GoabFormItem label="">
         <Tabs
           activeIndex={activeIndex}
@@ -430,22 +435,26 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
 
                         return (
                           <BodyEditorFooter>
-                            <span>{bodyEditorHintText}</span>
-                            <GoabCheckbox
-                              size="compact"
-                              name="use-default-template"
-                              checked={useDefaultTemplate}
-                              data-testid="default-template-checkbox"
-                              description={
-                                isBodyNotEmpty ? 'Clear the current body in order to use the default template.' : ''
-                              }
-                              onChange={(detail: GoabCheckboxOnChangeDetail) => {
-                                setUseDefaultTemplate(detail.checked);
-                                onBodyChange(detail.checked ? emailWrapper : '', item.name);
-                              }}
-                              text="Use default template to edit header and footer"
-                              disabled={isBodyNotEmpty}
-                            />
+                            <CheckboxRow>
+                              <GoabCheckbox
+                                size="compact"
+                                name="use-default-template"
+                                checked={useDefaultTemplate}
+                                data-testid="default-template-checkbox"
+                                onChange={(detail: GoabCheckboxOnChangeDetail) => {
+                                  setUseDefaultTemplate(detail.checked);
+                                  onBodyChange(detail.checked ? emailWrapper : '', item.name);
+                                }}
+                                text="Use default template to edit header and footer"
+                                disabled={isBodyNotEmpty}
+                              />
+                              <GoabTooltip content={bodyEditorHintText} position="top">
+                                <GoabIcon type="information-circle" ariaLabel="About default template" />
+                              </GoabTooltip>
+                              {isBodyNotEmpty && (
+                                <CheckboxHint>(Clear the current body to enable)</CheckboxHint>
+                              )}
+                            </CheckboxRow>
                           </BodyEditorFooter>
                         );
                       })()}

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.ts
@@ -4,13 +4,14 @@ import { SlackPreviewPortal } from './slackPreviewPortal';
 import { SmsPreviewPortal } from './smsPreviewPortal';
 
 // Edit Template components
-export const TemplateEditorContainer = styled.div`
+export const TemplateEditorContainer = styled.div<{ $propertiesOpen?: boolean }>`
   display: flex;
   flex-direction: column;
   flex: 1;
   height: calc(100% - 2rem);
   min-width: 0;
   padding-right: 0.5rem;
+  padding-bottom: ${({ $propertiesOpen }) => ($propertiesOpen ? 0 : 'var(--goa-space-2xl)')};
   margin-top: 2rem;
   overflow: hidden;
   container: template-editor / inline-size;
@@ -82,6 +83,18 @@ export const BodyEditorFooter = styled.div`
   color: var(--goa-color-text-secondary);
 `;
 
+export const CheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0;
+`;
+
+export const CheckboxHint = styled.span`
+  margin-left: var(--goa-space-xs);
+  font: var(--goa-typography-body-s);
+  color: var(--goa-color-text-secondary);
+`;
+
 // Keeps the long "Edit an <channel> template--<service>" heading from eating two lines of
 // vertical space that the body editor could use instead.
 export const TemplateEditorTitle = styled.h3`
@@ -120,8 +133,7 @@ export const EditTemplateActions = styled.div`
   z-index: 1;
   background: white;
   border-top: 1px solid var(--goa-color-greyscale-200);
-  padding: 1rem 0 0.5rem 0
-  padding-top: 1rem;
+  padding: var(--goa-space-xl) 0 var(--goa-space-xs) 0;
 `;
 
 // preview template components


### PR DESCRIPTION
# Summary

* Replace the static hint span below the checkbox with a GoabTooltip info icon so the GOA default header/footer hint is revealed on hover rather than displayed as a persistent block. When the body has content, show an inline hint next to the icon instead of the checkbox description prop. Reduce bottom padding when email properties accordion is open to avoid unnecessary whitespace above the action bar.

<img width="917" height="876" alt="image" src="https://github.com/user-attachments/assets/bd835f4c-ea55-4c44-b071-36a2416c4783" />
