### PR TITLE
feat(form-app): surface the form name and messages in the app header

### DIFF
--- a/apps/form-app/src/app/containers/Form.spec.tsx
+++ b/apps/form-app/src/app/containers/Form.spec.tsx
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockState: any;
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSelector: (selector: (state: any) => unknown) => selector(mockState),
+  useDispatch: () => mockDispatch,
+}));
+
+// The thunks are stubbed so the dispatches this container makes can be told apart.
+jest.mock('../state', () => ({
+  ...jest.requireActual('../state'),
+  loadForm: jest.fn(() => ({ type: 'load-form' })),
+  disconnectStream: jest.fn(() => ({ type: 'disconnect-stream' })),
+  setShowMessages: jest.fn((show: boolean) => ({ type: 'set-show-messages', payload: show })),
+}));
+
+jest.mock('../components/DraftFormWrapper', () => ({ DraftFormWrapper: () => <div /> }));
+jest.mock('../components/LogoutModal', () => ({ LogoutModal: () => <div /> }));
+jest.mock('../components/SubmittedForm', () => ({ SubmittedForm: () => <div /> }));
+jest.mock('../components/UserNotAuthorized', () => ({ UserNotAuthorized: () => <div /> }));
+jest.mock('./FormSupportPane', () => ({ FormSupportPane: () => <div data-testid="support-pane" /> }));
+
+const { Form } = require('./Form');
+
+const definition = { id: 'abc111232', name: 'abc111232', dataSchema: {}, uiSchema: { type: 'Categorization' } };
+
+beforeEach(() => {
+  mockDispatch.mockClear();
+  mockState = {
+    form: {
+      selected: definition.id,
+      definitions: { [definition.id]: definition },
+      form: null,
+      data: {},
+      files: {},
+      errors: [],
+      busy: { loading: false, saving: false, submitting: false },
+    },
+    file: { busy: { loaded: true, metadata: {}, download: {} } },
+  };
+});
+
+const renderForm = () =>
+  render(
+    <MemoryRouter>
+      <Form />
+    </MemoryRouter>,
+  );
+
+describe('Form', () => {
+  it('loads the form it is showing', () => {
+    renderForm();
+
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'load-form' });
+  });
+
+  // The drawer visibility is shared state now, so leaving the form has to close it or it would be
+  // open again on the next form.
+  it('closes the messages drawer on the way out', () => {
+    const { unmount } = renderForm();
+    mockDispatch.mockClear();
+
+    unmount();
+
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'disconnect-stream' });
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'set-show-messages', payload: false });
+  });
+});

--- a/apps/form-app/src/app/containers/Form.tsx
+++ b/apps/form-app/src/app/containers/Form.tsx
@@ -16,6 +16,7 @@ import {
   filesSelector,
   formSelector,
   loadForm,
+  setShowMessages,
   showSubmitSelector,
   submitForm,
   updateForm,
@@ -62,9 +63,10 @@ const FormComponent: FunctionComponent<FormProps> = ({ className }) => {
     // when the form has a support topic configured
     dispatch(loadForm(formId));
 
-    // Cleanup comment stream socket on unmount
+    // Cleanup comment stream socket on unmount, and close the drawer so it doesn't carry over.
     return () => {
       dispatch(disconnectStream());
+      dispatch(setShowMessages(false));
     };
   }, [dispatch, formId]);
 
