### PR TITLE
fix(form-admin-app): correct results summary total for tag filters

### DIFF
--- a/apps/form-admin-app/src/app/components/ResultsSummary.spec.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsSummary.spec.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import { ResultsSummary } from './ResultsSummary';
+
+describe('ResultsSummary', () => {
+  const renderSummary = (total?: number | null) =>
+    render(<ResultsSummary visible={3} total={total} itemLabel="definitions" onClearFilters={jest.fn()} />);
+
+  it('should show the visible count of the total when the total is known', () => {
+    const { container } = renderSummary(12);
+
+    expect(container.textContent).toContain('Showing 3 of 12 definitions matching your current filters.');
+  });
+
+  it('should show only the visible count when the total is not known', () => {
+    const { container } = renderSummary(null);
+
+    expect(container.textContent).toContain('Showing 3 definitions matching your current filters.');
+  });
+
+  it('should show only the visible count when no total is provided', () => {
+    const { container } = renderSummary();
+
+    expect(container.textContent).toContain('Showing 3 definitions matching your current filters.');
+  });
+
+  it('should show a zero total when nothing matches', () => {
+    const { container } = renderSummary(0);
+
+    expect(container.textContent).toContain('Showing 3 of 0 definitions matching your current filters.');
+  });
+});

--- a/apps/form-admin-app/src/app/components/ResultsSummary.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsSummary.tsx
@@ -25,7 +25,8 @@ const SummaryCount = styled.strong`
 
 interface ResultsSummaryProps {
   visible: number;
-  total: number;
+  // Total is not known for searches that resolve results by tag.
+  total?: number | null;
   itemLabel: string;
   loading?: boolean;
   onClearFilters: () => void;
@@ -41,9 +42,7 @@ export const ResultsSummary: FunctionComponent<ResultsSummaryProps> = ({
   <ResultsSummaryContainer>
     <SummaryText>
       Showing{' '}
-      <SummaryCount>
-        {visible} of {total}
-      </SummaryCount>{' '}
+      <SummaryCount>{typeof total === 'number' ? `${visible} of ${total}` : visible}</SummaryCount>{' '}
       {itemLabel} matching your current filters.
     </SummaryText>
     <GoabButton size="compact" type="secondary" disabled={loading} onClick={onClearFilters}>

--- a/apps/form-admin-app/src/app/state/form.slice.spec.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.spec.ts
@@ -1,4 +1,4 @@
-import { countActiveFilters, formFilterCountSelector, getDefaultFormCriteria } from './form.slice';
+import { countActiveFilters, formFilterCountSelector, getDefaultFormCriteria, resolveResultTotal } from './form.slice';
 
 describe('countActiveFilters', () => {
   it('should return zero for empty criteria', () => {
@@ -37,5 +37,27 @@ describe('formFilterCountSelector', () => {
     >[0];
 
     expect(formFilterCountSelector(state)).toBe(2);
+  });
+});
+
+describe('resolveResultTotal', () => {
+  it('should use the total from the page when it is included', () => {
+    expect(resolveResultTotal(null, { total: 12 })).toBe(12);
+  });
+
+  it('should use a zero total from the page', () => {
+    expect(resolveResultTotal(12, { total: 0 })).toBe(0);
+  });
+
+  it('should clear the previous total for a new search without a total', () => {
+    expect(resolveResultTotal(12, {})).toBeNull();
+  });
+
+  it('should keep the total for a subsequent page of the same search', () => {
+    expect(resolveResultTotal(12, { after: 'MTA=' })).toBe(12);
+  });
+
+  it('should keep an unknown total for a subsequent page of the same search', () => {
+    expect(resolveResultTotal(null, { after: 'MTA=' })).toBeNull();
   });
 });

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -90,6 +90,20 @@ export const countActiveFilters = (criteria: { dataCriteria?: Record<string, unk
   return [...Object.values(fields), ...Object.values(dataCriteria || {})].filter(hasFilterValue).length;
 };
 
+// Tag based searches resolve results via the directory service, which doesn't include a total in the page.
+// Carry the total across pages of the same search, but clear it when a new search comes back without one,
+// so the total of a previous search isn't reported against the current results.
+export const resolveResultTotal = (
+  current: number | null,
+  page: { after?: string; total?: number },
+): number | null => {
+  if (page.total !== undefined) {
+    return page.total;
+  }
+
+  return page.after ? current : null;
+};
+
 interface DataValue {
   name: string;
   path: string;
@@ -131,9 +145,9 @@ export interface FormState {
     submissions: string[];
   };
   resultTotals: {
-    definitions: number;
-    forms: number;
-    submissions: number;
+    definitions: number | null;
+    forms: number | null;
+    submissions: number | null;
   };
   definitionCriteria: DefinitionCriteria;
   formCriteria: FormCriteria;
@@ -1035,9 +1049,7 @@ const formSlice = createSlice({
           ...payload.results.map((result) => result.id),
         ];
         state.results.definitions = results;
-        if (payload.page.total !== undefined) {
-          state.resultTotals.definitions = payload.page.total;
-        }
+        state.resultTotals.definitions = resolveResultTotal(state.resultTotals.definitions, payload.page);
         state.next.definitions = payload.page.next;
       })
       .addCase(loadDefinitions.rejected, (state) => {
@@ -1096,9 +1108,7 @@ const formSlice = createSlice({
           ...payload.results.map((result) => result.id),
         ];
         state.results.forms = results;
-        if (payload.page.total !== undefined) {
-          state.resultTotals.forms = payload.page.total;
-        }
+        state.resultTotals.forms = resolveResultTotal(state.resultTotals.forms, payload.page);
         state.next.forms = payload.page.next;
       })
       .addCase(findForms.rejected, (state) => {
@@ -1118,9 +1128,7 @@ const formSlice = createSlice({
           ...payload.results.map((result) => result.id),
         ];
         state.results.submissions = results;
-        if (payload.page.total !== undefined) {
-          state.resultTotals.submissions = payload.page.total;
-        }
+        state.resultTotals.submissions = resolveResultTotal(state.resultTotals.submissions, payload.page);
         state.next.submissions = payload.page.next;
       })
       .addCase(findSubmissions.rejected, (state) => {


### PR DESCRIPTION
Resolves [CS-5293](https://goa-dio.atlassian.net/browse/CS-5293).

Tag based searches resolve results via the directory service, whose page has no `total`. The reducer only overwrote the total when one was returned, so the previous search's total was reported against the tag filtered results.

- `resolveResultTotal` clears the total for a new search that returns without one, and keeps it across pages of the same search.
- `ResultsSummary` shows only the visible count when the total is unknown.
- Applies to definitions, forms and submissions, which share the reducer pattern and the tag filter.

Unit tests added for both; `nx test form-admin-app` and `nx build form-admin-app` pass.