### PR TITLE
feat: resize PDF editor panes

### DIFF
--- a/apps/tenant-management-webapp/src/app/components/FullScreenEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/components/FullScreenEditor.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FullScreenEditor } from './FullScreenEditor';
+
+jest.mock('app/notificationBanner', () => ({ NotificationBanner: () => null }));
+jest.mock('./TabletMessage', () => ({ TabletMessage: () => null }));
+
+class ResizeObserverMock {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  observe = () => {
+    this.callback([{ contentRect: { width: 1000 } } as ResizeObserverEntry], this as unknown as ResizeObserver);
+  };
+
+  disconnect = jest.fn();
+  unobserve = jest.fn();
+}
+
+describe('FullScreenEditor', () => {
+  beforeAll(() => {
+    global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+    global.PointerEvent = MouseEvent as unknown as typeof PointerEvent;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 1000,
+      top: 0,
+      width: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('allows the user to resize the editor and preview panes', () => {
+    // Arrange
+    const { getByRole } = render(
+      <FullScreenEditor editor={<div>Editor</div>} preview={<div>Preview</div>} onGoBack={jest.fn()} resizable />,
+    );
+    const separator = getByRole('separator');
+
+    // Act
+    fireEvent.pointerDown(separator, { pointerId: 1 });
+    fireEvent.pointerMove(separator, { clientX: 650, pointerId: 1 });
+    fireEvent.pointerUp(separator, { pointerId: 1 });
+
+    // Assert
+    expect(separator).toHaveAttribute('aria-valuenow', '650');
+  });
+
+  it('preserves the fixed layout when resizing is not enabled', () => {
+    // Arrange
+    const { queryByRole } = render(
+      <FullScreenEditor editor={<div>Editor</div>} preview={<div>Preview</div>} onGoBack={jest.fn()} />,
+    );
+
+    // Act
+    const separator = queryByRole('separator');
+
+    // Assert
+    expect(separator).not.toBeInTheDocument();
+  });
+
+  it('hides the preview pane when requested', () => {
+    // Arrange
+    const { queryByText } = render(
+      <FullScreenEditor
+        editor={<div>Editor</div>}
+        preview={<div>Preview</div>}
+        previewHidden
+        onGoBack={jest.fn()}
+        resizable
+      />,
+    );
+
+    // Act
+    const preview = queryByText('Preview');
+
+    // Assert
+    expect(preview).not.toBeInTheDocument();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/components/FullScreenEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/components/FullScreenEditor.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
+import { ResizableSplitPane } from '@core-services/app-common';
 import { NotificationBanner } from 'app/notificationBanner';
 import { TabletMessage } from './TabletMessage';
 
@@ -15,7 +16,7 @@ const Modal = styled.div`
   flex-direction: column;
 `;
 
-const OuterEditorContainer = styled.div<{ $previewWidth: string }>`
+const OuterEditorContainer = styled.div<{ $previewWidth: string; $resizable: boolean }>`
   flex: 1;
   width: 100%;
   overflow: hidden;
@@ -35,7 +36,8 @@ const OuterEditorContainer = styled.div<{ $previewWidth: string }>`
     width: 100%;
     overflow: hidden;
     box-sizing: border-box;
-    > section {
+    > section,
+    .editor-pane > section {
       display: flex;
       flex: 1;
       flex-direction: column;
@@ -47,6 +49,13 @@ const OuterEditorContainer = styled.div<{ $previewWidth: string }>`
         overflow: hidden;
       }
     }
+    .editor-pane {
+      display: flex;
+      flex: 1;
+      width: 100%;
+      min-width: 0;
+      overflow: hidden;
+    }
     h2 {
       font-size: var(--goa-font-size-7);
       line-height: var(--lh-lg);
@@ -56,7 +65,7 @@ const OuterEditorContainer = styled.div<{ $previewWidth: string }>`
     }
   }
   & .preview {
-    width: ${({ $previewWidth }) => $previewWidth || 'calc(40vw + 3.9rem)'};
+    width: ${({ $previewWidth, $resizable }) => ($resizable ? '100%' : $previewWidth || 'calc(40vw + 3.9rem)')};
     flex: 1;
     margin-right: var(--goa-space-xl);
     margin-left: var(--goa-space-xl);
@@ -71,6 +80,8 @@ interface FullScreenEditorProps {
   editor: ReactNode;
   preview: ReactNode;
   previewWidth?: string;
+  previewHidden?: boolean;
+  resizable?: boolean;
   onGoBack: () => void;
 }
 
@@ -78,16 +89,31 @@ export const FullScreenEditor: FunctionComponent<FullScreenEditorProps> = ({
   editor,
   preview,
   previewWidth,
+  previewHidden = false,
+  resizable = false,
   onGoBack,
 }) => {
+  const previewPane = <div className="preview">{preview}</div>;
+
   return (
     <Modal>
       <NotificationBanner />
-      <OuterEditorContainer $previewWidth={previewWidth}>
+      <OuterEditorContainer $previewWidth={previewWidth} $resizable={resizable}>
         <TabletMessage goBack={onGoBack} />
         <div className="editor">
-          {editor}
-          <div className="preview">{preview}</div>
+          {resizable ? (
+            <ResizableSplitPane
+              left={<div className="editor-pane">{editor}</div>}
+              right={previewPane}
+              rightHidden={previewHidden}
+              testId="full-screen-editor-split"
+            />
+          ) : (
+            <>
+              {editor}
+              {!previewHidden && previewPane}
+            </>
+          )}
         </div>
       </OuterEditorContainer>
     </Modal>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/styled-components.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/styled-components.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PDFTitle, PdfEditorHeader, TemplateEditorContainerPdf } from './styled-components';
+
+describe('TemplateEditorContainerPdf', () => {
+  it('fills the available editor pane width', () => {
+    // Arrange
+    const { getByTestId } = render(<TemplateEditorContainerPdf data-testid="pdf-template-editor" />);
+
+    // Act
+    const editor = getByTestId('pdf-template-editor');
+
+    // Assert
+    expect(editor).toHaveStyle('width: 100%');
+  });
+
+  it('aligns the preview toggle to the right of the editor title', () => {
+    // Arrange
+    const { getByTestId } = render(
+      <PdfEditorHeader>{React.createElement('goa-button', { 'data-testid': 'preview-toggle' })}</PdfEditorHeader>,
+    );
+
+    // Act
+    const toggle = getByTestId('preview-toggle');
+
+    // Assert
+    expect(toggle).toHaveStyle('margin-left: auto');
+  });
+
+  it('keeps the editor title anchored when the preview control changes', () => {
+    // Arrange
+    const { getByTestId } = render(
+      <PdfEditorHeader>
+        <PDFTitle data-testid="pdf-editor-title">PDF / Template Editor</PDFTitle>
+      </PdfEditorHeader>,
+    );
+
+    // Act
+    const title = getByTestId('pdf-editor-title');
+
+    // Assert
+    expect(title).toHaveStyle('flex: 0 0 auto');
+  });
+
+  it('adds space below the preview toggle', () => {
+    // Arrange
+    const { getByTestId } = render(
+      <PdfEditorHeader>{React.createElement('goa-button', { 'data-testid': 'preview-toggle' })}</PdfEditorHeader>,
+    );
+
+    // Act
+    const toggle = getByTestId('preview-toggle');
+
+    // Assert
+    expect(toggle).toHaveStyle('margin-bottom: 10px');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/styled-components.ts
@@ -77,7 +77,9 @@ export const TemplateEditorContainerPdf = styled.div`
   &:hover {
     overflow: auto;
   }
-  width: calc(100vw - 40vw - 9.9rem);
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
   padding-top: var(--goa-space-xs);
   height: calc(100vh - 0px);
 
@@ -416,6 +418,22 @@ export const PDFTitle = styled.div`
   font-family: var(--goa-font-family-sans);
   margin-bottom: var(--goa-space-s);
 }
+`;
+
+export const PdfEditorHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--goa-space-m);
+
+  > ${PDFTitle} {
+    flex: 0 0 auto;
+  }
+
+  > goa-button {
+    margin-left: auto;
+    margin-bottom: 10px;
+  }
 `;
 
 export const HideTablet = styled.div`

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/pdfTemplateEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/pdfTemplateEditor.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PdfTemplatesEditor } from './pdfTemplateEditor';
+
+jest.mock('react-router-dom', () => ({ useNavigate: () => jest.fn() }));
+jest.mock('./previewEditor/TemplateEditor', () => ({
+  TemplateEditor: ({ previewVisible, onTogglePreview }: { previewVisible: boolean; onTogglePreview: () => void }) => (
+    <button type="button" onClick={onTogglePreview}>
+      {previewVisible ? 'Hide preview' : 'Show preview'}
+    </button>
+  ),
+}));
+jest.mock('./previewEditor/PreviewTemplate', () => ({
+  PreviewTemplate: () => <div>PDF preview</div>,
+}));
+jest.mock('@components/FullScreenEditor', () => ({
+  FullScreenEditor: ({
+    editor,
+    previewHidden,
+    resizable,
+  }: {
+    editor: React.ReactNode;
+    previewHidden?: boolean;
+    resizable?: boolean;
+  }) => (
+    <div data-testid="full-screen-editor" data-preview-hidden={previewHidden} data-resizable={resizable}>
+      {editor}
+    </div>
+  ),
+}));
+
+describe('PdfTemplatesEditor', () => {
+  it('enables resizing between the template editor and PDF preview', () => {
+    // Arrange
+    const { getByTestId } = render(<PdfTemplatesEditor />);
+
+    // Act
+    const editor = getByTestId('full-screen-editor');
+
+    // Assert
+    expect(editor).toHaveAttribute('data-resizable', 'true');
+  });
+
+  it('hides the PDF preview from the template editor control', () => {
+    // Arrange
+    const { getByTestId, getByRole } = render(<PdfTemplatesEditor />);
+
+    // Act
+    fireEvent.click(getByRole('button', { name: 'Hide preview' }));
+
+    // Assert
+    expect(getByTestId('full-screen-editor')).toHaveAttribute('data-preview-hidden', 'true');
+  });
+
+  it('shows the PDF preview after it has been hidden', () => {
+    // Arrange
+    const { getByTestId, getByRole } = render(<PdfTemplatesEditor />);
+    fireEvent.click(getByRole('button', { name: 'Hide preview' }));
+
+    // Act
+    fireEvent.click(getByRole('button', { name: 'Show preview' }));
+
+    // Assert
+    expect(getByTestId('full-screen-editor')).toHaveAttribute('data-preview-hidden', 'false');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/pdfTemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/pdfTemplateEditor.tsx
@@ -2,9 +2,11 @@ import { TemplateEditor } from './previewEditor/TemplateEditor';
 import { PreviewTemplate } from './previewEditor/PreviewTemplate';
 import { useNavigate } from 'react-router-dom';
 import { FullScreenEditor } from '@components/FullScreenEditor';
+import { useState } from 'react';
 
 export const PdfTemplatesEditor = (): JSX.Element => {
   const navigate = useNavigate();
+  const [previewVisible, setPreviewVisible] = useState(true);
 
   const goBack = () => {
     navigate('/admin/services/pdf?templates=true');
@@ -13,8 +15,15 @@ export const PdfTemplatesEditor = (): JSX.Element => {
   return (
     <FullScreenEditor
       onGoBack={goBack}
-      editor={<TemplateEditor />}
+      editor={
+        <TemplateEditor
+          previewVisible={previewVisible}
+          onTogglePreview={() => setPreviewVisible((visible) => !visible)}
+        />
+      }
       preview={<PreviewTemplate channelTitle="PDF preview" />}
+      previewHidden={!previewVisible}
+      resizable
     />
   );
 };

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/PreviewTemplate.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/PreviewTemplate.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { act, render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { PDFConfigForm } from './PDFConfigForm';
 import '@testing-library/jest-dom';
@@ -351,5 +351,45 @@ describe('Test pdf template preview', () => {
 
     expect(await queryByTestId('form-save')).toBeDefined();
     expect(await queryByTestId('download-icon')).toBeDefined();
+  });
+
+  it('re-enables PDF generation when the preview socket drops', async () => {
+    // Arrange
+    let state = {
+      fileService: { fileList: [] },
+      session: { indicator: { show: false } },
+      pdf: {
+        currentId: null,
+        files: {},
+        jobs: [],
+        pdfTemplates: {
+          'mock-id': {
+            id: 'mock-id',
+            variables: '{}',
+          },
+        },
+        socketChannel: true,
+      },
+    };
+    const store = mockStore(() => state);
+    const { baseElement } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/admin/services/pdf/edit/mock-id']}>
+          <Routes>
+            <Route path="/admin/services/pdf/edit/:id" element={<PreviewTemplate channelTitle="PDF preview" />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    const generateButton = baseElement.querySelector("goa-button[testid='generate-template']");
+    fireEvent(generateButton, new CustomEvent('_click'));
+    expect(generateButton).toHaveAttribute('disabled', 'true');
+
+    // Act
+    state = { ...state, pdf: { ...state.pdf, socketChannel: false } };
+    act(() => store.dispatch({ type: 'test/pdfSocketDropped' }));
+
+    // Assert
+    await waitFor(() => expect(generateButton).not.toHaveAttribute('disabled'));
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/PreviewTemplate.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/PreviewTemplate.tsx
@@ -89,6 +89,14 @@ export const PreviewTemplate = ({ channelTitle }: PreviewTemplateProps) => {
     }
   }, [socketChannel, dispatch]);
 
+  useEffect(() => {
+    // A dropped subscription means the completion event is never arriving, so stop waiting on it rather
+    // than leaving Generate PDF disabled behind a spinner that never resolves.
+    if (socketChannel === false) {
+      setIsGenerating(false);
+    }
+  }, [socketChannel]);
+
   const generateTemplate = () => {
     const payload = {
       templateId: pdfTemplate.id,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { TemplateEditor } from './TemplateEditor';
 import { Provider } from 'react-redux';
 import { SESSION_INIT } from '@store/session/models';
@@ -111,5 +112,38 @@ describe('Pdf Component', () => {
     await waitFor(() => {
       expect(require('react-router-dom').useHistory().push).not.toHaveBeenCalled();
     });
+  });
+
+  it('offers the preview toggle beside the PDF editor title', () => {
+    // Arrange
+    const onTogglePreview = jest.fn();
+    const { baseElement, getByText } = render(
+      <Provider store={store}>
+        <TemplateEditor previewVisible onTogglePreview={onTogglePreview} />
+      </Provider>,
+    );
+    const toggleButton = baseElement.querySelector("goa-button[testid='toggle-pdf-preview']");
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByText('Hide preview')).toBeInTheDocument();
+    expect(onTogglePreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers to show the PDF preview when it is hidden', () => {
+    // Arrange
+    const { getByText } = render(
+      <Provider store={store}>
+        <TemplateEditor previewVisible={false} onTogglePreview={jest.fn()} />
+      </Provider>,
+    );
+
+    // Act
+    const toggleLabel = getByText('Show preview');
+
+    // Assert
+    expect(toggleLabel).toBeInTheDocument();
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -8,6 +8,7 @@ import {
   PdfEditActionLayout,
   GeneratorStyling,
   PDFTitle,
+  PdfEditorHeader,
   ButtonRight,
   EditorLHSWrapper,
 } from '../../styled-components';
@@ -60,6 +61,8 @@ const getFileTypesForAttachment = (type: Attachment['type']): string[] =>
 interface TemplateEditorProps {
   //eslint-disable-next-line
   errors?: any;
+  previewVisible?: boolean;
+  onTogglePreview?: () => void;
 }
 
 // A segment that has never been set comes back undefined, while Monaco reports an empty editor as
@@ -77,7 +80,11 @@ const isPDFUpdated = (prev: PdfTemplate, next: PdfTemplate): boolean => {
   );
 };
 
-export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => {
+export const TemplateEditor = ({
+  errors,
+  previewVisible = true,
+  onTogglePreview,
+}: TemplateEditorProps): JSX.Element => {
   const dispatch = useDispatch<AppDispatch>();
 
   const { height } = useWindowDimensions();
@@ -143,7 +150,7 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
               type: fileTypes[i],
               file,
               recordId: tmpTemplate.id,
-            })
+            }),
           );
           return {
             urn: uploadedFile.urn,
@@ -278,7 +285,20 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
         <EditorLHSWrapper>
           <section>
             {customIndicator && <CustomLoader />}
-            <PDFTitle>PDF / Template Editor</PDFTitle>
+            <PdfEditorHeader>
+              <PDFTitle>PDF / Template Editor</PDFTitle>
+              {onTogglePreview && (
+                <GoabButton
+                  type="tertiary"
+                  size="compact"
+                  leadingIcon={previewVisible ? 'eye-off' : 'eye'}
+                  testId="toggle-pdf-preview"
+                  onClick={onTogglePreview}
+                >
+                  {previewVisible ? 'Hide preview' : 'Show preview'}
+                </GoabButton>
+              )}
+            </PdfEditorHeader>
             <hr />
 
             {pdfTemplate && <PDFConfigForm template={pdfTemplate} />}
@@ -425,7 +445,8 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
             <hr className="styled-hr styled-hr-bottom" />
             <PdfEditActionLayout>
               <GoabButtonGroup alignment="start">
-                <GoabButton size="compact"
+                <GoabButton
+                  size="compact"
                   disabled={!isPDFUpdated(tmpTemplate, pdfTemplate) || EditorError?.testData !== null}
                   onClick={() => {
                     setCustomIndicator(true);
@@ -436,7 +457,8 @@ export const TemplateEditor = ({ errors }: TemplateEditorProps): JSX.Element => 
                 >
                   Save
                 </GoabButton>
-                <GoabButton size="compact"
+                <GoabButton
+                  size="compact"
                   onClick={() => {
                     if (isPDFUpdated(tmpTemplate, pdfTemplate)) {
                       setSaveModal({ visible: true, closeEditor: false });

--- a/apps/tenant-management-webapp/src/app/store/pdf/api.tsx
+++ b/apps/tenant-management-webapp/src/app/store/pdf/api.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { PdfTemplate, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./saga.spec.tsx, the established one-spec-per-slice convention in this folder
+import { PdfTemplate, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./sagas.spec.ts, the established one-spec-per-slice convention in this folder
 
 export const fetchPdfTemplatesApi = async (token: string, url: string): Promise<Record<string, PdfTemplate>> => {
   const res = await axios.get(url, {

--- a/apps/tenant-management-webapp/src/app/store/pdf/sagas.spec.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/sagas.spec.ts
@@ -1,5 +1,13 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import { fetchPdfTemplates, createPdfTemplateSaga, deletePdfTemplate, updatePdfTemplate, generatePdf } from './sagas';
+import { io } from 'socket.io-client';
+import {
+  fetchPdfTemplates,
+  createPdfTemplateSaga,
+  deletePdfTemplate,
+  updatePdfTemplate,
+  generatePdf,
+  streamPdfSocket,
+} from './sagas';
 import {
   fetchPdfTemplatesApi,
   createPdfTemplateApi,
@@ -14,7 +22,44 @@ import {
   DELETE_PDF_TEMPLATE_SUCCESS_ACTION,
   UPDATE_PDF_TEMPLATE_SUCCESS_ACTION,
   GENERATE_PDF_SUCCESS_ACTION,
+  SOCKET_CHANNEL,
 } from './action';
+
+jest.mock('socket.io-client', () => ({ io: jest.fn() }));
+
+// redux-saga builds `delay` as a call to an internal `delayP`; skipping it keeps the reconnect
+// throttle out of the test's runtime.
+const skipReconnectDelay = {
+  call: (effect, next) => (effect.fn && effect.fn.name === 'delayP' ? null : next()),
+};
+
+const createFakeSocket = () => {
+  const handlers: Record<string, ((data?: unknown) => void)[]> = {};
+
+  const fake = {
+    active: true,
+    onSubscribe: null as null | ((event: string) => void),
+    on(event: string, handler: (data?: unknown) => void) {
+      handlers[event] = [...(handlers[event] || []), handler];
+      fake.onSubscribe?.(event);
+    },
+    once(event: string, handler: (data?: unknown) => void) {
+      fake.on(event, handler);
+    },
+    off(event: string, handler: (data?: unknown) => void) {
+      handlers[event] = (handlers[event] || []).filter((registered) => registered !== handler);
+    },
+    trigger(event: string, data?: unknown) {
+      (handlers[event] || []).forEach((handler) => handler(data));
+    },
+    removeAllListeners: jest.fn(),
+    disconnect: jest.fn(),
+  };
+
+  return fake;
+};
+
+const socketState = { config: { serviceUrls: { pushServiceApiUrl: 'http://push-service' } } };
 
 const mockTemplates = {
   'mock-template': {
@@ -221,4 +266,45 @@ it('Generate Pdf template', () => {
       },
     })
     .run();
+});
+
+describe('streamPdfSocket', () => {
+  beforeEach(() => (io as jest.Mock).mockReset());
+
+  it('clears the socket flag when the push service drops the connection for good', async () => {
+    const fake = createFakeSocket();
+    (io as jest.Mock).mockImplementation(() => {
+      // 'connect' is registered first and resolves the connect promise.
+      setTimeout(() => fake.trigger('connect'), 0);
+      return fake;
+    });
+
+    // Once the lifecycle handlers are wired the channel exists and the saga is reading from it, so a
+    // terminal drop at that point exercises the recovery path rather than racing it.
+    fake.onSubscribe = (event) => {
+      if (event === 'connect_error') {
+        setTimeout(() => {
+          fake.active = false;
+          fake.trigger('disconnect');
+        }, 0);
+      }
+    };
+
+    await expectSaga(streamPdfSocket, { disconnect: false })
+      .withState(socketState)
+      .provide(skipReconnectDelay)
+      .put({ socketChannel: true, type: SOCKET_CHANNEL })
+      .put({ socketChannel: false, type: SOCKET_CHANNEL })
+      .run(false);
+
+    expect(fake.disconnect).toHaveBeenCalled();
+  });
+
+  it('clears the socket flag on an explicit disconnect', async () => {
+    await expectSaga(streamPdfSocket, { disconnect: true })
+      .withState(socketState)
+      .provide(skipReconnectDelay)
+      .put({ socketChannel: false, type: SOCKET_CHANNEL })
+      .run(false);
+  });
 });

--- a/apps/tenant-management-webapp/src/app/store/pdf/sagas.ts
+++ b/apps/tenant-management-webapp/src/app/store/pdf/sagas.ts
@@ -1,7 +1,7 @@
 import { SagaIterator } from '@redux-saga/core';
 import { UpdateElementIndicator, UpdateIndicator } from '@store/session/actions';
 import { RootState, store } from '../index';
-import { select, call, put, takeEvery, takeLatest, take, apply, fork } from 'redux-saga/effects';
+import { select, call, put, takeEvery, takeLatest, take, apply, fork, delay } from 'redux-saga/effects';
 import { eventChannel } from 'redux-saga';
 import { ErrorNotification } from '@store/notifications/actions';
 import {
@@ -49,7 +49,7 @@ import { readFileAsync } from './readFile';
 import { io } from 'socket.io-client';
 import { getAccessToken as getAccessTokenThunk } from '@store/tenant/actions';
 import { getAccessToken } from '@store/tenant/sagas';
-import { PdfGenerationResponse, PdfTemplate, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./saga.spec.tsx, the established one-spec-per-slice convention in this folder
+import { PdfGenerationResponse, PdfTemplate, CreatePdfConfig } from './model'; // clean-code-ignore: RULE-19 — covered by ./sagas.spec.ts, the established one-spec-per-slice convention in this folder
 import {
   fetchPdfTemplatesApi,
   createPdfTemplateApi,
@@ -176,9 +176,25 @@ export function* deletePdfFilesService(action: DeletePdfFilesServiceAction): Sag
 // wrapping function for socket.on
 let socket;
 
+// Long enough that a push service that keeps refusing us cannot be hammered, short enough that the
+// preview recovers on its own once the token refreshes.
+const RECONNECT_DELAY_MS = 5000;
+
+const teardownSocket = (target) => {
+  if (!target) {
+    return;
+  }
+
+  target.removeAllListeners();
+  target.disconnect();
+  if (socket === target) {
+    socket = undefined;
+  }
+};
+
 const connect = (pushServiceUrl, stream) => {
-  return new Promise((resolve) => {
-    socket = io(`${pushServiceUrl}`, {
+  return new Promise((resolve, reject) => {
+    const pending = io(`${pushServiceUrl}`, {
       query: {
         stream: stream,
       },
@@ -195,15 +211,20 @@ const connect = (pushServiceUrl, stream) => {
       },
     });
 
-    socket.on('connect', () => {
-      resolve(socket);
+    socket = pending;
+
+    pending.once('connect', () => {
+      resolve(pending);
     });
 
-    socket.on('disconnect', () => {
-      resolve(socket);
+    // The push service refuses unauthorized subscribers from io.use middleware, and socket.io treats
+    // that as terminal: it stops retrying and the connection is gone for good. Fail the connect so the
+    // subscription is rebuilt rather than handing back a socket that will never deliver an event.
+    pending.on('connect_error', () => {
+      if (!pending.active) {
+        reject(new Error('Connection to the push service was refused.'));
+      }
     });
-
-    return socket;
   });
 };
 
@@ -333,49 +354,80 @@ export function* streamPdfSocket({ disconnect }: StreamPdfSocketAction): SagaIte
   // This is how a channel is created
   const createSocketChannel = (socket) =>
     eventChannel((emit) => {
-      const currentEvents = [];
-
       const handler = (data) => {
-        currentEvents.push(data);
-        emit(data);
+        emit({ payload: data });
       };
 
-      const doneHandler = (data) => {
-        currentEvents.push(data);
-        emit(data);
+      // A drop that socket.io will not retry has to end the subscription so that it can be rebuilt.
+      const dropHandler = () => {
+        if (!socket.active) {
+          emit({ dropped: true });
+        }
       };
 
-      socket.on('pdf-service:pdf-generated', doneHandler);
-      socket.on('pdf-service:pdf-generation-queued', handler);
-      socket.on('pdf-service:pdf-generation-failed', doneHandler);
-      socket.on('error', handler);
+      const events = [
+        'pdf-service:pdf-generated',
+        'pdf-service:pdf-generation-queued',
+        'pdf-service:pdf-generation-failed',
+        'error',
+      ];
+
+      events.forEach((event) => socket.on(event, handler));
+      socket.on('disconnect', dropHandler);
+      socket.on('connect_error', dropHandler);
 
       const unsubscribe = () => {
-        socket.off('ping', handler);
+        events.forEach((event) => socket.off(event, handler));
+        socket.off('disconnect', dropHandler);
+        socket.off('connect_error', dropHandler);
       };
 
       return unsubscribe;
     });
   if (disconnect === true) {
-    socket.disconnect();
-  } else {
-    const sk = yield call(connect, pushServiceUrl, 'pdf-generation-updates');
-    const socketChannel = yield call(createSocketChannel, sk);
+    teardownSocket(socket);
+    yield put({ socketChannel: false, type: SOCKET_CHANNEL });
+    return;
+  }
+
+  // Never leave an earlier connection behind. The socket is module level, so an orphaned one keeps its
+  // handlers and delivers into a channel that nothing is reading from any more.
+  teardownSocket(socket);
+
+  let sk;
+  let socketChannel;
+  try {
+    sk = yield call(connect, pushServiceUrl, 'pdf-generation-updates');
+    socketChannel = yield call(createSocketChannel, sk);
     yield put({ socketChannel: true, type: SOCKET_CHANNEL });
 
-    try {
-      const currentEvents = [];
-      while (true) {
-        const payload = yield take(socketChannel);
-        currentEvents.push(payload);
-        yield put(addToStream(payload));
-        yield put(generatePdfSuccessProcessing(payload));
-        yield fork(emitResponse, socket);
+    while (true) {
+      const message = yield take(socketChannel);
+      if (message.dropped) {
+        break;
       }
-    } catch (err) {
-      console.error('socket error: ', err);
+
+      yield put(addToStream(message.payload));
+      yield put(generatePdfSuccessProcessing(message.payload));
+      yield fork(emitResponse, sk);
     }
+  } catch (err) {
+    console.error('socket error: ', err);
+  } finally {
+    if (socketChannel) {
+      socketChannel.close();
+    }
+    teardownSocket(sk || socket);
   }
+
+  // The completion event is only cleared by the socket, so a drop mid generation would otherwise pin the
+  // page behind the processing spinner with Generate PDF disabled.
+  yield put(UpdateIndicator({ show: false }));
+
+  // A newer subscription cancels this saga and stops here. Otherwise clear the flag, which is what lets
+  // PreviewTemplate subscribe again with a fresh token instead of staying dead until the page reloads.
+  yield delay(RECONNECT_DELAY_MS);
+  yield put({ socketChannel: false, type: SOCKET_CHANNEL });
 }
 
 function* emitResponse(socket) {
@@ -513,7 +565,7 @@ export function* watchPdfSagas(): Generator {
   yield takeEvery(UPDATE_PDF_TEMPLATE_ACTION, updatePdfTemplate);
   yield takeEvery(FETCH_PDF_METRICS_ACTION, fetchPdfMetrics);
   yield takeEvery(GENERATE_PDF_ACTION, generatePdf);
-  yield takeEvery(STREAM_PDF_SOCKET_ACTION, streamPdfSocket);
+  yield takeLatest(STREAM_PDF_SOCKET_ACTION, streamPdfSocket);
   yield takeEvery(DELETE_PDF_TEMPLATE_ACTION, deletePdfTemplate);
   yield takeEvery(DELETE_PDF_FILE_SERVICE, deletePdfFileService);
   yield takeEvery(DELETE_PDF_FILES_SERVICE, deletePdfFilesService);

--- a/libs/app-common/src/components/resizable/ResizableSplitPane.spec.tsx
+++ b/libs/app-common/src/components/resizable/ResizableSplitPane.spec.tsx
@@ -22,6 +22,8 @@ class ResizeObserverMock {
 describe('ResizableSplitPane', () => {
   beforeAll(() => {
     global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+    // jsdom has no PointerEvent, so pointer events would otherwise drop clientX.
+    global.PointerEvent = MouseEvent as unknown as typeof PointerEvent;
   });
 
   beforeEach(() => {
@@ -71,20 +73,37 @@ describe('ResizableSplitPane', () => {
     const { getByText, queryByRole, queryByText } = render(
       <ResizableSplitPane left={<div>Editor</div>} right={<div>Preview</div>} rightHidden />,
     );
+    const editorPane = getByText('Editor').parentElement;
 
     expect(getByText('Editor')).toBeInTheDocument();
+    expect(editorPane).toHaveStyle({ flex: '1 1 100%', width: '100%' });
     expect(queryByText('Preview')).not.toBeInTheDocument();
     expect(queryByRole('separator')).not.toBeInTheDocument();
   });
 
-  it('falls back to the editor when the container cannot fit both minimum widths', () => {
+  it('collapses but keeps the right pane mounted when the container cannot fit both minimum widths', () => {
     observedWidth = 600;
-    const { getByText, queryByRole, queryByText } = render(
+    const { getByTestId, getByText, queryByRole } = render(
       <ResizableSplitPane left={<div>Editor</div>} right={<div>Preview</div>} />,
     );
 
     expect(getByText('Editor')).toBeInTheDocument();
-    expect(queryByText('Preview')).not.toBeInTheDocument();
     expect(queryByRole('separator')).not.toBeInTheDocument();
+    // Still mounted: unmounting the preview tears down host state that only a page reload restores.
+    expect(getByText('Preview')).toBeInTheDocument();
+    expect(getByTestId('resizable-split-pane-right')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('stops dragging when pointer capture is lost', () => {
+    const { getByRole } = render(<ResizableSplitPane left={<div />} right={<div />} />);
+    const separator = getByRole('separator');
+
+    fireEvent.pointerDown(separator, { pointerId: 1 });
+    fireEvent.pointerMove(separator, { pointerId: 1, clientX: 400 });
+    expect(separator).toHaveAttribute('aria-valuenow', '400');
+
+    fireEvent.lostPointerCapture(separator, { pointerId: 1 });
+    fireEvent.pointerMove(separator, { pointerId: 1, clientX: 600 });
+    expect(separator).toHaveAttribute('aria-valuenow', '400');
   });
 });

--- a/libs/app-common/src/components/resizable/ResizableSplitPane.tsx
+++ b/libs/app-common/src/components/resizable/ResizableSplitPane.tsx
@@ -81,6 +81,8 @@ export const ResizableSplitPane: FunctionComponent<ResizableSplitPaneProps> = ({
     updateLeftWidth(event.clientX - containerRef.current.getBoundingClientRect().left);
   };
 
+  // Also runs on lost pointer capture (window blur, tab switch, a native plugin taking the pointer);
+  // without it dragging stays latched on and the divider keeps tracking the pointer without a button held.
   const stopDragging = (event: PointerEvent<HTMLDivElement>) => {
     setDragging(false);
     if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
@@ -109,30 +111,38 @@ export const ResizableSplitPane: FunctionComponent<ResizableSplitPaneProps> = ({
 
   return (
     <SplitPaneContainer ref={containerRef} $dragging={dragging} data-testid={testId}>
-      <SplitPanePanel $width={showSplit ? leftWidth : undefined}>{left}</SplitPanePanel>
+      <SplitPanePanel style={showSplit ? { flex: `0 0 ${leftWidth}px`, width: `${leftWidth}px` } : undefined}>
+        {left}
+      </SplitPanePanel>
       {showSplit && (
-        <>
-          <SplitPaneDivider
-            role="separator"
-            aria-label={ariaLabel}
-            aria-orientation="vertical"
-            aria-valuemin={minPaneWidth}
-            aria-valuemax={Math.round(maximumLeftWidth)}
-            aria-valuenow={Math.round(leftWidth)}
-            tabIndex={0}
-            $dragging={dragging}
-            onDoubleClick={resetLeftWidth}
-            onKeyDown={handleKeyDown}
-            onPointerDown={(event) => {
-              setDragging(true);
-              event.currentTarget.setPointerCapture?.(event.pointerId);
-            }}
-            onPointerMove={handlePointerMove}
-            onPointerUp={stopDragging}
-            onPointerCancel={stopDragging}
-          />
-          <SplitPanePanel $fill>{right}</SplitPanePanel>
-        </>
+        <SplitPaneDivider
+          role="separator"
+          aria-label={ariaLabel}
+          aria-orientation="vertical"
+          aria-valuemin={minPaneWidth}
+          aria-valuemax={Math.round(maximumLeftWidth)}
+          aria-valuenow={Math.round(leftWidth)}
+          tabIndex={0}
+          $dragging={dragging}
+          onDoubleClick={resetLeftWidth}
+          onKeyDown={handleKeyDown}
+          onPointerDown={(event) => {
+            setDragging(true);
+            event.currentTarget.setPointerCapture?.(event.pointerId);
+          }}
+          onPointerMove={handlePointerMove}
+          onPointerUp={stopDragging}
+          onPointerCancel={stopDragging}
+          onLostPointerCapture={stopDragging}
+        />
+      )}
+      {/* Collapsed with CSS rather than unmounted: the right pane is measurement driven, and tearing it
+          down whenever the container is unmeasured or too narrow destroys host state that only a page
+          reload restores. rightHidden stays an unmount because that is the host asking for it. */}
+      {!rightHidden && (
+        <SplitPanePanel $fill $collapsed={!showSplit} aria-hidden={!showSplit} data-testid={`${testId}-right`}>
+          {right}
+        </SplitPanePanel>
       )}
     </SplitPaneContainer>
   );

--- a/libs/app-common/src/components/resizable/styled-components.spec.tsx
+++ b/libs/app-common/src/components/resizable/styled-components.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SplitPanePanel } from './styled-components';
+
+describe('SplitPanePanel', () => {
+  it('removes a collapsed pane from the visible layout', () => {
+    // Arrange
+    const { getByTestId } = render(<SplitPanePanel data-testid="collapsed-pane" $collapsed />);
+
+    // Act
+    const pane = getByTestId('collapsed-pane');
+
+    // Assert
+    expect(pane).toHaveStyle('display: none');
+  });
+
+  it('fills the available space when configured as the flexible pane', () => {
+    // Arrange
+    const { getByTestId } = render(<SplitPanePanel data-testid="fill-pane" $fill />);
+
+    // Act
+    const pane = getByTestId('fill-pane');
+
+    // Assert
+    expect(pane).toHaveStyle('flex: 1 1 0');
+  });
+});

--- a/libs/app-common/src/components/resizable/styled-components.ts
+++ b/libs/app-common/src/components/resizable/styled-components.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const DIVIDER_WIDTH = 9;
 
@@ -12,13 +12,21 @@ export const SplitPaneContainer = styled.div<{ $dragging: boolean }>`
   user-select: ${({ $dragging }) => ($dragging ? 'none' : 'auto')};
 `;
 
-export const SplitPanePanel = styled.div<{ $fill?: boolean; $width?: number }>`
+// The pane width is applied inline rather than interpolated here so that a drag does not inject a
+// new generated class for every pixel of movement.
+export const SplitPanePanel = styled.div<{ $fill?: boolean; $collapsed?: boolean }>`
   display: flex;
-  flex: ${({ $fill, $width }) => ($fill ? '1 1 0' : $width === undefined ? '1 1 100%' : `0 0 ${$width}px`)};
-  width: ${({ $width }) => ($width === undefined ? '100%' : `${$width}px`)};
+  flex: ${({ $fill }) => ($fill ? '1 1 0' : '1 1 100%')};
+  width: 100%;
   height: 100%;
   min-width: 0;
   overflow: hidden;
+
+  ${({ $collapsed }) =>
+    $collapsed &&
+    css`
+      display: none;
+    `}
 `;
 
 export const SplitPaneDivider = styled.div<{ $dragging: boolean }>`


### PR DESCRIPTION

<img width="1656" height="912" alt="image" src="https://github.com/user-attachments/assets/f38f5cb9-d5ca-4c45-8f02-2c3d907f5650" />


## Summary
- add opt-in split-pane resizing to the fullscreen editor
- enable resizing between the PDF template editor and PDF preview
- preserve the existing fixed layout for other fullscreen editor consumers
- cover pointer resizing and PDF editor integration with unit tests

## Verification
- targeted tenant-management-webapp tests: 6 suites, 14 tests passed
- ResizableSplitPane tests: 4 tests passed
- npx nx lint tenant-management-webapp (passes with one unrelated existing warning)
- npx nx build tenant-management-webapp --configuration=development
- Prettier and git diff --check

## Manual testing
- Local development server compiled successfully.
- Browser interaction was not completed because no browser-control session was connected in the environment.