### PR TITLE
fix(api-docs-app): normalize missing responses in swagger specs

### DIFF
--- a/apps/api-docs-app/src/docs/router.ts
+++ b/apps/api-docs-app/src/docs/router.ts
@@ -88,7 +88,7 @@ export const createDocsRouter = async ({
               url: `/docs/${serviceId.namespace}/${serviceId.service}${tenant ? `?tenant=${tenant.id}` : ''}`,
             };
           });
-          swaggerUrls.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+          swaggerUrls.sort((a, b) => (a.name ?? '').toLowerCase().localeCompare((b.name ?? '').toLowerCase()));
           req['options'] = { swaggerUrls };
         } catch (err) {
           next(err);

--- a/apps/api-docs-app/src/docs/serviceDocs.ts
+++ b/apps/api-docs-app/src/docs/serviceDocs.ts
@@ -48,16 +48,24 @@ export interface ServiceDocs {
 
 const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
-const ensureOperationIds = (doc: JsonObject): JsonObject => {
-  const paths = doc.paths as Record<string, Record<string, { operationId?: string }>>;
+type Operation = { operationId?: string; responses?: Record<string, unknown> };
+
+const normalizeSpec = (doc: JsonObject): JsonObject => {
+  const paths = doc.paths as Record<string, Record<string, Operation>>;
   if (!paths) return doc;
 
   for (const [path, pathItem] of Object.entries(paths)) {
     for (const method of HTTP_METHODS) {
       const operation = pathItem?.[method];
-      if (operation && !operation.operationId) {
+      if (!operation) continue;
+
+      if (!operation.operationId) {
         const pathPart = path.replace(/[{}]/g, '').replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_|_$/g, '');
         operation.operationId = `${method}_${pathPart}`;
+      }
+
+      if (!operation.responses || Object.keys(operation.responses).length === 0) {
+        operation.responses = { '200': { description: 'OK' } };
       }
     }
   }
@@ -91,7 +99,7 @@ class ServiceDocsImpl {
     try {
       const doc = (await withRetry(() => axios.get(docUrl)))?.data as JsonObject;
       if (doc?.openapi) {
-        return ensureOperationIds(doc);
+        return normalizeSpec(doc);
       }
     } catch (err) {
       this.logger.warn(`Failed retrieving doc from ${docUrl}`);
@@ -134,7 +142,7 @@ class ServiceDocsImpl {
               docs[id.toString()] = {
                 service: {
                   id: id,
-                  name: metadata?.displayName || metadata?.name,
+                  name: metadata?.displayName || metadata?.name || id.service,
                 },
                 url,
                 docUrl: metadata?._links?.docs?.href,


### PR DESCRIPTION
## Summary

Extends the spec normalization introduced in #5778 to also handle operations missing a `responses` object. Swagger UI 5 throws when rendering the response section of an operation that has no `responses` defined at all. A default `{ '200': { description: 'OK' } }` is filled in for any such operation at fetch time, before the spec is cached.

Also renames `ensureOperationIds` → `normalizeSpec` to reflect the broader scope of the normalization pass.

## Test plan

- [ ] Load API docs for a service whose OpenAPI spec has operations with no `responses` defined — verify the page renders without crashing
- [ ] Verify operations that already have `responses` defined are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)