### PR TITLE
fix(form-admin-app): scroll results tables that have more columns than fit

### DIFF
--- a/apps/form-admin-app/src/app/components/DataValueCell.tsx
+++ b/apps/form-admin-app/src/app/components/DataValueCell.tsx
@@ -1,5 +1,10 @@
 import styled from 'styled-components';
 
+// Data values are content of the form and can be long, so the cell is kept within a width that
+// leaves room for the other columns and wraps values that don't include spaces to break on.
 export const DataValueCell = styled.td`
   background: var(--goa-color-greyscale-100);
+  min-width: 10rem;
+  max-width: 20rem;
+  overflow-wrap: anywhere;
 `;

--- a/apps/form-admin-app/src/app/components/DataValueCell.tsx
+++ b/apps/form-admin-app/src/app/components/DataValueCell.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+// clean-code-ignore: RULE-19
 // Data values are content of the form and can be long, so the cell is kept within a width that
 // leaves room for the other columns and wraps values that don't include spaces to break on.
 export const DataValueCell = styled.td`

--- a/apps/form-admin-app/src/app/components/ResultsTable.spec.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsTable.spec.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { ActionsCell, ActionsColumnHeader, ResultsTable } from './ResultsTable';
+
+// goa-table isn't registered in tests, so a stub with a shadow root stands in for it.
+class StubTable extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+}
+
+const renderTable = () =>
+  render(
+    <ResultsTable width="100%">
+      <thead>
+        <tr>
+          <th>Submitted on</th>
+          <ActionsColumnHeader>Actions</ActionsColumnHeader>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Aug 25, 2026</td>
+          <ActionsCell>Open</ActionsCell>
+        </tr>
+      </tbody>
+    </ResultsTable>,
+  );
+
+describe('ResultsTable', () => {
+  beforeAll(() => {
+    customElements.define('goa-table', StubTable);
+  });
+
+  it('should let the table scroll to the columns that do not fit', () => {
+    const { baseElement } = renderTable();
+
+    const style = baseElement.querySelector('goa-table').shadowRoot.getElementById('results-table-scroll');
+    expect(style.textContent).toContain('overflow-x: auto');
+  });
+
+  it('should render the actions column as a heading and cell of the table', () => {
+    const { getByText } = renderTable();
+
+    expect(getByText('Actions').tagName).toBe('TH');
+    expect(getByText('Open').tagName).toBe('TD');
+  });
+
+  it('should stick the actions column to the right edge of the table', () => {
+    const { getByText } = renderTable();
+
+    expect(getComputedStyle(getByText('Open')).position).toBe('sticky');
+  });
+});

--- a/apps/form-admin-app/src/app/components/ResultsTable.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsTable.tsx
@@ -1,0 +1,53 @@
+import { GoabTable, GoabTableProps } from '@abgov/react-components';
+import { FunctionComponent, useCallback } from 'react';
+import styled from 'styled-components';
+
+// The table container of goa-table clips its content so that it can have rounded corners, and there
+// is no part or custom property to change that from outside the component. Results tables include a
+// column per data value of the definition, so they can be wider than the page, and the style is
+// added to the shadow root so that the table scrolls to the columns past the right edge instead of
+// hiding them.
+const SCROLL_STYLE_ID = 'results-table-scroll';
+const allowHorizontalScroll = (table: HTMLElement) => {
+  const root = table?.shadowRoot;
+  if (!root || root.getElementById(SCROLL_STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = SCROLL_STYLE_ID;
+  style.textContent = '.goatable { overflow-x: auto !important; }';
+  root.appendChild(style);
+};
+
+// Table for results with a column per data value of the definition; it scrolls horizontally when
+// the columns don't fit the page.
+export const ResultsTable: FunctionComponent<GoabTableProps> = (props) => {
+  const setScrollable = useCallback(
+    (container: HTMLDivElement) => allowHorizontalScroll(container?.querySelector('goa-table')),
+    [],
+  );
+
+  return (
+    <div ref={setScrollable}>
+      <GoabTable {...props} />
+    </div>
+  );
+};
+
+// Heading and cell of the trailing column of row actions. The column sticks to the right edge so
+// that actions are still reachable when the table is scrolled.
+const stickyRight = `
+  position: sticky;
+  right: 0;
+  z-index: 1;
+  border-left: 1px solid var(--goa-color-greyscale-200);
+`;
+
+export const ActionsColumnHeader = styled.th`
+  ${stickyRight}
+`;
+
+export const ActionsCell = styled.td`
+  ${stickyRight}
+`;

--- a/apps/form-admin-app/src/app/containers/FormSubmissions.tsx
+++ b/apps/form-admin-app/src/app/containers/FormSubmissions.tsx
@@ -1,11 +1,4 @@
-import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabTable,
-} from '@abgov/react-components';
+import { GoabButton, GoabButtonGroup, GoabDropdown, GoabDropdownItem, GoabFormItem } from '@abgov/react-components';
 import { RowLoadMore, RowSkeleton } from '@core-services/app-common';
 import { useDispatch, useSelector } from 'react-redux';
 import { FunctionComponent, useEffect, useState } from 'react';
@@ -33,6 +26,7 @@ import {
 import { ContentContainer } from '../components/ContentContainer';
 import { FilterDrawerLayout } from '../components/FilterDrawerLayout';
 import { DataValueCell } from '../components/DataValueCell';
+import { ActionsCell, ActionsColumnHeader, ResultsTable } from '../components/ResultsTable';
 import { ExportModal } from '../components/ExportModal';
 import { FilterFormItemsContainer } from '../components/FilterFormItemsContainer';
 import { DataValueCriteriaItem } from '../components/DataValueCriteriaItem';
@@ -189,7 +183,7 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
           loading={busy.loading}
           onClearFilters={clearFilters}
         />
-        <GoabTable key={sortableColumnsKey} width="100%" onSort={handleSort}>
+        <ResultsTable key={sortableColumnsKey} width="100%" onSort={handleSort}>
           <thead>
             <tr>
               <SortableColumnHeader name="created" sort={sort}>
@@ -204,7 +198,7 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
                   {name}
                 </SortableColumnHeader>
               ))}
-              <th>Actions</th>
+              <ActionsColumnHeader>Actions</ActionsColumnHeader>
             </tr>
           </thead>
           <tbody>
@@ -227,13 +221,13 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
                     </DataValueCell>
                   );
                 })}
-                <td>
+                <ActionsCell>
                   <GoabButtonGroup alignment="end">
                     <GoabButton type="secondary" size="compact" onClick={() => navigate(submission.id)}>
                       Open
                     </GoabButton>
                   </GoabButtonGroup>
-                </td>
+                </ActionsCell>
               </tr>
             ))}
             <RowSkeleton columns={4 + dataValues.length} show={busy.loading} />
@@ -244,7 +238,7 @@ export const FormSubmissions: FunctionComponent<FormSubmissionsProps> = ({ defin
               onLoadMore={handleFindSubmissions}
             />
           </tbody>
-        </GoabTable>
+        </ResultsTable>
       </ContentContainer>
       <AddTagModal
         open={!!showTagSubmission}

--- a/apps/form-admin-app/src/app/containers/Forms.tsx
+++ b/apps/form-admin-app/src/app/containers/Forms.tsx
@@ -5,7 +5,6 @@ import {
   GoabDropdownItem,
   GoabFormItem,
   GoabIcon,
-  GoabTable,
 } from '@abgov/react-components';
 import { RowLoadMore, RowSkeleton } from '@core-services/app-common';
 import { FunctionComponent, useEffect, useState } from 'react';
@@ -39,6 +38,7 @@ import {
 import { FilterDrawerLayout } from '../components/FilterDrawerLayout';
 import { ContentContainer } from '../components/ContentContainer';
 import { DataValueCell } from '../components/DataValueCell';
+import { ActionsCell, ActionsColumnHeader, ResultsTable } from '../components/ResultsTable';
 import { ExportModal } from '../components/ExportModal';
 import { FilterFormItemsContainer } from '../components/FilterFormItemsContainer';
 import { DataValueCriteriaItem } from '../components/DataValueCriteriaItem';
@@ -84,13 +84,13 @@ const FormRow: FunctionComponent<FormRowProps> = ({ dispatch, navigate, hasSuppo
           </DataValueCell>
         );
       })}
-      <td>
+      <ActionsCell>
         <GoabButtonGroup alignment="end">
           <GoabButton size="compact" type="secondary" onClick={() => navigate(form.id)}>
             Open
           </GoabButton>
         </GoabButtonGroup>
-      </td>
+      </ActionsCell>
     </tr>
   );
 };
@@ -239,7 +239,7 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
           loading={busy.loading}
           onClearFilters={clearFilters}
         />
-        <GoabTable key={sortableColumnsKey} width="100%" onSort={handleSort}>
+        <ResultsTable key={sortableColumnsKey} width="100%" onSort={handleSort}>
           <thead>
             <tr>
               <th></th>
@@ -255,7 +255,7 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
                   {name}
                 </SortableColumnHeader>
               ))}
-              <th>Actions</th>
+              <ActionsColumnHeader>Actions</ActionsColumnHeader>
             </tr>
           </thead>
           <tbody>
@@ -278,7 +278,7 @@ export const Forms: FunctionComponent<FormsProps> = ({ definitionId }) => {
               onLoadMore={handleFindForms}
             />
           </tbody>
-        </GoabTable>
+        </ResultsTable>
       </ContentContainer>
       <AddTagModal
         open={!!showTagForm}


### PR DESCRIPTION
CS-5317: with many fields in the review configuration, the submissions table ran past the page and goa-table clipped the extra columns, so the Open action was unreachable and there was no horizontal scrollbar.

- `ResultsTable` adds a style to the goa-table shadow root so the table container scrolls instead of clipping (there is no part or custom property for it).
- The actions column sticks to the right edge, so Open stays visible while scrolling.
- Data value columns get a min/max width and wrap long values, so columns aren't crushed.

Applies to both the submissions and forms tables.