### PR TITLE
fix(form): index nested sort columns singly and add wildcard data indexes

### DIFF
--- a/apps/form-service/src/mongo/schema.spec.ts
+++ b/apps/form-service/src/mongo/schema.spec.ts
@@ -1,0 +1,51 @@
+import { connect, connection, model } from 'mongoose';
+import { formSchema, formSubmissionSchema } from './schema';
+
+// The sortable columns depend on an index the sort can be served from; the deployed database refuses
+// a sort it has no index for rather than sorting the results itself. These cover the declarations so
+// that removing one, or declaring it in a shape the database cannot serve, fails here rather than in
+// the running service.
+describe('schema indexes', () => {
+  let formIndexes: Record<string, unknown>[];
+  let submissionIndexes: Record<string, unknown>[];
+
+  beforeAll(async () => {
+    await connect(process.env.MONGO_URL, { autoIndex: true });
+
+    const formModel = model('schemaSpecForm', formSchema);
+    const submissionModel = model('schemaSpecSubmission', formSubmissionSchema);
+    await formModel.init();
+    await submissionModel.init();
+
+    formIndexes = (await formModel.collection.indexes()) as Record<string, unknown>[];
+    submissionIndexes = (await submissionModel.collection.indexes()) as Record<string, unknown>[];
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  const keysOf = (indexes: Record<string, unknown>[]) =>
+    indexes.map(({ key }) => JSON.stringify(key as Record<string, number>));
+
+  it('can index the form columns that are sorted on', () => {
+    // Top level column with the create date tie breaker, and a wildcard for the data value columns.
+    expect(keysOf(formIndexes)).toEqual(expect.arrayContaining(['{"status":1,"created":1}', '{"data.$**":1}']));
+  });
+
+  it('can index the submission columns that are sorted on', () => {
+    expect(keysOf(submissionIndexes)).toEqual(
+      expect.arrayContaining(['{"submissionStatus":1,"created":1}', '{"disposition.status":1}', '{"formData.$**":1}']),
+    );
+  });
+
+  it('can avoid declaring a composite index on a nested path', () => {
+    // The database supports a composite index on a top level path only, so a compound index that
+    // names a nested path cannot serve the sort it was declared for.
+    const compoundOnNested = [...formIndexes, ...submissionIndexes]
+      .map(({ key }) => Object.keys(key as Record<string, number>))
+      .filter((paths) => paths.length > 1 && paths.some((path) => path.includes('.')));
+
+    expect(compoundOnNested).toEqual([]);
+  });
+});

--- a/apps/form-service/src/mongo/schema.ts
+++ b/apps/form-service/src/mongo/schema.ts
@@ -76,9 +76,12 @@ export const formSchema = new Schema(
 formSchema.index({ tenantId: 1, id: 1 }, { unique: true });
 formSchema.index({ tenantId: 1, definitionId: 1, applicantId: 1 }, { unique: true });
 
-// Sortable columns need an index the sort can be served from. The tie breaker on a column sort
-// follows the sort direction, so one composite index covers both ascending and descending.
+// Sortable columns need an index the sort can be served from. A top level column is sorted with the
+// create date as tie breaker, which one composite index covers in both directions. Data value
+// columns are at paths that vary by definition, so a wildcard index covers them; it indexes single
+// fields only, which is why those columns are sorted on one key.
 formSchema.index({ status: 1, created: 1 });
+formSchema.index({ 'data.$**': 1 });
 
 export const createdBy = {
   id: {
@@ -204,4 +207,6 @@ export const formSubmissionSchema = new Schema(
 
 formSubmissionSchema.index({ tenantId: 1, formDefinitionId: 1 });
 formSubmissionSchema.index({ submissionStatus: 1, created: 1 });
-formSubmissionSchema.index({ 'disposition.status': 1, created: 1 });
+// Nested columns are indexed on their own; a composite index is not supported on a nested path.
+formSubmissionSchema.index({ 'disposition.status': 1 });
+formSubmissionSchema.index({ 'formData.$**': 1 });

--- a/apps/form-service/src/mongo/schema.ts
+++ b/apps/form-service/src/mongo/schema.ts
@@ -1,5 +1,3 @@
-// clean-code-ignore: RULE-19 — schema and index declarations only; the sorts the indexes serve are
-// covered by sort.spec.ts and the repositories that use them by form.spec.ts and formSubmission.spec.ts.
 import { Schema } from 'mongoose';
 import { FormStatus } from '../form';
 

--- a/apps/form-service/src/mongo/sort.spec.ts
+++ b/apps/form-service/src/mongo/sort.spec.ts
@@ -20,9 +20,17 @@ describe('toSortQuery', () => {
     expect(toSortQuery({ field: 'created', direction: 'desc' }, fields, 'data')).toEqual({ created: -1 });
   });
 
-  it('can sort on mapped field with create date tie breaker', () => {
+  it('can sort on a nested mapped field without a tie breaker', () => {
+    // A tie breaker makes it a sort on two keys, which needs a composite index; the database does
+    // not support those on a nested path.
     expect(toSortQuery({ field: 'disposition', direction: 'asc' }, fields, 'data')).toEqual({
       'disposition.status': 1,
+    });
+  });
+
+  it('can sort on a top level mapped field with create date tie breaker', () => {
+    expect(toSortQuery({ field: 'status', direction: 'asc' }, fields, 'data')).toEqual({
+      status: 1,
       created: 1,
     });
   });
@@ -76,6 +84,8 @@ describe('toSortError', () => {
     const result = toSortError(err, sort);
     expect(result).toBeInstanceOf(InvalidOperationError);
     expect(result.message).toContain('data.firstName');
+    // Distinct from the message for a column that is not sortable at all, so the two are told apart.
+    expect(result.message).toContain('no index to serve it');
   });
 
   it('can report an excluded order by path as a request error', () => {

--- a/apps/form-service/src/mongo/sort.ts
+++ b/apps/form-service/src/mongo/sort.ts
@@ -8,24 +8,17 @@ const DATA_VALUE_PATH_PATTERN = /^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/;
 
 const DEFAULT_SORT: Record<string, 1 | -1> = { created: -1 };
 
-interface SortField {
-  field: string;
-  // Data values are at paths that vary by definition, so there is no index declared for them and
-  // the sort has to be one the database can serve without one.
-  isDataValue: boolean;
-}
-
-function toSortField(sort: ResultsSort, fields: Record<string, string>, dataField: string): SortField {
+function toSortField(sort: ResultsSort, fields: Record<string, string>, dataField: string): string {
   // Own properties only; a lookup of an inherited name (constructor, toString) would otherwise pass
   // for a mapped field and put a value that is not a field name into the sort.
   if (Object.prototype.hasOwnProperty.call(fields, sort.field)) {
-    return { field: fields[sort.field], isDataValue: false };
+    return fields[sort.field];
   }
 
   if (sort.field.startsWith(DATA_VALUE_PREFIX)) {
     const path = sort.field.substring(DATA_VALUE_PREFIX.length);
     if (DATA_VALUE_PATH_PATTERN.test(path)) {
-      return { field: `${dataField}.${path}`, isDataValue: true };
+      return `${dataField}.${path}`;
     }
   }
 
@@ -37,9 +30,9 @@ function toSortField(sort: ResultsSort, fields: Record<string, string>, dataFiel
 // follows the sort direction rather than being pinned to descending, so that one composite index
 // serves the column in both directions.
 //
-// A sort on more than one key has to be served from a composite index, which can only be declared
-// for the columns known ahead of time. Data value columns are at paths that vary by definition, so
-// they are sorted on their key alone and ties there fall back to the natural order.
+// The tie breaker makes it a sort on two keys, which has to be served from a composite index, and
+// the database does not support those on a nested path. Nested columns are therefore sorted on
+// their own key, served by a single field index, and ties there fall back to the natural order.
 export function toSortQuery(
   sort: ResultsSort,
   fields: Record<string, string>,
@@ -49,14 +42,12 @@ export function toSortQuery(
     return DEFAULT_SORT;
   }
 
-  const { field, isDataValue } = toSortField(sort, fields, dataField);
+  const field = toSortField(sort, fields, dataField);
   const direction = sort.direction === 'asc' ? 1 : -1;
 
-  if (field === 'created' || isDataValue) {
-    return { [field]: direction };
-  }
-
-  return { [field]: direction, created: direction };
+  return field === 'created' || field.includes('.')
+    ? { [field]: direction }
+    : { [field]: direction, created: direction };
 }
 
 // The database rejects a sort it has no index to serve rather than sorting the results itself, and
@@ -66,6 +57,6 @@ const UNSERVABLE_SORT_PATTERN = /order.by|composite index/i;
 
 export function toSortError(err: Error, sort: ResultsSort): Error {
   return sort?.field && UNSERVABLE_SORT_PATTERN.test(err?.message || '')
-    ? new InvalidOperationError(`Cannot sort results on field: ${sort.field}`)
+    ? new InvalidOperationError(`Cannot sort results on field: ${sort.field} — no index to serve it`)
     : err;
 }


### PR DESCRIPTION
Follow-up to #5758. Sorting still returns 400 in UAT for the Disposition column and every form data column.

Cosmos supports a composite index on a top level path only, so the create date tie breaker is what it could not serve on `disposition.status` — not the nested path itself. Nested columns are now sorted on their own key and indexed singly; top level columns keep the tie breaker and its composite index. Data value paths vary by definition, so a wildcard index covers them, and wildcard indexes are single field which is why those sort on one key too.

The two sort errors now read differently, so "column is not sortable" and "no index to serve it" can be told apart.

Verified: 450 form-service and 48 form-admin-app tests pass, coverage gate holds, both apps build. Nested single-key sorts confirmed index-served via explain, in both directions from one index.

Note for review: MongoDB will not use a wildcard index for a sort, so the data column half cannot be verified locally — per Microsoft's docs Cosmos wildcard indexes behave differently. That needs a dev deploy plus a sort on a data column to confirm.
