### PR TITLE
fix(role-table): save every role selection on new form definitions

### DIFF
--- a/apps/form-management-app/src/app/components/RoleTable.spec.tsx
+++ b/apps/form-management-app/src/app/components/RoleTable.spec.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { ClientRoleTable } from './RoleTable';
+
+const mockStore = configureStore([]);
+const initialState = { user: { tenant: { name: 'autotest' } } };
+
+const APPLICANT = 'Applicant roles';
+const FORM_APPLICANT = 'urn:ads:platform:form-service:form-applicant';
+const SERVICE = 'FormService';
+
+const testIdFor = (compositeRole: string) => `${SERVICE}-${APPLICANT}-role-checkbox-${compositeRole}`;
+
+/**
+ * Mirrors the form definition roles tab: one table per client, all of them editing the same
+ * applicantRoles array held by the parent.
+ */
+const RolesTabHarness = ({
+  initialApplicantRoles = [],
+  onRolesChange,
+}: {
+  initialApplicantRoles?: string[];
+  onRolesChange?: (roles: string[]) => void;
+}) => {
+  const [applicantRoles, setApplicantRoles] = useState<string[]>(initialApplicantRoles);
+
+  const roleSelectFunc = (roles: string[]) => {
+    setApplicantRoles(roles);
+    onRolesChange?.(roles);
+  };
+
+  const clients = [
+    { clientId: 'autotest', roleNames: ['tester'] },
+    { clientId: 'urn:ads:platform:form-service', roleNames: ['form-applicant'] },
+  ];
+
+  return (
+    <Provider store={mockStore(initialState)}>
+      {clients.map(({ clientId, roleNames }) => (
+        <ClientRoleTable
+          key={clientId}
+          roles={roleNames}
+          clientId={clientId}
+          service={SERVICE}
+          roleSelectFunc={roleSelectFunc}
+          checkedRoles={[{ title: APPLICANT, selectedRoles: applicantRoles }]}
+        />
+      ))}
+    </Provider>
+  );
+};
+
+describe('ClientRoleTable', () => {
+  const toggle = (baseElement: Element, compositeRole: string) => {
+    const checkbox = baseElement.querySelector(`goa-checkbox[testId='${testIdFor(compositeRole)}']`);
+    expect(checkbox).toBeInTheDocument();
+    fireEvent(checkbox as Element, new CustomEvent('_change', { detail: { checked: true } }));
+  };
+
+  // The web component reflects a checked box as checked="true" and omits the attribute otherwise.
+  const isChecked = (baseElement: Element, compositeRole: string) =>
+    baseElement.querySelector(`goa-checkbox[testId='${testIdFor(compositeRole)}']`)?.getAttribute('checked') ===
+    'true';
+
+  it('checks a role and reports it to the parent', () => {
+    const onRolesChange = jest.fn();
+    const { baseElement } = render(<RolesTabHarness onRolesChange={onRolesChange} />);
+
+    toggle(baseElement, 'tester');
+
+    expect(onRolesChange).toHaveBeenCalledWith(['tester']);
+    expect(isChecked(baseElement, 'tester')).toBe(true);
+  });
+
+  it('unchecks a role and reports it to the parent', () => {
+    const onRolesChange = jest.fn();
+    const { baseElement } = render(
+      <RolesTabHarness initialApplicantRoles={[FORM_APPLICANT]} onRolesChange={onRolesChange} />
+    );
+
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(true);
+
+    toggle(baseElement, FORM_APPLICANT);
+
+    expect(onRolesChange).toHaveBeenCalledWith([]);
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(false);
+  });
+
+  // CS-5291: each client rendered its own table, and every table kept a copy of the selections taken
+  // when it mounted. Editing one table then another replayed the first table's stale copy, silently
+  // undoing the earlier change.
+  it('keeps selections made in another client table when unselecting a role', () => {
+    const onRolesChange = jest.fn();
+    const { baseElement } = render(
+      <RolesTabHarness initialApplicantRoles={[FORM_APPLICANT]} onRolesChange={onRolesChange} />
+    );
+
+    toggle(baseElement, 'tester');
+    toggle(baseElement, FORM_APPLICANT);
+
+    expect(onRolesChange).toHaveBeenLastCalledWith(['tester']);
+    expect(isChecked(baseElement, 'tester')).toBe(true);
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(false);
+  });
+
+  it('does not restore an unselected role when a later selection is made in another client table', () => {
+    const onRolesChange = jest.fn();
+    const { baseElement } = render(
+      <RolesTabHarness initialApplicantRoles={[FORM_APPLICANT]} onRolesChange={onRolesChange} />
+    );
+
+    toggle(baseElement, FORM_APPLICANT);
+    toggle(baseElement, 'tester');
+
+    expect(onRolesChange).toHaveBeenLastCalledWith(['tester']);
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(false);
+  });
+
+  it('reflects selections changed outside the table, such as reloading a saved definition', () => {
+    const table = (selectedRoles: string[]) => (
+      <Provider store={mockStore(initialState)}>
+        <ClientRoleTable
+          roles={['form-applicant']}
+          clientId="urn:ads:platform:form-service"
+          service={SERVICE}
+          roleSelectFunc={jest.fn()}
+          checkedRoles={[{ title: APPLICANT, selectedRoles }]}
+        />
+      </Provider>
+    );
+
+    const { baseElement, rerender } = render(table([FORM_APPLICANT]));
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(true);
+
+    rerender(table([]));
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(false);
+  });
+
+  it('renders unchecked when a role list is not set', () => {
+    const { baseElement } = render(
+      <Provider store={mockStore(initialState)}>
+        <ClientRoleTable
+          roles={['form-applicant']}
+          clientId="urn:ads:platform:form-service"
+          service={SERVICE}
+          roleSelectFunc={jest.fn()}
+          checkedRoles={[{ title: APPLICANT, selectedRoles: undefined }]}
+        />
+      </Provider>
+    );
+
+    expect(isChecked(baseElement, FORM_APPLICANT)).toBe(false);
+  });
+});

