### PR TITLE
fix(adsp-service-sdk): correct span status, route labels, shutdown flush and instrumentation leaks

### DIFF
--- a/libs/adsp-service-sdk/src/healthCheck.ts
+++ b/libs/adsp-service-sdk/src/healthCheck.ts
@@ -102,9 +102,10 @@ export const createHealthCheck = (
           dependency,
           cache_hit: 'false',
         });
-        if (!healthy) {
-          dependencyFailureMetric?.add(1, { dependency });
-        }
+        // Record 0 for healthy dependencies too. An OTel counter that is never incremented is
+        // never exported, so a platform with no failures produced no series at all -- and a panel
+        // built on it read "No data", indistinguishable from broken instrumentation.
+        dependencyFailureMetric?.add(healthy ? 0 : 1, { dependency });
       });
 
       resultCache.set('health', results);

--- a/libs/adsp-service-sdk/src/initialize/platform.ts
+++ b/libs/adsp-service-sdk/src/initialize/platform.ts
@@ -4,6 +4,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor, TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-base';
+import { registerTelemetryShutdown } from './telemetryShutdown';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import { createRealmStrategy, createTenantStrategy, createTokenProvider } from '../access';
 import { createConfigurationHandler, createConfigurationService } from '../configuration';
@@ -234,9 +235,12 @@ export async function initializePlatform(
   }
 
   // Note: Sample rate is not currently used in the SDK.
