### PR TITLE
feat(form-app): form name and messages in the app header, with a live unread count

### DIFF
--- a/apps/form-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-app/src/app/state/comment.slice.spec.ts
@@ -1,11 +1,23 @@
 import '@testing-library/jest-dom';
 import axios from 'axios';
-import { commentReducer, loadComments, loadUnreadMessages, setShowMessages } from './comment.slice';
+import { io } from 'socket.io-client';
+import {
+  commentReducer,
+  connectStream,
+  loadComments,
+  loadUnreadMessages,
+  selectTopic,
+  setShowMessages,
+} from './comment.slice';
 
 jest.mock('axios');
 const axiosMock = axios as jest.Mocked<typeof axios>;
 
+jest.mock('socket.io-client', () => ({ io: jest.fn() }));
+const ioMock = io as jest.MockedFunction<typeof io>;
+
 const COMMENT_SERVICE_URL = 'https://comment-service';
+const PUSH_SERVICE_URL = 'https://push-service';
 const TOPIC = { resourceId: 'urn:ads:platform:form-service:v1:/forms/form-1', id: 12, name: 'form-1', commenters: [] };
 
 const initialState = commentReducer(undefined, { type: 'unknown' });
@@ -20,7 +32,12 @@ const getState =
   (comment: unknown = stateWithTopic) =>
   () =>
     ({
-      config: { directory: { 'urn:ads:platform:comment-service': COMMENT_SERVICE_URL } },
+      config: {
+        directory: {
+          'urn:ads:platform:comment-service': COMMENT_SERVICE_URL,
+          'urn:ads:platform:push-service': PUSH_SERVICE_URL,
+        },
+      },
       user: { user: { id: 'applicant' } },
       comment,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -65,14 +82,24 @@ describe('comment slice messages', () => {
       expect(payload).toEqual({ lastReadCommentId: 5, latestCommentId: 5, unread: 0 });
     });
 
-    // Message ids are per topic, so what was tracked for a previously opened form has to go.
-    it('drops the counts of the previous form', () => {
+    it('keeps the previous count when the request fails', () => {
       const state = commentReducer(
         { ...stateWithTopic, messages: { show: false, latestCommentId: 40, lastReadCommentId: 38, unread: 2 } },
-        { type: loadUnreadMessages.pending.type },
+        { type: loadUnreadMessages.fulfilled.type, payload: null },
       );
 
-      expect(state.messages).toEqual({ show: false, latestCommentId: 0, lastReadCommentId: 0, unread: 0 });
+      expect(state.messages).toEqual({ show: false, latestCommentId: 40, lastReadCommentId: 38, unread: 2 });
+    });
+
+    // Anything that arrives while the drawer is open has been read as it came in, and the id has to
+    // be recorded so a reload doesn't count it again.
+    it('marks arriving messages read while the drawer is open', async () => {
+      const comment = { ...stateWithTopic, messages: { ...initialState.messages, show: true } };
+      axiosMock.get.mockResolvedValue({ data: { results: [{ id: 8, createdBy: { id: 'assessor' } }] } });
+
+      await loadUnreadMessages({ topicId: TOPIC.id })(jest.fn(), getState(comment), undefined);
+
+      expect(localStorage.getItem(`form-app.messages.last-read.${TOPIC.id}`)).toBe('8');
     });
 
     it('stays clear when the drawer was opened while loading', () => {
@@ -91,6 +118,35 @@ describe('comment slice messages', () => {
       });
 
       expect(state.messages).toEqual(expect.objectContaining({ unread: 2, lastReadCommentId: 5, latestCommentId: 8 }));
+    });
+  });
+
+  describe('selectTopic', () => {
+    // Message ids are per topic, so what was tracked for a previously opened form has to go.
+    it('drops the counts of the previous form', () => {
+      const state = commentReducer(
+        { ...stateWithTopic, messages: { show: false, latestCommentId: 40, lastReadCommentId: 38, unread: 2 } },
+        {
+          type: selectTopic.fulfilled.type,
+          meta: { arg: { resourceId: 'urn:ads:platform:form-service:v1:/forms/form-2' } },
+          payload: { canRead: true, canComment: true },
+        },
+      );
+
+      expect(state.messages).toEqual({ show: false, latestCommentId: 0, lastReadCommentId: 0, unread: 0 });
+    });
+
+    it('keeps the counts when the same form is selected again', () => {
+      const state = commentReducer(
+        { ...stateWithTopic, messages: { show: false, latestCommentId: 40, lastReadCommentId: 38, unread: 2 } },
+        {
+          type: selectTopic.fulfilled.type,
+          meta: { arg: { resourceId: TOPIC.resourceId } },
+          payload: { canRead: true, canComment: true },
+        },
+      );
+
+      expect(state.messages).toEqual({ show: false, latestCommentId: 40, lastReadCommentId: 38, unread: 2 });
     });
   });
 
@@ -129,6 +185,41 @@ describe('comment slice messages', () => {
 
       expect(state.messages).toEqual(expect.objectContaining({ show: false, lastReadCommentId: 8 }));
     });
+  });
+
+  // The stream event carries no author, so the count is refreshed from the service instead.
+  it('refreshes the unread count when a comment arrives on the stream', async () => {
+    const handlers: Record<string, (update: { topic: typeof TOPIC }) => void> = {};
+    ioMock.mockReturnValue({
+      connected: false,
+      disconnect: jest.fn(),
+      on: (event: string, handler: (update: { topic: typeof TOPIC }) => void) => {
+        handlers[event] = handler;
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    axiosMock.get.mockResolvedValue({ data: { results: [], page: {} } });
+
+    // Stands in for the thunk middleware so the dispatches the handler makes actually run.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dispatch: any = jest.fn((action: unknown) =>
+      typeof action === 'function' ? action(dispatch, getState(), undefined) : action,
+    );
+
+    await connectStream({ stream: 'form-questions-updates', typeId: 'form-questions', topicId: TOPIC.id })(
+      dispatch,
+      getState(),
+      undefined,
+    );
+    axiosMock.get.mockClear();
+
+    handlers['comment-service:comment-created']({ topic: TOPIC });
+    await new Promise(process.nextTick);
+
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      `${COMMENT_SERVICE_URL}/comment/v1/topics/${TOPIC.id}/comments`,
+      expect.objectContaining({ params: expect.objectContaining({ top: 100 }) }),
+    );
   });
 
   // Comments loaded into the drawer are what the next open marks as read.

--- a/apps/form-app/src/app/state/comment.slice.ts
+++ b/apps/form-app/src/app/state/comment.slice.ts
@@ -63,6 +63,14 @@ function writeLastReadCommentId(topicId: number, commentId: number): void {
   }
 }
 
