### PR TITLE
fix(tenant-management-webapp): CS-5313 make event stream role checkboxes selectable

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/addEditStream/addEditStream.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/addEditStream/addEditStream.spec.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { AddEditStream } from './addEditStream';
+import { EditModalType, AddModalType, Stream } from '@store/stream/models';
+
+const mockStore = configureStore([]);
+
+const SUBSCRIBE = 'Subscribe';
+const EVENT_SERVICE = 'urn:ads:platform:event-service';
+
+const existingStream: Stream = {
+  id: 'test-stream',
+  name: 'test stream',
+  description: '',
+  events: [],
+  publicSubscribe: false,
+  subscriberRoles: [],
+};
+
+const buildState = (stream: Stream) => ({
+  session: {
+    modal: {
+      [EditModalType]: { isOpen: true, id: stream.id },
+      [AddModalType]: { isOpen: false },
+    },
+  },
+  stream: { tenant: { [stream.id]: stream } },
+  tenant: { name: 'autotest', realmRoles: [{ name: 'tester' }] },
+  serviceRoles: { keycloak: { [EVENT_SERVICE]: { roles: [{ role: 'stream-listener' }] } } },
+});
+
+const renderModal = (stream: Stream = existingStream) => {
+  const onSave = jest.fn();
+  render(
+    <Provider store={mockStore(buildState(stream))}>
+      <AddEditStream onSave={onSave} eventDefinitions={{}} streams={{}} />
+    </Provider>
+  );
+  return onSave;
+};
+
+const checkboxFor = (role: string) => screen.getByRole('checkbox', { name: `${role} ${SUBSCRIBE}` });
+
+// GoabButton exposes its click as a `_click` custom event on the underlying goa-button element.
+const save = () => fireEvent(document.querySelector('goa-button[testid="form-save"]'), new CustomEvent('_click'));
+
+describe('AddEditStream subscriber roles', () => {
+  it('checks a realm role and keeps it checked', () => {
+    const onSave = renderModal();
+
+    expect(checkboxFor('tester')).not.toBeChecked();
+    fireEvent.click(checkboxFor('tester'));
+
+    expect(checkboxFor('tester')).toBeChecked();
+    save();
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ subscriberRoles: ['tester'] }));
+  });
+
+  it('checks a client role and stores it as a urn', () => {
+    const onSave = renderModal();
+
+    fireEvent.click(checkboxFor('stream-listener'));
+
+    expect(checkboxFor('stream-listener')).toBeChecked();
+    save();
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ subscriberRoles: [`${EVENT_SERVICE}:stream-listener`] })
+    );
+  });
+
+  it('unchecks a role that was already selected', () => {
+    const onSave = renderModal({ ...existingStream, subscriberRoles: ['tester'] });
+
+    expect(checkboxFor('tester')).toBeChecked();
+    fireEvent.click(checkboxFor('tester'));
+
+    expect(checkboxFor('tester')).not.toBeChecked();
+    save();
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ subscriberRoles: [] }));
+  });
+
+  it('keeps selections from one client table when another is changed', () => {
+    const onSave = renderModal();
+
+    fireEvent.click(checkboxFor('tester'));
+    fireEvent.click(checkboxFor('stream-listener'));
+
+    expect(checkboxFor('tester')).toBeChecked();
+    expect(checkboxFor('stream-listener')).toBeChecked();
+    save();
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriberRoles: expect.arrayContaining(['tester', `${EVENT_SERVICE}:stream-listener`]),
+      })
+    );
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/addEditStream/addEditStream.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/events/stream/addEditStream/addEditStream.tsx
@@ -44,7 +44,8 @@ export const AddEditStream = ({ onSave, eventDefinitions, streams }: AddEditStre
   const isOpen = editModal?.isOpen || addModal?.isOpen;
   const isEdit = editModal.isOpen;
   const rolesObj = useSelector(selectRolesObject);
-  const selectedRoles = constructRoleObjFromUrns(initStream?.subscriberRoles);
+  // Derived from state, not initStream, so the role tables re-render with each selection (CS-5313).
+  const selectedRoles = useMemo(() => constructRoleObjFromUrns(stream?.subscriberRoles), [stream?.subscriberRoles]);
 
   const { errors, validators } = useValidators(
     'name',
@@ -219,14 +220,13 @@ export const AddEditStream = ({ onSave, eventDefinitions, streams }: AddEditStre
             return (
               <ClientRoleTable
                 roles={roles || []}
-                roleSelectFunc={(roleNames, type) => {
-                  if (roleNames && roleNames.length > 0) {
-                    selectedRoles[clientId] = roleNames.map((r) => r.split(':').pop());
-                  } else {
-                    selectedRoles[clientId] = [];
-                  }
-                  // no need to use setStream here.
-                  stream.subscriberRoles = roleObjectToUrns(selectedRoles);
+                roleSelectFunc={(roleNames) => {
+                  // Read from the previous state so a table for one client cannot clobber another's selections.
+                  setStream((previous) => {
+                    const updatedRoles = constructRoleObjFromUrns(previous?.subscriberRoles);
+                    updatedRoles[clientId] = (roleNames || []).map((r) => r.split(':').pop());
+                    return { ...previous, subscriberRoles: roleObjectToUrns(updatedRoles) };
+                  });
                 }}
                 clientId={clientId}
                 key={`client-role-group-${clientId}`}


### PR DESCRIPTION


https://github.com/user-attachments/assets/61ef6af8-51df-4c83-b57c-dee0404a5f0e


## CS-5313 — Role checkboxes for event stream modal aren't usable

Role selection in the add/edit event stream modal was derived from the Redux `initStream` and mutated in place with no `setStream`, so the modal never re-rendered. `ClientRoleTable` renders selections straight from props since CS-5291, so the checkbox never changed state.

Selection is now derived from component state and updated through `setStream`, reading from the previous state so one client's table cannot clobber another's.

Added `addEditStream.spec.tsx` — 4 tests covering check, uncheck, urn round-trip, and cross-client selection. All 4 fail on `main` and pass with the fix.

Verified: `nx test tenant-management-webapp` 72 suites / 328 tests pass; `nx lint` clean.