-  const traceHandler = createTraceHandler({ logger, sampleRate: 0, tracerProvider });
+  const traceHandler = createTraceHandler({ logger, tracerProvider });
+
+  const shutdownTelemetry = registerTelemetryShutdown({ tracerProvider, meterProvider }, logger);
 
   return {
+    shutdownTelemetry,
     tokenProvider,
     coreStrategy,
     tenantService,

--- a/libs/adsp-service-sdk/src/initialize/service.ts
+++ b/libs/adsp-service-sdk/src/initialize/service.ts
@@ -41,6 +41,7 @@ export async function initializeService(options: Options, logOptions: Logger | L
     tracerProvider,
     meterProvider,
     traceHandler,
+    shutdownTelemetry,
     logger,
   } = await initializePlatform({ ...options }, logOptions);
 
@@ -75,6 +76,7 @@ export async function initializeService(options: Options, logOptions: Logger | L
     traceHandler,
     tracerProvider,
     meterProvider,
+    shutdownTelemetry,
     logger,
     clearCached: (serviceId) => clearCached(tenant?.id, serviceId),
   };

--- a/libs/adsp-service-sdk/src/initialize/telemetryShutdown.ts
+++ b/libs/adsp-service-sdk/src/initialize/telemetryShutdown.ts
@@ -1,0 +1,84 @@
+import type { MeterProvider } from '@opentelemetry/sdk-metrics';
+import type { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import type { Logger } from 'winston';
+
+const SIGNALS: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
+const FLUSH_TIMEOUT_MS = 5000;
+
+interface TelemetryProviders {
+  tracerProvider?: NodeTracerProvider;
+  meterProvider?: MeterProvider;
+}
+
+let registered = false;
+
+async function withTimeout(work: Promise<unknown>, label: string, logger: Logger): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      work,
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${FLUSH_TIMEOUT_MS} ms`)), FLUSH_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (err) {
+    logger.warn(`Telemetry ${label} did not complete: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Flush and shut down the telemetry providers, and arrange for the same on SIGTERM/SIGINT.
+ *
+ * Without this, buffered telemetry is discarded on every pod termination: the BatchSpanProcessor
+ * holds spans for up to its 5s scheduled delay, and the PeriodicExportingMetricReader holds metrics
+ * for up to its 60s export interval. Across a rolling deploy that is a minute of metrics missing per
+ * pod, which reads as a gap in the dashboards rather than as lost data.
+ *
+ * Returns the shutdown function so a service can await it from its own signal handler. That matters
+ * because Node runs every listener for a signal and does not wait for async ones -- a service whose
+ * handler calls process.exit synchronously (file-service and tenant-management-api both do) will cut
+ * this flush short. Those services should await the returned function before exiting.
+ */
+export function registerTelemetryShutdown(
+  { tracerProvider, meterProvider }: TelemetryProviders,
+  logger: Logger
+): () => Promise<void> {
+  const shutdown = async (): Promise<void> => {
+    if (meterProvider) {
+      await withTimeout(meterProvider.forceFlush(), 'metric flush', logger);
+      await withTimeout(meterProvider.shutdown(), 'metric shutdown', logger);
+    }
+
+    if (tracerProvider) {
+      await withTimeout(tracerProvider.forceFlush(), 'span flush', logger);
+      await withTimeout(tracerProvider.shutdown(), 'span shutdown', logger);
+    }
+  };
+
+  if ((tracerProvider || meterProvider) && !registered) {
+    registered = true;
+
+    for (const signal of SIGNALS) {
+      process.once(signal, () => {
+        // Adding a listener suppresses Node's default termination for that signal. If nothing else
+        // is listening we are responsible for exiting; if something is, it owns the exit and we
+        // only flush.
+        const weAreTheOnlyListener = process.listenerCount(signal) === 0;
+
+        shutdown()
+          .catch((err) => logger.warn(`Telemetry shutdown failed: ${err instanceof Error ? err.message : String(err)}`))
+          .finally(() => {
+            if (weAreTheOnlyListener) {
+              process.exit(0);
+            }
+          });
+      });
+    }
+  }
+
+  return shutdown;
+}

--- a/libs/adsp-service-sdk/src/initialize/types.ts
+++ b/libs/adsp-service-sdk/src/initialize/types.ts
@@ -311,6 +311,15 @@ export interface PlatformCapabilities extends PlatformServices {
    * @memberof PlatformCapabilities
    */
   meterProvider?: MeterProvider;
+
+  /**
+   * Flush and shut down the telemetry providers.
+   *
+   * Registered on SIGTERM and SIGINT by the SDK, so most services need not call it. Await it from
+   * your own signal handler if you call process.exit there: Node does not wait for async listeners,
+   * so an immediate exit truncates the flush and discards buffered spans and metrics.
+   */
+  shutdownTelemetry: () => Promise<void>;
   /**
    * Logger used by SDK components.
    *

--- a/libs/adsp-service-sdk/src/metrics/handler.spec.ts
+++ b/libs/adsp-service-sdk/src/metrics/handler.spec.ts
@@ -46,37 +46,37 @@ describe('handler', () => {
 
     it('can handle request', async () => {
       const req = { tenant: { id: tenantId } };
-      const res = {};
+      const res = { on: jest.fn(), writeHead: jest.fn() };
       const next = jest.fn();
 
       responseTimeMock.mockImplementationOnce((fn) => (req, res, _next) => fn(req, res, 123));
       const handler = await createMetricsHandler(serviceId, loggerMock, tokenProviderMock, directoryMock);
-      handler(req as unknown as Request, res as Response, next);
+      handler(req as unknown as Request, res as unknown as Response, next);
     });
 
     it('can handle request with user tenant context', async () => {
       const req = { user: { tenantId } };
-      const res = {};
+      const res = { on: jest.fn(), writeHead: jest.fn() };
       const next = jest.fn();
 
       responseTimeMock.mockImplementationOnce((fn) => (req, res, _next) => fn(req, res, 123));
       const handler = await createMetricsHandler(serviceId, loggerMock, tokenProviderMock, directoryMock);
-      handler(req as unknown as Request, res as Response, next);
+      handler(req as unknown as Request, res as unknown as Response, next);
     });
 
     it('can handle request with static tenant context', async () => {
       const req = { user: { tenantId } };
-      const res = {};
+      const res = { on: jest.fn(), writeHead: jest.fn() };
       const next = jest.fn();
 
       responseTimeMock.mockImplementationOnce((fn) => (req, res, _next) => fn(req, res, 123));
       const handler = await createMetricsHandler(serviceId, loggerMock, tokenProviderMock, directoryMock, tenantId);
-      handler(req as unknown as Request, res as Response, next);
+      handler(req as unknown as Request, res as unknown as Response, next);
     });
 
     it('can handle request with benchmark metric', async () => {
       const req = { user: { tenantId } };
-      const res = {};
+      const res = { on: jest.fn(), writeHead: jest.fn() };
       const next = jest.fn();
 
       responseTimeMock.mockImplementationOnce((fn) => (req, res, _next) => {
@@ -84,7 +84,43 @@ describe('handler', () => {
         fn(req, res, 123);
       });
       const handler = await createMetricsHandler(serviceId, loggerMock, tokenProviderMock, directoryMock, tenantId);
-      handler(req as unknown as Request, res as Response, next);
+      handler(req as unknown as Request, res as unknown as Response, next);
+    });
+
+    it('can release the active gauge when a request is aborted without finishing', async () => {
+      const activeRequestsAdd = jest.fn();
+      const meterProviderMock = {
+        getMeter: () => ({
+          createCounter: () => ({ add: jest.fn() }),
+          createHistogram: () => ({ record: jest.fn() }),
+          createUpDownCounter: () => ({ add: activeRequestsAdd }),
+        }),
+      };
+      const listeners: Record<string, Array<() => void>> = {};
+      const req = { method: 'GET' };
+      const res = {
+        on: jest.fn((event: string, cb: () => void) => {
+          (listeners[event] = listeners[event] || []).push(cb);
+        }),
+        writeHead: jest.fn(),
+      };
+
+      responseTimeMock.mockImplementationOnce(() => (_req, _res, _next) => undefined);
+      const handler = await createMetricsHandler(
+        serviceId,
+        loggerMock,
+        tokenProviderMock,
+        directoryMock,
+        tenantId,
+        meterProviderMock as never,
+      );
+
+      handler(req as unknown as Request, res as unknown as Response, jest.fn());
+      expect(activeRequestsAdd).toHaveBeenCalledWith(1, { 'http.request.method': 'GET' });
+
+      // No finish: the client went away. response-time never fires, so only close can release it.
+      listeners['close'].forEach((cb) => cb());
+      expect(activeRequestsAdd).toHaveBeenCalledWith(-1, { 'http.request.method': 'GET' });
     });
 
     it('can record OpenTelemetry metrics when meter provider is provided', async () => {
@@ -109,7 +145,14 @@ describe('handler', () => {
         route: { path: '/:id' },
         user: { tenantId },
       };
-      const res = { statusCode: 503 };
+      const listeners: Record<string, Array<() => void>> = {};
+      const res = {
+        on: jest.fn((event: string, cb: () => void) => {
+          (listeners[event] = listeners[event] || []).push(cb);
+        }),
+        writeHead: jest.fn(),
+        statusCode: 503,
+      };
       const next = jest.fn();
 
       responseTimeMock.mockImplementationOnce((fn) => (req, res, _next) => fn(req, res, 123));
@@ -122,7 +165,7 @@ describe('handler', () => {
         meterProviderMock as never,
       );
 
-      handler(req as unknown as Request, res as Response, next);
+      handler(req as unknown as Request, res as unknown as Response, next);
 
       expect(requestCountAdd).toHaveBeenCalledWith(
         1,
@@ -141,7 +184,16 @@ describe('handler', () => {
         }),
       );
       expect(activeRequestsAdd).toHaveBeenCalledWith(1, { 'http.request.method': 'GET' });
+
+      // The gauge is released on the response terminating, not from the response-time callback,
+      // so that an aborted connection (close without finish) does not leave it incremented.
+      expect(activeRequestsAdd).not.toHaveBeenCalledWith(-1, { 'http.request.method': 'GET' });
+      listeners['finish'].forEach((cb) => cb());
       expect(activeRequestsAdd).toHaveBeenCalledWith(-1, { 'http.request.method': 'GET' });
+
+      // finish and close both fire on a normal response; the release must be idempotent.
+      listeners['close'].forEach((cb) => cb());
+      expect(activeRequestsAdd.mock.calls.filter(([delta]) => delta === -1)).toHaveLength(1);
       expect(errorCountAdd).toHaveBeenCalledWith(
         1,
         expect.objectContaining({
@@ -173,14 +225,14 @@ describe('handler', () => {
           ip: '127.0.0.1',
           user: { tenantId },
         };
-        const res = { statusCode: 200 };
+        const res = { on: jest.fn(), writeHead: jest.fn(), statusCode: 200 };
         const next = jest.fn();
 
         responseTimeMock.mockImplementationOnce((fn) => (req, res, _next) => fn(req, res, 123));
         const handler = await createMetricsHandler(serviceId, loggerMock, tokenProviderMock, directoryMock);
 
         await otelContext.with(otelContext.active().setValue(testKey, 'request-span-context'), async () => {
-          handler(req as unknown as Request, res as Response, next);
+          handler(req as unknown as Request, res as unknown as Response, next);
         });
 
         await jest.advanceTimersByTimeAsync(60000);

--- a/libs/adsp-service-sdk/src/metrics/handler.ts
+++ b/libs/adsp-service-sdk/src/metrics/handler.ts
@@ -10,7 +10,7 @@ import { ServiceDirectory } from '../directory';
 import { adspId, AdspId } from '../utils';
 import { RequestBenchmark, REQ_BENCHMARK } from './types';
 import { getContextTrace } from '../trace';
-import { getRouteLabel } from '../utils/route';
+import { captureRouteLabel, getCapturedRouteLabel } from '../utils/route';
 import { formatTenantAttribute } from './attributes';
 
 function resolveTenantId(req: Request, defaultTenantId?: AdspId): string | undefined {
@@ -25,7 +25,7 @@ function resolveTenantName(req: Request): string | undefined {
 function getMetricAttributes(req: Request, res: Response, defaultTenantId?: AdspId): Record<string, string | number> {
   const attributes: Record<string, string | number> = {
     'http.request.method': req.method,
-    'http.route': getRouteLabel(req),
+    'http.route': getCapturedRouteLabel(req),
     'http.response.status_code': res.statusCode || 0,
   };
 
@@ -122,10 +122,7 @@ export async function createMetricsHandler(
     const otelAttributes = getMetricAttributes(req, _res, defaultTenantId);
     requestCount?.add(1, otelAttributes);
     requestDuration?.record(time, otelAttributes);
-    activeRequests?.add(-1, { 'http.request.method': req.method });
-    if ((_res.statusCode || 0) >= 500) {
-      errorCount?.add(1, otelAttributes);
-    }
+    errorCount?.add((_res.statusCode || 0) >= 500 ? 1 : 0, otelAttributes);
 
     // Write if there is a tenant context to the request.
     // Check user tenant context if tenant handler is not included on route.
@@ -185,7 +182,23 @@ export async function createMetricsHandler(
   });
 
   return function (req, res, next) {
-    activeRequests?.add(1, { 'http.request.method': req.method });
+    const methodAttributes = { 'http.request.method': req.method };
+    activeRequests?.add(1, methodAttributes);
+
+    let settled = false;
+    const releaseActive = () => {
+      if (!settled) {
+        settled = true;
+        activeRequests?.add(-1, methodAttributes);
+      }
+    };
+
+    // `close` covers client aborts, which never emit `finish` -- without it the gauge only ever
+    // climbs. Both fire in the normal case, hence the guard.
+    res.on('finish', releaseActive);
+    res.on('close', releaseActive);
+
+    captureRouteLabel(req);
     req[REQ_BENCHMARK] = { timings: {}, metrics: {} } as RequestBenchmark;
     responseTimeHandler(req, res, next);
   };

--- a/libs/adsp-service-sdk/src/metrics/handler.ts
+++ b/libs/adsp-service-sdk/src/metrics/handler.ts
@@ -10,12 +10,8 @@ import { ServiceDirectory } from '../directory';
 import { adspId, AdspId } from '../utils';
 import { RequestBenchmark, REQ_BENCHMARK } from './types';
 import { getContextTrace } from '../trace';
-import { getRouteTemplate } from '../utils/route';
+import { getRouteLabel } from '../utils/route';
 import { formatTenantAttribute } from './attributes';
-
-function getRoute(req: Request): string {
-  return getRouteTemplate(req) ?? (req.baseUrl || req.path || req.originalUrl || 'unknown');
-}
 
 function resolveTenantId(req: Request, defaultTenantId?: AdspId): string | undefined {
   const tenantId = defaultTenantId || req.tenant?.id || req.user?.tenantId;
@@ -29,7 +25,7 @@ function resolveTenantName(req: Request): string | undefined {
 function getMetricAttributes(req: Request, res: Response, defaultTenantId?: AdspId): Record<string, string | number> {
   const attributes: Record<string, string | number> = {
     'http.request.method': req.method,
-    'http.route': getRoute(req),
+    'http.route': getRouteLabel(req),
     'http.response.status_code': res.statusCode || 0,
   };
 

--- a/libs/adsp-service-sdk/src/trace/handler.spec.ts
+++ b/libs/adsp-service-sdk/src/trace/handler.spec.ts
@@ -16,7 +16,7 @@ const loggerMock = {
 describe('handler', () => {
   describe('createTraceHandler', () => {
     it('can create handler', () => {
-      const handler = createTraceHandler({ logger: loggerMock, sampleRate: 0 });
+      const handler = createTraceHandler({ logger: loggerMock });
       expect(handler).toBeTruthy();
       expect(axiosMock.interceptors.request.use).toHaveBeenCalled();
     });
@@ -28,7 +28,6 @@ describe('handler', () => {
 
       const handler = createTraceHandler({
         logger: loggerMock,
-        sampleRate: 0,
         tracerProvider: tracerProvider as never,
       });
 
@@ -45,7 +44,7 @@ describe('handler', () => {
         const res = {};
         const next = jest.fn();
 
-        const handler = createTraceHandler({ logger: loggerMock, sampleRate: 0 });
+        const handler = createTraceHandler({ logger: loggerMock });
         handler(req as unknown as Request, res as Response, next);
         expect(next).toHaveBeenCalledWith(undefined);
       });
@@ -57,7 +56,7 @@ describe('handler', () => {
         const res = {};
         const next = jest.fn();
 
-        const handler = createTraceHandler({ logger: loggerMock, sampleRate: 0 });
+        const handler = createTraceHandler({ logger: loggerMock });
         handler(req as unknown as Request, res as Response, next);
         // Without tracerProvider there is no error path; handler calls next() directly
         expect(next).toHaveBeenCalled();
@@ -204,7 +203,7 @@ describe('handler', () => {
         getTracer: jest.fn().mockReturnValue({ startSpan: jest.fn().mockReturnValue(clientSpan) }),
       };
 
-      createTraceHandler({ logger: loggerMock, sampleRate: 0, tracerProvider: tracerProvider as never });
+      createTraceHandler({ logger: loggerMock, tracerProvider: tracerProvider as never });
 
       const responseUse = axiosMock.interceptors.response.use as unknown as jest.Mock;
       const onError = responseUse.mock.lastCall?.[1] as (error: unknown) => Promise<unknown>;

--- a/libs/adsp-service-sdk/src/trace/handler.ts
+++ b/libs/adsp-service-sdk/src/trace/handler.ts
@@ -9,7 +9,6 @@ import { createHttpServerTraceHandler } from './instrument';
 
 interface TraceHandlerOptions {
   logger: Logger;
-  sampleRate: number;
   tracerProvider?: NodeTracerProvider;
 }
 
@@ -136,11 +135,7 @@ export function traceRequestInterceptor(config: InternalAxiosRequestConfig, trac
   return config;
 }
 
-export function createTraceHandler({
-  logger,
-  sampleRate: _sampleRate,
-  tracerProvider,
-}: TraceHandlerOptions): RequestHandler {
+export function createTraceHandler({ logger, tracerProvider }: TraceHandlerOptions): RequestHandler {
   const tracer = tracerProvider?.getTracer('adsp-service-sdk');
 
   // Use an axios interceptor to inject trace context into outbound request headers.

--- a/libs/adsp-service-sdk/src/trace/instrument.spec.ts
+++ b/libs/adsp-service-sdk/src/trace/instrument.spec.ts
@@ -285,4 +285,93 @@ describe('instrument', () => {
       setSpanSpy.mockRestore();
     });
   });
+
+  describe('server span status', () => {
+    const runWith = (statusCode: number) => {
+      const span = {
+        setAttributes: jest.fn(),
+        setStatus: jest.fn(),
+        updateName: jest.fn(),
+        end: jest.fn(),
+        isRecording: jest.fn().mockReturnValue(true),
+        recordException: jest.fn(),
+      };
+      const tracerProvider = { getTracer: () => ({ startSpan: () => span }) };
+      const listeners: Record<string, (arg?: unknown) => void> = {};
+      const req = { method: 'GET', path: '/x', route: { path: '/x' }, headers: {}, get: jest.fn() };
+      const res = {
+        statusCode,
+        json: jest.fn((b) => b),
+        send: jest.fn((b) => b),
+        on: jest.fn((e: string, cb: (arg?: unknown) => void) => {
+          listeners[e] = cb;
+          return res;
+        }),
+      };
+
+      const withSpy = jest.spyOn(otelContext, 'with').mockImplementation((_ctx, fn) => fn());
+      const setSpanSpy = jest.spyOn(otelTrace, 'setSpan').mockReturnValue({} as never);
+      createHttpServerTraceHandler(tracerProvider as never)(req as never, res as never, jest.fn());
+      (res.json as (b: unknown) => unknown)({});
+      withSpy.mockRestore();
+      setSpanSpy.mockRestore();
+      return { span, listeners };
+    };
+
+    it('can leave a 4xx server span status unset, per semconv', () => {
+      // A 4xx is the caller's failure, not the server's. Marking it ERROR made every expected
+      // rejection show up as a failed edge in the service graph.
+      const { span } = runWith(424);
+
+      expect(span.setStatus).not.toHaveBeenCalled();
+    });
+
+    it('can mark a 5xx server span as an error', () => {
+      const { span } = runWith(503);
+
+      expect(span.setStatus).toHaveBeenCalledWith(expect.objectContaining({ code: SpanStatusCode.ERROR }));
+    });
+
+    it('can mark a 2xx server span as ok', () => {
+      const { span } = runWith(200);
+
+      expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.OK });
+    });
+  });
+
+  describe('aborted requests', () => {
+    it('can end the span when the client aborts without finishing', () => {
+      const span = {
+        setAttributes: jest.fn(),
+        setStatus: jest.fn(),
+        updateName: jest.fn(),
+        end: jest.fn(),
+        isRecording: jest.fn().mockReturnValue(true),
+        recordException: jest.fn(),
+      };
+      const tracerProvider = { getTracer: () => ({ startSpan: () => span }) };
+      const listeners: Record<string, (arg?: unknown) => void> = {};
+      const req = { method: 'GET', path: '/x', headers: {}, get: jest.fn() };
+      const res = {
+        statusCode: 200,
+        json: jest.fn(),
+        send: jest.fn(),
+        on: jest.fn((e: string, cb: (arg?: unknown) => void) => {
+          listeners[e] = cb;
+          return res;
+        }),
+      };
+
+      const withSpy = jest.spyOn(otelContext, 'with').mockImplementation((_ctx, fn) => fn());
+      const setSpanSpy = jest.spyOn(otelTrace, 'setSpan').mockReturnValue({} as never);
+      createHttpServerTraceHandler(tracerProvider as never)(req as never, res as never, jest.fn());
+
+      // No finish: an aborted connection emits only close, and previously produced no span at all.
+      listeners['close']();
+
+      expect(span.end).toHaveBeenCalled();
+      withSpy.mockRestore();
+      setSpanSpy.mockRestore();
+    });
+  });
 });

--- a/libs/adsp-service-sdk/src/trace/instrument.ts
+++ b/libs/adsp-service-sdk/src/trace/instrument.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { InternalAxiosRequestConfig } from 'axios';
 import type { Request, RequestHandler } from 'express';
 import type { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { Logger } from 'winston';
@@ -15,29 +15,46 @@ function getTenantName(req: Request): string | undefined {
 }
 
 export function instrumentAxios(logger: Logger) {
-  const timings = new Map();
+  // WeakMap, not Map: entries are keyed by the axios config, and a rejected request has no
+  // response interceptor to delete its entry. With a strong Map every failed outbound call leaked
+  // an entry -- and its config -- for the lifetime of the process.
+  const timings = new WeakMap<object, [number, number]>();
+
+  const logTiming = (config: InternalAxiosRequestConfig | undefined, outcome: string) => {
+    if (!config) {
+      return;
+    }
+
+    const start = timings.get(config);
+    if (!start) {
+      return;
+    }
+
+    timings.delete(config);
+    const [sec, nano] = process.hrtime(start);
+    const duration = Math.round(sec * 1e3 + nano * 1e-6);
+    const trace = config.headers?.get?.('traceparent');
+    logger.debug(`Timing for ${outcome} request to ${config.url}: ${duration} ms`, {
+      context: 'Instrumentation',
+      trace,
+    });
+  };
 
   axios.interceptors.request.use(function (config) {
     timings.set(config, process.hrtime());
     return config;
   });
 
-  axios.interceptors.response.use(function (response) {
-    const config = response?.config;
-    if (config) {
-      const start = timings.get(config);
-      if (start) {
-        timings.delete(config);
-
-        const [sec, nano] = process.hrtime(start);
-        const duration = Math.round(sec * 1e3 + nano * 1e-6);
-
-        const trace = config.headers?.get('traceparent');
-        logger.debug(`Timing for request to ${config.url}: ${duration} ms`, { context: 'Instrumentation', trace });
-      }
+  axios.interceptors.response.use(
+    function (response) {
+      logTiming(response?.config, 'completed');
+      return response;
+    },
+    function (err) {
+      logTiming(err?.config, 'failed');
+      return Promise.reject(err);
     }
-    return response;
-  });
+  );
 }
 
 /**
@@ -115,13 +132,17 @@ export function createHttpServerTraceHandler(tracerProvider: NodeTracerProvider)
 
       span.setAttributes(completionAttributes);
 
-      // Determine span status based on HTTP status code
-      if (res.statusCode >= 400) {
+      // Per the OTel HTTP semantic conventions, 4xx leaves a SERVER span's status unset: the
+      // server did its job by rejecting the request, and the failure belongs to the caller. Only
+      // 5xx is a server error. Marking 4xx as ERROR here made every expected rejection -- the
+      // directory's 424 for entries without a HAL document, status-service probing dead URLs --
+      // show up as a failed edge in the service graph.
+      if (res.statusCode >= 500) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: `HTTP ${res.statusCode}`,
         });
-      } else {
+      } else if (res.statusCode < 400) {
         span.setStatus({ code: SpanStatusCode.OK });
       }
 
@@ -144,12 +165,16 @@ export function createHttpServerTraceHandler(tracerProvider: NodeTracerProvider)
       span.setStatus({ code: SpanStatusCode.ERROR });
     });
 
-    // Ensure span ends even if response is not sent through json/send
-    res.on('finish', () => {
+    // Ensure the span ends even if the response did not go through json/send. `close` covers
+    // client aborts, which never emit `finish` -- those requests previously produced no span at
+    // all, which is unfortunate given an aborted request is often a slow one.
+    const endIfUnfinished = () => {
       if (span.isRecording()) {
         recordSpanCompletion();
       }
-    });
+    };
+    res.on('finish', endIfUnfinished);
+    res.on('close', endIfUnfinished);
 
     // Run downstream handlers with span context active
     otelContext.with(otelTrace.setSpan(parentContext, span), () => {

--- a/libs/adsp-service-sdk/src/utils/route.spec.ts
+++ b/libs/adsp-service-sdk/src/utils/route.spec.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import { getRouteLabel, getRouteTemplate, UNMATCHED_ROUTE } from './route';
+import { captureRouteLabel, getCapturedRouteLabel, getRouteLabel, getRouteTemplate, UNMATCHED_ROUTE } from './route';
 
 describe('getRouteTemplate', () => {
   it('can resolve a mounted route template', () => {
@@ -57,5 +57,54 @@ describe('getRouteLabel', () => {
     const req = { path: '/.env' };
 
     expect(getRouteLabel(req as unknown as Request)).toBe(UNMATCHED_ROUTE);
+  });
+});
+
+describe('captureRouteLabel', () => {
+  it('can capture the mount prefix at the moment the route is matched', () => {
+    const req = { baseUrl: '/form/v1' } as never;
+
+    captureRouteLabel(req);
+    (req as { route?: unknown }).route = { path: '/definitions/:definitionId' };
+    // Express restores baseUrl when the router stack unwinds, e.g. into an app error handler.
+    (req as { baseUrl: string }).baseUrl = '';
+
+    expect(getCapturedRouteLabel(req)).toBe('/form/v1/definitions/:definitionId');
+  });
+
+  it('can keep req.route readable after capture', () => {
+    const req = { baseUrl: '/form/v1' } as never;
+
+    captureRouteLabel(req);
+    (req as { route?: unknown }).route = { path: '/forms' };
+
+    expect((req as { route?: { path: string } }).route?.path).toBe('/forms');
+  });
+
+  it('can take the innermost mount for a nested router', () => {
+    const req = { baseUrl: '/form/v1' } as never;
+
+    captureRouteLabel(req);
+    (req as { baseUrl: string }).baseUrl = '/form/v1/nested';
+    (req as { route?: unknown }).route = { path: '/deep/:id' };
+
+    expect(getCapturedRouteLabel(req)).toBe('/form/v1/nested/deep/:id');
+  });
+
+  it('can fall back for a request that never matched a route', () => {
+    const req = { baseUrl: '', path: '/.env' } as never;
+
+    captureRouteLabel(req);
+
+    expect(getCapturedRouteLabel(req)).toBe(UNMATCHED_ROUTE);
+  });
+
+  it('can ignore a non-string route path', () => {
+    const req = { baseUrl: '/form/v1' } as never;
+
+    captureRouteLabel(req);
+    (req as { route?: unknown }).route = { path: /^\/forms$/ };
+
+    expect(getCapturedRouteLabel(req)).toBe('/form/v1');
   });
 });

--- a/libs/adsp-service-sdk/src/utils/route.spec.ts
+++ b/libs/adsp-service-sdk/src/utils/route.spec.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import { getRouteTemplate } from './route';
+import { getRouteLabel, getRouteTemplate, UNMATCHED_ROUTE } from './route';
 
 describe('getRouteTemplate', () => {
   it('can resolve a mounted route template', () => {
@@ -30,5 +30,32 @@ describe('getRouteTemplate', () => {
     const req = { baseUrl: '/form/v1', route: { path: /^\/forms$/ } };
 
     expect(getRouteTemplate(req as unknown as Request)).toBeUndefined();
+  });
+});
+
+describe('getRouteLabel', () => {
+  it('can use the matched route template', () => {
+    const req = { baseUrl: '/form/v1', route: { path: '/forms/:id' }, path: '/forms/abc' };
+
+    expect(getRouteLabel(req as unknown as Request)).toBe('/form/v1/forms/:id');
+  });
+
+  it('can fall back to the router mount path when no route matched', () => {
+    const req = { baseUrl: '/form/v1', path: '/does-not-exist' };
+
+    expect(getRouteLabel(req as unknown as Request)).toBe('/form/v1');
+  });
+
+  it('can label an unmatched request without leaking its path', () => {
+    // Scanner traffic: no router matched, so Express leaves baseUrl as an empty string.
+    const req = { baseUrl: '', path: '/.aws/credentials', originalUrl: '/.aws/credentials' };
+
+    expect(getRouteLabel(req as unknown as Request)).toBe(UNMATCHED_ROUTE);
+  });
+
+  it('can label an unmatched request when baseUrl is absent entirely', () => {
+    const req = { path: '/.env' };
+
+    expect(getRouteLabel(req as unknown as Request)).toBe(UNMATCHED_ROUTE);
   });
 });

--- a/libs/adsp-service-sdk/src/utils/route.ts
+++ b/libs/adsp-service-sdk/src/utils/route.ts
@@ -31,3 +31,44 @@ export function getRouteLabel(req: Request): string {
   // `||` not `??`: Express sets baseUrl to '' when no router matched, which ?? would pass through.
   return getRouteTemplate(req) ?? (req.baseUrl || UNMATCHED_ROUTE);
 }
+
+const CAPTURED_ROUTE = Symbol('adspCapturedRoute');
+
+/**
+ * Capture the route label at the instant Express assigns req.route.
+ *
+ * req.baseUrl is only correct while the router that matched is still on the stack. Express restores
+ * it as the stack unwinds, so anything that reads it later can see the wrong value:
+ *
+ *   success  -> response written inside the router      -> /form/v1/definitions/:definitionId
+ *   error    -> response written by the app error handler -> /definitions/:definitionId
+ *
+ * Both variants were live in adsp-dev for the same endpoints, splitting one endpoint's traffic
+ * across two series. Reading at `finish`, or even at writeHead, is too late -- the error handler
+ * writes the headers itself, after the unwind. Assignment of req.route is the one moment the
+ * mount path and the route template are both correct.
+ */
+export function captureRouteLabel(req: Request): void {
+  let route = req.route;
+
+  Object.defineProperty(req, 'route', {
+    configurable: true,
+    enumerable: true,
+    get: () => route,
+    set: (value) => {
+      route = value;
+      if (typeof value?.path === 'string') {
+        req[CAPTURED_ROUTE] = `${req.baseUrl || ''}${value.path}`;
+      }
+    },
+  });
+}
+
+/**
+ * Route label for a completed request, preferring the value captured when the route was matched.
+ *
+ * Falls back to resolving it now, which covers requests that never matched a route at all.
+ */
+export function getCapturedRouteLabel(req: Request): string {
+  return (req[CAPTURED_ROUTE] as string) ?? getRouteLabel(req);
+}

--- a/libs/adsp-service-sdk/src/utils/route.ts
+++ b/libs/adsp-service-sdk/src/utils/route.ts
@@ -11,3 +11,23 @@ import type { Request } from 'express';
 export function getRouteTemplate(req: Request): string | undefined {
   return typeof req.route?.path === 'string' ? `${req.baseUrl || ''}${req.route.path}` : undefined;
 }
+
+/**
+ * Label value for requests that never matched a route. Falling through to req.path would put the
+ * raw URL in the http_route label, and unmatched traffic is mostly internet scanners probing paths
+ * like /.env, /.aws/credentials and /+CSCOE+/logon.html -- so the label would grow with hostile
+ * traffic rather than with the service's own surface. Measured in adsp-dev before this change: 377
+ * distinct http_route values, of which only 38 were real route templates and 87 were scanner probes.
+ */
+export const UNMATCHED_ROUTE = '<unmatched>';
+
+/**
+ * Resolve the bounded `http.route` label value for a request.
+ *
+ * A router mount path is kept when there is one, because mount paths are bounded by the number of
+ * routers and still identify which API was hit.
+ */
+export function getRouteLabel(req: Request): string {
+  // `||` not `??`: Express sets baseUrl to '' when no router matched, which ?? would pass through.
+  return getRouteTemplate(req) ?? (req.baseUrl || UNMATCHED_ROUTE);
+}


### PR DESCRIPTION
An independent review of the SDK instrumentation surface, after several one-off fixes suggested the problems were not isolated. **Eight defects**, all in the trace/metrics handlers, measured against `adsp-dev`.

## Wrong data

**1. Server spans marked ERROR at `>= 400`.** The OTel HTTP semantic conventions require 4xx to leave a SERVER span's status unset — the server did its job by rejecting the request, and the failure belongs to the caller. Only 5xx is a server error. Client spans keep `>= 400`, which is correct for that kind.

Every expected rejection was therefore a failed service-graph edge:

```
user           -> form-service          failed=100.0%
status-service -> unknown               failed= 89.4%
user           -> directory-service      failed= 31.0%
```

Almost entirely the directory's 424 for entries with no HAL document, and status-service probing dead URLs — both expected outcomes.

**2. The same endpoint recorded under two different `http_route` labels.** `req.baseUrl` is only valid while the matching router is on the stack, and an error response is written by the *app-level* error handler after Express has unwound it:

```
success -> /form/v1/definitions/:definitionId
error   -> /definitions/:definitionId
```

Both were live for **seven endpoints across five services** — `/form/v1/forms` and `/forms`, `/event/v1/events` and `/events` — splitting one endpoint's traffic across two series and understating both.

The label is now captured when Express assigns `req.route`, the one moment both the mount path and the route template are correct. Reading at `finish`, or even at `writeHead`, is too late; I verified that against a real Express app before settling on this.

**3. Unmatched requests put their raw URL in `http_route`.** 377 distinct values in dev, only 38 real route templates, **87 scanner probes** (`/.aws/credentials`, `/.env.aws`, `/+CSCOE+/logon.html`). The label grew with hostile traffic rather than with the service's own surface. Now `<unmatched>`, keeping a router mount path when present.

## Missing data

**4. No shutdown or flush, and no signal handling.** The `BatchSpanProcessor` holds spans for up to 5s and the `PeriodicExportingMetricReader` holds metrics for up to 60s, so every pod termination silently discarded them — up to a minute of metrics per pod, per rolling deploy. The SDK now registers SIGTERM/SIGINT and exposes `shutdownTelemetry()`.

> **Follow-up for `file-service` and `tenant-management-api`:** both call `process.exit` synchronously from their own signal handlers, and Node does not wait for async listeners, so their flush will still be truncated until they `await shutdownTelemetry()`. Left to those services deliberately.

**5. Aborted requests produced no span at all.** Only `error` and `finish` were handled; a client abort emits neither — unfortunate, since an aborted request is often a slow one. `close` is now handled, guarded against double-recording.

**6. Counters were never exported until first incremented.** `http.server.request.errors` and `platform.healthcheck.dependency.failures` therefore did not exist on a healthy platform, and panels built on them read "No data" — indistinguishable from broken instrumentation. Both now record `0` on the healthy path, with correct labels.

## Leaks

**7. `instrumentAxios` leaked memory on every failed outbound request.** Timings were held in a strong `Map` keyed by the axios config and deleted only in the success interceptor — there was no error interceptor at all. Unbounded, and proportional to failures. Now a `WeakMap` plus an error path, so failures are both logged and reclaimed.

**8. `http.server.request.active` could only climb.** Incremented in the middleware, decremented from the `response-time` callback, which never runs for an aborted connection. The release is now on finish/close and idempotent. The gauge reads 0 across dev today, so this was latent rather than live — verified before claiming it.

## Also

Removes `createTraceHandler`'s unused `sampleRate` option. `platform.ts` passed `0` while the real sampler used `tracingOptions.sampleRate`, which read as though tracing were disabled.

## Verification

- **226/226 SDK tests pass**, up from 216 — new cases cover 4xx/5xx/2xx span status, span-on-abort, gauge release on abort and its idempotence, and route capture across nested routers, unwound `baseUrl`, non-string route paths and unmatched requests.
- Lint clean. `adsp-service-sdk`, `form-service`, `file-service`, `directory-service`, `agent-service` all build.
- Fix 2's mechanism was confirmed empirically against a real Express app — success, sync throw, `next(err)`, nested routers, unmatched — after an earlier hypothesis and its fix both proved wrong.

## Deliberately excluded

Each wants its own decision rather than being bundled here:

| | why |
|---|---|
| `platform.healthcheck.duration` has no `dependency` label (only `cache_hit`) | needs a call on the attribute shape |
| `service.version` hardcoded `'1.0.0'` | needs a real version source |
| Spans use old-semconv names, metrics use new | `.openshift/observability/stack.yml` reads the span names, so this needs a coordinated change |
| `http.client_ip` puts a client IP on every server span | a privacy policy call, not a bug |

## Rollout note

Existing `http_route` and span-status series age out with `PROMETHEUS_RETENTION` (7d), so dashboard counts will not drop immediately on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
