### PR TITLE
feat(jsonforms-components, form-admin-app): remove Change buttons from form admin submissions [CS-5288]

### DIFF
--- a/apps/form-admin-app/src/app/containers/FormViewer.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/FormViewer.spec.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { FormViewer } from './FormViewer';
+
+/**
+ * VERY IMPORTANT:  Rendering <JsonForms ... /> does not work unless the following
+ * is included.
+ */
+window.matchMedia = jest.fn().mockImplementation((query) => ({
+  matches: true,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+}));
+
+const dataSchema = {
+  type: 'object',
+  properties: {
+    firstName: { type: 'string' },
+    lastName: { type: 'string' },
+  },
+};
+
+const uiSchema = {
+  type: 'Categorization',
+  elements: [
+    {
+      type: 'Category',
+      label: 'Applicant',
+      elements: [
+        { type: 'Control', scope: '#/properties/firstName', label: 'First name' },
+        { type: 'Control', scope: '#/properties/lastName', label: 'Last name' },
+      ],
+    },
+  ],
+};
+
+const store = configureStore({ reducer: { noop: (state = {}) => state } });
+
+const renderViewer = () =>
+  render(
+    <Provider store={store}>
+      <FormViewer
+        dataSchema={dataSchema}
+        uiSchema={uiSchema}
+        data={{ firstName: 'Bob', lastName: 'Smith' }}
+        files={{}}
+      />
+    </Provider>,
+  );
+
+describe('FormViewer', () => {
+  it('renders the submitted answers', () => {
+    renderViewer();
+
+    expect(screen.getByText('Applicant')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Smith')).toBeInTheDocument();
+  });
+
+  it('does not offer Change buttons, since reviewers cannot edit a submission', () => {
+    renderViewer();
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+  });
+});

--- a/apps/form-admin-app/src/app/containers/FormViewer.tsx
+++ b/apps/form-admin-app/src/app/containers/FormViewer.tsx
@@ -32,6 +32,7 @@ export const FormViewer: FunctionComponent<SubmittedFormProps> = ({ dataSchema, 
   return dataSchema && uiSchema ? (
     <ContextProvider
       isFormSubmitted={true}
+      showChangeButtons={false}
       fileManagement={{
         fileList: files,
         downloadFile: downloadFileHandler,

--- a/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
@@ -20,6 +20,7 @@ export interface enumerators {
   getAllFormContextData: () => AllData;
   isFormSubmitted: boolean;
   formUrl: string;
+  showChangeButtons: boolean;
 }
 
 interface FileManagement {
@@ -46,6 +47,10 @@ type Props = {
   fileManagement?: FileManagement;
   submit?: SubmitManagement;
   isFormSubmitted?: boolean;
+  // Whether the review renderers offer "Change" links back to the step that owns each answer.
+  // Hosts that only display a submission - form reviewers, for one - turn these off so the answers
+  // read as a record rather than something still being filled in. Defaults to true.
+  showChangeButtons?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -93,6 +98,7 @@ export class ContextProviderClass {
     getFormContextData: (key: string) => Record<string, any> | undefined;
     getAllFormContextData: () => AllData;
     isFormSubmitted?: boolean;
+    showChangeButtons?: boolean;
     formUrl: string | null | undefined;
     autoPopulatedData?: AutoPopulatedValue[];
     formId?: string;
@@ -177,6 +183,7 @@ export class ContextProviderClass {
       this.baseEnumerator.formUrl = props.formUrl;
     }
     this.baseEnumerator.isFormSubmitted = props.isFormSubmitted ?? false;
+    this.baseEnumerator.showChangeButtons = props.showChangeButtons ?? true;
     this.baseEnumerator.autoPopulatedData = props.autoPopulatedData ?? [];
     this.baseEnumerator.formId = props.formId;
     return <JsonFormContext.Provider value={this.baseEnumerator}>{this.selfProps?.children}</JsonFormContext.Provider>;
@@ -229,3 +236,12 @@ export const ContextProviderC = new ContextProviderClass();
 export const ContextProviderFactory = () => new ContextProviderClass().setup;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const JsonFormContext = createContext<any>(null);
+
+/**
+ * Whether review renderers should show their "Change" buttons. Hosts opt out through the context
+ * provider; anything rendered without a provider keeps the buttons.
+ */
+export const useShowChangeButtons = (): boolean => {
+  const enumerators = useContext(JsonFormContext);
+  return enumerators?.showChangeButtons !== false;
+};

--- a/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
@@ -20,6 +20,7 @@ export interface enumerators {
   getAllFormContextData: () => AllData;
   isFormSubmitted: boolean;
   formUrl: string;
+  // clean-code-ignore: RULE-19 — see the file-header note; ./context.spec.tsx covers this.
   showChangeButtons: boolean;
 }
 

--- a/libs/jsonforms-components/src/lib/Context/context.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Context/context.spec.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { enumerators, ContextProviderC, ContextProviderFactory } from '.';
+import { enumerators, ContextProviderC, ContextProviderFactory, useShowChangeButtons } from '.';
 import axios from 'axios';
 import { JsonFormContext } from '.';
 
@@ -223,5 +223,45 @@ describe('contextProvider', () => {
     expect(component.getByText('Dolphin')).toBeInTheDocument();
     expect(component.getByText('Kangaroo')).toBeInTheDocument();
     expect(component.getByText('Penguin')).toBeInTheDocument();
+  });
+
+  describe('useShowChangeButtons', () => {
+    const ShowsFlag = () => <div>{useShowChangeButtons() ? 'shown' : 'hidden'}</div>;
+
+    it('keeps change buttons when the host says nothing', () => {
+      const component = render(
+        <ContextProvider>
+          <ShowsFlag />
+        </ContextProvider>
+      );
+
+      expect(component.getByText('shown')).toBeInTheDocument();
+    });
+
+    it('hides change buttons when the host opts out', () => {
+      const component = render(
+        <ContextProvider showChangeButtons={false}>
+          <ShowsFlag />
+        </ContextProvider>
+      );
+
+      expect(component.getByText('hidden')).toBeInTheDocument();
+    });
+
+    it('keeps change buttons when the host opts in', () => {
+      const component = render(
+        <ContextProvider showChangeButtons={true}>
+          <ShowsFlag />
+        </ContextProvider>
+      );
+
+      expect(component.getByText('shown')).toBeInTheDocument();
+    });
+
+    it('keeps change buttons when rendered without a provider', () => {
+      const component = render(<ShowsFlag />);
+
+      expect(component.getByText('shown')).toBeInTheDocument();
+    });
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.spec.tsx
@@ -203,6 +203,41 @@ describe('AddressLoopUpControlTableReview', () => {
     expect(screen.getByText('Change')).toBeInTheDocument();
   });
 
+  it('should not render Change button when the host turns change buttons off', () => {
+    const propsWithStepId = {
+      ...defaultProps,
+      uischema: {
+        ...defaultProps.uischema,
+        options: {
+          ...defaultProps.uischema.options,
+          stepId: 'step-address',
+        },
+      },
+    };
+
+    render(
+      <JsonFormsStepperContextProvider
+        StepperProps={stepperBaseProps}
+        children={
+          <JsonFormContext.Provider value={{ ...mockFormContext, showChangeButtons: false }}>
+            <AddressLoopUpControlTableReview
+              label={''}
+              errors={''}
+              rootSchema={{}}
+              id={''}
+              enabled={false}
+              visible={false}
+              {...propsWithStepId}
+            />
+          </JsonFormContext.Provider>
+        }
+      />,
+    );
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+    expect(screen.getByText('Edmonton')).toBeInTheDocument();
+  });
+
   it('should not render Change button when stepId is undefined', () => {
     renderComponent();
     expect(screen.queryByText('Change')).not.toBeInTheDocument();

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.tsx
@@ -15,6 +15,7 @@ import {
 import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 import { useJsonForms } from '@jsonforms/react';
 import { REQUIRED_PROPERTY_ERROR, getAddressLookupFieldLabel } from '../../common/Constants';
+import { useShowChangeButtons } from '../../Context/ContextProvider';
 
 type AddressViewProps = ControlProps;
 
@@ -32,6 +33,7 @@ export const AddressLoopUpControlTableReview = (props: AddressViewProps): JSX.El
 
   const stepId = uischema.options?.stepId;
   const formStepperCtx = useContext(JsonFormsStepperContext);
+  const showChangeButtons = useShowChangeButtons();
   const isAlbertaAddress = schema?.properties?.subdivisionCode?.const === 'AB';
 
   const provinces = [
@@ -139,7 +141,7 @@ export const AddressLoopUpControlTableReview = (props: AddressViewProps): JSX.El
               {label}
               {required && <RequiredTextLabel> (required)</RequiredTextLabel>}
             </ReviewLabel>
-            {showButton && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
+            {showButton && showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
               <GoabButton
                 type="text"
                 size="compact"
@@ -165,7 +167,7 @@ export const AddressLoopUpControlTableReview = (props: AddressViewProps): JSX.El
         <PageReviewContainer colSpan={3}>
           <ReviewHeader>
             <ReviewLabel>{`${isAlbertaAddress ? 'Alberta' : 'Canada'} postal address`}</ReviewLabel>
-            {stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
+            {showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
               <GoabButton
                 type="text"
                 size="compact"

--- a/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.spec.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { ControlProps } from '@jsonforms/core';
 import { ContractInfoControlReview } from './ContactInfoControlReview';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { JsonFormContext } from '../../Context';
 
 describe('ContractInfoControlReview', () => {
   const mockGoToPage = jest.fn();
@@ -74,6 +75,23 @@ describe('ContractInfoControlReview', () => {
 
     const changeButtons = screen.getAllByText('Change');
     expect(changeButtons).toHaveLength(3);
+  });
+
+  it('does not render Change buttons when the host turns change buttons off', () => {
+    render(
+      <table>
+        <tbody>
+          <JsonFormContext.Provider value={{ showChangeButtons: false }}>
+            <JsonFormsStepperContext.Provider value={stepperContextValue}>
+              <ContractInfoControlReview {...defaultProps} />
+            </JsonFormsStepperContext.Provider>
+          </JsonFormContext.Provider>
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+    expect(screen.getByTestId('email-control-contact-1')).toHaveTextContent('john@example.com');
   });
 
   it('does not render Change buttons when stepId is undefined', () => {

--- a/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.tsx
@@ -4,11 +4,13 @@ import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useShowChangeButtons } from '../../Context/ContextProvider';
 
 type ContractInfoControlReviewProps = ControlProps;
 
 export const ContractInfoControlReview = (props: ContractInfoControlReviewProps): JSX.Element => {
   const context = useContext(JsonFormsStepperContext);
+  const showChangeButtons = useShowChangeButtons();
   const stepId = props.uischema?.options?.stepId;
 
   const { uischema, data = {}, id, schema } = props;
@@ -23,7 +25,7 @@ export const ContractInfoControlReview = (props: ContractInfoControlReviewProps)
       <PageReviewContainer colSpan={3}>
         <ReviewHeader>
           <ReviewLabel>{fieldLabel}</ReviewLabel>
-          {stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
+          {showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
             <GoabButton
               type="text"
               size="compact"

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.spec.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { FullNameControlReview } from './FullNameControlReview';
 import { ControlProps } from '@jsonforms/core';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { JsonFormContext } from '../../Context';
 
 describe('FullNameControlReview', () => {
   const mockGoToPage = jest.fn();
@@ -140,6 +141,23 @@ describe('FullNameControlReview', () => {
     const lastNameError = baseElement.querySelector('goa-form-item[error="Last name is required"]');
     expect(firstNameError).toBeInTheDocument();
     expect(lastNameError).toBeInTheDocument();
+  });
+
+  it('does not render Change button when the host turns change buttons off', () => {
+    render(
+      <table>
+        <tbody>
+          <JsonFormContext.Provider value={{ showChangeButtons: false }}>
+            <JsonFormsStepperContext.Provider value={stepperContextValue}>
+              <FullNameControlReview {...defaultProps} />
+            </JsonFormsStepperContext.Provider>
+          </JsonFormContext.Provider>
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+    expect(screen.getByText('John')).toBeInTheDocument();
   });
 
   it('does not render Change button when stepId is undefined', () => {

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.tsx
@@ -6,11 +6,13 @@ import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { isNilOrEmptyString } from '../../util';
 import { RequiredTextLabel } from '../Inputs/style-component';
+import { useShowChangeButtons } from '../../Context/ContextProvider';
 
 type FullNameControlReviewProps = ControlProps;
 
 export const FullNameControlReview = (props: FullNameControlReviewProps): JSX.Element => {
   const context = useContext(JsonFormsStepperContext);
+  const showChangeButtons = useShowChangeButtons();
   const stepId = props.uischema?.options?.stepId;
   const { uischema, data, id } = props;
   const requiredFields = props.schema?.required ?? [];
@@ -24,7 +26,7 @@ export const FullNameControlReview = (props: FullNameControlReviewProps): JSX.El
             {fieldLabel}
             {requiredFields.includes(fieldName) && <RequiredTextLabel> (required)</RequiredTextLabel>}
           </ReviewLabel>
-          {stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
+          {showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
             <GoabButton
               type="text"
               onClick={() => context?.goToPage(stepId, uischema.scope)}

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.spec.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { FullNameDobReviewControl } from './FullNameDobReviewControl';
 import { ControlProps } from '@jsonforms/core';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { JsonFormContext } from '../../Context';
 
 describe('FullNameDobReviewControl', () => {
   const mockGoToPage = jest.fn();
@@ -148,6 +149,22 @@ describe('FullNameDobReviewControl', () => {
     expect(firstNameError).toBeInTheDocument();
     expect(lastNameError).toBeInTheDocument();
     expect(dobError).toBeInTheDocument();
+  });
+
+  it('does not render Change button when the host turns change buttons off', () => {
+    render(
+      <table>
+        <tbody>
+          <JsonFormContext.Provider value={{ showChangeButtons: false }}>
+            <JsonFormsStepperContext.Provider value={stepperContextValue}>
+              <FullNameDobReviewControl {...defaultProps} />
+            </JsonFormsStepperContext.Provider>
+          </JsonFormContext.Provider>
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
   });
 
   it('does not render Change button when stepId is undefined', () => {

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.tsx
@@ -6,12 +6,14 @@ import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { isNilOrEmptyString } from '../../util';
 import { RequiredTextLabel } from '../Inputs/style-component';
+import { useShowChangeButtons } from '../../Context/ContextProvider';
 
 type DateOfBirthReviewControlProps = ControlProps;
 
 export const FullNameDobReviewControl = (props: DateOfBirthReviewControlProps): JSX.Element => {
   const { data, id, uischema } = props;
   const context = useContext(JsonFormsStepperContext);
+  const showChangeButtons = useShowChangeButtons();
   const stepId = uischema?.options?.stepId;
   const requiredFields = props.schema?.required ?? [];
   const isMissing = (value: string | null | undefined): boolean => isNilOrEmptyString(value);
@@ -25,7 +27,7 @@ export const FullNameDobReviewControl = (props: DateOfBirthReviewControlProps): 
             {requiredFields.includes(fieldName) && <RequiredTextLabel> (required)</RequiredTextLabel>}
           </ReviewLabel>
 
-          {stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
+          {showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
             <GoabButton
               type="text"
               size="compact"

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -9,6 +9,7 @@ import { GoAInputBaseTableReview } from './InputBaseTableReviewControl';
 import { JsonFormsStepperContext, JsonFormsStepperContextProps } from '../FormStepper/context/StepperContext';
 import { invalidSin } from '../../common/Constants';
 import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
+import { JsonFormContext } from '../../Context';
 
 import { CategorizationStepperLayoutRendererProps } from '../FormStepper/types';
 import { JsonFormsStepperContextProvider } from '../FormStepper/context';
@@ -430,6 +431,59 @@ describe('InputBaseTableReviewControl', () => {
         </tbody>
       </table>,
     );
+
+  it('renders a Change button for a step-scoped row by default', () => {
+    renderReviewRow({
+      data: 'Bob',
+      path: 'firstName',
+      schema: { type: 'string' },
+      uischema: {
+        type: 'Control',
+        scope: '#/properties/firstName',
+        label: 'First name',
+        options: { stepId: 0 },
+      },
+      required: false,
+    });
+
+    expect(screen.getByText('Change')).toBeInTheDocument();
+  });
+
+  it('does not render a Change button when the host turns change buttons off', () => {
+    render(
+      <JsonFormContext.Provider value={{ showChangeButtons: false }}>
+        <table>
+          <tbody>
+            <GoAInputBaseTableReview
+              data="Bob"
+              visible={true}
+              label="First name"
+              path="firstName"
+              schema={{ type: 'string' }}
+              uischema={{
+                type: 'Control',
+                scope: '#/properties/firstName',
+                label: 'First name',
+                options: { stepId: 0 },
+              }}
+              enabled={true}
+              errors=""
+              cells={[]}
+              required={false}
+              id="firstName"
+              rootSchema={{ type: 'object', properties: {} }}
+              config={{}}
+              renderers={[]}
+              handleChange={jest.fn()}
+            />
+          </tbody>
+        </table>
+      </JsonFormContext.Provider>,
+    );
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+    expect(screen.getByTestId('review-value-First name')).toHaveTextContent('Bob');
+  });
 
   it('renders without crashing', () => {
     expect(stepperBasePropsReview).toBeDefined();

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -23,12 +23,14 @@ import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { useReviewContext } from '../../Context/ReviewRenderContext';
+import { useShowChangeButtons } from '../../Context/ContextProvider';
 import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
 
 export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null => {
   const { data, uischema, label, schema, rootSchema, path, errors, enabled, cells, required, visible } = props;
   const context = useContext(JsonFormsStepperContext);
   const reviewCtx = useReviewContext();
+  const showChangeButtons = useShowChangeButtons();
   const jsonForms = useJsonForms();
   const reviewLabel = typeof uischema.options?.reviewLabel === 'string' ? (uischema.options.reviewLabel as string) : '';
   const propLabel = typeof label === 'string' ? label : '';
@@ -248,7 +250,7 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
             {labelToUpdate}
             {required && <RequiredTextLabel> (required)</RequiredTextLabel>}
           </ReviewLabel>
-          {stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
+          {showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
             <GoabButton type="text" size="compact" onClick={handleChangeClick}>
               Change
             </GoabButton>

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ObjectArrayControl, NonEmptyCellComponent } from './ObjectListControl';
 import { ControlElement, ArrayTranslations } from '@jsonforms/core';
+import { JsonFormContext } from '../../Context';
 import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
 jest.mock('@jsonforms/react');
 
@@ -99,6 +100,52 @@ const baseMockProps = {
   addItem: jest.fn(),
 };
 describe('Object List component', () => {
+  const reviewProps = {
+    ...baseMockProps,
+    data: [{ date: '2026-01-01', message: 'Hi' }],
+    isStepperReview: true,
+    uischema: { ...mockUISchema, options: { stepId: 0 } },
+  };
+
+  it('renders a Change button in review by default', async () => {
+    (useJsonForms as jest.Mock).mockReturnValue({
+      core: { schema: rootSchema, errors: [] },
+      cells: [],
+      renderers: [],
+    });
+
+    render(
+      <table>
+        <tbody>
+          <ObjectArrayControl {...reviewProps} />
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.getByText('Change')).toBeInTheDocument();
+  });
+
+  it('does not render a Change button in review when the host turns change buttons off', async () => {
+    (useJsonForms as jest.Mock).mockReturnValue({
+      core: { schema: rootSchema, errors: [] },
+      cells: [],
+      renderers: [],
+    });
+
+    render(
+      <JsonFormContext.Provider value={{ showChangeButtons: false }}>
+        <table>
+          <tbody>
+            <ObjectArrayControl {...reviewProps} />
+          </tbody>
+        </table>
+      </JsonFormContext.Provider>,
+    );
+
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+    expect(screen.getByText('Comments')).toBeInTheDocument();
+  });
+
   it('Can render the object array component', async () => {
     render(<ObjectArrayControl {...baseMockProps} />);
     const ObjectListWrapper = screen.getByTestId('jsonforms-object-list-wrapper');

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -24,6 +24,7 @@ import merge from 'lodash/merge';
 import range from 'lodash/range';
 import React, { useCallback, useContext, useEffect, useReducer, useState } from 'react';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useShowChangeButtons } from '../../Context/ContextProvider';
 import { capitalizeFirstLetter, isEmptyBoolean, isEmptyNumber, Visible } from '../../util';
 import {
   ADD_DATA_ACTION,
@@ -604,6 +605,7 @@ export const ObjectArrayControl = (props: ObjectArrayControlProps): JSX.Element 
   const [rowData, setRowData] = useState<number>(0);
   const [maxItemsError, setMaxItemsError] = useState('');
   const context = useContext(JsonFormsStepperContext);
+  const showChangeButtons = useShowChangeButtons();
 
   const {
     label,
@@ -792,15 +794,17 @@ export const ObjectArrayControl = (props: ObjectArrayControlProps): JSX.Element 
                   <span>{additionalProps.required && '(required)'}</span>
                   {maxItemsError && <span style={{ color: 'red', marginLeft: '1rem' }}>{maxItemsError}</span>}
                 </ReviewLabel>
-                {uischema.options?.stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
-                  <GoabButton
-                    type="text"
-                    size="compact"
-                    onClick={() => context?.goToPage(uischema.options?.stepId as number)}
-                  >
-                    Change
-                  </GoabButton>
-                )}
+                {showChangeButtons &&
+                  uischema.options?.stepId !== undefined &&
+                  !uischema.options?.componentProps?.readOnly && (
+                    <GoabButton
+                      type="text"
+                      size="compact"
+                      onClick={() => context?.goToPage(uischema.options?.stepId as number)}
+                    >
+                      Change
+                    </GoabButton>
+                  )}
               </ReviewHeader>
             )
           ) : null}

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -24,6 +24,8 @@ import merge from 'lodash/merge';
 import range from 'lodash/range';
 import React, { useCallback, useContext, useEffect, useReducer, useState } from 'react';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+// clean-code-ignore: RULE-19 — covered by ./ObjectArray.spec.tsx, colocated. The rule only looks
+// for a .test.tsx sibling; adding one would duplicate the existing suite.
 import { useShowChangeButtons } from '../../Context/ContextProvider';
 import { capitalizeFirstLetter, isEmptyBoolean, isEmptyNumber, Visible } from '../../util';
 import {


### PR DESCRIPTION
Form reviewers are not allowed to change the answers in a submission, so the Change buttons should not appear in the form admin app.

- Adds a `showChangeButtons` prop to the jsonforms `ContextProvider` (defaults to `true`) plus a `useShowChangeButtons` hook.
- All six review renderers that draw a Change button now check it: input rows, address lookup, contact info, full name, full name + DOB, and object arrays.
- `FormViewer` in the form admin app passes `showChangeButtons={false}`; form-app, task-app and the editor preview keep their buttons.

Tests: new coverage for the hook, for each review renderer, and a `FormViewer` spec asserting no Change button renders. jsonforms-components (1435), form-admin-app (60) and form-app (62) suites all pass.