### PR TITLE
feat(form-admin-app): move definition count widget into the sticky header

### DIFF
--- a/apps/form-admin-app/src/app/components/SearchFormItemsContainer.tsx
+++ b/apps/form-admin-app/src/app/components/SearchFormItemsContainer.tsx
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19 — styled component declarations only; exercised via FormDefinitions.spec.tsx.
 import styled from 'styled-components';
 
 export const SearchFormItemsContainer = styled.div`

--- a/apps/form-admin-app/src/app/components/SearchFormItemsContainer.tsx
+++ b/apps/form-admin-app/src/app/components/SearchFormItemsContainer.tsx
@@ -5,3 +5,12 @@ export const SearchFormItemsContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
 `;
+
+// Aligns an action control with the inputs of the search form items it sits beside,
+// since those items stack a label above their input.
+export const SearchFormActionItem = styled.div`
+  display: flex;
+  align-items: flex-end;
+  margin-right: var(--goa-space-m);
+  padding-bottom: var(--goa-space-2xs);
+`;

--- a/apps/form-admin-app/src/app/components/SearchFormItemsContainer.tsx
+++ b/apps/form-admin-app/src/app/components/SearchFormItemsContainer.tsx
@@ -5,6 +5,7 @@ export const SearchFormItemsContainer = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  margin-bottom: var(--goa-space-m);
 `;
 
 // Aligns an action control with the inputs of the search form items it sits beside,

--- a/apps/form-admin-app/src/app/containers/FormDefinitions.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/FormDefinitions.spec.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { FormsDefinitions } from './FormDefinitions';
+import { loadDefinitions } from '../state';
+
+jest.mock('../state', () => {
+  const actual = jest.requireActual('../state');
+  return {
+    ...actual,
+    loadDefinitions: jest.fn((payload) => ({ type: 'form/load-definitions', payload })),
+    getTags: jest.fn((payload) => ({ type: 'directory/get-tags', payload })),
+    getResourceTags: jest.fn((payload) => ({ type: 'directory/get-resource-tags', payload })),
+    tagResource: jest.fn((payload) => ({ type: 'directory/tag-resource', payload })),
+  };
+});
+
+const mockStore = configureStore();
+const definitionId = 'intake-form';
+const definitionUrn = 'urn:ads:platform:configuration-service:v2:/configuration/form-service/intake-form';
+
+const createState = ({
+  definitionResults = [definitionId],
+  totalDefinitions = 12,
+  definitionCriteria = {},
+}: {
+  definitionResults?: string[];
+  totalDefinitions?: number | null;
+  definitionCriteria?: Record<string, unknown>;
+} = {}) => ({
+  user: {
+    user: {
+      id: 'user-1',
+      name: 'Test User',
+      email: 'test@gov.ab.ca',
+      roles: ['urn:ads:platform:form-service:form-admin'],
+    },
+  },
+  form: {
+    busy: {
+      initializing: false,
+      loading: false,
+      findPdf: false,
+      executing: false,
+      exporting: false,
+    },
+    forms: {},
+    submissions: {},
+    definitions: {
+      [definitionId]: {
+        id: definitionId,
+        name: 'Intake form',
+        urn: definitionUrn,
+        anonymousApply: false,
+        oneFormPerApplicant: true,
+      },
+    },
+    pdfs: {},
+    dataValues: {},
+    results: {
+      definitions: definitionResults,
+      forms: [],
+      submissions: [],
+    },
+    resultTotals: {
+      definitions: totalDefinitions,
+      forms: 0,
+      submissions: 0,
+    },
+    definitionCriteria,
+    formCriteria: {},
+    submissionCriteria: {},
+    next: {
+      definitions: null,
+      forms: null,
+      submissions: null,
+    },
+    selectedDefinition: null,
+    selectedForm: null,
+    selectedSubmission: null,
+    dispositionDraft: { status: '', reason: '' },
+    export: { forms: {}, submissions: {} },
+  },
+  directory: {
+    resources: {},
+    tags: {},
+    resourceTags: {},
+    tagResources: {},
+    results: [],
+    next: null,
+    busy: {
+      loading: false,
+      loadingResourceTags: {},
+      executing: false,
+    },
+  },
+});
+
+const renderDefinitions = (state = createState()) => {
+  const store = mockStore(state);
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <FormsDefinitions />
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  return { store, ...view };
+};
+
+const SUMMARY_TEXT = 'matching your current filters';
+
+describe('FormsDefinitions', () => {
+  beforeEach(() => {
+    (loadDefinitions as unknown as jest.Mock).mockClear();
+  });
+
+  it('should show the results summary in the sticky header instead of the scrolling content', () => {
+    const { container } = renderDefinitions();
+
+    const searchForm = container.querySelector('form');
+    expect(searchForm.textContent).toContain(SUMMARY_TEXT);
+    expect(searchForm.textContent).toContain('Showing 1 of 12');
+
+    const content = container.querySelector('goa-table').parentElement;
+    expect(content.textContent).not.toContain(SUMMARY_TEXT);
+  });
+
+  it('should show the search action as an icon button beside the tag filter', () => {
+    const { baseElement } = renderDefinitions();
+
+    const action = baseElement.querySelector("goa-icon-button[testId='load-definitions']");
+    expect(action).toBeTruthy();
+    expect(action.getAttribute('icon')).toBe('search');
+    expect(action.getAttribute('arialabel')).toBe('Load definitions');
+  });
+
+  it('should no longer show the load definitions text button', () => {
+    const { queryByText } = renderDefinitions();
+
+    expect(queryByText('Load definitions')).toBeNull();
+  });
+
+  it('should load definitions when the search action is clicked', () => {
+    const criteria = { tag: 'urgent' };
+    const { baseElement } = renderDefinitions(createState({ definitionCriteria: criteria }));
+    (loadDefinitions as unknown as jest.Mock).mockClear();
+
+    fireEvent(baseElement.querySelector("goa-icon-button[testId='load-definitions']"), new CustomEvent('_click'));
+
+    expect(loadDefinitions).toHaveBeenCalledWith({ after: undefined, tag: 'urgent', criteria });
+  });
+
+  it('should clear the filters from the header summary', () => {
+    const { baseElement } = renderDefinitions(createState({ definitionCriteria: { tag: 'urgent' } }));
+    (loadDefinitions as unknown as jest.Mock).mockClear();
+
+    fireEvent(baseElement.querySelector('form goa-button'), new CustomEvent('_click'));
+
+    expect(loadDefinitions).toHaveBeenCalledWith({ criteria: {} });
+  });
+});

--- a/apps/form-admin-app/src/app/containers/FormDefinitions.tsx
+++ b/apps/form-admin-app/src/app/containers/FormDefinitions.tsx
@@ -1,4 +1,11 @@
-import { GoabBadge, GoabButton, GoabButtonGroup, GoabCallout, GoabTable } from '@abgov/react-components';
+import {
+  GoabBadge,
+  GoabButton,
+  GoabButtonGroup,
+  GoabCallout,
+  GoabIconButton,
+  GoabTable,
+} from '@abgov/react-components';
 import { RowLoadMore, RowSkeleton } from '@core-services/app-common';
 import { FunctionComponent, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -21,7 +28,7 @@ import { NavigateFunction, useNavigate } from 'react-router-dom';
 import { AddTagModal } from '../components/AddTagModal';
 import { SearchLayout } from '../components/SearchLayout';
 import { ContentContainer } from '../components/ContentContainer';
-import { SearchFormItemsContainer } from '../components/SearchFormItemsContainer';
+import { SearchFormActionItem, SearchFormItemsContainer } from '../components/SearchFormItemsContainer';
 import { DateRangeCriteriaItem, isSearchDisabled } from '../components/DateRangeCriteriaItem';
 import { Tags } from './Tags';
 import { TagSearchFilter } from './TagSearchFilter';
@@ -111,17 +118,24 @@ export const FormsDefinitions = () => {
                 onChangeTo={(value) => updateCriteria({ ...criteria, createDateBefore: value })}
               />
               <TagSearchFilter value={criteria.tag} onChange={(value) => updateCriteria({ ...criteria, tag: value })} />
+              <SearchFormActionItem>
+                <GoabIconButton
+                  icon="search"
+                  ariaLabel="Load definitions"
+                  title="Load definitions"
+                  testId="load-definitions"
+                  disabled={searchDisabled}
+                  onClick={() => handleLoadDefinitions()}
+                />
+              </SearchFormActionItem>
             </SearchFormItemsContainer>
-            <GoabButtonGroup alignment="end" mt="l">
-              <GoabButton
-                size="compact"
-                type="primary"
-                disabled={searchDisabled}
-                onClick={() => handleLoadDefinitions()}
-              >
-                Load definitions
-              </GoabButton>
-            </GoabButtonGroup>
+            <ResultsSummary
+              visible={definitions.length}
+              total={totalDefinitions}
+              itemLabel="definitions"
+              loading={busy.loading}
+              onClearFilters={clearFilters}
+            />
           </form>
         ) : (
           <div>
@@ -134,13 +148,6 @@ export const FormsDefinitions = () => {
       }
     >
       <ContentContainer>
-        <ResultsSummary
-          visible={definitions.length}
-          total={totalDefinitions}
-          itemLabel="definitions"
-          loading={busy.loading}
-          onClearFilters={clearFilters}
-        />
         <GoabTable width="100%">
           <thead>
             <tr>


### PR DESCRIPTION
Resolves [CS-5296](https://goa-dio.atlassian.net/browse/CS-5296).

The results summary sat inside the scrolling content, so it scrolled out of view on tenants with many definitions.

- The summary widget now renders in the sticky search header, above the definitions table.
- The load action moved from the button group below the filters to just right of the tag filter.
- It is now a search icon button (`GoabIconButton icon="search"`), with `Load definitions` kept as its aria-label and title.

Added `FormDefinitions.spec.tsx` covering the summary's placement in the header, the icon button, and the load/clear-filter dispatches. `nx test form-admin-app` (11 suites / 65 tests) and `nx build form-admin-app` pass.

Note: the mockup attached to the ticket isn't reachable through the Jira API, so the layout follows the written requirements — spacing and the widget's contrast against the grey header band may want a designer's eye.