### PR TITLE
fix(adsp-service-sdk): keep the tenant metric label free of regex metacharacters

### DIFF
--- a/libs/adsp-service-sdk/src/metrics/attributes.spec.ts
+++ b/libs/adsp-service-sdk/src/metrics/attributes.spec.ts
@@ -2,17 +2,27 @@ import { formatTenantAttribute } from './attributes';
 
 describe('formatTenantAttribute', () => {
   const urn = 'urn:ads:platform:tenant-service:v2:/tenants/64d4eef5abc788a358dece8c';
+  const id = '64d4eef5abc788a358dece8c';
 
-  it('can combine the name and urn', () => {
-    expect(formatTenantAttribute(urn, 'Wildfire')).toBe(`Wildfire (${urn})`);
+  it('can combine the name and tenant id', () => {
+    expect(formatTenantAttribute(urn, 'Wildfire')).toBe(`Wildfire ${id}`);
   });
 
-  it('can fall back to the urn when there is no name', () => {
-    expect(formatTenantAttribute(urn, undefined)).toBe(urn);
+  it('can keep the value free of regex metacharacters', () => {
+    // Grafana's ${var:regex} formatter escapes these and PromQL rejects the escapes.
+    expect(formatTenantAttribute(urn, 'Wildfire')).not.toMatch(/[\\/(){}[\]^$*+?|]/);
   });
 
-  it('can fall back to the name when there is no urn', () => {
+  it('can fall back to the tenant id when there is no name', () => {
+    expect(formatTenantAttribute(urn, undefined)).toBe(id);
+  });
+
+  it('can fall back to the name when there is no id', () => {
     expect(formatTenantAttribute(undefined, 'Wildfire')).toBe('Wildfire');
+  });
+
+  it('can handle an id that is not a urn', () => {
+    expect(formatTenantAttribute('plain-id', 'Wildfire')).toBe('Wildfire plain-id');
   });
 
   it('can return undefined when there is no tenant context', () => {

--- a/libs/adsp-service-sdk/src/metrics/attributes.ts
+++ b/libs/adsp-service-sdk/src/metrics/attributes.ts
@@ -1,18 +1,30 @@
 /**
- * Combine the tenant name and URN into a single metric label value, e.g.
- * `Wildfire (urn:ads:platform:tenant-service:v2:/tenants/64d4eef5abc788a358dece8c)`.
+ * Combine the tenant name and id into a single metric label value, e.g. `Wildfire 64d4eef5abc788a358dece8c`.
  *
- * Name and URN are one-to-one, so carrying them as separate labels adds index weight without
+ * Name and id are one-to-one, so carrying them as separate labels adds index weight without
  * distinguishing any additional series. The name leads because Grafana legends truncate from the
- * right, and the URN follows so the value remains a canonical identifier.
+ * right; the bare id follows so the value still resolves to a specific tenant.
  *
- * Spans keep the two as separate attributes: span attributes are not aggregated, so there is no
- * cost to them, and keeping the URN on its own supports exact-match filtering in TraceQL.
+ * The value must stay free of regex metacharacters. Grafana's `${var:regex}` formatter
+ * backslash-escapes them and PromQL rejects the result -- `\(` and `\/` are not valid string
+ * escapes -- so a value like `Wildfire (urn:ads:platform:tenant-service:v2:/tenants/64d4...)` makes
+ * every panel that filters by tenant fail to parse. Hence the trailing path segment of the URN
+ * rather than the whole URN, and no punctuation around it. The URN prefix is constant, so nothing
+ * identifying is lost.
+ *
+ * A tenant *name* containing a metacharacter (there is a `roy.test` in dev) is still a hazard here,
+ * because the name is passed through verbatim. Dashboards should interpolate with `${var:pipe}`
+ * rather than `${var:regex}`: pipe does not escape, and a `.` in a name still matches itself.
+ *
+ * Spans keep adsp.tenant.id and adsp.tenant.name as separate attributes. Span attributes are not
+ * aggregated, so they cost nothing there, and the full URN supports exact-match TraceQL filtering.
  */
 export function formatTenantAttribute(tenantId?: string, tenantName?: string): string | undefined {
-  if (tenantId && tenantName) {
-    return `${tenantName} (${tenantId})`;
+  const id = tenantId ? tenantId.split('/').pop() || undefined : undefined;
+
+  if (id && tenantName) {
+    return `${tenantName} ${id}`;
   }
 
-  return tenantName || tenantId || undefined;
+  return tenantName || id || undefined;
 }

--- a/libs/adsp-service-sdk/src/metrics/benchmark.spec.ts
+++ b/libs/adsp-service-sdk/src/metrics/benchmark.spec.ts
@@ -112,7 +112,7 @@ describe('benchmark', () => {
 
       expect(record).toHaveBeenCalledWith(
         expect.any(Number),
-        expect.objectContaining({ 'adsp.tenant': `Wildfire (${urn})` })
+        expect.objectContaining({ 'adsp.tenant': 'Wildfire 64d4eef5abc788a358dece8c' })
       );
       expect(record).toHaveBeenCalledWith(
         expect.any(Number),


### PR DESCRIPTION
## Problem

Selecting a tenant on any Grafana dashboard fails:

```
1:84: parse error: unknown escape sequence U+0028 '('
```

The `adsp.tenant` metric label was formatted `name (urn)`:

```
ACSAL (urn:ads:platform:tenant-service:v2:/tenants/66621c17e212889801f60ded)
```

Grafana's `${var:regex}` formatter backslash-escapes regex metacharacters, so the interpolated matcher becomes:

```
ACSAL \(urn:ads:platform:tenant-service:v2:\/tenants\/66621c17e212889801f60ded\)
```

PromQL string literals don't permit `\(`, `\)` or `\/` — they aren't valid escape sequences — so the query fails to parse. Every panel filtering by tenant broke.

This was introduced by the combined-label change in #5795. The parentheses were mine; the slashes came from including the full URN.

## Fix

The label is now `name id` — the trailing path segment of the URN rather than the whole thing:

```
ACSAL 66621c17e212889801f60ded
```

The URN prefix (`urn:ads:platform:tenant-service:v2:/tenants/`) is constant, so the value still resolves to a specific tenant, and there is nothing left for Grafana to escape.

## Verified against adsp-dev

| interpolated value | result |
|---|---|
| `ACSAL \(urn:...\)` (current, `:regex`) | **parse error** — reproduces the report |
| `ACSAL 66621c17e212889801f60ded` | parses |
| `Wildfire 64d4...\|autotest 61e9...` (multi-select) | parses |
| `roy.test 637e4a33b78479430a8e579b` | parses |
| `.*` (All) | parses, 17 groups — untenanted requests still included |

212/212 SDK tests pass. Lint clean. `adsp-service-sdk`, `configuration-service`, `agent-service` all build. Rebased on `main` at 9ec9f3566.

## Known limitation

A tenant *name* containing a regex metacharacter still breaks `${var:regex}` — there is a `roy.test` in dev, and `\.` is rejected for the same reason. I deliberately did **not** sanitize the name: a label that no longer matches the real tenant name would be worse than the current failure.

This case predates the combined label — the previous `adsp_tenant_name` label hit it identically — so it is not a regression from #5795.

The dashboard-side fix is to interpolate with `${var:pipe}` instead of `${var:regex}`: pipe does not escape, and `.` still matches itself. That change is prepared in the working-tree dashboard JSON under `.openshift/observability/` (17 panel queries and 5 template queries, plus `allValue: ".*"` on the tenant variable so All keeps matching untenanted series) and is **not** part of this PR.

The two are independent: once this deploys, `:regex` works for 15 of the 16 tenants in dev; `:pipe` covers the 16th.

## Not changed

Span attributes keep `adsp.tenant.id` and `adsp.tenant.name` separate. Span attributes are not aggregated, so they cost nothing there, and the full URN supports exact-match TraceQL filtering. The asymmetry with metrics is deliberate.

## Test added

Alongside the format assertion, there is now a test asserting the value contains no regex metacharacters, so this cannot silently regress:

```typescript
expect(formatTenantAttribute(urn, 'Wildfire')).not.toMatch(/[\\/(){}[\]^$*+?|]/);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