--- a/apps/form-management-app/src/app/components/RoleTable.tsx
+++ b/apps/form-management-app/src/app/components/RoleTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useLayoutEffect, useRef } from 'react';
+import React, { useMemo, useCallback, useRef } from 'react';
 import { GoabCheckbox, GoabTable } from '@abgov/react-components';
 import styles from './RoleTable.module.scss';
 import { useSelector } from 'react-redux';
@@ -33,7 +33,10 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
     tenantName: state.user.tenant.name,
   }));
 
-  const [checkedRoles, setCheckedRoles] = useState(props.checkedRoles);
+  // Selections are rendered straight from props. A table is mounted per client, but they all edit the
+  // same role arrays, so keeping a local copy lets one table overwrite another table's changes with a
+  // stale snapshot taken when it mounted (CS-5291).
+  const { checkedRoles, roleSelectFunc } = props;
 
   const scrollPaneRef = useRef<HTMLDivElement | null>(null);
 
@@ -54,25 +57,11 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
 
   const handleCheckboxChange = useCallback(
     (checkedRole: SelectedRoles, compositeRole: string) => {
-      setCheckedRoles((prev) => {
-        const updated = prev.map((cr) =>
-          cr.title === checkedRole.title
-            ? {
-                ...cr,
-                selectedRoles: cr.selectedRoles.includes(compositeRole)
-                  ? cr.selectedRoles.filter((r) => r !== compositeRole)
-                  : [...cr.selectedRoles, compositeRole],
-              }
-            : cr
-        );
-
-        const updatedRole = updated.find((cr) => cr.title === checkedRole.title);
-        if (updatedRole) {
-          props.roleSelectFunc(updatedRole.selectedRoles, checkedRole.title);
-        }
-
-        return updated;
-      });
+      const selectedRoles = checkedRole.selectedRoles ?? [];
+      const newRoles = selectedRoles.includes(compositeRole)
+        ? selectedRoles.filter((r) => r !== compositeRole)
+        : [...selectedRoles, compositeRole];
+      roleSelectFunc(newRoles, checkedRole.title);
 
       // Save scroll position
       if (scrollPaneRef.current) {
@@ -82,7 +71,7 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
         });
       }
     },
