### PR TITLE
feat: json-form-component can check if base project used design syste…

### DIFF
--- a/apps/sandbox-app/project.json
+++ b/apps/sandbox-app/project.json
@@ -20,6 +20,11 @@
           "apps/sandbox-app/src/favicon.ico",
           "apps/sandbox-app/src/assets",
           {
+            "glob": "config.json",
+            "input": "apps/sandbox-app/src/config/",
+            "output": "./config/"
+          },
+          {
             "glob": "silent-check-sso.html",
             "input": "apps/sandbox-app/src/",
             "output": "./"
@@ -67,6 +72,18 @@
           "buildTarget": "sandbox-app:build:production",
           "hmr": false
         }
+      }
+    },
+    "serve-ds1": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "SANDBOX_DESIGN_SYSTEMS_VERSION=1.0 ./node_modules/.bin/nx run sandbox-app:serve:development --port=4200"
+      }
+    },
+    "serve-ds2": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "SANDBOX_DESIGN_SYSTEMS_VERSION=2.0 ./node_modules/.bin/nx run sandbox-app:serve:development --port=4201"
       }
     },
     "lint": {

--- a/apps/sandbox-app/src/app/components/SandboxTenant.tsx
+++ b/apps/sandbox-app/src/app/components/SandboxTenant.tsx
@@ -24,7 +24,7 @@ import { StatusServiceMain } from './services/StatusServiceMain';
 import { ValueServiceMain } from './services/ValueServiceMain';
 import { TaskServiceMain } from './services/TaskServiceMain';
 import { FileServiceMain } from './services/FileServiceMain';
-import { GoabAppFooter, GoabButton, GoabButtonGroup, GoabCircularProgress } from '@abgov/react-components';
+import { GoabAppFooter, GoabButton, GoabButtonGroup } from '@abgov/react-components';
 import { ScriptServiceMain } from './services/ScriptServiceMain';
 import { CacheServiceMain } from './services/CacheServiceMain';
 import { DirectoryServiceMain } from './services/DirectoryServiceMain';
@@ -47,6 +47,11 @@ export const SandBoxTenant = () => {
   const configInitialized = useSelector(configInitializedSelector);
 
   const environment = useSelector(environmentSelector);
+  const activeTenantName = environment.tenantName || tenantName;
+  const isFormServicePath = location.pathname.endsWith('/services/form');
+  const isJsonformsControlExamplesPath = location.pathname.includes('/services/jsonforms/example1/control-examples');
+  const isLocalJsonformsTestPath = isFormServicePath || isJsonformsControlExamplesPath;
+  const canShowServiceContent = Boolean(authenticatedUser) || isLocalJsonformsTestPath;
 
   useEffect(() => {
     if (configInitialized) {
@@ -55,29 +60,29 @@ export const SandBoxTenant = () => {
   }, [configInitialized, dispatch, tenantName]);
 
   useEffect(() => {
-    if (authenticatedUser && location.pathname.endsWith(`/${environment.tenantName}`)) {
-      navigate(`/${environment.tenantName}/services`);
+    if (authenticatedUser && activeTenantName && location.pathname.endsWith(`/${activeTenantName}`)) {
+      navigate(`/${activeTenantName}/services`);
     }
-  }, [authenticatedUser, environment.tenantName, location.pathname, navigate]);
+  }, [activeTenantName, authenticatedUser, location.pathname, navigate]);
 
-  useFeedbackWidget(environment.tenantName);
+  useFeedbackWidget(activeTenantName);
   return (
     <React.Fragment>
       <Header />
       <FeedbackNotification />
       <main>
-        {authenticatedUser === null ? (
+        {authenticatedUser === null && !isLocalJsonformsTestPath ? (
           <SignIn url={window.location.href} />
         ) : (
-          authenticatedUser && (
+          canShowServiceContent && (
             <section>
               <Band title="Sandbox services">Services/libraries available for POC</Band>
-              {authenticatedUser && !location.pathname.endsWith(`${environment.tenantName}`) && (
+              {authenticatedUser && activeTenantName && !location.pathname.endsWith(`/${activeTenantName}`) && (
                 <GoabButtonGroup alignment="end" mr={'xl'} mt="l">
                   <GoabButton
                     type="tertiary"
                     onClick={() => {
-                      navigate(`/${tenantName}/services`);
+                      navigate(`/${activeTenantName}/services`);
                     }}
                   >
                     Back to services

--- a/apps/sandbox-app/src/app/components/Services.tsx
+++ b/apps/sandbox-app/src/app/components/Services.tsx
@@ -1,13 +1,13 @@
-import { GoabAppFooter, GoabCircularProgress, GoabContainer } from '@abgov/react-components';
-import React, { useEffect } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { CenteredProgress, FlexItem, ServiceContainer } from './styled-components';
+import { GoabAppFooter, GoabContainer } from '@abgov/react-components';
+import React from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { FlexItem, ServiceContainer } from './styled-components';
 
 import { Band } from '@core-services/app-common';
 import Header from './Header';
 import { useFeedbackWidget } from '../hooks/useFeedbackWidget';
 import { useSelector } from 'react-redux';
-import { authenticatedUserSelector, environmentSelector, userSelector } from '../state';
+import { environmentSelector } from '../state';
 
 interface ServiceInfo {
   /**
@@ -176,51 +176,38 @@ const sortServices = (services: ServiceInfo[], key: keyof ServiceInfo, direction
 
 export default function Services() {
   const location = useLocation();
-  const navigate = useNavigate();
-  const { user, initialized: userInitialized } = useSelector(userSelector);
-  const authenticatedUser = useSelector(authenticatedUserSelector);
+  const { tenant: tenantName } = useParams<{ tenant: string }>();
   const environment = useSelector(environmentSelector);
+  const feedbackTenant = environment.tenantName || tenantName;
 
-  useEffect(() => {
-    if (!user && userInitialized) {
-      navigate(`/`);
-    }
-  }, [navigate, user, userInitialized]);
-
-  useFeedbackWidget(environment.tenantName);
+  useFeedbackWidget(feedbackTenant);
   return (
     <>
       <Header />
       <Band title="Sandbox application">Services/libraries available for POC</Band>
 
-      {authenticatedUser === null && (
-        <CenteredProgress>
-          <GoabCircularProgress variant="inline" size="large" message="Loading services..." visible={true} />
-        </CenteredProgress>
-      )}
       <ServiceContainer>
-        {user &&
-          sortServices(SERVICES, 'name')
-            .filter((y) => y.show)
-            .map((service, i) => {
-              return (
-                <FlexItem key={`${service.id}_${i}`}>
-                  <GoabContainer
-                    accent="thick"
-                    type="non-interactive"
-                    width={'full'}
-                    testId={service.id}
-                    heading={
-                      <h3>
-                        <Link to={`${location.pathname}${service.url}`}>{service.name}</Link>
-                      </h3>
-                    }
-                  >
-                    {service.description}
-                  </GoabContainer>
-                </FlexItem>
-              );
-            })}
+        {sortServices(SERVICES, 'name')
+          .filter((y) => y.show)
+          .map((service, i) => {
+            return (
+              <FlexItem key={`${service.id}_${i}`}>
+                <GoabContainer
+                  accent="thick"
+                  type="non-interactive"
+                  width={'full'}
+                  testId={service.id}
+                  heading={
+                    <h3>
+                      <Link to={`${location.pathname}${service.url}`}>{service.name}</Link>
+                    </h3>
+                  }
+                >
+                  {service.description}
+                </GoabContainer>
+              </FlexItem>
+            );
+          })}
       </ServiceContainer>
       <GoabAppFooter />
     </>

--- a/apps/sandbox-app/src/app/components/services/FormServiceMain.tsx
+++ b/apps/sandbox-app/src/app/components/services/FormServiceMain.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { ServiceContainer } from '../styled-components';
-import { GoabContainer, GoabText } from '@abgov/react-components';
+import { GoabButton, GoabButtonGroup, GoabContainer, GoabText } from '@abgov/react-components';
 import { ServiceMainProps } from './types';
-import { DefaultServiceListTemplate } from './DefaultServiceListTemplate';
+import { useNavigate } from 'react-router-dom';
 
 export const FormServiceMain = ({ tenantName }: ServiceMainProps) => {
+  const navigate = useNavigate();
+  const jsonformsExampleUrl = `/${tenantName}/services/jsonforms/example1/control-examples`;
+
   return (
     <ServiceContainer>
       <GoabContainer
@@ -17,7 +20,22 @@ export const FormServiceMain = ({ tenantName }: ServiceMainProps) => {
         <GoabText size="body-m" mb="none">
           The following contains POC or samples for the Form service.
         </GoabText>
-        <DefaultServiceListTemplate prefix="Form service item " />
+        <GoabButtonGroup alignment="start" mt="m">
+          <GoabButton
+            type="secondary"
+            testId="jsonforms-ds1-test"
+            onClick={() => navigate(`${jsonformsExampleUrl}?designSystemsVersion=1.0`)}
+          >
+            Test JSONForms DS1
+          </GoabButton>
+          <GoabButton
+            type="primary"
+            testId="jsonforms-ds2-test"
+            onClick={() => navigate(`${jsonformsExampleUrl}?designSystemsVersion=2.0`)}
+          >
+            Test JSONForms DS2
+          </GoabButton>
+        </GoabButtonGroup>
       </GoabContainer>
     </ServiceContainer>
   );

--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsExampleOne.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsExampleOne.tsx
@@ -8,23 +8,129 @@ import { GoabContainer } from '@abgov/react-components';
 import { JsonForms } from '@jsonforms/react';
 import { ContextProviderFactory, createDefaultAjv, GoACells, GoARenderers } from '@abgov/jsonforms-components';
 import { ErrorObject } from 'ajv';
+import { JsonSchema, UISchemaElement } from '@jsonforms/core';
 
 export const ContextProvider = ContextProviderFactory();
+
+const CONTROL_EXAMPLES_DEFINITION_ID = 'control-examples';
+
+const controlExamplesDefinition: {
+  id: string;
+  name: string;
+  dataSchema: JsonSchema;
+  uiSchema: UISchemaElement;
+} = {
+  id: CONTROL_EXAMPLES_DEFINITION_ID,
+  name: 'JSONForms control examples',
+  dataSchema: {
+    type: 'object',
+    properties: {
+      fullName: {
+        type: 'string',
+        title: 'Full name',
+      },
+      email: {
+        type: 'string',
+        format: 'email',
+        title: 'Email',
+      },
+      startDate: {
+        type: 'string',
+        format: 'date',
+        title: 'Start date',
+      },
+      appointmentTime: {
+        type: 'string',
+        format: 'time',
+        title: 'Appointment time',
+      },
+      serviceType: {
+        type: 'string',
+        title: 'Service type',
+        enum: ['Information request', 'Application support', 'Technical help'],
+      },
+      contactMethod: {
+        type: 'string',
+        title: 'Preferred contact method',
+        enum: ['Email', 'Phone'],
+      },
+      consent: {
+        type: 'boolean',
+        title: 'Consent',
+      },
+      comments: {
+        type: 'string',
+        title: 'Comments',
+      },
+    },
+    required: ['fullName', 'email', 'startDate', 'serviceType', 'consent'],
+  },
+  uiSchema: {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/fullName',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/email',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/startDate',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/appointmentTime',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/serviceType',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/contactMethod',
+        options: {
+          format: 'radio',
+        },
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/consent',
+        options: {
+          text: 'I agree to be contacted about this request.',
+        },
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/comments',
+        options: {
+          multi: true,
+        },
+      },
+    ],
+  },
+};
+
 export const JsonformsExampleOne = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   const { definitionId } = useParams();
+  const isControlExamples = definitionId === CONTROL_EXAMPLES_DEFINITION_ID;
 
   const [formData, setFormData] = useState<Record<string, unknown>>({});
   const tenant = useSelector(tenantSelector);
   const { definition, initialized: definitionInitialized } = useSelector(definitionSelector);
   const busy = useSelector(busySelector);
+  const currentDefinition = isControlExamples ? controlExamplesDefinition : definition;
+  const currentDefinitionInitialized = isControlExamples || definitionInitialized;
 
   useEffect(() => {
-    if (tenant) {
+    if (tenant && !isControlExamples) {
       dispatch(selectedDefinition(definitionId));
     }
-  }, [dispatch, definitionId, tenant]);
+  }, [dispatch, definitionId, isControlExamples, tenant]);
 
   // Memoize the ajv instance to prevent recreation on every render
   const ajvInstance = useMemo(() => createDefaultAjv(), []);
@@ -39,21 +145,21 @@ export const JsonformsExampleOne = () => {
 
   return (
     <ServiceContainer>
-      <LoadingIndicator isLoading={!definitionInitialized || busy.loading} />
+      <LoadingIndicator isLoading={!currentDefinitionInitialized || busy.loading} />
       <GoabContainer
         accent="thick"
         type="non-interactive"
         width={'full'}
         testId={'JsonformsExampleOneContainer'}
-        heading={'Jsonforms example one'}
+        heading={currentDefinition?.name || 'Jsonforms example one'}
       >
-        {definition && (
+        {currentDefinition && (
           <ContextProvider>
             <JsonForms
               key="example-form"
               ajv={ajvInstance}
-              schema={definition.dataSchema}
-              uischema={definition.uiSchema}
+              schema={currentDefinition.dataSchema}
+              uischema={currentDefinition.uiSchema}
               readonly={false}
               data={formData}
               renderers={memoizedRenderers}

--- a/apps/sandbox-app/src/app/hooks/useFeedbackWidget.spec.ts
+++ b/apps/sandbox-app/src/app/hooks/useFeedbackWidget.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { useFeedbackWidget, getFeedbackContext } from './useFeedbackWidget';
+import { useFeedbackWidget, getFeedbackContext, resolveFeedbackTenant } from './useFeedbackWidget';
 
 describe('useFeedbackWidget', () => {
   const mockInitialize = jest.fn();
@@ -8,6 +8,7 @@ describe('useFeedbackWidget', () => {
     jest.clearAllMocks();
     globalThis.adspFeedback = { initialize: mockInitialize };
     document.body.innerHTML = '<div class="adsp-fb-badge"></div>';
+    window.history.pushState({}, '', '/');
   });
 
   afterEach(() => {
@@ -41,9 +42,32 @@ describe('useFeedbackWidget', () => {
     expect(mockInitialize).not.toHaveBeenCalled();
   });
 
-  test('sets data-show="true" on the badge element on mount', () => {
+  test('does not call initialize without a tenant context', () => {
     // Act
     renderHook(() => useFeedbackWidget());
+
+    // Assert
+    expect(mockInitialize).not.toHaveBeenCalled();
+  });
+
+  test('initializes feedback widget with tenant from the route', () => {
+    // Arrange
+    window.history.pushState({}, '', '/route-tenant/services');
+
+    // Act
+    renderHook(() => useFeedbackWidget());
+
+    // Assert
+    expect(mockInitialize).toHaveBeenCalledWith({
+      tenant: 'route-tenant',
+      getContext: expect.any(Function),
+      designSystemsVersion: '2.0',
+    });
+  });
+
+  test('sets data-show="true" on the badge element on mount', () => {
+    // Act
+    renderHook(() => useFeedbackWidget('test-tenant'));
 
     // Assert
     const badge = document.querySelector('.adsp-fb-badge') as HTMLElement;
@@ -52,12 +76,32 @@ describe('useFeedbackWidget', () => {
 
   test('sets data-show="false" on the badge element on unmount', () => {
     // Act
-    const { unmount } = renderHook(() => useFeedbackWidget());
+    const { unmount } = renderHook(() => useFeedbackWidget('test-tenant'));
     unmount();
 
     // Assert
     const badge = document.querySelector('.adsp-fb-badge') as HTMLElement;
     expect(badge.getAttribute('data-show')).toBe('false');
+  });
+});
+
+describe('resolveFeedbackTenant', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+  });
+
+  test('returns trimmed tenant name when provided', () => {
+    expect(resolveFeedbackTenant(' custom-tenant ')).toBe('custom-tenant');
+  });
+
+  test('returns tenant from the current route when tenant name is not provided', () => {
+    window.history.pushState({}, '', '/route-tenant/services/form');
+
+    expect(resolveFeedbackTenant()).toBe('route-tenant');
+  });
+
+  test('returns an empty string when no tenant context exists', () => {
+    expect(resolveFeedbackTenant()).toBe('');
   });
 });
 

--- a/apps/sandbox-app/src/app/hooks/useFeedbackWidget.ts
+++ b/apps/sandbox-app/src/app/hooks/useFeedbackWidget.ts
@@ -21,11 +21,30 @@ function updateWidgetVisibility(show: boolean) {
   }
 }
 
+export const resolveFeedbackTenant = (tenantName?: string) => {
+  const configuredTenant = tenantName?.trim();
+  if (configuredTenant) {
+    return configuredTenant;
+  }
+
+  const [tenantFromPath] = document.location.pathname.split('/').filter(Boolean);
+  return tenantFromPath || '';
+};
+
 export const useFeedbackWidget = (tenantName?: string) => {
   useEffect(() => {
+    const tenant = resolveFeedbackTenant(tenantName);
+
     if (globalThis.adspFeedback !== undefined) {
+      if (!tenant) {
+        updateWidgetVisibility(false);
+        return () => {
+          updateWidgetVisibility(false);
+        };
+      }
+
       globalThis.adspFeedback.initialize({
-        tenant: tenantName ?? '',
+        tenant,
         getContext: () => getFeedbackContext(),
         designSystemsVersion: '2.0',
       });

--- a/apps/sandbox-app/src/app/hooks/useInitializeFeedbackScript.spec.ts
+++ b/apps/sandbox-app/src/app/hooks/useInitializeFeedbackScript.spec.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { useInitializeFeedbackScript } from './useInitializeFeedbackScript';
 import { useSelector } from 'react-redux';
-import { getFeedbackContext } from './useFeedbackWidget';
+import { getFeedbackContext, resolveFeedbackTenant } from './useFeedbackWidget';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -12,14 +12,15 @@ jest.mock('../state', () => ({
 }));
 
 jest.mock('./useFeedbackWidget', () => ({
-  DEFAULT_TENANT: 'default-tenant',
   getFeedbackContext: jest.fn(),
+  resolveFeedbackTenant: jest.fn(),
 }));
 
 describe('useInitializeFeedbackScript', () => {
   afterEach(() => {
     jest.clearAllMocks();
     document.head.innerHTML = ''; // Clean up DOM
+    delete globalThis.adspFeedback;
   });
 
   test('does not append script if environment.feedback.url is undefined', () => {
@@ -72,6 +73,7 @@ describe('useInitializeFeedbackScript', () => {
 
     (useSelector as jest.Mock).mockReturnValue({ feedback: { url: mockUrl } });
     (getFeedbackContext as jest.Mock).mockReturnValue({ user: 'test-user' });
+    (resolveFeedbackTenant as jest.Mock).mockReturnValue('custom-tenant');
 
     // Act
     renderHook(() => useInitializeFeedbackScript('custom-tenant'));
@@ -88,5 +90,24 @@ describe('useInitializeFeedbackScript', () => {
     // Verify getContext function
     const getContext = mockInitialize.mock.calls[0][0].getContext;
     expect(getContext()).toEqual({ user: 'test-user' });
+  });
+
+  test('does not initialize feedback when script loads without tenant context', () => {
+    // Arrange
+    const mockUrl = 'https://feedback.example.com/script.js';
+    const mockInitialize = jest.fn();
+    globalThis.adspFeedback = { initialize: mockInitialize };
+
+    (useSelector as jest.Mock).mockReturnValue({ feedback: { url: mockUrl } });
+    (resolveFeedbackTenant as jest.Mock).mockReturnValue('');
+
+    // Act
+    renderHook(() => useInitializeFeedbackScript());
+
+    const script = document.querySelector(`script[src="${mockUrl}"]`);
+    script?.onload?.(new Event('load'));
+
+    // Assert
+    expect(mockInitialize).not.toHaveBeenCalled();
   });
 });

--- a/apps/sandbox-app/src/app/hooks/useInitializeFeedbackScript.ts
+++ b/apps/sandbox-app/src/app/hooks/useInitializeFeedbackScript.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { environmentSelector } from '../state';
-import { getFeedbackContext } from './useFeedbackWidget';
+import { getFeedbackContext, resolveFeedbackTenant } from './useFeedbackWidget';
 
 export const useInitializeFeedbackScript = (tenantName?: string) => {
   const environment = useSelector(environmentSelector);
@@ -19,8 +19,13 @@ export const useInitializeFeedbackScript = (tenantName?: string) => {
     script.async = true;
     script.src = src;
     script.onload = () => {
+      const tenant = resolveFeedbackTenant(tenantName);
+      if (!tenant) {
+        return;
+      }
+
       globalThis.adspFeedback?.initialize({
-        tenant: tenantName ?? '',
+        tenant,
         getContext: () => getFeedbackContext(),
       });
     };

--- a/apps/sandbox-app/src/config/config.json
+++ b/apps/sandbox-app/src/config/config.json
@@ -1,0 +1,15 @@
+{
+  "production": false,
+  "directory": {
+    "url": "https://directory-service.adsp-dev.gov.ab.ca"
+  },
+  "access": {
+    "url": "https://access.adsp-dev.gov.ab.ca",
+    "client_id": "urn:ads:platform:sandbox-app"
+  },
+  "feedback": {
+    "url": "https://feedback-service.adsp-dev.gov.ab.ca/feedback/v1/script/adspFeedback.js"
+  },
+  "tenantName": "",
+  "recaptchaKey": ""
+}

--- a/apps/sandbox-app/webpack.config.js
+++ b/apps/sandbox-app/webpack.config.js
@@ -1,6 +1,12 @@
 const { composePlugins, withNx } = require('@nx/webpack');
 const { withReact } = require('@nx/react');
 const { ProvidePlugin } = require('webpack');
+const { aliasReactComponents } = require('../../tools/webpack/react-components-version');
+
+const getReactComponentsPackage = () => {
+  const version = process.env.SANDBOX_DESIGN_SYSTEMS_VERSION;
+  return version === '1' || version === '1.0' ? '@abgov/react-components-ds1' : '@abgov/react-components';
+};
 
 // Nx plugins for webpack.
 module.exports = composePlugins(withNx(), withReact(), (config) => {
@@ -19,5 +25,5 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
     }),
   );
 
-  return config;
+  return aliasReactComponents(config, getReactComponentsPackage());
 });

--- a/libs/jsonforms-components/eslint.config.mjs
+++ b/libs/jsonforms-components/eslint.config.mjs
@@ -33,8 +33,6 @@ export default [
         {
           ignoredDependencies: [
             '@abgov/react-components',
-            '@abgov/react-components-ds1',
-            '@abgov/react-components-new',
           ],
           ignoredFiles: ['libs/jsonforms-components/rollup.config.js'],
         },

--- a/libs/jsonforms-components/jest.config.ts
+++ b/libs/jsonforms-components/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'jsonforms-components',
   preset: '../../jest-cover.preset.js',
@@ -7,8 +6,7 @@ export default {
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
   },
   moduleNameMapper: {
-    '^@abgov/react-components$': '@abgov/react-components-ds1',
-    '^@abgov/react-components-ds1$': '@abgov/react-components-ds1',
+    '^@abgov/react-components$': '@abgov/react-components',
     // @mdx-js/mdx, react-markdown and rehype-sanitize are ESM-only; stub them so Jest (babel-jest) can parse tests.
     // clean-code-ignore: RULE-19
     '@mdx-js/mdx': '<rootDir>/src/lib/.jest/mdx-js-stub.js',

--- a/libs/jsonforms-components/package.json
+++ b/libs/jsonforms-components/package.json
@@ -5,7 +5,7 @@
   "description": "Government of Alberta - React renderers for JSON Forms based on the design system.",
   "repository": "https://github.com/GovAlta/adsp-monorepo",
   "peerDependencies": {
-    "@abgov/react-components": "^6.9.3",
+    "@abgov/react-components": "^7.2.2",
     "@abgov/ui-components-common": "2.2.1",
     "@jsonforms/core": "^3.1.0",
     "@jsonforms/react": "^3.1.0",

--- a/libs/jsonforms-components/project.json
+++ b/libs/jsonforms-components/project.json
@@ -38,7 +38,7 @@
         "entryFile": "libs/jsonforms-components/src/index.ts",
         "external": [
           "@apidevtools/json-schema-ref-parser",
-          "@abgov/react-components-new",
+          "@abgov/react-components",
           "@jsonforms/core",
           "@jsonforms/react",
           "react",

--- a/libs/jsonforms-components/src/lib/Additional/GoACalloutControl.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/GoACalloutControl.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ControlProps, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { GoabCallout } from '@abgov/react-components-ds1';
+import { GoabCallout } from '@abgov/react-components';
 import { Visible } from '../util';
 import { GoabCalloutSize, GoabCalloutType } from '@abgov/ui-components-common';
 import { sanitizeHtml } from '../common/sanitize';

--- a/libs/jsonforms-components/src/lib/Additional/HelpContent.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/HelpContent.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
-import { GoabDetails } from '@abgov/react-components-ds1';
+import { GoabDetails } from '@abgov/react-components';
 import { HelpContentDiv, InvalidMarkdown } from './styled-components';
 import { ControlProps, ControlElement } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';

--- a/libs/jsonforms-components/src/lib/Additional/LinkControl.tsx
+++ b/libs/jsonforms-components/src/lib/Additional/LinkControl.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { isValidHref, isMailToHref } from '../Context/register/util';
-import { GoabFormItem, GoabIconButton } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabIconButton } from '@abgov/react-components';
 
 import { GoAContextMenuIcon } from '../Controls/FileUploader/ContextMenu';
 

--- a/libs/jsonforms-components/src/lib/Components/Dropdown.tsx
+++ b/libs/jsonforms-components/src/lib/Components/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { GoabInput, GoabInputProps } from '@abgov/react-components-ds1';
+import { GoabInput, GoabInputProps } from '@abgov/react-components';
 import { isEqual } from 'lodash';
 import {
   ALT_KEY,

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressInputs.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressInputs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Address } from './types';
-import { GoabFormItem, GoabInput, GoabGrid, GoabDropdownItem, GoabDropdown } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabInput, GoabGrid, GoabDropdownItem, GoabDropdown } from '@abgov/react-components';
 import { LabelDiv } from './styled-components';
 import {
   GoabInputOnChangeDetail,

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControl.tsx
@@ -3,7 +3,7 @@ import { ControlProps } from '@jsonforms/core';
 import { JsonFormContext } from '../../Context';
 import { AddressInputs } from './AddressInputs';
 
-import { GoabFormItem, GoabInput, GoabSpinner } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabInput, GoabSpinner } from '@abgov/react-components';
 import { Address, Suggestion } from './types';
 import { handleAddressKeyDown } from './utils';
 import {

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.tsx
@@ -12,7 +12,7 @@ import {
   RequiredTextLabel,
   NoneGivenText,
 } from '../Inputs/style-component';
-import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabButton, GoabFormItem } from '@abgov/react-components';
 import { useJsonForms } from '@jsonforms/react';
 import { REQUIRED_PROPERTY_ERROR, getAddressLookupFieldLabel } from '../../common/Constants';
 

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressViews.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressViews.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GoabFormItem, GoabGrid } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabGrid } from '@abgov/react-components';
 import { AddressIndent, LabelDiv, TextWrap } from './styled-components';
 
 interface AddressInputsProps {

--- a/libs/jsonforms-components/src/lib/Controls/Calculation/CalculationControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Calculation/CalculationControl.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { withJsonFormsControlProps, useJsonForms } from '@jsonforms/react';
 import { ControlProps, JsonSchema } from '@jsonforms/core';
-import { GoabFormItem, GoabInput } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabInput } from '@abgov/react-components';
 import { Visible } from '../../util';
 import { RankedTester, rankWith, and, schemaTypeIs, formatIs } from '@jsonforms/core';
 import { evaluateExpression, EvalResult, collectScopes } from './CalculationEngine';

--- a/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { ControlProps } from '@jsonforms/core';
-import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabButton, GoabFormItem } from '@abgov/react-components';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';

--- a/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContractInfoControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContractInfoControl.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ControlProps } from '@jsonforms/core';
 import { PhoneNumberControl } from '../PhoneNumber';
 import { GoAEmailInput } from '../Inputs/InputEmailControl';
-import { GoabDropdown, GoabDropdownItem, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabDropdown, GoabDropdownItem, GoabFormItem } from '@abgov/react-components';
 import { FormFieldWrapper } from './style-component';
 
 export const ContractInfoControl = (props: ControlProps): JSX.Element => {

--- a/libs/jsonforms-components/src/lib/Controls/FileUploader/ContextMenu.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FileUploader/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { GoabButton, GoabIconButton } from '@abgov/react-components-ds1';
+import { GoabButton, GoabIconButton } from '@abgov/react-components';
 import { GoabIconType } from '@abgov/ui-components-common';
 import styled from 'styled-components';
 

--- a/libs/jsonforms-components/src/lib/Controls/FileUploader/DeleteFileModal.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FileUploader/DeleteFileModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GoabButton, GoabModal, GoabButtonGroup } from '@abgov/react-components-ds1';
+import { GoabButton, GoabModal, GoabButtonGroup } from '@abgov/react-components';
 interface deleteModalProps {
   title: string;
   content?: string | JSX.Element;

--- a/libs/jsonforms-components/src/lib/Controls/FileUploader/FileUploaderControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FileUploader/FileUploaderControl.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { GoabFileUploadInput, GoabFormItem, GoabCircularProgress, GoabModal } from '@abgov/react-components-ds1';
+import { GoabFileUploadInput, GoabFormItem, GoabCircularProgress, GoabModal } from '@abgov/react-components';
 import { WithClassname, ControlProps } from '@jsonforms/core';
 
 import styled from 'styled-components';

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/ApplicationStatus.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/ApplicationStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GoabBadge } from '@abgov/react-components-ds1';
+import { GoabBadge } from '@abgov/react-components';
 import { CompletionStatus, BadgeWrapper, CompletionTextHeader, Bar, BarTop } from './styled-components';
 
 export const ApplicationStatus = ({

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/CategoryStatus.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/CategoryStatus.tsx
@@ -1,4 +1,4 @@
-import { GoabBadge } from '@abgov/react-components-ds1';
+import { GoabBadge } from '@abgov/react-components';
 import { CategoryState } from './context';
 
 export enum PageStatus {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperControl.tsx
@@ -7,7 +7,7 @@ import {
   GoabModal,
   GoabButtonGroup,
   GoabGrid,
-} from '@abgov/react-components-ds1';
+} from '@abgov/react-components';
 import { GoabButtonType } from '@abgov/ui-components-common';
 import { withJsonFormsLayoutProps, withTranslateProps } from '@jsonforms/react';
 import { withAjvProps } from '../../util/layout';

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/FormStepperReviewControl.tsx
@@ -5,7 +5,7 @@ import { withJsonFormsLayoutProps, withTranslateProps } from '@jsonforms/react';
 import { CategorizationStepperLayoutReviewRendererProps } from './types';
 import { Anchor, ReviewItem, ReviewItemHeader, ReviewItemSection, ReviewItemTitle } from './styled-components';
 import { withAjvProps } from '../../util/layout';
-import { GoabTable } from '@abgov/react-components-ds1';
+import { GoabTable } from '@abgov/react-components';
 import { FormStepperComponentProps } from './types';
 
 import { JsonFormsRendererRegistryEntry } from '@jsonforms/core';

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/RenderPages.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/RenderPages.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { GoabButton, GoabButtonGroup, GoabModal, GoabGrid } from '@abgov/react-components-ds1';
+import { GoabButton, GoabButtonGroup, GoabModal, GoabGrid } from '@abgov/react-components';
 import { Visible } from '../../util';
 import { PageBorder, PageRenderPadding } from './styled-components';
 import FormStepperPageReviewer from './PageStepperReviewControl';

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/TaskList.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/TaskList.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
-import { GoabTable, GoabText } from '@abgov/react-components-ds1';
+import { GoabTable, GoabText } from '@abgov/react-components';
 import { GoabCalloutType } from '@abgov/ui-components-common';
 import { PageBorder } from '../styled-components';
 import { CategoriesState, CategoryState } from '../context';

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/additionalInstructionsRow.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/additionalInstructionsRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GoabCallout } from '@abgov/react-components-ds1';
+import { GoabCallout } from '@abgov/react-components';
 import { GoabCalloutType } from '@abgov/ui-components-common';
 import { sanitizeHtml } from '../../../common/sanitize';
 

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/sectionHeaderRow.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/sectionHeaderRow.tsx
@@ -1,4 +1,4 @@
-import { GoabText } from '@abgov/react-components-ds1';
+import { GoabText } from '@abgov/react-components';
 import { SectionHeaderRowTr } from '../styled-components';
 
 interface SectionHeaderRowProps {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/summaryRow.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/TaskList/summaryRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SummaryRowLink, SummaryTd } from '../styled-components';
-import { GoabText } from '@abgov/react-components-ds1';
+import { GoabText } from '@abgov/react-components';
 
 interface SummaryRowProps {
   index: number;

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControl.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useEffect, useState, useRef, useContext, useMemo } from 'react';
 import { ControlProps, isEnabled } from '@jsonforms/core';
-import { GoabFormItem, GoabGrid } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabGrid } from '@abgov/react-components';
 import { NameInputs } from './FullNameInputs';
 import { TextWrapDiv } from '../AddressLookup/styled-components';
 import { Visible } from '../../util';

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { ControlProps } from '@jsonforms/core';
-import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabButton, GoabFormItem } from '@abgov/react-components';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameInputs.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameInputs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { GoabFormItem, GoabInput, GoabGrid } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabInput, GoabGrid } from '@abgov/react-components';
 import { GoabInputOnChangeDetail, GoabInputOnBlurDetail } from '@abgov/ui-components-common';
 
 interface Data {

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobControl.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { GoabFormItem, GoabGrid, GoabInput } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabGrid, GoabInput } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { useState, useRef, useEffect, useContext, useMemo } from 'react';
 import { useSyncAutofillFields } from '../../util/useSyncAutofillFields';

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabButton, GoabFormItem } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseControl.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useContext, useEffect, useRef } from 'react';
-import { GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabFormItem } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { checkFieldValidity, getControlLabelText } from '../../util/stringUtils';
 import { Visible } from '../../util';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseReviewControl.tsx
@@ -2,7 +2,7 @@ import { CellProps, WithClassname, ControlProps, StatePropsOfControl } from '@js
 import { WithInputProps } from './type';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { GoabIcon } from '@abgov/react-components-ds1';
+import { GoabIcon } from '@abgov/react-components';
 import { RequiredTextLabel, WarningIconDiv } from './style-component';
 import { getControlLabelText, to12HourFormat, UTCToFullLocalTime } from '../../util';
 

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -19,7 +19,7 @@ import {
   isNilOrEmptyValue,
 } from '../../util';
 import { humanizeAjvError } from '../ObjectArray/ListWithDetailControl';
-import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabButton, GoabFormItem } from '@abgov/react-components';
 
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { useReviewContext } from '../../Context/ReviewRenderContext';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanControl.tsx
@@ -1,6 +1,6 @@
 import { isBooleanControl, RankedTester, rankWith, ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { GoabCheckbox } from '@abgov/react-components-ds1';
+import { GoabCheckbox } from '@abgov/react-components';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { getLastSegmentFromPointer, convertToReadableFormat } from '../../util/stringUtils';
 import { WithInputProps } from './type';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanRadioControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBooleanRadioControl.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { isBooleanControl, RankedTester, rankWith, ControlProps, optionIs, and, or } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { GoabRadioGroup, GoabRadioItem } from '@abgov/react-components-ds1';
+import { GoabRadioGroup, GoabRadioItem } from '@abgov/react-components';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { WithInputProps } from './type';
 import { GoabRadioGroupOnChangeDetail } from '@abgov/ui-components-common';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputDateControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputDateControl.tsx
@@ -1,5 +1,5 @@
 import { CellProps, WithClassname, ControlProps, isDateControl, RankedTester, rankWith } from '@jsonforms/core';
-import { GoabInput } from '@abgov/react-components-ds1';
+import { GoabInput } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoAInputBaseControl } from './InputBaseControl';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputDateTimeControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputDateTimeControl.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CellProps, WithClassname, ControlProps, isDateTimeControl, RankedTester, rankWith } from '@jsonforms/core';
-import { GoabInput } from '@abgov/react-components-ds1';
+import { GoabInput } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoAInputBaseControl } from './InputBaseControl';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEmailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEmailControl.tsx
@@ -11,7 +11,7 @@ import {
   schemaTypeIs,
   formatIs,
 } from '@jsonforms/core';
-import { GoabInput, GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabInput, GoabFormItem } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { onChangeForInputControl, onBlurForTextControl } from '../../util/inputControlUtils';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnum.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnum.tsx
@@ -9,7 +9,7 @@ import { RegisterDataType } from '../../Context/register';
 import { callout } from '../../Additional/GoACalloutControl';
 import { JsonFormsRegisterContext, RegisterConfig } from '../../Context/register';
 import _ from 'lodash';
-import { GoabDropdown, GoabDropdownItem } from '@abgov/react-components-ds1';
+import { GoabDropdown, GoabDropdownItem } from '@abgov/react-components';
 import { GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
 type EnumSelectProps = EnumCellProps & WithClassname & TranslateProps & WithInputProps & ControlProps;
 

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumCheckboxes.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumCheckboxes.tsx
@@ -5,7 +5,7 @@ import { WithInputProps } from './type';
 import merge from 'lodash/merge';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { WithOptionLabel } from '../../util';
-import { GoabCheckbox } from '@abgov/react-components-ds1';
+import { GoabCheckbox } from '@abgov/react-components';
 import { EnumCellProps, WithClassname } from '@jsonforms/core';
 import Checkboxes from '../../Components/CheckboxGroup';
 import { GoabCheckboxListOnChangeDetail } from '@abgov/ui-components-common';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumRadios.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputEnumRadios.tsx
@@ -16,10 +16,6 @@ import { WithInputProps } from './type';
 import merge from 'lodash/merge';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { WithOptionLabel } from '../../util';
-// Use @abgov/react-components so the React wrapper matches the goa-radio web component the app
-// registers (@abgov/web-components); @abgov/web-components-ds1 is never registered, so the ds1
-// wrapper rendered against the old element and left the checked dot on its grey fallback.
-// Revisit when the design system migration registers the ds1 web components app-wide.
 import { GoabRadioGroup, GoabRadioItem } from '@abgov/react-components';
 import { EnumCellProps, WithClassname } from '@jsonforms/core';
 import { GoabRadioGroupOnChangeDetail } from '@abgov/ui-components-common';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputIntegerControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputIntegerControl.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { CellProps, WithClassname, ControlProps, isIntegerControl, RankedTester, rankWith } from '@jsonforms/core';
-import { GoabInput } from '@abgov/react-components-ds1';
+import { GoabInput } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoAInputBaseControl } from './InputBaseControl';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputMultiLineTextControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputMultiLineTextControl.tsx
@@ -9,7 +9,7 @@ import {
   and,
   optionIs,
 } from '@jsonforms/core';
-import { GoabTextArea } from '@abgov/react-components-ds1';
+import { GoabTextArea } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoAInputBaseControl } from './InputBaseControl';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputNumberControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputNumberControl.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { CellProps, WithClassname, ControlProps, isNumberControl, RankedTester, rankWith } from '@jsonforms/core';
-import { GoabInput } from '@abgov/react-components-ds1';
+import { GoabInput } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoAInputBaseControl } from './InputBaseControl';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 import _ from 'lodash';
 import { CellProps, WithClassname, ControlProps, isStringControl, RankedTester, rankWith } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { GoabInput, GoabDropdown, GoabDropdownItem } from '@abgov/react-components-ds1';
+import { GoabInput, GoabDropdown, GoabDropdownItem } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { JsonFormRegisterProvider, RegisterDataType } from '../../Context/register';

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTimeControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTimeControl.tsx
@@ -1,5 +1,5 @@
 import { CellProps, WithClassname, ControlProps, isTimeControl, RankedTester, rankWith } from '@jsonforms/core';
-import { GoabInput } from '@abgov/react-components-ds1';
+import { GoabInput } from '@abgov/react-components';
 import { WithInputProps } from './type';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { GoAInputBaseControl } from './InputBaseControl';

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/DeleteDialog.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/DeleteDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { GoabButton, GoabModal, GoabButtonGroup } from '@abgov/react-components-ds1';
+import { GoabButton, GoabModal, GoabButtonGroup } from '@abgov/react-components';
 import { DeleteDialogContent } from './styled-components';
 
 export interface DeleteDialogProps {

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ListWithDetailControl.tsx
@@ -21,7 +21,7 @@ import type { ErrorObject } from 'ajv';
 import { WithDeleteDialogSupport } from './DeleteDialog';
 import ObjectArrayToolBar from './ObjectArrayToolBar';
 
-import { GoabButton, GoabGrid, GoabIconButton, GoabFormItem, GoabTable } from '@abgov/react-components-ds1';
+import { GoabButton, GoabGrid, GoabIconButton, GoabFormItem, GoabTable } from '@abgov/react-components';
 import {
   ToolBarHeader,
   ObjectArrayTitle,

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.tsx
@@ -14,7 +14,7 @@ import { ObjectArrayControl } from './ObjectListControl';
 import { Visible } from '../../util';
 import { composePaths } from '@jsonforms/core';
 
-import { GoabButton, GoabIconButton, GoabCheckbox } from '@abgov/react-components-ds1';
+import { GoabButton, GoabIconButton, GoabCheckbox } from '@abgov/react-components';
 import { JsonFormsDispatch } from '@jsonforms/react';
 import { getLabelText } from '../../util';
 import pluralize from 'pluralize';

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArrayToolBar.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArrayToolBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ControlElement, createDefaultValue, JsonSchema } from '@jsonforms/core';
-import { GoabButton } from '@abgov/react-components-ds1';
+import { GoabButton } from '@abgov/react-components';
 import { getLabelText } from '../../util';
 import { MarginTop } from './styled-components';
 import pluralize from 'pluralize';

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -9,7 +9,7 @@ import {
   GoabIconButton,
   GoabInput,
   GoabTable,
-} from '@abgov/react-components-ds1';
+} from '@abgov/react-components';
 import {
   ControlElement,
   JsonFormsCellRendererRegistryEntry,

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControlUtils.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { GoabTable } from '@abgov/react-components';
 import { DataObject, NestedItem, RenderCellColumnProps } from './ObjectListControlTypes';
-import { GoabIcon } from '@abgov/react-components-ds1';
+import { GoabIcon } from '@abgov/react-components';
 import { HilightCellWarning, ObjectArrayWarningIconDiv } from './styled-components';
 import { isEmpty } from 'lodash';
 import { ErrorObject } from 'ajv';

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberControl.tsx
@@ -1,4 +1,4 @@
-import { GoabFormItem, GoabInput } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabInput } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { useState } from 'react';

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberReviewControl.tsx
@@ -1,4 +1,4 @@
-import { GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabFormItem } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { TextWrapDiv } from '../AddressLookup/styled-components';

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberWithTypeControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberWithTypeControl.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { GoabFormItem, GoabInput, GoabDropdown, GoabDropdownItem } from '@abgov/react-components-ds1';
+import { GoabFormItem, GoabInput, GoabDropdown, GoabDropdownItem } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { useEffect, useState } from 'react';

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberWithTypeReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberWithTypeReviewControl.tsx
@@ -1,4 +1,4 @@
-import { GoabFormItem } from '@abgov/react-components-ds1';
+import { GoabFormItem } from '@abgov/react-components';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { TextWrapDiv } from '../AddressLookup/styled-components';


### PR DESCRIPTION
**Reviewer Instructions**

This change upgrades `libs/jsonforms-components` to support DS1/DS2 compatibility through webpack aliasing.

Please review with this expectation:

- `libs/jsonforms-components` should import `@abgov/react-components` only.
- The consuming app decides which Design System package is used at build time.
- DS1 compatibility should be preserved by aliasing `@abgov/react-components` to `@abgov/react-components-ds1`.
- DS2 apps can alias `@abgov/react-components` to the default `@abgov/react-components` package.
- No form schema or uiSchema changes should be required.
- No business component code should need to pass a runtime `designSystemsVersion` prop.

Suggested validation:

```bash
./node_modules/.bin/nx run jsonforms-components:lint --skip-nx-cache
./node_modules/.bin/nx run jsonforms-components:test --runInBand --skip-nx-cache
./node_modules/.bin/nx run jsonforms-components:build --skip-nx-cache
./node_modules/.bin/nx run sandbox-app:build:development --skip-nx-cache
```

Manual sandbox validation:

```bash
SANDBOX_DESIGN_SYSTEMS_VERSION=1.0 ./node_modules/.bin/nx run sandbox-app:serve:development --port=4200
SANDBOX_DESIGN_SYSTEMS_VERSION=2.0 ./node_modules/.bin/nx run sandbox-app:serve:development --port=4201
```

Compare:

```text
DS1: http://localhost:4200/autotest/services/jsonforms/example1/control-examples
DS2: http://localhost:4201/autotest/services/jsonforms/example1/control-examples
```

**User / Consuming App Instructions**

If your app uses `libs/jsonforms-components`, you do not need to change your form definitions, data schemas, uiSchemas, or page/component code.

The Design System version is selected by the host app webpack config.

DS1 app:

```js
return aliasReactComponents(config, '@abgov/react-components-ds1');
```

DS2 app:

```js
return aliasReactComponents(config, '@abgov/react-components');
```

Recommended default policy:

- If no Design System version is specified, use DS1 to avoid breaking older apps.
- Apps that are ready for DS2 should explicitly opt in with `2.0`.

Example env-based config:

```js
const version = process.env.JSONFORMS_DESIGN_SYSTEMS_VERSION;
const packageName = version === '2.0' ? '@abgov/react-components' : '@abgov/react-components-ds1';

return aliasReactComponents(config, packageName);
```

Run DS2 locally:

```bash
JSONFORMS_DESIGN_SYSTEMS_VERSION=2.0 ./node_modules/.bin/nx run <app-name>:serve:development
```