+// Recording the newest comment seen is what marks messages as read; it happens both when the drawer
+// is opened and when a message arrives while it is already open.
+function markMessagesRead(topicId: number, latestCommentId: number, lastReadCommentId: number): void {
+  if (latestCommentId > lastReadCommentId) {
+    writeLastReadCommentId(topicId, latestCommentId);
+  }
+}
+
 function latestOf(commentId: number, comments: Comment[]): number {
   return comments.reduce((latest, { id }) => (id > latest ? id : latest), commentId);
 }
@@ -127,6 +135,9 @@ export const connectStream = createAsyncThunk(
       const { comment } = getState() as AppState;
       if (comment.selected.resourceId === topic.resourceId) {
         dispatch(loadComments({ topic: comment.topics[topic.resourceId] }));
+        // Loading the comments doesn't recount them, and the update event doesn't say who wrote the
+        // comment, so the count is refreshed from the service rather than incremented here.
+        dispatch(loadUnreadMessages({ topicId: topic.id }));
       }
     };
 
@@ -226,29 +237,42 @@ export const selectTopic = createAsyncThunk(
 export const loadUnreadMessages = createAsyncThunk(
   'comment/load-unread-messages',
   async ({ topicId }: { topicId: number }, { getState }) => {
-    const { config, user } = getState() as AppState;
+    const { config } = getState() as AppState;
     const commentServiceUrl = config.directory[COMMENT_SERVICE_ID];
     const lastReadCommentId = readLastReadCommentId(topicId);
 
-    const token = await getAccessToken();
-    const { data } = await axios.get<{ results: Comment[] }>(
-      new URL(`/comment/v1/topics/${topicId}/comments`, commentServiceUrl).href,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        params: {
-          top: UNREAD_MESSAGES_MAX,
-          criteria: JSON.stringify({ idGreaterThan: lastReadCommentId }),
+    try {
+      const token = await getAccessToken();
+      const { data } = await axios.get<{ results: Comment[] }>(
+        new URL(`/comment/v1/topics/${topicId}/comments`, commentServiceUrl).href,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          params: {
+            top: UNREAD_MESSAGES_MAX,
+            criteria: JSON.stringify({ idGreaterThan: lastReadCommentId }),
+          },
         },
-      },
-    );
+      );
 
-    const userId = user.user?.id;
-    return {
-      lastReadCommentId,
-      latestCommentId: latestOf(lastReadCommentId, data.results),
-      // Comments the applicant wrote themselves were never unread.
-      unread: data.results.filter(({ createdBy }) => createdBy?.id !== userId).length,
-    };
+      // The comments may have been reloaded into the drawer while this was in flight.
+      const { comment, user } = getState() as AppState;
+      const latestCommentId = Math.max(latestOf(lastReadCommentId, data.results), comment.messages.latestCommentId);
+
+      if (comment.messages.show) {
+        markMessagesRead(topicId, latestCommentId, lastReadCommentId);
+      }
+
+      return {
+        lastReadCommentId,
+        latestCommentId,
+        // Comments the applicant wrote themselves were never unread.
+        unread: data.results.filter(({ createdBy }) => createdBy?.id !== user.user?.id).length,
+      };
+    } catch (err) {
+      // clean-code-ignore: 2.13
+      console.error('Loading unread messages error: ' + err.message);
+      return null;
+    }
   },
 );
 
