### PR TITLE
fix(api-docs-app): fix crash under tenant context and improve cache freshness

### DIFF
--- a/apps/api-docs-app/src/docs/entryUpdateSubscription.ts
+++ b/apps/api-docs-app/src/docs/entryUpdateSubscription.ts
@@ -1,0 +1,49 @@
+import { adspId, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
+import { io, Socket } from 'socket.io-client';
+import { Logger } from 'winston';
+import { ServiceDocs } from './serviceDocs';
+
+interface SubscriptionProps {
+  logger: Logger;
+  directory: ServiceDirectory;
+  tokenProvider: TokenProvider;
+  serviceDocs: ServiceDocs;
+}
+
+const LOG_CONTEXT = { context: 'connectEntryUpdateSubscription' };
+
+export const connectEntryUpdateSubscription = async ({
+  logger,
+  directory,
+  tokenProvider,
+  serviceDocs,
+}: SubscriptionProps): Promise<Socket> => {
+  const pushServiceUrl = await directory.getServiceUrl(adspId`urn:ads:platform:push-service`);
+  const streamUrl = new URL('', pushServiceUrl);
+
+  const socket = io(streamUrl.href, {
+    autoConnect: true,
+    reconnection: true,
+    query: { stream: 'directory-entry-updates' },
+    transports: ['websocket'],
+    withCredentials: true,
+    auth: async (cb) => cb({ token: await tokenProvider.getAccessToken() }),
+  });
+
+  socket.on('connect', () => logger.info('Connected for directory entry updates...', LOG_CONTEXT));
+  socket.on('connect_error', (err) => logger.error(`Connect to directory entry updates failed with error: ${err}`, LOG_CONTEXT));
+  socket.on('disconnect', (reason) => logger.debug(`Disconnected from directory entry updates due to reason: ${reason}`, LOG_CONTEXT));
+
+  const handleEntryEvent = ({ payload }: { payload: { namespace: string } }) => {
+    const { namespace } = payload;
+    if (namespace) {
+      logger.debug(`Received directory entry update for namespace ${namespace}, invalidating cache.`, LOG_CONTEXT);
+      serviceDocs.invalidate(adspId`urn:ads:${namespace}`);
+    }
+  };
+
+  socket.on('directory-service:entry-updated', handleEntryEvent);
+  socket.on('directory-service:entry-deleted', handleEntryEvent);
+
+  return socket;
+};

--- a/apps/api-docs-app/src/docs/index.ts
+++ b/apps/api-docs-app/src/docs/index.ts
@@ -3,6 +3,7 @@ import { Application } from 'express';
 import { Logger } from 'winston';
 import { createDocsRouter } from './router';
 import { createServiceDocs } from './serviceDocs';
+import { connectEntryUpdateSubscription } from './entryUpdateSubscription';
 import { createFetchJob } from '../job';
 import * as schedule from 'node-schedule';
 interface MiddlewareProps {
@@ -16,9 +17,12 @@ interface MiddlewareProps {
 export const applyDocsMiddleware = async (app: Application, props: MiddlewareProps): Promise<Application> => {
   const serviceDocs = createServiceDocs(props);
 
-  //Pre-loading platform api docs and scheduling loading all docs for each tenant api doc in 11:00pm every night
-  serviceDocs.getDocs(adspId`urn:ads:platform:service`);
+  serviceDocs.getDocs(adspId`urn:ads:platform`).catch((err) => props.logger.warn(`Failed pre-loading platform docs: ${err.message}`));
   schedule.scheduleJob('0 23 * * *', createFetchJob({ ...props, serviceDocs }));
+  connectEntryUpdateSubscription({ ...props, serviceDocs }).catch((err) =>
+    props.logger.warn(`Failed connecting to directory entry updates stream: ${err.message}`)
+  );
+
   const docsRouter = await createDocsRouter({ ...props, serviceDocs });
   app.use('/', docsRouter);
   return app;

--- a/apps/api-docs-app/src/docs/router.ts
+++ b/apps/api-docs-app/src/docs/router.ts
@@ -64,22 +64,27 @@ export const createDocsRouter = async ({
       const { tenant: tenantName } = req.params as unknown as { tenant: string };
 
       if (req.url === '/swagger-ui-init.js') {
-        const tenant = tenantName ? await tenantService.getTenantByName(tenantName.replace(/-/g, ' ') as string) : null;
-        const namespace = tenant ? toKebabName(tenant.name) : null;
-        const docs = {
-          ...(await serviceDocs.getDocs(adspId`urn:ads:platform`)),
-          ...(namespace ? await serviceDocs.getDocs(adspId`urn:ads:${namespace}`) : null),
-        };
-
-        const swaggerUrls = Object.entries(docs).map(([id, serviceDoc]) => {
-          const serviceId = AdspId.parse(id);
-          return {
-            name: serviceDoc.service.name,
-            url: `/docs/${serviceId.namespace}/${serviceId.service}${tenant ? `?tenant=${tenant.id}` : ''}`,
+        try {
+          const tenant = tenantName ? await tenantService.getTenantByName(tenantName.replace(/-/g, ' ') as string) : null;
+          const namespace = tenant ? toKebabName(tenant.name) : null;
+          const docs = {
+            ...(await serviceDocs.getDocs(adspId`urn:ads:platform`)),
+            ...(namespace ? await serviceDocs.getDocs(adspId`urn:ads:${namespace}`) : null),
           };
-        });
-        swaggerUrls.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
-        req['options'] = { swaggerUrls };
+
+          const swaggerUrls = Object.entries(docs).map(([id, serviceDoc]) => {
+            const serviceId = AdspId.parse(id);
+            return {
+              name: serviceDoc.service.name,
+              url: `/docs/${serviceId.namespace}/${serviceId.service}${tenant ? `?tenant=${tenant.id}` : ''}`,
+            };
+          });
+          swaggerUrls.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+          req['options'] = { swaggerUrls };
+        } catch (err) {
+          next(err);
+          return;
+        }
       }
       next();
     },

--- a/apps/api-docs-app/src/docs/serviceDocs.ts
+++ b/apps/api-docs-app/src/docs/serviceDocs.ts
@@ -1,4 +1,4 @@
-import { adspId, AdspId, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
+import { adspId, AdspId, LimitToOne, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
 import axios from 'axios';
 import * as NodeCache from 'node-cache';
 import { JsonObject } from 'swagger-ui-express';
@@ -42,6 +42,8 @@ interface Directory {
 
 export interface ServiceDocs {
   getDocs(id: AdspId): Promise<Record<string, ServiceDoc>>;
+  invalidate(id: AdspId): void;
+  refresh(id: AdspId): Promise<Record<string, ServiceDoc>>;
 }
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -86,7 +88,13 @@ class ServiceDocsImpl {
 
       const tenantDirectoryUrl = new URL(`directory/v2/namespaces/${namespace}/entries`, directoryServiceUrl);
 
-      const { data } = await axios.get<Array<Directory>>(tenantDirectoryUrl.href);
+      let data: Array<Directory>;
+      try {
+        ({ data } = await axios.get<Array<Directory>>(tenantDirectoryUrl.href));
+      } catch (err) {
+        this.logger.warn(`Failed retrieving directory entries for namespace ${namespace}: ${err.message}`);
+        return docs;
+      }
       for (const entry of data) {
         const url = entry.url;
         const id = adspId`${entry.urn}`;
@@ -120,45 +128,39 @@ class ServiceDocsImpl {
     return docs;
   };
 
+  @LimitToOne((propertyKey, namespace: string, force = false) => (force ? '' : `${propertyKey}:${namespace}`))
+  private async loadNamespace(namespace: string, force = false): Promise<void> {
+    const docs = await this.#retrieveDocEntries(namespace);
+    this.cache.set(namespace, docs);
+  }
+
   async getDocs(id?: AdspId): Promise<Record<string, ServiceDoc>> {
-    const namespaces = this.cache.keys();
-    let mergedDocs: Record<string, ServiceDoc> = {};
-    const docs: Record<string, ServiceDoc> = {};
-    if (!namespaces.includes(id.namespace)) {
-      const docs = await this.#retrieveDocEntries(id.namespace);
-      this.cache.set(id.namespace, docs);
+    // Kick off background loads without awaiting — callers get whatever is currently cached.
+    if (!this.cache.keys().includes(id.namespace)) {
+      this.loadNamespace(id.namespace);
     }
-    // Avoid re-cache of platform
-    if (id.namespace !== 'platform' && !namespaces.includes('platform')) {
-      const docs = await this.#retrieveDocEntries('platform');
-      this.cache.set('platform', docs);
+    if (id.namespace !== 'platform' && !this.cache.keys().includes('platform')) {
+      this.loadNamespace('platform');
     }
 
-    if (id.namespace === 'platform') {
-      mergedDocs = {
-        ...this.cache.get<Record<string, ServiceDoc>>('platform'),
-      };
-    } else {
-      // Merge the platform and tenant docs
-      mergedDocs = {
-        ...this.cache.get<Record<string, ServiceDoc>>('platform'),
-        ...this.cache.get<Record<string, ServiceDoc>>(id.namespace),
-      };
-    }
+    const mergedDocs: Record<string, ServiceDoc> =
+      id.namespace === 'platform'
+        ? { ...(this.cache.get<Record<string, ServiceDoc>>('platform') ?? {}) }
+        : {
+            ...(this.cache.get<Record<string, ServiceDoc>>('platform') ?? {}),
+            ...(this.cache.get<Record<string, ServiceDoc>>(id.namespace) ?? {}),
+          };
 
     if (id.type === 'service') {
+      const docs: Record<string, ServiceDoc> = {};
       let doc = id.toString() in mergedDocs ? { ...mergedDocs[id.toString()] } : null;
 
       if (doc) {
-        // metadata has been fetched, but the actual doc swagger has not
         if (doc?.docUrl && !doc?.docs) {
           const docJson = await this.#retrieveDocJson(doc.docUrl);
           if (docJson) {
             docJson.servers = [{ url: doc.url }];
-            doc = {
-              ...doc,
-              docs: docJson,
-            };
+            doc = { ...doc, docs: docJson };
             mergedDocs[id.toString()] = doc;
             this.cache.set(id.namespace, { ...mergedDocs });
           }
@@ -168,6 +170,19 @@ class ServiceDocsImpl {
       return docs;
     }
     return mergedDocs;
+  }
+
+  invalidate(id: AdspId): void {
+    if (this.cache.keys().includes(id.namespace)) {
+      this.cache.del(id.namespace);
+      this.loadNamespace(id.namespace);
+    }
+  }
+
+  async refresh(id: AdspId): Promise<Record<string, ServiceDoc>> {
+    this.cache.del(id.namespace);
+    await this.loadNamespace(id.namespace, true);
+    return this.getDocs(id);
   }
 }
 

--- a/apps/api-docs-app/src/job/index.ts
+++ b/apps/api-docs-app/src/job/index.ts
@@ -1,4 +1,4 @@
-import { TenantService, adspId } from '@abgov/adsp-service-sdk';
+import { TenantService, adspId, toKebabName } from '@abgov/adsp-service-sdk';
 
 import { Logger } from 'winston';
 import { ServiceDocs } from '../docs/serviceDocs';
@@ -15,9 +15,9 @@ export const createFetchJob =
     try {
       logger.info('Starting fetch api docs and put into cache');
       const tenants = await tenantService.getTenants();
-      tenants.map(async (tenant) => {
-        serviceDocs.getDocs(adspId`urn:ads:${tenant.name}`);
-      });
+      await Promise.all(
+        tenants.map((tenant) => serviceDocs.refresh(adspId`urn:ads:${toKebabName(tenant.name)}`))
+      );
       logger.info('Ending fetch api docs and put into cache');
     } catch (err) {
       const errMessage = `Error getting notices: ${err.message}`;


### PR DESCRIPTION
## Summary

- **Fix crash on load under tenant context**: `#retrieveDocEntries` had no error handling around the directory entries fetch — an HTTP error from the directory service became an unhandled rejection, crashing the Node.js process (Node 15+). Also fixed the async middleware in the router missing `next(err)` forwarding, which had the same effect in Express 4.
- **Fix incorrect pre-load URN**: startup pre-load used `urn:ads:platform:service` (a non-existent service) instead of `urn:ads:platform`, so the platform namespace was never actually warmed.
- **Non-blocking namespace loading**: `getDocs` now returns cached data immediately and kicks off a background load via a `LimitToOne`-decorated `loadNamespace` method, preventing duplicate concurrent fetches. First requests no longer block on directory service I/O.
- **Event-driven cache invalidation**: subscribes to the directory service's `directory-entry-updates` push stream. On `entry-updated` / `entry-deleted`, calls `invalidate()` which is a no-op if the namespace isn't cached, and uses `LimitToOne` deduplication to handle rapid bursts of events without triggering redundant fetches.
- **Nightly job now actually refreshes**: previously used `getDocs` which skipped cached namespaces — switched to `refresh()` which force-clears and re-fetches. Also fixed tenant name using `toKebabName` and properly awaits all tenant refreshes with `Promise.all`.

## Test plan

- [ ] Load API docs without a tenant context — verify page loads and platform services are listed
- [ ] Load API docs under a tenant context (e.g. `/my-tenant`) — verify page loads without crash and both platform and tenant services are listed
- [ ] Update a directory entry for a tenant service and confirm the cached docs for that namespace are refreshed (check logs for invalidation message)
- [ ] Verify the nightly job (or trigger manually) refreshes all tenant namespaces
- [ ] Verify app starts successfully and logs show connection to directory entry updates stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)