### PR TITLE
fix(api-docs-app): generate missing operationIds before caching swagger docs

### DIFF
--- a/apps/api-docs-app/src/docs/serviceDocs.ts
+++ b/apps/api-docs-app/src/docs/serviceDocs.ts
@@ -46,6 +46,25 @@ export interface ServiceDocs {
   refresh(id: AdspId): Promise<Record<string, ServiceDoc>>;
 }
 
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
+const ensureOperationIds = (doc: JsonObject): JsonObject => {
+  const paths = doc.paths as Record<string, Record<string, { operationId?: string }>>;
+  if (!paths) return doc;
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem?.[method];
+      if (operation && !operation.operationId) {
+        const pathPart = path.replace(/[{}]/g, '').replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_|_$/g, '');
+        operation.operationId = `${method}_${pathPart}`;
+      }
+    }
+  }
+
+  return doc;
+};
+
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const withRetry = async <T>(fn: () => Promise<T>, retries = 3, delayMs = 1000): Promise<T> => {
@@ -72,7 +91,7 @@ class ServiceDocsImpl {
     try {
       const doc = (await withRetry(() => axios.get(docUrl)))?.data as JsonObject;
       if (doc?.openapi) {
-        return doc;
+        return ensureOperationIds(doc);
       }
     } catch (err) {
       this.logger.warn(`Failed retrieving doc from ${docUrl}`);


### PR DESCRIPTION
## Summary

Swagger UI requires unique `operationId` values on all operations. When a service's OpenAPI spec omits `operationId`, swagger-ui auto-generates them client-side — but the generated IDs can collide across operations, causing the renderer to crash or display incorrectly.

This fix fills in missing `operationId` values server-side in `#retrieveDocJson` when the spec is first fetched, using `method_path_segments` as the pattern (e.g. `get_api_v1_users_id` for `GET /api/v1/users/{id}`). Path parameter braces are stripped since swagger-ui uses the ID as a DOM anchor. Applied once at fetch time so the cached doc is always clean with no per-request overhead.

## Test plan

- [ ] Load API docs for a service whose OpenAPI spec has operations missing `operationId` — verify the page renders without crashing
- [ ] Confirm generated IDs follow the `method_path` pattern in the served JSON (`/docs/:namespace/:service`)
- [ ] Verify services that already have `operationId` on all operations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)