@@ -258,8 +282,8 @@ export const setShowMessages = createAsyncThunk('comment/set-show-messages', (sh
   const topic = comment.topics[comment.selected.resourceId];
   const { latestCommentId, lastReadCommentId } = comment.messages;
 
-  if (show && topic && latestCommentId > lastReadCommentId) {
-    writeLastReadCommentId(topic.id, latestCommentId);
+  if (show && topic) {
+    markMessagesRead(topic.id, latestCommentId, lastReadCommentId);
   }
 
   return show;
@@ -384,6 +408,13 @@ const commentSlice = createSlice({
         state.busy.loading = false;
       })
       .addCase(selectTopic.fulfilled, (state, { meta, payload }) => {
+        // Message ids are per topic, so what was tracked for a previously opened form has to go.
+        if (state.selected.resourceId !== meta.arg.resourceId) {
+          state.messages.unread = 0;
+          state.messages.latestCommentId = 0;
+          state.messages.lastReadCommentId = 0;
+        }
+
         state.selected.resourceId = meta.arg.resourceId;
         state.selected.canComment = payload.canComment;
         state.selected.canRead = payload.canRead;
@@ -417,17 +448,21 @@ const commentSlice = createSlice({
       .addCase(addComment.rejected, (state) => {
         state.busy.executing = false;
       })
-      .addCase(loadUnreadMessages.pending, (state) => {
-        // The counts are for a single topic, so drop what was tracked for the previously loaded form.
-        state.messages.unread = 0;
-        state.messages.latestCommentId = 0;
-        state.messages.lastReadCommentId = 0;
-      })
       .addCase(loadUnreadMessages.fulfilled, (state, { payload }) => {
+        // The count couldn't be loaded, so leave the messages counted before it as they were.
+        if (!payload) {
+          return;
+        }
+
         state.messages.lastReadCommentId = Math.max(state.messages.lastReadCommentId, payload.lastReadCommentId);
         state.messages.latestCommentId = Math.max(state.messages.latestCommentId, payload.latestCommentId);
-        // The drawer may have been opened while the count was loading, which already read them.
-        state.messages.unread = state.messages.show ? 0 : payload.unread;
+        if (state.messages.show) {
+          // The drawer is open, so the counted messages have been read as they arrived.
+          state.messages.unread = 0;
+          state.messages.lastReadCommentId = Math.max(state.messages.lastReadCommentId, state.messages.latestCommentId);
+        } else {
+          state.messages.unread = payload.unread;
+        }
       })
       .addCase(setShowMessages.fulfilled, (state, { payload }) => {
         state.messages.show = payload;


### PR DESCRIPTION



https://github.com/user-attachments/assets/3c506ad0-91fe-4ce4-ab83-221717df3c2e



CS-5275. The form name now sits under the Alberta logo and a Messages control with an unread count sits under the sign out link; the '?' launcher is gone and the questions drawer opens on the right.

The second commit fixes the count, which only loaded once with the form and so never moved when the other party posted:

- the count is refreshed whenever a comment arrives on the update stream (the event carries no author, so it is recounted from the service rather than incremented)
- the per topic reset moved off the in-flight request onto selecting the topic, so a recount no longer blanks the last-read marker while it runs
- messages that arrive while the drawer is open are marked read, so closing it and reloading doesn't resurface them
- a failed count keeps the previous value instead of silently reading zero

Covered by `comment.slice.spec.ts`, including a stream test that fails without the first fix.