@@ -112,7 +114,8 @@ export const Form = styled(FormComponent)`
   left: 0;
   right: 0;
   display: flex;
-  flex-direction: row-reverse;
+  /* The support pane follows the form content so that it sits on the right hand side. */
+  flex-direction: row;
 
   @media (max-width: 639px) {
     flex-direction: column;

--- a/apps/form-app/src/app/containers/FormHeader.spec.tsx
+++ b/apps/form-app/src/app/containers/FormHeader.spec.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { FormHeader } from './FormHeader';
+
+// The GoA button is a web component; it isn't defined in jsdom, so clicks are simulated with the
+// custom event that the React wrapper listens for.
+function clickMessages(container: HTMLElement) {
+  const button = container.querySelector('goa-button[testid="form-messages-toggle"]');
+  fireEvent(button, new CustomEvent('_click'));
+}
+
+describe('FormHeader', () => {
+  it('shows the form name under the logo', () => {
+    const { getByTestId } = render(<FormHeader heading="Auto test form" />);
+
+    expect(getByTestId('form-header-name')).toHaveTextContent('Auto test form');
+  });
+
+  it('renders the account actions it is given', () => {
+    const { getByText } = render(
+      <FormHeader heading="Auto test form">
+        <span>Roy Styan</span>
+      </FormHeader>,
+    );
+
+    expect(getByText('Roy Styan')).toBeInTheDocument();
+  });
+
+  // The messages control is only for definitions that create a support topic.
+  it('does not show messages by default', () => {
+    const { container } = render(<FormHeader heading="Auto test form" />);
+
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).toBeNull();
+  });
+
+  it('shows messages without a count when nothing is unread', () => {
+    const { container } = render(<FormHeader heading="Auto test form" showMessages={true} unreadMessages={0} />);
+
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).toHaveTextContent('Messages');
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).not.toHaveTextContent('(');
+  });
+
+  it('shows the number of unread messages', () => {
+    const { container } = render(<FormHeader heading="Auto test form" showMessages={true} unreadMessages={3} />);
+
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).toHaveTextContent('Messages (3)');
+  });
+
+  it('toggles the drawer when messages is clicked', () => {
+    const onToggleMessages = jest.fn();
+    const { container } = render(
+      <FormHeader
+        heading="Auto test form"
+        showMessages={true}
+        unreadMessages={1}
+        onToggleMessages={onToggleMessages}
+      />,
+    );
+
+    clickMessages(container);
+
+    expect(onToggleMessages).toHaveBeenCalled();
+  });
+});

--- a/apps/form-app/src/app/containers/FormHeader.tsx
+++ b/apps/form-app/src/app/containers/FormHeader.tsx
@@ -1,0 +1,87 @@
+import { GoabAppHeader, GoabButton } from '@abgov/react-components';
+import { FunctionComponent, ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface FormHeaderProps {
+  className?: string;
+  heading: string;
+  // Messages are only offered on forms whose definition creates a support topic.
+  showMessages?: boolean;
+  unreadMessages?: number;
+  onToggleMessages?: () => void;
+  // Account actions; rendered in the app header utilities slot.
+  children?: ReactNode;
+}
+
+const FormHeaderComponent: FunctionComponent<FormHeaderProps> = ({
+  className,
+  heading,
+  showMessages,
+  unreadMessages,
+  onToggleMessages,
+  children,
+}) => (
+  <div className={className}>
+    {/* The app header falls back to a '[Service Name]' placeholder when heading is empty, so it is
+        given a blank one and the space it reserves is collapsed in the styles below. */}
+    <GoabAppHeader url="/" heading=" ">
+      <div slot="utilities">
+        <span style={{ display: 'none' }}></span>
+        {children}
+      </div>
+    </GoabAppHeader>
+    <div className="headerDetails">
+      <span className="formName" data-testid="form-header-name">
+        {heading}
+      </span>
+      {showMessages && (
+        <GoabButton
+          type="tertiary"
+          size="compact"
+          leadingIcon="chatbubble-ellipses"
+          testId="form-messages-toggle"
+          onClick={onToggleMessages}
+        >
+          {unreadMessages > 0 ? `Messages (${unreadMessages})` : 'Messages'}
+        </GoabButton>
+      )}
+    </div>
+  </div>
+);
+
+// The app header supplies the logo and the account actions only; the form name and the messages
+// toggle sit under them in a second row, and the separator and background belong to the whole
+// header area rather than to the app header alone.
+export const FormHeader = styled(FormHeaderComponent)`
+  --goa-app-header-color-bg: transparent;
+  --goa-app-header-border-bottom: none;
+  --goa-app-header-min-width-service-name: 0;
+  --goa-app-header-max-width-service-name: 0;
+
+  background: var(--goa-color-greyscale-50);
+  border-bottom: var(--goa-border-width-s) solid var(--goa-color-greyscale-150);
+
+  .headerDetails {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--goa-space-m);
+    /* The app header pads its own row with these tokens, switching at 624px, so the form name lines
+       up under the logo and the messages control under the sign out link. */
+    padding: 0 var(--goa-app-header-padding-h-mobile) var(--goa-space-s);
+  }
+
+  @media (min-width: 624px) {
+    .headerDetails {
+      padding-left: var(--goa-app-header-padding-h-desktop);
+      padding-right: var(--goa-app-header-padding-h-desktop);
+    }
+  }
+
+  .formName {
+    font: var(--goa-app-header-typography-service-name);
+    color: var(--goa-app-header-color-service-name);
+    overflow-wrap: anywhere;
+  }
+`;

--- a/apps/form-app/src/app/containers/FormSupportPane.spec.tsx
+++ b/apps/form-app/src/app/containers/FormSupportPane.spec.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockState: any;
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSelector: (selector: (state: any) => unknown) => selector(mockState),
+  useDispatch: () => jest.fn(),
+}));
+
+// The agent connection check is a socket handshake; the pane only needs it to stay unconnected here.
+jest.mock('socket.io-client', () => ({ io: () => ({ on: jest.fn(), disconnect: jest.fn() }) }));
+jest.mock('./CommentsViewer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="comments-viewer" />,
+}));
+jest.mock('./FormAgentChat', () => ({ FormAgentChat: () => <div data-testid="agent-chat" /> }));
+
+const { FormSupportPane } = require('./FormSupportPane');
+
+const FORM = { id: 'form-1', urn: 'urn:form-1', definition: { id: 'abc111232' } };
+const TOPIC = { resourceId: FORM.urn, id: 12, name: 'form-1', commenters: [] };
+
+const stateWith = ({ topic = TOPIC, show = false } = {}) => ({
+  config: { directory: {} },
+  user: { user: { id: 'applicant' } },
+  comment: {
+    topics: topic ? { [topic.resourceId]: topic } : {},
+    selected: { resourceId: topic?.resourceId ?? null },
+    messages: { show, unread: 0, latestCommentId: 0, lastReadCommentId: 0 },
+  },
+});
+
+const renderPane = () => render(<FormSupportPane form={FORM} data={{}} files={{}} />);
+
+describe('FormSupportPane', () => {
+  // The drawer is opened from the header now, so it follows the shared messages state.
+  it('stays closed while messages are not shown', () => {
+    mockState = stateWith({ show: false });
+
+    const { container } = renderPane();
+
+    expect(container.querySelector('[data-show]')).toHaveAttribute('data-show', 'false');
+  });
+
+  it('opens on the questions when messages are shown', () => {
+    mockState = stateWith({ show: true });
+
+    const { container, getByTestId } = renderPane();
+
+    expect(container.querySelector('[data-show]')).toHaveAttribute('data-show', 'true');
+    expect(getByTestId('comments-viewer')).toBeInTheDocument();
+  });
+
+  // CS-5275 removed the '?' launcher from the bottom left of the form.
+  it('has no support launcher of its own', () => {
+    mockState = stateWith({ show: false });
+
+    const { container } = renderPane();
+
+    expect(container.querySelector('goa-icon-button')).toBeNull();
+  });
+});

--- a/apps/form-app/src/app/containers/FormSupportPane.tsx
+++ b/apps/form-app/src/app/containers/FormSupportPane.tsx
@@ -1,4 +1,3 @@
-import { GoabIconButton } from '@abgov/react-components';
 import { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { io } from 'socket.io-client';
@@ -11,6 +10,7 @@ import {
   getAccessToken,
   selectTopic,
   selectedTopicSelector,
+  showMessagesSelector,
 } from '../state';
 import CommentsViewer from './CommentsViewer';
 import { FormAgentChat } from './FormAgentChat';
@@ -50,13 +50,13 @@ const FormSupportPaneComponent: FunctionComponent<FormSupportPaneProps> = ({ cla
 
   const agentServiceUrl = useMemo(() => resolveAgentServiceUrl(directory), [directory]);
 
-  const [showSupportPane, setShowSupportPane] = useState(false);
+  // The pane is opened from the Messages control in the app header, so its visibility is shared state.
+  const showSupportPane = useSelector(showMessagesSelector);
   const [supportTab, setSupportTab] = useState<'comments' | 'agent'>('agent');
   const [agentConnected, setAgentConnected] = useState(false);
 
   const showCommentsFeature = !!topic;
   const showAgentFeature = !!agentServiceUrl && agentConnected;
-  const hasSupportFeature = showCommentsFeature || showAgentFeature;
   const showSupportTabs = showCommentsFeature && showAgentFeature;
 
   useEffect(() => {
@@ -91,6 +91,13 @@ const FormSupportPaneComponent: FunctionComponent<FormSupportPaneProps> = ({ cla
       socket.disconnect();
     };
   }, [agentServiceUrl, connectedUser]);
+
+  // The Messages control in the header opens the drawer on the questions, not on the AI chat.
+  useEffect(() => {
+    if (showSupportPane && showCommentsFeature) {
+      setSupportTab('comments');
+    }
+  }, [showSupportPane, showCommentsFeature]);
 
   useEffect(() => {
     if (supportTab === 'comments' && showCommentsFeature) {
@@ -148,24 +155,6 @@ const FormSupportPaneComponent: FunctionComponent<FormSupportPaneProps> = ({ cla
           ) : null}
         </div>
       </div>
-      <GoabIconButton
-        disabled={!form || !hasSupportFeature}
-        icon="help-circle"
-        size="large"
-        title="Support"
-        onClick={() => {
-          if (!hasSupportFeature) {
-            return;
-          }
-
-          const nextShow = !showSupportPane;
-          setShowSupportPane(nextShow);
-
-          if (nextShow && supportTab === 'comments' && topic?.resourceId !== form?.urn) {
-            dispatch(selectTopic({ resourceId: form.urn }));
-          }
-        }}
-      />
     </div>
   );
 };
@@ -181,7 +170,7 @@ export const FormSupportPane = styled(FormSupportPaneComponent)`
     display: none;
     height: 100%;
     width: 100%;
