### PR TITLE
fix(api-docs-app): harden entry processing and async error handling

### DIFF
--- a/apps/api-docs-app/src/docs/router.ts
+++ b/apps/api-docs-app/src/docs/router.ts
@@ -18,35 +18,44 @@ export const createDocsRouter = async ({
   const router = Router();
 
   router.get('/docs/:namespace/:service', async (req: Request, res: Response, next: NextFunction) => {
-    const { namespace, service } = req.params;
-    const tenantId = req.query.tenant ? AdspId.parse(req.query.tenant as string) : null;
-    const tenant = tenantId ? await tenantService.getTenant(tenantId) : null;
+    try {
+      const { namespace, service } = req.params;
+      const tenantId = req.query.tenant ? AdspId.parse(req.query.tenant as string) : null;
+      const tenant = tenantId ? await tenantService.getTenant(tenantId) : null;
 
-    const serviceId = adspId`urn:ads:${namespace}:${service}`;
+      const serviceId = adspId`urn:ads:${namespace}:${service}`;
 
-    const serviceDoc = (await serviceDocs.getDocs(serviceId))[serviceId.toString()];
-    if (!serviceDoc) {
-      next(new NotFoundError('API docs', service));
-      return;
+      const serviceDoc = (await serviceDocs.getDocs(serviceId))[serviceId.toString()];
+      if (!serviceDoc) {
+        next(new NotFoundError('API docs', service));
+        return;
+      }
+
+      if (!serviceDoc.docs) {
+        next(new NotFoundError('API docs', service));
+        return;
+      }
+
+      if (tenant && serviceDoc.docs?.components?.securitySchemes) {
+        const oidcUrl = new URL(`auth/realms/${tenant.realm}/.well-known/openid-configuration`, accessServiceUrl);
+        serviceDoc.docs.components.securitySchemes = {
+          ...serviceDoc.docs.components.securitySchemes,
+          openId: {
+            type: 'openIdConnect',
+            openIdConnectUrl: oidcUrl.href,
+          },
+        };
+        serviceDoc.docs.security = [
+          ...(serviceDoc.docs.security || []),
+          {
+            openId: [],
+          },
+        ];
+      }
+      res.send(serviceDoc.docs);
+    } catch (err) {
+      next(err);
     }
-
-    if (tenant && serviceDoc.docs?.components?.securitySchemes) {
-      const oidcUrl = new URL(`auth/realms/${tenant.realm}/.well-known/openid-configuration`, accessServiceUrl);
-      serviceDoc.docs.components.securitySchemes = {
-        ...serviceDoc.docs.components.securitySchemes,
-        openId: {
-          type: 'openIdConnect',
-          openIdConnectUrl: oidcUrl.href,
-        },
-      };
-      serviceDoc.docs.security = [
-        ...(serviceDoc.docs.security || []),
-        {
-          openId: [],
-        },
-      ];
-    }
-    res.send(serviceDoc.docs);
   });
 
   // NOTE: This is not a normal use of swagger-ui-express. We are dynamically resolving swagger URLs based on tenant

--- a/apps/api-docs-app/src/docs/serviceDocs.ts
+++ b/apps/api-docs-app/src/docs/serviceDocs.ts
@@ -95,11 +95,15 @@ class ServiceDocsImpl {
         this.logger.warn(`Failed retrieving directory entries for namespace ${namespace}: ${err.message}`);
         return docs;
       }
+      if (!Array.isArray(data)) {
+        this.logger.warn(`Unexpected response shape for namespace ${namespace} directory entries`);
+        return docs;
+      }
       for (const entry of data) {
         const url = entry.url;
-        const id = adspId`${entry.urn}`;
-        if (id.type === 'service') {
-          try {
+        try {
+          const id = adspId`${entry.urn}`;
+          if (id.type === 'service') {
             const serviceDirectoryUrl = new URL(
               `directory/v2/namespaces/${namespace}/services/${id.service}`,
               directoryServiceUrl.href
@@ -117,9 +121,9 @@ class ServiceDocsImpl {
                 docUrl: metadata?._links?.docs?.href,
               };
             }
-          } catch (err) {
-            this.logger.warn(`Failed retrieving docs for ${id} with error ${err.message}`);
           }
+        } catch (err) {
+          this.logger.warn(`Failed processing entry ${entry.urn}: ${err.message}`);
         }
       }
     }
@@ -137,10 +141,10 @@ class ServiceDocsImpl {
   async getDocs(id?: AdspId): Promise<Record<string, ServiceDoc>> {
     // Kick off background loads without awaiting — callers get whatever is currently cached.
     if (!this.cache.keys().includes(id.namespace)) {
-      this.loadNamespace(id.namespace);
+      this.loadNamespace(id.namespace).catch((err) => this.logger.warn(`Failed loading namespace ${id.namespace}: ${err.message}`));
     }
     if (id.namespace !== 'platform' && !this.cache.keys().includes('platform')) {
-      this.loadNamespace('platform');
+      this.loadNamespace('platform').catch((err) => this.logger.warn(`Failed loading namespace platform: ${err.message}`));
     }
 
     const mergedDocs: Record<string, ServiceDoc> =
@@ -175,7 +179,7 @@ class ServiceDocsImpl {
   invalidate(id: AdspId): void {
     if (this.cache.keys().includes(id.namespace)) {
       this.cache.del(id.namespace);
-      this.loadNamespace(id.namespace);
+      this.loadNamespace(id.namespace).catch((err) => this.logger.warn(`Failed reloading namespace ${id.namespace}: ${err.message}`));
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up resilience fixes identified by code review.

- **Non-array directory response guard** (`serviceDocs.ts`): if the directory service returns a non-array body (e.g. a wrapped object or `null`), `for...of data` would throw `TypeError: data is not iterable`. Added `Array.isArray` check before the loop.
- **Per-entry try-catch covers URN parsing** (`serviceDocs.ts`): `adspId\`${entry.urn}\`` was outside the per-entry error boundary, so a malformed URN in any entry would throw and abort processing of all remaining entries. Consolidated into a single try-catch per entry that covers both URN parsing and the downstream service metadata fetch.
- **`.catch()` on fire-and-forget `loadNamespace` calls** (`serviceDocs.ts`): background loads in `getDocs` and `invalidate` had no error handler, leaving unhandled promise rejections that crash Node.js 15+. Added `.catch(warn)` to all three call sites.
- **try-catch in `/docs/:namespace/:service` handler** (`router.ts`): `AdspId.parse` on a malformed `?tenant=` query param, `adspId` on invalid path params, and `tenantService.getTenant` rejections were all unhandled in Express 4 async middleware. Wrapped handler body in try-catch forwarding to `next(err)`.
- **404 when `serviceDoc.docs` is absent** (`router.ts`): if the swagger JSON fetch failed or a service has no docs URL, `serviceDoc.docs` is `undefined` and `res.send(undefined)` sent a 200 with an empty body. Now returns 404.

## Test plan

- [ ] Request `/docs/:namespace/:service` with a malformed `?tenant=` param — verify 400/500 error response rather than crash
- [ ] Simulate directory service returning a non-array for namespace entries — verify warning is logged and app continues
- [ ] Request docs for a service whose swagger URL is unreachable — verify 404 response instead of empty 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)