### PR TITLE
CS-5305: add secret service overview page to TMW

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/index.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/index.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TenantManagement from './index';
+import { HeaderCtx } from '@lib/headerContext';
+
+const mockStore = configureStore([]);
+
+const storeWith = (featureFlags: Record<string, boolean>) =>
+  mockStore({
+    config: { serviceUrls: {}, featureFlags, keycloakApi: {} },
+    tenant: { name: 'test-tenant' },
+    session: {
+      authenticated: true,
+      realm: 'test',
+      resourceAccess: { 'urn:ads:platform:tenant-service': { roles: ['tenant-admin'] } },
+    },
+  });
+
+const renderAt = (path: string, featureFlags: Record<string, boolean>) =>
+  render(
+    <Provider store={storeWith(featureFlags)}>
+      <HeaderCtx.Provider value={{ setTitle: jest.fn() }}>
+        <MemoryRouter initialEntries={[path]}>
+          <TenantManagement />
+        </MemoryRouter>
+      </HeaderCtx.Provider>
+    </Provider>,
+  );
+
+describe('TenantManagement routing', () => {
+  it('routes to the secret service overview when the flag is on', () => {
+    const { getByTestId } = renderAt('/services/secret', { Secret: true });
+
+    expect(getByTestId('secret-title')).toHaveTextContent('Secret service');
+  });
+
+  it('does not register the secret route when the flag is off', () => {
+    const { queryByTestId } = renderAt('/services/secret', { Secret: false });
+
+    expect(queryByTestId('secret-title')).toBeNull();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/index.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/index.tsx
@@ -24,6 +24,7 @@ import { CommentRouter } from './services/comment';
 import { FormRouter } from './services/form';
 import { FileRouter } from './services/file';
 import { ValueRouter } from './services/value';
+import { Secret } from './services/secret';
 import { SharePoint } from './services/sharePoint';
 import { CacheRouter } from './services/cache';
 import { AgentRouter } from './services/agent';
@@ -76,6 +77,8 @@ const TenantManagement = (): JSX.Element => {
         return <PDFRouter />;
       case 'Script':
         return <ScriptRouter />;
+      case 'Secret':
+        return <Secret />;
       case 'SharePoint':
         return <SharePoint />;
       case 'Status':

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/secret/index.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/secret/index.spec.tsx
@@ -1,0 +1,8 @@
+import { Secret } from './index';
+import { Secret as SecretComponent } from './secret';
+
+describe('secret barrel', () => {
+  it('re-exports the component the admin router mounts', () => {
+    expect(Secret).toBe(SecretComponent);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/secret/index.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/secret/index.tsx
@@ -1,0 +1,1 @@
+export { Secret } from './secret';

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/secret/overview.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/secret/overview.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SecretOverview } from './overview';
+
+describe('SecretOverview', () => {
+  it('describes the service and how applications reach a saved secret', () => {
+    const { getByTestId } = render(<SecretOverview />);
+
+    const overview = getByTestId('secret-service-overall');
+    expect(overview).toHaveTextContent(
+      'The secret service allows applications to save sensitive data in a highly secure storage facility.',
+    );
+    expect(overview).toHaveTextContent('it will not be accessible to anyone outside of the secret service itself');
+    expect(overview).toHaveTextContent('through a callback function that has been registered through the service');
+  });
+
+  it('offers no way to add a secret, which is out of scope', () => {
+    const { container } = render(<SecretOverview />);
+
+    expect(container.querySelector('goa-button')).toBeNull();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/secret/overview.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/secret/overview.tsx
@@ -1,0 +1,22 @@
+import React, { FunctionComponent } from 'react';
+import { OverviewLayout } from '@components/Overview';
+
+export const SecretOverview: FunctionComponent = () => {
+  return (
+    <OverviewLayout
+      testId="secret-service-overall"
+      description={
+        <div>
+          <section>
+            <p>
+              The secret service allows applications to save sensitive data in a highly secure storage facility. Once a
+              secret has been saved, it will not be accessible to anyone outside of the secret service itself.
+              Applications can use the data indirectly through a callback function that has been registered through the
+              service.
+            </p>
+          </section>
+        </div>
+      }
+    />
+  );
+};

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/secret/secret.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/secret/secret.spec.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Secret } from './secret';
+
+const mockStore = configureStore([]);
+
+describe('Secret service', () => {
+  const renderSecret = () =>
+    render(
+      <Provider store={mockStore({ config: { serviceUrls: {} }, tenant: { name: 'test-tenant' } })}>
+        <MemoryRouter>
+          <Secret />
+        </MemoryRouter>
+      </Provider>,
+    );
+
+  it('renders the overview tab with the service description', () => {
+    const { getByTestId } = renderSecret();
+
+    expect(getByTestId('secret-title')).toHaveTextContent('Secret service');
+    expect(getByTestId('secret-service-overall')).toHaveTextContent(
+      'The secret service allows applications to save sensitive data in a highly secure storage facility.',
+    );
+  });
+
+  it('links out to the secret service code and API docs', () => {
+    const { getByTestId } = renderSecret();
+
+    expect(getByTestId('code-link').querySelector('a')).toHaveAttribute(
+      'href',
+      'https://github.com/GovAlta/adsp-monorepo/tree/main/apps/secret-service',
+    );
+    expect(getByTestId('docs-link').querySelector('a')).toHaveAttribute(
+      'href',
+      expect.stringContaining('urls.primaryName=Secret service'),
+    );
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/secret/secret.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/secret/secret.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent } from 'react';
+import { Aside, AsidePadding, Main, Page } from '@components/Html';
+import { Tab, Tabs } from '@components/Tabs';
+import AsideLinks from '@components/AsideLinks';
+import { SecretOverview } from './overview';
+
+export const Secret: FunctionComponent = () => {
+  return (
+    <Page>
+      <Main>
+        <h1 data-testid="secret-title">Secret service</h1>
+        <Tabs activeIndex={0} data-testid="secret-tabs">
+          <Tab label="Overview" data-testid="secret-overview-tab">
+            <SecretOverview />
+          </Tab>
+        </Tabs>
+      </Main>
+      <Aside>
+        <AsidePadding>
+          <AsideLinks serviceName="secret" />
+        </AsidePadding>
+      </Aside>
+    </Page>
+  );
+};

--- a/apps/tenant-management-webapp/src/app/store/config/models.ts
+++ b/apps/tenant-management-webapp/src/app/store/config/models.ts
@@ -60,6 +60,7 @@ export interface FeatureFlags {
   NotificationEmailAI: boolean;
   PDF: boolean;
   Script: boolean;
+  Secret: boolean;
   SharePoint: boolean;
   Status: boolean;
   Task: boolean;

--- a/apps/tenant-management-webapp/src/featureFlag.spec.ts
+++ b/apps/tenant-management-webapp/src/featureFlag.spec.ts
@@ -1,0 +1,45 @@
+import { defaultFeaturesVisible, serviceVariables } from './featureFlag';
+
+describe('serviceVariables', () => {
+  it('returns only the services enabled by the merged flags', () => {
+    const names = serviceVariables({ Secret: true }).map((service) => service.name);
+
+    expect(names).toContain('Secret');
+    expect(names).not.toContain('SharePoint');
+  });
+
+  it('lets caller flags override the defaults in both directions', () => {
+    const names = serviceVariables({ Secret: true, Value: false }).map((service) => service.name);
+
+    expect(names).toContain('Secret');
+    expect(names).not.toContain('Value');
+  });
+
+  it('sorts the enabled services by name', () => {
+    const names = serviceVariables({ Secret: true, SharePoint: true, Task: true }).map((service) => service.name);
+
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+    expect(names.indexOf('Secret')).toBe(names.indexOf('Script') + 1);
+    expect(names.indexOf('SharePoint')).toBe(names.indexOf('Secret') + 1);
+  });
+
+  it('does not mutate the underlying service list when sorting', () => {
+    const first = serviceVariables({ Secret: true }).map((service) => service.name);
+    const second = serviceVariables({ Secret: true }).map((service) => service.name);
+
+    expect(second).toEqual(first);
+  });
+});
+
+describe('secret service flag', () => {
+  it('is hidden by default', () => {
+    expect(defaultFeaturesVisible.Secret).toBe(false);
+    expect(serviceVariables().find((service) => service.name === 'Secret')).toBeUndefined();
+  });
+
+  it('is an alpha service linking to the secret overview page', () => {
+    const secret = serviceVariables({ Secret: true }).find((service) => service.name === 'Secret');
+
+    expect(secret).toMatchObject({ link: 'services/secret', alpha: true, beta: false });
+  });
+});

--- a/apps/tenant-management-webapp/src/featureFlag.ts
+++ b/apps/tenant-management-webapp/src/featureFlag.ts
@@ -96,6 +96,14 @@ const completeServiceVariables = [
     beta: true,
   },
   {
+    name: 'Secret',
+    link: 'services/secret',
+    description:
+      'The secret service allows applications to save sensitive data in a highly secure storage facility. Once a secret has been saved, it will not be accessible to anyone outside of the secret service itself. Applications can use the data indirectly through a callback function that has been registered through the service.',
+    beta: false,
+    alpha: true,
+  },
+  {
     name: 'SharePoint',
     link: 'services/sharepoint',
     description:
@@ -141,6 +149,7 @@ export const defaultFeaturesVisible = {
   NotificationEmailAI: true,
   PDF: true,
   Script: true,
+  Secret: false,
   SharePoint: false,
   Status: true,
   Task: false,
@@ -151,7 +160,9 @@ export const defaultFeaturesVisible = {
 
 export const serviceVariables = (featuresVisible = {}) => {
   const mergedFeaturesVisible = { ...defaultFeaturesVisible, ...featuresVisible };
-  return completeServiceVariables.filter((adminF) => {
-    return mergedFeaturesVisible[adminF.name];
-  });
+  return completeServiceVariables
+    .filter((adminF) => {
+      return mergedFeaturesVisible[adminF.name];
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 };


### PR DESCRIPTION

<img width="434" height="185" alt="image" src="https://github.com/user-attachments/assets/32c9c07c-1215-43ce-bbfd-9da304481ed8" />

<img width="1911" height="914" alt="image" src="https://github.com/user-attachments/assets/897836a1-62d3-4c16-86ce-0dc1f2550744" />


Adds the secret service to the tenant management webapp with an overview-only page.

- New `services/secret` page: "Secret service" heading, single Overview tab with the copy from the ticket, standard helpful-links aside.
- Registered in `featureFlag.ts` with `alpha: true` (Alpha badge in sidebar and dashboard card) and `Secret: false` in `defaultFeaturesVisible`, so it stays hidden until enabled per environment.
- `serviceVariables` now sorts by name, so sidebar/dashboard ordering is enforced rather than incidental. No-op against the current list, which was already alphabetical.

Adding secrets is out of scope, so there is no store wiring and no add button.

Note for whoever enables the flag: `tenant-admin.feature:79` asserts dashboard cards by exact count and index, so turning `Secret` on in an e2e environment needs `"Secret"` added to that list and `'The secret service allows'` to `cardTextArray`, both between Script and SharePoint. Left untouched here since the flag is off.
