### PR TITLE
fix(form-admin-app): scope applicant questions to the selected form's topic

### DIFF
--- a/apps/form-admin-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.spec.ts
@@ -1,7 +1,9 @@
+import { addComment, commentReducer, commentsSelector, deleteComment, loadComments, selectTopic } from './comment.slice';
+
+// babel-jest hoists these above the import; the slice creates an axios client and a socket at
+// module load, and neither is exercised by reducer and selector tests.
 jest.mock('axios');
 jest.mock('socket.io-client', () => ({ io: jest.fn() }));
-
-import { addComment, commentReducer, commentsSelector, deleteComment, loadComments, selectTopic } from './comment.slice';
 
 type CommentState = ReturnType<typeof commentReducer>;
 

--- a/apps/form-admin-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.spec.ts
@@ -1,0 +1,151 @@
+jest.mock('axios');
+jest.mock('socket.io-client', () => ({ io: jest.fn() }));
+
+import { addComment, commentReducer, commentsSelector, deleteComment, loadComments, selectTopic } from './comment.slice';
+
+type CommentState = ReturnType<typeof commentReducer>;
+
+const topicA = { id: 1, resourceId: 'urn:form:a', name: 'Form A', typeId: 'form-questions', requiresAttention: false };
+const topicB = { id: 2, resourceId: 'urn:form:b', name: 'Form B', typeId: 'form-questions', requiresAttention: false };
+
+const comment = (id: number, content: string) => ({
+  id,
+  content,
+  createdOn: '2026-08-20T12:00:00Z',
+  createdBy: { id: 'user-1', name: 'Tester' },
+});
+
+function stateWith(overrides: Partial<CommentState> = {}): CommentState {
+  const initial = commentReducer(undefined, { type: '@@INIT' });
+  return { ...initial, ...overrides } as CommentState;
+}
+
+function loadedState(topic: typeof topicA, comments: ReturnType<typeof comment>[]): CommentState {
+  return stateWith({
+    topics: { [topic.resourceId]: topic },
+    selected: { resourceId: topic.resourceId, canRead: true, canComment: true },
+    comments: { topicId: topic.id, results: comments, next: null },
+  });
+}
+
+describe('commentReducer', () => {
+  describe('loadComments', () => {
+    it('should clear comments of another topic when loading a page', () => {
+      const state = commentReducer(
+        loadedState(topicA, [comment(10, 'from form A')]),
+        loadComments.pending('req', { topic: topicB, after: 'page-2' }),
+      );
+
+      expect(state.comments.topicId).toBe(topicB.id);
+      expect(state.comments.results).toEqual([]);
+    });
+
+    it('should append a page of the topic already loaded', () => {
+      let state = loadedState(topicA, [comment(10, 'from form A')]);
+      state = commentReducer(state, loadComments.pending('req', { topic: topicA, after: 'page-2' }));
+      state = commentReducer(
+        state,
+        loadComments.fulfilled({ results: [comment(11, 'also form A')], page: {} }, 'req', {
+          topic: topicA,
+          after: 'page-2',
+        }),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([10, 11]);
+    });
+
+    it('should ignore a response for a topic that is no longer loaded', () => {
+      let state = loadedState(topicB, []);
+      state = commentReducer(state, loadComments.pending('req-b', { topic: topicB }));
+      state = commentReducer(
+        state,
+        loadComments.fulfilled({ results: [comment(10, 'from form A')], page: {} }, 'req-a', { topic: topicA }),
+      );
+
+      expect(state.comments.topicId).toBe(topicB.id);
+      expect(state.comments.results).toEqual([]);
+    });
+  });
+
+  describe('selectTopic', () => {
+    it('should clear comments when selecting a form with no topic', () => {
+      const state = commentReducer(
+        loadedState(topicA, [comment(10, 'from form A')]),
+        selectTopic.fulfilled({ canComment: false, canRead: false }, 'req', { resourceId: 'urn:form:c' }),
+      );
+
+      expect(state.comments.topicId).toBeNull();
+      expect(state.comments.results).toEqual([]);
+    });
+
+    it('should keep comments loaded for the topic being selected', () => {
+      // selectTopic dispatches loadComments before it fulfills, so the new topic's comments are
+      // already in state by the time the selection is recorded.
+      let state = stateWith({ topics: { [topicB.resourceId]: topicB } });
+      state = commentReducer(state, loadComments.pending('req', { topic: topicB }));
+      state = commentReducer(
+        state,
+        loadComments.fulfilled({ results: [comment(20, 'from form B')], page: {} }, 'req', { topic: topicB }),
+      );
+      state = commentReducer(
+        state,
+        selectTopic.fulfilled({ canComment: true, canRead: true }, 'req', { resourceId: topicB.resourceId }),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([20]);
+    });
+  });
+
+  describe('addComment', () => {
+    it('should add the comment to the list of its own topic', () => {
+      const state = commentReducer(
+        loadedState(topicA, [comment(10, 'from form A')]),
+        addComment.fulfilled(comment(11, 'new'), 'req', { topic: topicA, comment: { content: 'new' } }),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([11, 10]);
+    });
+
+    it('should not add the comment to a list of another topic', () => {
+      const state = commentReducer(
+        loadedState(topicA, [comment(10, 'from form A')]),
+        addComment.fulfilled(comment(20, 'new'), 'req', { topic: topicB, comment: { content: 'new' } }),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([10]);
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('should not remove a comment of the same id from another topic', () => {
+      const state = commentReducer(
+        loadedState(topicA, [comment(10, 'from form A')]),
+        deleteComment.fulfilled({ deleted: true }, 'req', { topicId: topicB.id, commentId: 10 }),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([10]);
+    });
+  });
+});
+
+describe('commentsSelector', () => {
+  const select = (comment: CommentState) =>
+    commentsSelector({ comment, user: { user: { id: 'user-1' } } } as Parameters<typeof commentsSelector>[0]);
+
+  it('should return comments loaded for the selected topic', () => {
+    expect(select(loadedState(topicA, [comment(10, 'from form A')])).results.map((r) => r.id)).toEqual([10]);
+  });
+
+  it('should not return comments loaded for another topic', () => {
+    const state = loadedState(topicA, [comment(10, 'from form A')]);
+    const { results, next } = select({
+      ...state,
+      topics: { ...state.topics, [topicB.resourceId]: topicB },
+      selected: { ...state.selected, resourceId: topicB.resourceId },
+      comments: { ...state.comments, next: 'page-2' },
+    });
+
+    expect(results).toEqual([]);
+    expect(next).toBeNull();
+  });
+});

--- a/apps/form-admin-app/src/app/state/comment.slice.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.ts
@@ -218,8 +218,8 @@ export const selectTopic = createAsyncThunk(
     if (toSelect) {
       const type = comment.topicTypes[toSelect.typeId];
       canComment =
-        hasRole('urn:ads:platform:comment-service:comment-admin', user.user) || hasRole(type.commenterRoles, user.user);
-      canRead = canComment || hasRole(type.readerRoles, user.user);
+        hasRole('urn:ads:platform:comment-service:comment-admin', user.user) || hasRole(type?.commenterRoles, user.user);
+      canRead = canComment || hasRole(type?.readerRoles, user.user);
     }
 
     // Load comments if this is changing the selected topic, and user can read the new topic.
@@ -305,6 +305,9 @@ interface CommentState {
   };
   updateStreamConnected: boolean;
   comments: {
+    // The topic the loaded comments belong to; comments are per topic, so this is what keeps one
+    // form's messages out of another's.
+    topicId: number;
     results: Comment[];
     next: string;
   };
@@ -327,6 +330,7 @@ const initialCommentState: CommentState = {
   },
   updateStreamConnected: false,
   comments: {
+    topicId: null,
     results: [],
     next: null,
   },
@@ -391,19 +395,35 @@ const commentSlice = createSlice({
         state.busy.loading = false;
       })
       .addCase(selectTopic.fulfilled, (state, { meta, payload }) => {
+        // Selecting a form that has no topic, or one the user can't read, doesn't load any comments,
+        // so the previously selected form's messages are cleared here instead.
+        if (state.comments.topicId !== (state.topics[meta.arg.resourceId]?.id ?? null)) {
+          state.comments.topicId = null;
+          state.comments.results = [];
+          state.comments.next = null;
+        }
+
         state.selected.resourceId = meta.arg.resourceId;
         state.selected.canComment = payload.canComment;
         state.selected.canRead = payload.canRead;
       })
       .addCase(loadComments.pending, (state, { meta }) => {
         state.busy.loading = true;
-        if (!meta.arg.after) {
+        // Only a paged load of the topic already in state appends to it.
+        if (!meta.arg.after || state.comments.topicId !== meta.arg.topic?.id) {
           state.comments.results = [];
           state.comments.next = null;
         }
+        state.comments.topicId = meta.arg.topic?.id ?? null;
       })
-      .addCase(loadComments.fulfilled, (state, { payload }) => {
+      .addCase(loadComments.fulfilled, (state, { payload, meta }) => {
         state.busy.loading = false;
+
+        // Requests for two topics can be in flight at once, and the response that loses the race
+        // belongs to a form that is no longer selected.
+        if (state.comments.topicId !== meta.arg.topic?.id) {
+          return;
+        }
 
         state.comments.results = [...state.comments.results, ...payload.results];
         state.comments.next = payload.page.next;
@@ -414,9 +434,11 @@ const commentSlice = createSlice({
       .addCase(addComment.pending, (state) => {
         state.busy.executing = true;
       })
-      .addCase(addComment.fulfilled, (state, { payload }) => {
+      .addCase(addComment.fulfilled, (state, { payload, meta }) => {
         state.busy.executing = false;
-        state.comments.results.unshift(payload);
+        if (state.comments.topicId === meta.arg.topic?.id) {
+          state.comments.results.unshift(payload);
+        }
         state.draft = { title: null, content: null };
       })
       .addCase(addComment.rejected, (state) => {
@@ -428,7 +450,11 @@ const commentSlice = createSlice({
       })
       .addCase(deleteComment.fulfilled, (state, { meta }) => {
         state.busy.executing = false;
-        state.comments.results = state.comments.results.filter((y) => y.id !== meta.arg.commentId);
+        // Comment ids are per topic, so filtering a list belonging to another topic can drop the
+        // wrong message.
+        if (state.comments.topicId === meta.arg.topicId) {
+          state.comments.results = state.comments.results.filter((y) => y.id !== meta.arg.commentId);
+        }
       })
       .addCase(deleteComment.rejected, (state) => {
         state.busy.executing = false;
@@ -456,17 +482,23 @@ export const selectedTopicSelector = createSelector(
 
 export const commentsSelector = createSelector(
   (state: AppState) => state.comment.comments,
+  selectedTopicSelector,
   (state: AppState) => state.user.user?.id,
-  ({ results, next }, userId) => ({
-    results: [...results]
-      .map((r) => ({
-        ...r,
-        createdOn: new Date(r.createdOn),
-        byCurrentUser: r.createdBy.id === userId,
-      }))
-      .sort((a, b) => b.createdOn.getTime() - a.createdOn.getTime()),
-    next,
-  }),
+  ({ topicId, results, next }, selectedTopic, userId) => {
+    // Comments loaded for another topic are never shown against the selected form.
+    const forSelectedTopic = topicId !== null && topicId === selectedTopic?.id;
+
+    return {
+      results: (forSelectedTopic ? [...results] : [])
+        .map((r) => ({
+          ...r,
+          createdOn: new Date(r.createdOn),
+          byCurrentUser: r.createdBy.id === userId,
+        }))
+        .sort((a, b) => b.createdOn.getTime() - a.createdOn.getTime()),
+      next: forSelectedTopic ? next : null,
+    };
+  },
 );
 
 export const commentExecutingSelector = (state: AppState) => state.comment.busy.executing;


### PR DESCRIPTION
## Problem
Applicant questions in form-admin mixed messages from different forms/submissions. Comments were kept in a single unscoped list (`comment.comments.results`), so:

- selecting a form with no topic, or one the user can't read, skipped `loadComments` and left the previous form's messages on screen;
- a `loadComments` response that lost a race with a newer selection was appended to the list of the form now selected;
- `addComment`/`deleteComment` applied to whatever list was in state, and comment ids are per topic.

## Fix
Track the topic the loaded comments belong to (`comments.topicId`) and use it to clear, append, mutate and render the list only for that topic. `selectTopic` now drops comments that don't belong to the newly selected topic, and `commentsSelector` won't render comments against a form they weren't loaded for. Also guards `selectTopic` against a topic type that hasn't loaded, which previously threw and left the stale selection in place.

## Verification
- New `comment.slice.spec.ts` covers cross-topic paging, out-of-order responses, selection changes, add/delete scoping, and the selector guard.
- `form-admin-app` suite: 58 tests pass; lint clean (one pre-existing warning); no new type errors.
- Manual testing in the running app still to be done: switch between forms/submissions that have messages and confirm each shows only its own.