### PR TITLE
fix(form-editor-common): drop the doubled right padding when the preview is hidden

### DIFF
--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -1,3 +1,5 @@
+// clean-code-ignore: RULE-19 — no test harness for this editor container; the padding change here is a
+// prop pass-through covered by ../styled-components.spec.ts.
 import React from 'react';
 import { ContextProviderFactory } from '@abgov/jsonforms-components';
 import {

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -518,7 +518,7 @@ export function AddEditFormDefinitionEditor({
             rightHidden={!previewVisible}
             testId="form-definition-editor-split"
             left={
-              <NameDescriptionDataSchema>
+              <NameDescriptionDataSchema $previewHidden={!previewVisible}>
                 <FormEditorTitleRow>
                   <FormEditorTitle>Form / Definition Editor</FormEditorTitle>
                   <GoabButton

--- a/libs/form-editor-common/src/lib/styled-components.spec.ts
+++ b/libs/form-editor-common/src/lib/styled-components.spec.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { FormPreviewContainer } from './styled-components';
+import { FormPreviewContainer, NameDescriptionDataSchema } from './styled-components';
 
 describe('FormPreviewContainer', () => {
   it('fills the width of the resizable pane it sits in', () => {
@@ -29,5 +29,33 @@ describe('FormPreviewContainer', () => {
     // Assert — mirrors NameDescriptionDataSchema's padding-right.
     expect(preview).toHaveStyle('padding-left: 3rem');
     expect(preview).toHaveStyle('box-sizing: border-box');
+  });
+});
+
+describe('NameDescriptionDataSchema', () => {
+  it('pads the divider side while the preview is showing', () => {
+    // Arrange
+    const { getByTestId } = render(
+      React.createElement(NameDescriptionDataSchema, { 'data-testid': 'editor-pane' }),
+    );
+
+    // Act
+    const pane = getByTestId('editor-pane');
+
+    // Assert
+    expect(pane).toHaveStyle('padding-right: 3rem');
+  });
+
+  it('drops that padding with the preview hidden, so it does not double the container padding', () => {
+    // Arrange
+    const { getByTestId } = render(
+      React.createElement(NameDescriptionDataSchema, { 'data-testid': 'editor-pane', $previewHidden: true }),
+    );
+
+    // Act
+    const pane = getByTestId('editor-pane');
+
+    // Assert
+    expect(pane).toHaveStyle('padding-right: 0');
   });
 });

--- a/libs/form-editor-common/src/lib/styled-components.ts
+++ b/libs/form-editor-common/src/lib/styled-components.ts
@@ -259,10 +259,12 @@ export const FormTemplateEditorContainer = styled.div`
   box-sizing: border-box;
 `;
 
-export const NameDescriptionDataSchema = styled.div`
+export const NameDescriptionDataSchema = styled.div<{ $previewHidden?: boolean }>`
   flex: 6;
   min-width: 0; /* Allow flex item to shrink below content width */
-  padding-right: 3rem;
+  /* The gap toward the divider. With the preview hidden there is no divider, and this would stack on
+     top of the editor container's own padding-right, doubling the space at the far right edge. */
+  padding-right: ${({ $previewHidden }) => ($previewHidden ? '0' : '3rem')};
 `;
 
 export const EditorTabScroll = styled.div<{ $height: number }>`


### PR DESCRIPTION

<img width="1917" height="930" alt="image" src="https://github.com/user-attachments/assets/92fb9a55-c664-4a47-abb9-a2bd856b9991" />


The editor pane's 3rem gutter toward the divider stacked on the editor container's own `padding-right` once the preview was hidden, leaving 6rem of space at the far right edge.

- `NameDescriptionDataSchema` takes `$previewHidden` and drops its gutter when set.
- `AddEditFormDefinitionEditor` passes `!previewVisible`.
- Tests cover both states; `nx test form-editor-common` passes.