### PR TITLE
fix(directory-service): return 409 Conflict when service entry already exists

### DIFF
--- a/apps/directory-service/src/directory/router/directory.spec.ts
+++ b/apps/directory-service/src/directory/router/directory.spec.ts
@@ -674,6 +674,18 @@ describe('router', () => {
       await handler(req, res as unknown as Response, next);
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.CREATED);
     });
+    it('returns 409 when the service entry already exists', async () => {
+      const testDirectory = {
+        name: 'platform',
+        services: [{ service: 'added-service', host: '/existing/url' }],
+      };
+      const res = {
+        sendStatus: jest.fn(),
+      };
+      repositoryMock.getDirectories.mockResolvedValueOnce(testDirectory);
+      await handler(req, res as unknown as Response, next);
+      expect(res.sendStatus).toHaveBeenCalledWith(HttpStatusCodes.CONFLICT);
+    });
     it('addService can call next with not found', async () => {
       const testDirectory = {
         name: 'platform',
@@ -729,6 +741,27 @@ describe('router', () => {
       });
       await handler(req, res as unknown as Response, next);
       expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.CREATED);
+    });
+    it('returns 409 when the service api entry already exists', async () => {
+      const handler = addServiceApi(repositoryMock, eventServiceMock, loggerMock as Logger);
+      const testDirectory = {
+        name: 'platform',
+        services: [{ service: 'added-service:v1', host: '/existing/url' }],
+      };
+      const req = {
+        tenant: { id: tenantId },
+        user: { isCore: false, roles: [ServiceRoles.DirectoryAdmin], tenantId } as User,
+        params: { namespace, service: 'added-service' },
+        query: {},
+        body: { api: 'v1', url: '/new/url' },
+      } as unknown as Request;
+      const res = {
+        sendStatus: jest.fn(),
+      };
+      const next = jest.fn();
+      repositoryMock.getDirectories.mockResolvedValueOnce(testDirectory);
+      await handler(req, res as unknown as Response, next);
+      expect(res.sendStatus).toHaveBeenCalledWith(HttpStatusCodes.CONFLICT);
     });
     it('addServiceApi can call next with not found', async () => {
       const handler = addServiceApi(repositoryMock, eventServiceMock, loggerMock as Logger);

--- a/apps/directory-service/src/directory/router/directory.ts
+++ b/apps/directory-service/src/directory/router/directory.ts
@@ -175,6 +175,9 @@ export const addService =
     const entry = service;
     try {
       const result = await addEntry(namespace, entry, url, directoryRepository);
+      if (result === 'exists') {
+        return res.sendStatus(HttpStatusCodes.CONFLICT);
+      }
       if (!result) {
         return res.sendStatus(HttpStatusCodes.CREATED);
       }
@@ -196,6 +199,9 @@ export const addServiceApi =
     const entry = `${service}:${api}`;
     try {
       const result = await addEntry(namespace, entry, url, directoryRepository);
+      if (result === 'exists') {
+        return res.sendStatus(HttpStatusCodes.CONFLICT);
+      }
       if (!result) {
         return res.sendStatus(HttpStatusCodes.CREATED);
       }
@@ -212,7 +218,7 @@ const addEntry = async (
   entry: string,
   url: string,
   directoryRepository: DirectoryRepository
-): Promise<Service> => {
+): Promise<Service | 'exists' | null> => {
   const result = await directoryRepository.getDirectories(namespace);
 
   const mappingService = {
@@ -228,7 +234,7 @@ const addEntry = async (
   const isExist = services.find((x) => x.service === entry);
 
   if (isExist) {
-    throw new InvalidValueError('Create new service', `${entry} already exists in ${namespace}`);
+    return 'exists';
   } else {
     services.push(mappingService);
     const directory = { name: namespace, services: services };


### PR DESCRIPTION
## Summary

- `POST /directory/v2/namespaces/:namespace/services` was returning **400 Bad Request** when the service entry already exists — conflating a malformed request with a resource-state conflict
- Changed to return **409 Conflict**, which is the correct HTTP status for a duplicate-entry attempt
- 400 is now reserved for genuinely malformed requests (missing fields, bad values)

## Changes

- `addEntry()` now returns `'exists'` instead of throwing `InvalidValueError` for the duplicate case
- `addService` and `addServiceApi` handlers map the `'exists'` result to `res.sendStatus(409)`
- Two new tests: one for `addService` 409, one for `addServiceApi` 409

## Why this matters

API clients (e.g. `@abgov/adsp-cli`'s `registerDirectoryService`) need to distinguish "entry already exists" from other errors without parsing the response body. 409 makes this unambiguous.

## Test plan

- [ ] 54/54 unit tests pass for `directory-service` (coverage threshold failure is pre-existing on `main`, not introduced by this change)
- [ ] `addService` returns 409 when the entry already exists
- [ ] `addServiceApi` returns 409 when the api entry already exists
- [ ] Normal creation (new entry) still returns 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)