-    [props.roleSelectFunc]
+    [roleSelectFunc]
   );
 
   const tableBody = useMemo(() => {
@@ -98,7 +87,7 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
             <td className="role" key={`${props.service}-${role}-checkbox-${index}`}>
               <GoabCheckbox size="compact"
                 name={`${props.service}-${checkedRole.title}-role-checkbox-${compositeRole}`}
-                checked={checkedRole.selectedRoles.includes(compositeRole)}
+                checked={(checkedRole.selectedRoles ?? []).includes(compositeRole)}
                 testId={`${props.service}-${checkedRole.title}-role-checkbox-${compositeRole}`}
                 disabled={(props.anonymousRead && checkedRole.title === 'read') || checkedRole?.disabled}
                 ariaLabel={`${props.service}-${checkedRole.title}-role-checkbox-${compositeRole}`}

--- a/apps/tenant-management-webapp/src/app/components/RoleTable.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/components/RoleTable.spec.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { ClientRoleTable } from './RoleTable';
+
+const mockStore = configureStore([]);
+const initialState = { tenant: { name: 'autotest' } };
+
+const APPLICANT = 'Applicant roles';
+const FORM_APPLICANT = 'urn:ads:platform:form-service:form-applicant';
+
+/**
+ * Mirrors the form definition editor: one table per client, all of them editing the same
+ * applicantRoles array held by the parent.
+ */
+const RolesTabHarness = ({
+  initialApplicantRoles = [],
+  onRolesChange,
+}: {
+  initialApplicantRoles?: string[];
+  onRolesChange?: (roles: string[]) => void;
+}) => {
+  const [applicantRoles, setApplicantRoles] = useState<string[]>(initialApplicantRoles);
+
+  const roleSelectFunc = (roles: string[]) => {
+    setApplicantRoles(roles);
+    onRolesChange?.(roles);
+  };
+
+  const clients = [
+    { clientId: 'autotest', roleNames: ['tester'] },
+    { clientId: 'urn:ads:platform:form-service', roleNames: ['form-applicant'] },
+  ];
+
+  return (
+    <Provider store={mockStore(initialState)}>
+      {clients.map(({ clientId, roleNames }) => (
+        <ClientRoleTable
+          key={clientId}
+          roles={roleNames}
+          clientId={clientId}
+          service="FormService"
+          roleSelectFunc={roleSelectFunc}
+          checkedRoles={[{ title: APPLICANT, selectedRoles: applicantRoles }]}
+        />
+      ))}
+    </Provider>
+  );
+};
+
+describe('ClientRoleTable', () => {
+  const checkboxFor = (role: string) => screen.getByRole('checkbox', { name: `${role} ${APPLICANT}` });
+
+  it('checks a role and reports it to the parent', () => {
+    const onRolesChange = jest.fn();
+    render(<RolesTabHarness onRolesChange={onRolesChange} />);
+
+    fireEvent.click(checkboxFor('tester'));
+
+    expect(onRolesChange).toHaveBeenCalledWith(['tester']);
+    expect(checkboxFor('tester')).toBeChecked();
+  });
+
+  it('unchecks a role and reports it to the parent', () => {
+    const onRolesChange = jest.fn();
+    render(<RolesTabHarness initialApplicantRoles={[FORM_APPLICANT]} onRolesChange={onRolesChange} />);
+
+    expect(checkboxFor('form-applicant')).toBeChecked();
+
+    fireEvent.click(checkboxFor('form-applicant'));
+
+    expect(onRolesChange).toHaveBeenCalledWith([]);
+    expect(checkboxFor('form-applicant')).not.toBeChecked();
+  });
+
+  // CS-5291: each client rendered its own table, and every table kept a copy of the selections taken
+  // when it mounted. Editing one table then another replayed the first table's stale copy, silently
+  // undoing the earlier change.
+  it('keeps selections made in another client table when unselecting a role', () => {
+    const onRolesChange = jest.fn();
+    render(<RolesTabHarness initialApplicantRoles={[FORM_APPLICANT]} onRolesChange={onRolesChange} />);
+
+    fireEvent.click(checkboxFor('tester'));
+    fireEvent.click(checkboxFor('form-applicant'));
+
+    expect(onRolesChange).toHaveBeenLastCalledWith(['tester']);
+    expect(checkboxFor('tester')).toBeChecked();
+    expect(checkboxFor('form-applicant')).not.toBeChecked();
+  });
+
+  it('does not restore an unselected role when a later selection is made in another client table', () => {
+    const onRolesChange = jest.fn();
+    render(<RolesTabHarness initialApplicantRoles={[FORM_APPLICANT]} onRolesChange={onRolesChange} />);
+
+    fireEvent.click(checkboxFor('form-applicant'));
+    fireEvent.click(checkboxFor('tester'));
+
+    expect(onRolesChange).toHaveBeenLastCalledWith(['tester']);
+    expect(checkboxFor('form-applicant')).not.toBeChecked();
+  });
+
+  it('reflects selections changed outside the table, such as reloading a saved definition', () => {
+    const { rerender } = render(
+      <Provider store={mockStore(initialState)}>
+        <ClientRoleTable
+          roles={['form-applicant']}
+          clientId="urn:ads:platform:form-service"
+          service="FormService"
+          roleSelectFunc={jest.fn()}
+          checkedRoles={[{ title: APPLICANT, selectedRoles: [FORM_APPLICANT] }]}
+        />
+      </Provider>
+    );
+
+    expect(checkboxFor('form-applicant')).toBeChecked();
+
+    rerender(
+      <Provider store={mockStore(initialState)}>
+        <ClientRoleTable
+          roles={['form-applicant']}
+          clientId="urn:ads:platform:form-service"
+          service="FormService"
+          roleSelectFunc={jest.fn()}
+          checkedRoles={[{ title: APPLICANT, selectedRoles: [] }]}
+        />
+      </Provider>
+    );
+
+    expect(checkboxFor('form-applicant')).not.toBeChecked();
+  });
+
+  it('renders unchecked when a role list is not set', () => {
+    render(
+      <Provider store={mockStore(initialState)}>
+        <ClientRoleTable
+          roles={['form-applicant']}
+          clientId="urn:ads:platform:form-service"
+          service="FormService"
+          roleSelectFunc={jest.fn()}
+          checkedRoles={[{ title: APPLICANT, selectedRoles: undefined }]}
+        />
+      </Provider>
+    );
+
+    expect(checkboxFor('form-applicant')).not.toBeChecked();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/components/RoleTable.tsx
+++ b/apps/tenant-management-webapp/src/app/components/RoleTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { GoabTable } from '@abgov/react-components';
 import { MarginAdjustment, PaddingRem } from './styled-components';
 import { Checkbox } from './Checkbox';
@@ -49,7 +49,10 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
       tenantName: state.tenant.name,
     };
   });
-  const [checkedRoles, setCheckedRoles] = useState(props.checkedRoles);
+  // Selections are rendered straight from props. A table is mounted per client, but they all edit the
+  // same role arrays, so keeping a local copy lets one table overwrite another table's changes with a
+  // stale snapshot taken when it mounted (CS-5291).
+  const checkedRoles = props.checkedRoles;
   const service = props.service;
   const nameColumnStyle = {
     width: props?.nameColumnWidth ? `${props.nameColumnWidth}%` : '',
@@ -69,7 +72,7 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
             <th id={`${service}-roles-${getClientId()}`} style={nameColumnStyle}>
               Roles
             </th>
-            {props.checkedRoles.map((role, index) => {
+            {checkedRoles.map((role, index) => {
               return (
                 <th key={`${role.title}-${index}`} id={`${role.title}-role-action-${getClientId()}`} className="role">
                   <div>{capitalizeFirstLetter(role.title)}</div>
@@ -90,28 +93,23 @@ export const ClientRoleTable = (props: ClientRoleTableProps): JSX.Element => {
                   {role}
                 </td>
                 {checkedRoles.map((checkedRole, index) => {
+                  const selectedRoles = checkedRole.selectedRoles ?? [];
+                  const isChecked = selectedRoles.includes(compositeRole);
+
                   return (
                     <td className="role" key={`${service}-${role}-checkbox-${index}`}>
                       <Checkbox
-                        checked={checkedRole.selectedRoles?.includes(compositeRole)}
+                        checked={isChecked}
                         disabled={
                           (props.anonymousRead && checkedRole.title === 'read') || checkedRole?.disabled === true
                         }
                         ariaLabel={`${role} ${checkedRole.title}`}
                         onChange={() => {
-                          if (checkedRole.selectedRoles?.includes(compositeRole)) {
-                            const newRoles = checkedRole.selectedRoles.filter((readRole) => {
-                              return readRole !== compositeRole;
-                            });
-                            checkedRole.selectedRoles = newRoles;
-                            setCheckedRoles(checkedRoles);
-                            props.roleSelectFunc(newRoles, checkedRole.title);
-                          } else {
-                            const newRoles = [...checkedRole.selectedRoles, compositeRole];
-                            checkedRole.selectedRoles = newRoles;
-                            setCheckedRoles(checkedRoles);
-                            props.roleSelectFunc(newRoles, checkedRole.title);
-                          }
+                          const newRoles = isChecked
+                            ? selectedRoles.filter((selected) => selected !== compositeRole)
+                            : [...selectedRoles, compositeRole];
+                          props.roleSelectFunc(newRoles, checkedRole.title);
+
                           const scrollPane = document.querySelector('.roles-scroll-pane');
                           const scrollTop = scrollPane ? scrollPane.scrollTop : 0;
                           setTimeout(() => {


### PR DESCRIPTION

<img width="880" height="469" alt="image" src="https://github.com/user-attachments/assets/d612b33e-81b7-475c-85f3-3f63153c52e6" />


Fixes [CS-5291](https://goa-dio.atlassian.net/browse/CS-5291) — role selections silently lost on new form definitions.

`ClientRoleTable` seeded local state from props once at mount and never resynced. The roles tab renders one table per Keycloak client, but they all edit the same role arrays, so each table computed its next value from a stale copy and the last table clicked overwrote the others. New definitions always hit this because `defaultFormDefinition` pre-seeds `form-applicant`.

Now renders from props (Redux is the source of truth) and no longer mutates them — which also fixes "Show selected roles" showing wrong selections. Applied to both copies of the component, since `form-editor-common` resolves `@components/RoleTable` per app.

New `RoleTable.spec.tsx`: 6 tests, 3 of which fail against the pre-fix component. Full TMW suite (296 tests) and form-management-app suite pass.