-    border-right: 1px solid var(--goa-color-greyscale-200);
+    border-left: 1px solid var(--goa-color-greyscale-200);
     background: white;
 
     .supportTabs {
@@ -246,17 +235,5 @@ export const FormSupportPane = styled(FormSupportPaneComponent)`
     flex: 1 1 30%;
     width: auto;
     min-width: 300px;
-  }
-
-  > :last-child {
-    z-index: 3;
-    position: absolute;
-    bottom: var(--goa-space-l);
-    left: var(--goa-space-l);
-    background: white;
-  }
-
-  &[data-show='true'] > :last-child {
-    background: var(--goa-color-greyscale-100);
   }
 `;

--- a/apps/form-app/src/app/containers/FormTenant.spec.tsx
+++ b/apps/form-app/src/app/containers/FormTenant.spec.tsx
@@ -1,0 +1,103 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// The container reads the store through plain selectors, so feeding them a state object is enough
+// and avoids standing up the real store.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockState: any;
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSelector: (selector: (state: any) => unknown) => selector(mockState),
+  useDispatch: () => mockDispatch,
+}));
+
+// The routed content and the feedback widget are not what these tests are about.
+jest.mock('./FormDefinition', () => ({ FormDefinition: () => <div /> }));
+jest.mock('./Forms', () => ({ Forms: () => <div /> }));
+jest.mock('./FeedbackNotification', () => ({ FeedbackNotification: () => <div /> }));
+jest.mock('../util/feedbackUtils', () => ({ useFeedbackLinkHandler: () => undefined }));
+
+const { FormTenant } = require('./FormTenant');
+
+const TOPIC = { resourceId: 'urn:form-1', id: 12, name: 'form-1', commenters: [] };
+
+const stateWith = ({ supportTopic = false, topic = null, unread = 0, show = false } = {}) => ({
+  config: { initialized: true },
+  user: {
+    initialized: true,
+    user: { id: 'applicant', name: 'Roy Styan' },
+    tenant: { id: 'urn:tenant', name: 'autotest' },
+  },
+  form: {
+    selected: 'abc111232',
+    definitions: { abc111232: { id: 'abc111232', name: 'abc111232', supportTopic } },
+    form: null,
+  },
+  comment: {
+    topics: topic ? { [topic.resourceId]: topic } : {},
+    selected: { resourceId: topic?.resourceId ?? null },
+    messages: { show, unread, latestCommentId: 0, lastReadCommentId: 0 },
+  },
+});
+
+const renderTenant = () =>
+  render(
+    <MemoryRouter initialEntries={['/autotest/abc111232']}>
+      <FormTenant />
+    </MemoryRouter>,
+  );
+
+describe('FormTenant', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+  });
+
+  it('shows the form name in the header', () => {
+    mockState = stateWith();
+
+    const { getByTestId } = renderTenant();
+
+    expect(getByTestId('form-header-name')).toHaveTextContent('abc111232');
+  });
+
+  // The support topic checkbox on the definition is what makes questions available at all.
+  it('does not offer messages when the definition has no support topic', () => {
+    mockState = stateWith({ supportTopic: false, topic: TOPIC });
+
+    const { container } = renderTenant();
+
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).toBeNull();
+  });
+
+  // Until a form is loaded there is no topic, so there would be nothing for the drawer to show.
+  it('does not offer messages before the form has a topic', () => {
+    mockState = stateWith({ supportTopic: true, topic: null });
+
+    const { container } = renderTenant();
+
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).toBeNull();
+  });
+
+  it('offers messages with the unread count once there is a topic', () => {
+    mockState = stateWith({ supportTopic: true, topic: TOPIC, unread: 2 });
+
+    const { container } = renderTenant();
+
+    expect(container.querySelector('goa-button[testid="form-messages-toggle"]')).toHaveTextContent('Messages (2)');
+  });
+
+  it('opens the drawer when messages is clicked', () => {
+    mockState = stateWith({ supportTopic: true, topic: TOPIC, show: false });
+
+    const { container } = renderTenant();
+    // Mount dispatches its own initialization, so only what the click causes is of interest.
+    mockDispatch.mockClear();
+    fireEvent(container.querySelector('goa-button[testid="form-messages-toggle"]'), new CustomEvent('_click'));
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/form-app/src/app/containers/FormTenant.tsx
+++ b/apps/form-app/src/app/containers/FormTenant.tsx
@@ -1,4 +1,4 @@
-import { GoabAppHeader, GoabButton, GoabMicrositeHeader } from '@abgov/react-components';
+import { GoabButton, GoabMicrositeHeader } from '@abgov/react-components';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
@@ -11,11 +11,16 @@ import {
   initializeTenant,
   logoutUser,
   selectedDefinition,
+  selectedTopicSelector,
+  setShowMessages,
+  showMessagesSelector,
   tenantSelector,
+  unreadMessagesSelector,
   userSelector,
 } from '../state';
 import { FeedbackNotification } from './FeedbackNotification';
 import { FormDefinition } from './FormDefinition';
+import { FormHeader } from './FormHeader';
 import { useFeedbackLinkHandler } from '../util/feedbackUtils';
 import { Forms } from './Forms';
 
@@ -50,41 +55,48 @@ export const FormTenant = () => {
   useFeedbackLinkHandler();
 
   const { definition } = useSelector(definitionSelector);
+  const topic = useSelector(selectedTopicSelector);
+  const showMessages = useSelector(showMessagesSelector);
+  const unreadMessages = useSelector(unreadMessagesSelector);
   const headerTitle =
     definition?.uiSchema?.options?.mainTitle || definition?.name || 'Alberta Digital Service Platform - Form';
 
   return (
     <React.Fragment>
       <GoabMicrositeHeader type="alpha" feedbackUrlTarget="self" headerUrlTarget="self" feedbackUrl="#" />
-      <GoabAppHeader url="/" heading={headerTitle}>
-        <div slot="utilities">
-          <span style={{ display: 'none' }}></span>
-          {userInitialized && (
-            <AccountActionsDiv>
-              {user && (
-                <>
-                  <span className="username">{user?.name}</span>
-                  <GoabButton
-                    size="compact"
-                    ml="s"
-                    type="tertiary"
-                    data-testid="form-sign-out"
-                    onClick={() => {
-                      if (userForm?.definition) {
-                        dispatch(logoutUser({ tenant, from: `/${tenant.name}/${userForm.definition.id}` }));
-                      } else {
-                        dispatch(logoutUser({ tenant, from: `${location.pathname}` }));
-                      }
-                    }}
-                  >
-                    Sign out
-                  </GoabButton>
-                </>
-              )}
-            </AccountActionsDiv>
-          )}
-        </div>
-      </GoabAppHeader>
+      <FormHeader
+        heading={headerTitle}
+        // The topic is only created for definitions with 'create support topic' checked, and only
+        // once there is a form to raise questions about.
+        showMessages={!!definition?.supportTopic && !!topic}
+        unreadMessages={unreadMessages}
+        onToggleMessages={() => dispatch(setShowMessages(!showMessages))}
+      >
+        {userInitialized && (
+          <AccountActionsDiv>
+            {user && (
+              <>
+                <span className="username">{user?.name}</span>
+                <GoabButton
+                  size="compact"
+                  ml="s"
+                  type="tertiary"
+                  data-testid="form-sign-out"
+                  onClick={() => {
+                    if (userForm?.definition) {
+                      dispatch(logoutUser({ tenant, from: `/${tenant.name}/${userForm.definition.id}` }));
+                    } else {
+                      dispatch(logoutUser({ tenant, from: `${location.pathname}` }));
+                    }
+                  }}
+                >
+                  Sign out
+                </GoabButton>
+              </>
+            )}
+          </AccountActionsDiv>
+        )}
+      </FormHeader>
       <FeedbackNotification />
       <main>
         {userInitialized && (

--- a/apps/form-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-app/src/app/state/comment.slice.spec.ts
@@ -1,0 +1,143 @@
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import { commentReducer, loadComments, loadUnreadMessages, setShowMessages } from './comment.slice';
+
+jest.mock('axios');
+const axiosMock = axios as jest.Mocked<typeof axios>;
+
+const COMMENT_SERVICE_URL = 'https://comment-service';
+const TOPIC = { resourceId: 'urn:ads:platform:form-service:v1:/forms/form-1', id: 12, name: 'form-1', commenters: [] };
+
+const initialState = commentReducer(undefined, { type: 'unknown' });
+
+const stateWithTopic = {
+  ...initialState,
+  topics: { [TOPIC.resourceId]: TOPIC },
+  selected: { ...initialState.selected, resourceId: TOPIC.resourceId },
+};
+
+const getState =
+  (comment: unknown = stateWithTopic) =>
+  () =>
+    ({
+      config: { directory: { 'urn:ads:platform:comment-service': COMMENT_SERVICE_URL } },
+      user: { user: { id: 'applicant' } },
+      comment,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+describe('comment slice messages', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('loadUnreadMessages', () => {
+    it('counts comments the applicant did not write', async () => {
+      axiosMock.get.mockResolvedValue({
+        data: {
+          results: [
+            { id: 8, createdBy: { id: 'assessor' } },
+            { id: 7, createdBy: { id: 'applicant' } },
+            { id: 6, createdBy: { id: 'assessor' } },
+          ],
+        },
+      });
+
+      const { payload } = await loadUnreadMessages({ topicId: TOPIC.id })(jest.fn(), getState(), undefined);
+
+      expect(payload).toEqual({ lastReadCommentId: 0, latestCommentId: 8, unread: 2 });
+    });
+
+    // Everything newer than the last comment seen when the drawer was open is unread.
+    it('only asks for comments newer than the last read one', async () => {
+      localStorage.setItem(`form-app.messages.last-read.${TOPIC.id}`, '5');
+      axiosMock.get.mockResolvedValue({ data: { results: [] } });
+
+      const { payload } = await loadUnreadMessages({ topicId: TOPIC.id })(jest.fn(), getState(), undefined);
+
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        `${COMMENT_SERVICE_URL}/comment/v1/topics/${TOPIC.id}/comments`,
+        expect.objectContaining({
+          params: expect.objectContaining({ criteria: JSON.stringify({ idGreaterThan: 5 }) }),
+        }),
+      );
+      expect(payload).toEqual({ lastReadCommentId: 5, latestCommentId: 5, unread: 0 });
+    });
+
+    // Message ids are per topic, so what was tracked for a previously opened form has to go.
+    it('drops the counts of the previous form', () => {
+      const state = commentReducer(
+        { ...stateWithTopic, messages: { show: false, latestCommentId: 40, lastReadCommentId: 38, unread: 2 } },
+        { type: loadUnreadMessages.pending.type },
+      );
+
+      expect(state.messages).toEqual({ show: false, latestCommentId: 0, lastReadCommentId: 0, unread: 0 });
+    });
+
+    it('stays clear when the drawer was opened while loading', () => {
+      const state = commentReducer(
+        { ...stateWithTopic, messages: { ...initialState.messages, show: true } },
+        { type: loadUnreadMessages.fulfilled.type, payload: { lastReadCommentId: 5, latestCommentId: 8, unread: 2 } },
+      );
+
+      expect(state.messages.unread).toBe(0);
+    });
+
+    it('records the unread count', () => {
+      const state = commentReducer(stateWithTopic, {
+        type: loadUnreadMessages.fulfilled.type,
+        payload: { lastReadCommentId: 5, latestCommentId: 8, unread: 2 },
+      });
+
+      expect(state.messages).toEqual(expect.objectContaining({ unread: 2, lastReadCommentId: 5, latestCommentId: 8 }));
+    });
+  });
+
+  describe('setShowMessages', () => {
+    it('remembers the latest comment so it is not counted again', async () => {
+      const comment = { ...stateWithTopic, messages: { ...initialState.messages, latestCommentId: 8, unread: 2 } };
+
+      const { payload } = await setShowMessages(true)(jest.fn(), getState(comment), undefined);
+
+      expect(payload).toBe(true);
+      expect(localStorage.getItem(`form-app.messages.last-read.${TOPIC.id}`)).toBe('8');
+    });
+
+    it('does not mark messages read on close', async () => {
+      const comment = { ...stateWithTopic, messages: { ...initialState.messages, latestCommentId: 8, unread: 2 } };
+
+      await setShowMessages(false)(jest.fn(), getState(comment), undefined);
+
+      expect(localStorage.getItem(`form-app.messages.last-read.${TOPIC.id}`)).toBeNull();
+    });
+
+    it('clears the unread count when the drawer is opened', () => {
+      const state = commentReducer(
+        { ...stateWithTopic, messages: { ...initialState.messages, latestCommentId: 8, unread: 2 } },
+        { type: setShowMessages.fulfilled.type, payload: true },
+      );
+
+      expect(state.messages).toEqual(expect.objectContaining({ show: true, unread: 0, lastReadCommentId: 8 }));
+    });
+
+    it('leaves the unread count alone when the drawer is closed', () => {
+      const state = commentReducer(
+        { ...stateWithTopic, messages: { show: true, latestCommentId: 8, lastReadCommentId: 8, unread: 0 } },
+        { type: setShowMessages.fulfilled.type, payload: false },
+      );
+
+      expect(state.messages).toEqual(expect.objectContaining({ show: false, lastReadCommentId: 8 }));
+    });
+  });
+
+  // Comments loaded into the drawer are what the next open marks as read.
+  it('tracks the latest comment loaded into the drawer', () => {
+    const state = commentReducer(stateWithTopic, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 9 }, { id: 8 }], page: {} },
+    });
+
+    expect(state.messages.latestCommentId).toBe(9);
+  });
+});

--- a/apps/form-app/src/app/state/comment.slice.ts
+++ b/apps/form-app/src/app/state/comment.slice.ts
@@ -40,6 +40,33 @@ interface NewComment {
 
 const COMMENT_SERVICE_ID = 'urn:ads:platform:comment-service';
 
+// The comment service has no server side read tracking, so 'read' is recorded per browser as the id
+// of the newest comment that was in the drawer the last time the user opened it.
+const LAST_READ_STORAGE_PREFIX = 'form-app.messages.last-read.';
+// Unread messages are counted from a single page of comments, so the count saturates at this value.
+const UNREAD_MESSAGES_MAX = 100;
+
+function readLastReadCommentId(topicId: number): number {
+  try {
+    return parseInt(localStorage.getItem(`${LAST_READ_STORAGE_PREFIX}${topicId}`)) || 0;
+  } catch {
+    // Storage isn't available, so treat everything as unread.
+    return 0;
+  }
+}
+
+function writeLastReadCommentId(topicId: number, commentId: number): void {
+  try {
+    localStorage.setItem(`${LAST_READ_STORAGE_PREFIX}${topicId}`, `${commentId}`);
+  } catch {
+    // Storage isn't available, so the count is only cleared for this session.
+  }
+}
+
+function latestOf(commentId: number, comments: Comment[]): number {
+  return comments.reduce((latest, { id }) => (id > latest ? id : latest), commentId);
+}
+
 let socket: Socket;
 
 export const disconnectStream = createAsyncThunk('comment/disconnectStream', async (_, { dispatch }) => {
@@ -196,6 +223,48 @@ export const selectTopic = createAsyncThunk(
   },
 );
 
+export const loadUnreadMessages = createAsyncThunk(
+  'comment/load-unread-messages',
+  async ({ topicId }: { topicId: number }, { getState }) => {
+    const { config, user } = getState() as AppState;
+    const commentServiceUrl = config.directory[COMMENT_SERVICE_ID];
+    const lastReadCommentId = readLastReadCommentId(topicId);
+
+    const token = await getAccessToken();
+    const { data } = await axios.get<{ results: Comment[] }>(
+      new URL(`/comment/v1/topics/${topicId}/comments`, commentServiceUrl).href,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        params: {
+          top: UNREAD_MESSAGES_MAX,
+          criteria: JSON.stringify({ idGreaterThan: lastReadCommentId }),
+        },
+      },
+    );
+
+    const userId = user.user?.id;
+    return {
+      lastReadCommentId,
+      latestCommentId: latestOf(lastReadCommentId, data.results),
+      // Comments the applicant wrote themselves were never unread.
+      unread: data.results.filter(({ createdBy }) => createdBy?.id !== userId).length,
+    };
+  },
+);
+
+// Opening the drawer is what marks messages as read; the id is recorded so the count survives a reload.
+export const setShowMessages = createAsyncThunk('comment/set-show-messages', (show: boolean, { getState }) => {
+  const { comment } = getState() as AppState;
+  const topic = comment.topics[comment.selected.resourceId];
+  const { latestCommentId, lastReadCommentId } = comment.messages;
+
+  if (show && topic && latestCommentId > lastReadCommentId) {
+    writeLastReadCommentId(topic.id, latestCommentId);
+  }
+
+  return show;
+});
+
 export const addComment = createAsyncThunk(
   'comment/add-comment',
   async (
@@ -243,6 +312,12 @@ interface CommentState {
     next: string;
   };
   draft: NewComment;
+  messages: {
+    show: boolean;
+    unread: number;
+    latestCommentId: number;
+    lastReadCommentId: number;
+  };
   busy: {
     loading: boolean;
     executing: boolean;
@@ -265,6 +340,12 @@ const initialCommentState: CommentState = {
   draft: {
     title: null,
     content: null,
+  },
+  messages: {
+    show: false,
+    unread: 0,
+    latestCommentId: 0,
+    lastReadCommentId: 0,
   },
   busy: {
     loading: false,
@@ -319,6 +400,7 @@ const commentSlice = createSlice({
 
         state.comments.results = [...state.comments.results, ...payload.results];
         state.comments.next = payload.page.next;
+        state.messages.latestCommentId = latestOf(state.messages.latestCommentId, payload.results);
       })
       .addCase(loadComments.rejected, (state) => {
         state.busy.loading = false;
@@ -330,9 +412,29 @@ const commentSlice = createSlice({
         state.busy.executing = false;
         state.comments.results.unshift(payload);
         state.draft = { title: null, content: null };
+        state.messages.latestCommentId = latestOf(state.messages.latestCommentId, [payload]);
       })
       .addCase(addComment.rejected, (state) => {
         state.busy.executing = false;
+      })
+      .addCase(loadUnreadMessages.pending, (state) => {
+        // The counts are for a single topic, so drop what was tracked for the previously loaded form.
+        state.messages.unread = 0;
+        state.messages.latestCommentId = 0;
+        state.messages.lastReadCommentId = 0;
+      })
+      .addCase(loadUnreadMessages.fulfilled, (state, { payload }) => {
+        state.messages.lastReadCommentId = Math.max(state.messages.lastReadCommentId, payload.lastReadCommentId);
+        state.messages.latestCommentId = Math.max(state.messages.latestCommentId, payload.latestCommentId);
+        // The drawer may have been opened while the count was loading, which already read them.
+        state.messages.unread = state.messages.show ? 0 : payload.unread;
+      })
+      .addCase(setShowMessages.fulfilled, (state, { payload }) => {
+        state.messages.show = payload;
+        if (payload) {
+          state.messages.unread = 0;
+          state.messages.lastReadCommentId = Math.max(state.messages.lastReadCommentId, state.messages.latestCommentId);
+        }
       });
   },
 });
@@ -367,3 +469,7 @@ export const commentLoadingSelector = (state: AppState) => state.comment.busy.lo
 export const draftSelector = (state: AppState) => state.comment.draft;
 
 export const canCommentSelector = (state: AppState) => state.comment.selected.canComment;
+
+export const showMessagesSelector = (state: AppState) => state.comment.messages.show;
+
+export const unreadMessagesSelector = (state: AppState) => state.comment.messages.unread;

--- a/apps/form-app/src/app/state/form.slice.ts
+++ b/apps/form-app/src/app/state/form.slice.ts
@@ -9,7 +9,7 @@ import { DateTime } from 'luxon';
 import { AppState } from './store';
 import { hashData } from './util';
 import { getAccessToken } from './user.slice';
-import { connectStream, loadTopic, selectTopic } from './comment.slice';
+import { connectStream, loadTopic, loadUnreadMessages, selectTopic } from './comment.slice';
 import { loadFileMetadata } from './file.slice';
 import { PagedResults } from './types';
 
@@ -26,6 +26,7 @@ interface SerializableFormDefinition {
   registerData?: RegisterData;
   anonymousApply: boolean;
   generatesPdf?: boolean;
+  supportTopic?: boolean;
   scheduledIntakes: boolean;
   intake?: {
     start: string;
@@ -316,6 +317,7 @@ export const loadForm = createAsyncThunk(
       const result = await dispatch(loadTopic({ resourceId: form.urn, typeId: SUPPORT_TOPIC_TYPE_ID })).unwrap();
       if (result) {
         dispatch(selectTopic({ resourceId: form.urn }));
+        dispatch(loadUnreadMessages({ topicId: result.id }));
         dispatch(
           connectStream({
             stream: SUPPORT_TOPIC_STREAM_ID,


### PR DESCRIPTION

<img width="1918" height="912" alt="image" src="https://github.com/user-attachments/assets/6debf557-363a-423d-aac1-2406bd1b3429" />


CS-5275 — makes the form app's header features discoverable without changing what they do.

- Form name moved from beside the Alberta logo to under it; a `Messages` control with an unread count sits under the sign out link. Both rows share a light background and a single separator underneath.
- Messages only appears when the definition has *create support topic* checked and the form has a topic; it toggles the questions drawer, which has moved from the left of the screen to the right. The `?` launcher at the bottom left is gone.
- Unread is tracked per topic as the id of the newest comment present when the drawer was last opened (`localStorage`), since the comment service has no server-side read state. The count refreshes on launch and on open, per the ticket's out-of-scope note on webhooks.

Two things reviewers should weigh in on:

- Removing the `?` also removes the only launcher for the AI chat pane when a definition has no support topic. That follows the AC as written, but the agent chat is unreachable in that case.
- Questions the applicant writes themselves are not counted as unread; only replies coming back count.

Unit tests cover the header rendering and toggle, and the unread count, read marking, and per-topic reset in the comment slice. Not yet run against a live environment.