### PR TITLE
feat(observability): fix the collector stack, provision dashboards from the repo

### DIFF
--- a/.openshift/managed/event-service.yml
+++ b/.openshift/managed/event-service.yml
@@ -101,6 +101,10 @@ objects:
         loopback_users.guest = false
 
         ## Clustering
+        # RabbitMQ 4.1.6 logs "Peer discovery: ignoring deprecated configuration options:
+        # [k8s_host,k8s_service_name,k8s_address_type,k8s_hostname_suffix]" on startup, so the four
+        # cluster_formation.k8s.* settings below are inert. Clustering forms correctly regardless.
+        # Left in place because removing them is a behaviour change to verify separately.
         cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
         cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
         cluster_formation.k8s.address_type = hostname
@@ -115,13 +119,13 @@ objects:
         quorum_queue.continuous_membership_reconciliation.enabled = true
         quorum_queue.continuous_membership_reconciliation.target_group_size = 3
         ## Disk space
-        disk_free_limit.absolute = 1.5GB
+        disk_free_limit.absolute = 2GB
         ## Memory
         vm_memory_high_watermark.absolute = 3Gi
         ## Logging
         log.console = true
       enabled_plugins: |
-        [rabbitmq_management,rabbitmq_peer_discovery_k8s,rabbitmq_shovel,rabbitmq_shovel_management].
+        [rabbitmq_management,rabbitmq_peer_discovery_k8s,rabbitmq_prometheus,rabbitmq_shovel,rabbitmq_shovel_management].
   - apiVersion: v1
     kind: Service
     metadata:
@@ -254,6 +258,9 @@ objects:
                 - name: clustering
                   protocol: TCP
                   containerPort: 25672
+                - name: metrics
+                  protocol: TCP
+                  containerPort: 15692
               livenessProbe:
                 exec:
                   command: ['rabbitmq-diagnostics', 'ping']

--- a/.openshift/observability/README.md
+++ b/.openshift/observability/README.md
@@ -6,7 +6,7 @@ the shared collector endpoint and should not deploy their own tracing stack.
 
 Files in this folder:
 
-- `stack.yml`: one-template deployment of Tempo + Collector + Grafana.
+- `observability-stack.yml`: one-template deployment of Tempo + Collector + Grafana.
 
 ## Topology
 
@@ -18,7 +18,7 @@ Run one stack per environment, owned by the platform team.
 
 ## Components
 
-`stack.yml` deploys all three components together:
+`observability-stack.yml` deploys all three components together:
 
 - Tempo with persistent local storage and OTLP ingest (`4317`/`4318`)
 - OpenTelemetry Collector with retry queue, batching, and environment tagging
@@ -31,7 +31,7 @@ Application services should target the collector service, not Tempo directly.
 Fastest path: deploy the whole stack with one template.
 
 ```sh
-oc process -f .openshift/observability/stack.yml \
+oc process -f .openshift/observability/observability-stack.yml \
   -p ENVIRONMENT_NAME=dev \
   -p INFRA_NAMESPACE=core-services-infra \
   -p IMAGE_TAG=latest \
@@ -100,3 +100,61 @@ Grafana reaches Tempo internally at:
 - Tempo uses a persistent volume in this configuration so traces survive pod restarts.
 - For larger-scale production, the next step would typically be distributed Tempo with object storage.
 - Suggested evaluation path: deploy the stack in one environment, point one or two services at the collector, validate HTTP and RabbitMQ trace flows, then standardize SDK configuration for all teams.
+
+## Dashboards
+
+`dashboards/` holds the Grafana dashboards as JSON, and they are provisioned rather than imported by
+hand. `observability-stack.yml` mounts two ConfigMaps into Grafana:
+
+- `grafana-dashboard-provider` -- the provisioning provider config, inline in `observability-stack.yml`, mounted at
+  `/etc/grafana/provisioning/dashboards`.
+- `grafana-dashboards` -- the dashboard JSON itself, mounted at `/etc/grafana/dashboards`. This one is
+  built from the files in this directory rather than inlined, because ~100KB of JSON in the template
+  would make it unreadable. The volume is marked optional, so Grafana starts even before it exists.
+
+Apply or update the dashboards with:
+
+```sh
+tools/observability/apply-dashboards.sh adsp-dev
+```
+
+The script validates each file against the conventions below and fails rather than shipping something
+Grafana would reject. It is idempotent, so it is safe to re-run.
+
+UI edits are permitted (`allowUiUpdates: true`) so panels can be iterated on, but the ConfigMap is
+reloaded on pod restart and every 60s, so anything not exported back into this directory is eventually
+overwritten. Export and commit when you are happy with a change.
+
+| File | Answers |
+|---|---|
+| `adsp-service-overview.json` | Is a service healthy, and which routes are slow or failing? |
+| `configuration-service-performance.json` | The same, narrowed to configuration-service, plus its internal benchmark phases. |
+| `adsp-service-dependencies.json` | What is a service waiting on? Outbound latency per callee, service graph edges, event bus depth. |
+| `adsp-event-bus-rabbitmq.json` | Is the event bus about to block, and are domain events flowing without loss? Broker-side view. |
+
+`adsp-event-bus-rabbitmq.json` covers only per-node aggregates, because
+`prometheus.return_per_object_metrics` is deliberately off -- per-object series scale with
+queues x channels x connections. It can show that the bus is backing up but not which queue is
+responsible; use the management UI on the affected node for that.
+
+### Conventions
+
+Keep these so the files stay diffable:
+
+- **Filename is the dashboard `uid`**, kebab-case. The uid is the stable identifier Grafana uses in
+  links and provisioning; the title is not. Grafana's own export adds a timestamp suffix and spaces,
+  so rename before committing.
+- **`id` must be `null`.** Grafana's export writes its own instance-local numeric id, which collides
+  when the file is imported into a different Grafana. `null` means "create new".
+- **No `version` key.** Grafana increments it on every save, so leaving it in makes every re-export
+  a diff even when nothing changed.
+
+After exporting from the UI, normalise before committing with
+`tools/observability/normalize-dashboard.mjs <exported-file>`.
+
+### Template variables
+
+Interpolate with `${var:pipe}`, never `${var:regex}`. The regex formatter backslash-escapes regex
+metacharacters and PromQL rejects escapes such as `\(` and `\.`, so a label value containing a dot
+or a bracket makes the panel fail to parse rather than return no data. Set `allValue` to `.*` on
+multi-select variables so "All" also matches series where the label is absent.

--- a/.openshift/observability/dashboards/adsp-event-bus-rabbitmq.json
+++ b/.openshift/observability/dashboards/adsp-event-bus-rabbitmq.json
@@ -1,0 +1,1095 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "id": null,
+  "description": "Broker-side health of the RabbitMQ event bus: resource alarms that block publishers, where messages are lost, throughput, capacity headroom and quorum queue health. Per-node aggregates only -- see the notes panel.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "ADSP Service Dependencies",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/adsp-service-dependencies"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 1,
+      "type": "stat",
+      "title": "Publishers Blocked",
+      "description": "Number of resource alarms active on any node. Non-zero means RabbitMQ is refusing publishes: services block on publish with no error returned, so this is the first thing to check when events stop flowing. Which alarm it is shows in the Capacity Headroom panel below.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(rabbitmq_alarms_free_disk_space_watermark) + max(rabbitmq_alarms_memory_used_watermark) + max(rabbitmq_alarms_file_descriptor_limit)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 2,
+      "type": "stat",
+      "title": "Unreachable Peers",
+      "description": "Cluster peers a node cannot reach. Non-zero means a partition, and quorum queues lose availability if it reaches 2 of 3.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(rabbitmq_unreachable_cluster_peers_count)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 3,
+      "type": "stat",
+      "title": "Ready Messages",
+      "description": "Messages waiting for a consumer, across all queues and nodes. A steady climb means consumers are not keeping up. Thresholds are placeholders -- set them from your own observed baseline.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rabbitmq_queue_messages_ready)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 4,
+      "type": "stat",
+      "title": "Messages Lost / sec",
+      "description": "Domain events discarded rather than delivered: unroutable (published with no matching binding) plus every dead-letter reason. Any non-zero value means events are being silently lost. Reads 0 rather than 'No data' when healthy.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum(rate(rabbitmq_global_messages_unroutable_dropped_total[$__rate_interval])) or vector(0)) + (sum(rate(rabbitmq_global_messages_dead_lettered_maxlen_total[$__rate_interval])) or vector(0)) + (sum(rate(rabbitmq_global_messages_dead_lettered_expired_total[$__rate_interval])) or vector(0)) + (sum(rate(rabbitmq_global_messages_dead_lettered_rejected_total[$__rate_interval])) or vector(0)) + (sum(rate(rabbitmq_global_messages_dead_lettered_delivery_limit_total[$__rate_interval])) or vector(0))",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "Where Messages Are Lost",
+      "description": "Each series is a distinct way an event fails to reach a consumer. 'Unroutable - dropped' usually means an event was published to an exchange with no binding for its routing key, which is a configuration problem rather than a load problem.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_unroutable_dropped_total[$__rate_interval]))",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "unroutable - dropped"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_unroutable_returned_total[$__rate_interval]))",
+          "range": true,
+          "refId": "B",
+          "legendFormat": "unroutable - returned"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_dead_lettered_expired_total[$__rate_interval]))",
+          "range": true,
+          "refId": "C",
+          "legendFormat": "dead-lettered - expired (TTL)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_dead_lettered_maxlen_total[$__rate_interval]))",
+          "range": true,
+          "refId": "D",
+          "legendFormat": "dead-lettered - queue full"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_dead_lettered_rejected_total[$__rate_interval]))",
+          "range": true,
+          "refId": "E",
+          "legendFormat": "dead-lettered - rejected"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_dead_lettered_delivery_limit_total[$__rate_interval]))",
+          "range": true,
+          "refId": "F",
+          "legendFormat": "dead-lettered - retry limit"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "Backlog by Node",
+      "description": "Both series are message counts, so they share one axis. 'Ready' is waiting for a consumer; 'unacked' has been delivered but not yet acknowledged. Rising unacked with flat ready means consumers are slow to acknowledge rather than absent.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (rabbitmq_queue_messages_ready)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "ready - {{instance}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (rabbitmq_queue_messages_unacked)",
+          "range": true,
+          "refId": "B",
+          "legendFormat": "unacked - {{instance}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "Message Flow",
+      "description": "Delivered is normally much higher than received -- one published event fans out to every bound queue, and ADSP routes domain events to several. What matters is that delivered and acknowledged track each other, and that routed does not fall away from received.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_received_total[$__rate_interval]))",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "received (published in)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_routed_total[$__rate_interval]))",
+          "range": true,
+          "refId": "B",
+          "legendFormat": "routed to a queue"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_delivered_total[$__rate_interval]))",
+          "range": true,
+          "refId": "C",
+          "legendFormat": "delivered to consumers"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rabbitmq_global_messages_acknowledged_total[$__rate_interval]))",
+          "range": true,
+          "refId": "D",
+          "legendFormat": "acknowledged"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 8,
+      "type": "timeseries",
+      "title": "Capacity Headroom (% of limit)",
+      "description": "Everything expressed against its own limit so one axis works: 100% is where the corresponding alarm fires and publishers get blocked. The disk series is the configured free-space floor (disk_free_limit.absolute, 2GB) as a share of the space actually available -- so it rises as the disk fills.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (instance) (rabbitmq_process_resident_memory_bytes) / sum by (instance) (rabbitmq_resident_memory_limit_bytes)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "memory - {{instance}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (instance) (rabbitmq_process_open_fds) / sum by (instance) (rabbitmq_process_max_fds)",
+          "range": true,
+          "refId": "B",
+          "legendFormat": "file descriptors - {{instance}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (instance) (rabbitmq_erlang_processes_used) / sum by (instance) (rabbitmq_erlang_processes_limit)",
+          "range": true,
+          "refId": "C",
+          "legendFormat": "erlang processes - {{instance}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (instance) (rabbitmq_disk_space_available_limit_bytes) / sum by (instance) (rabbitmq_disk_space_available_bytes)",
+          "range": true,
+          "refId": "D",
+          "legendFormat": "disk vs free-space floor - {{instance}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 9,
+      "type": "timeseries",
+      "title": "Quorum Queue Health",
+      "description": "Raft commit latency for quorum queues -- 24 of the queues in this cluster are quorum with target_group_size 3. A climbing latency means replication is struggling, which shows up to publishers as slow confirms before it shows up as anything else.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(rabbitmq_raft_entry_commit_latency_seconds)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "worst commit latency"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 10,
+      "type": "timeseries",
+      "title": "Connections, Channels, Consumers, Queues",
+      "description": "All counts, so one axis. Connections and channels dropping together points at services restarting or losing the broker; consumers dropping while queues stay flat means something stopped consuming.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rabbitmq_connections)",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "connections"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rabbitmq_channels)",
+          "range": true,
+          "refId": "B",
+          "legendFormat": "channels"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rabbitmq_consumers)",
+          "range": true,
+          "refId": "C",
+          "legendFormat": "consumers"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rabbitmq_queues)",
+          "range": true,
+          "refId": "D",
+          "legendFormat": "queues"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 11,
+      "type": "text",
+      "title": "How To Read It",
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**This dashboard answers \"is the event bus about to block, and are domain events flowing without loss?\"**\n\n**Read it in this order**\n1. **Publishers Blocked.** Non-zero and nothing else matters: RabbitMQ has hit a resource watermark\n   and is refusing publishes. Services block on publish *without an error*, so the symptom elsewhere\n   is hung requests, not failures. Capacity Headroom shows which limit was hit.\n2. **Messages Lost / sec.** Non-zero means domain events are being discarded. `Where Messages Are Lost`\n   separates a routing misconfiguration (unroutable) from a load or retry problem (dead-lettered).\n3. **Backlog by Node** and **Message Flow.** A rising backlog with healthy flow means consumers are\n   behind; a backlog with flow at zero means they are gone.\n4. **Quorum Queue Health** if publishes are slow but nothing is blocked.\n\n**A limit worth knowing.** Every metric here is a **per-node aggregate**. RabbitMQ's `/metrics`\nendpoint returns per-object detail only when `prometheus.return_per_object_metrics` is enabled, and it\nis deliberately off: per-object series scale with queues x channels x connections, which is a large\ncardinality cost for this cluster. So this dashboard can tell you *that* the bus is backing up, but\nnot *which queue* is doing it. For that, use the management UI on the affected node, or enable\nper-object metrics temporarily.\n\n**Also deliberate:** there is no consumer-utilisation panel. `rabbitmq_queue_consumer_utilisation`\nexists, but on the aggregated endpoint it is the sum of per-queue ratios for a node (observed values\nof 9, 14 and 23 rather than 0-1), which has no useful interpretation.\n\n**Overlap with other dashboards.** *ADSP Service Dependencies* has an Event Bus Depth panel for the\nservice-centric view -- \"is the bus part of why my service is slow\". This dashboard is the broker's\nown view.\n\n**Thresholds on the tiles are placeholders.** Ready Messages in particular should be set from your own\nobserved baseline rather than the round numbers here.\n"
+      }
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "adsp",
+    "rabbitmq",
+    "event-bus",
+    "infrastructure"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ADSP Event Bus (RabbitMQ)",
+  "uid": "adsp-event-bus-rabbitmq",
+  "weekStart": ""
+}

--- a/.openshift/observability/dashboards/adsp-service-dependencies.json
+++ b/.openshift/observability/dashboards/adsp-service-dependencies.json
@@ -1,0 +1,1205 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Outbound dependency latency, service graph and event bus flow for ADSP services. Built on the bounded span names and collector self-telemetry added in Aug 2026.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "ADSP Service Overview",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/adsp-service-overview"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 1,
+      "type": "stat",
+      "title": "Outbound Calls / sec",
+      "description": "Client spans from the SDK's axios interceptor. Named 'METHOD host', so bounded per callee.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 2,
+      "type": "stat",
+      "title": "Outbound Error Rate",
+      "description": "Share of outbound calls returning 5xx. Uses the http_status_code spanmetrics dimension, not span status: the SDK marks a span ERROR at >=400, so span status would count 404s as failures. Reads 0% when healthy rather than 'No data'.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (sum(rate(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\", http_status_code=~\"5..\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval])), 1e-9)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 3,
+      "type": "stat",
+      "title": "Slowest Dependency P95",
+      "description": "Worst P95 across all callees currently in scope.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(histogram_quantile(0.95, sum by (span_name, le) (rate(traces_span_metrics_duration_milliseconds_bucket{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval]))) and on (span_name) (sum by (span_name) (rate(traces_span_metrics_duration_milliseconds_count{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval])) > 0))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 4,
+      "type": "stat",
+      "title": "Telemetry Dropped / sec",
+      "description": "Collector self-telemetry. Non-zero means this dashboard is missing data - check it before trusting the rest.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum(rate(otelcol_exporter_send_failed_spans_total[$__rate_interval])) or vector(0)) + (sum(rate(otelcol_receiver_refused_spans_total[$__rate_interval])) or vector(0))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "value"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "Outbound Call Rate by Dependency",
+      "description": "topk(8) keeps the series count inside a readable categorical palette.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(8, sum by (span_name) (rate(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval])))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{span_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 6,
+      "type": "timeseries",
+      "title": "Outbound P95 Latency by Dependency",
+      "description": "What a slow service is waiting on. Compare against inbound P95 on ADSP Service Overview.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(8, histogram_quantile(0.95, sum by (span_name, le) (rate(traces_span_metrics_duration_milliseconds_bucket{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval]))) and on (span_name) (sum by (span_name) (rate(traces_span_metrics_duration_milliseconds_count{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\"}[$__rate_interval])) > 0))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{span_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 7,
+      "type": "timeseries",
+      "title": "Outbound 5xx by Dependency",
+      "description": "Empty is the healthy state; the tile above reads 0%. For 4xx (a dependency rejecting requests rather than failing) swap the matcher to http_status_code=~\"4..\" - useful when a caller is sending bad input.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (span_name) (rate(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\", service_name=~\"${service:pipe}\", span_name=~\"${dependency:pipe}\", http_status_code=~\"5..\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{span_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 8,
+      "type": "timeseries",
+      "title": "Request Self-Time Decomposition (P95)",
+      "description": "SDK stopwatch phases inside the request, excluding outbound HTTP. Buckets now start at 0.1ms so sub-millisecond phases have real resolution. get-tenant-time carries no http_route label because it runs before Express routing.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (benchmark_name, le) (rate(adsp_benchmark_duration_milliseconds_bucket{service_name=~\"${service:pipe}\"}[$__rate_interval])))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{benchmark_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 9,
+      "type": "timeseries",
+      "title": "Consumer Span Rate by Service",
+      "description": "RabbitMQ consumers, from core-common's amqp CONSUMER spans. Grouped by service rather than span_name because those names embed the tenant URN and are unbounded.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (service_name) (rate(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CONSUMER\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{service_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 10,
+      "type": "timeseries",
+      "title": "Event Bus Depth by Broker Node",
+      "description": "Both series are message counts, so they share one axis. Per-node rather than per-queue: the broker serves aggregated metrics by default and per-object metrics scale with connections and channels.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "mappings": [],
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (rabbitmq_queue_messages_ready)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "ready - {{instance}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (rabbitmq_channel_messages_unacked)",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "unacked - {{instance}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 11,
+      "type": "table",
+      "title": "Service Graph Edges",
+      "description": "Caller/callee pairs Tempo derived from paired client and server spans.\n\nFailed % counts an edge as failed when either span has ERROR status. Server spans only do so for 5xx, but CLIENT spans treat any >=400 as an error -- correctly, since a 4xx outbound call did fail for the caller. So edges to \"unknown\" (an uninstrumented callee, e.g. status-service probing external URLs) can legitimately sit near 100% without anything being down.\n\nEdges can also be missing when a call's two spans land on different collector replicas.",
+      "pluginVersion": "11.5.2",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Calls/sec"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P95 (ms)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Calls/sec"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (client, server) (rate(traces_service_graph_request_total[$__rate_interval]))",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (sum by (client, server) (rate(traces_service_graph_request_failed_total[$__rate_interval])) or vector(0)) / clamp_min(sum by (client, server) (rate(traces_service_graph_request_total[$__rate_interval])), 1e-9)",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "1000 * histogram_quantile(0.95, sum by (client, server, le) (rate(traces_service_graph_request_server_seconds_bucket[$__rate_interval]))) and on (client, server) (sum by (client, server) (rate(traces_service_graph_request_server_seconds_count[$__rate_interval])) > 0)",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "client",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
+            "renameByName": {
+              "client": "Caller",
+              "server": "Callee",
+              "server 1": "Callee",
+              "Value #A": "Calls/sec",
+              "Value #B": "Failed %",
+              "Value #C": "P95 (ms)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "id": 12,
+      "type": "text",
+      "title": "How To Read It",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**This dashboard answers \"what is this service waiting on?\"** Inbound health lives on\n*ADSP Service Overview*; this is the outbound and event-driven side.\n\n**Order to read it in**\n1. **Telemetry Dropped / sec** first. Non-zero means the collector is shedding data and every other\n   panel is understated.\n2. **Outbound P95 Latency by Dependency** against inbound P95 on *ADSP Service Overview*. If inbound is\n   slow and one dependency matches it, you have your answer.\n3. **Request Self-Time Decomposition** if no dependency accounts for the latency. These are the SDK\n   stopwatch phases. If they don't add up either, the remaining time is uninstrumented work - database\n   queries have no spans yet.\n4. **Service Graph Edges** for topology, and **Event Bus Depth** if the symptom is lag rather than latency.\n\n**Caveats**\n- Dependency names come from client span names, which are `METHOD host` - the callee, not the endpoint.\n  The full URL is on the span's `http.url` attribute in Tempo.\n- Consumer spans are grouped by service, not span name: those names embed the tenant URN.\n- Service graph edges need a call's client and server spans on the same collector replica, so edges can\n  be missing while more than one replica runs.\n\n**Drill down:** pick a slow dependency, then query Tempo with\n`{resource.service.name=\"<service>\" && span.kind=client && duration > 250ms}`.\n"
+      }
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "adsp",
+    "opentelemetry",
+    "dependencies",
+    "tracing"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(traces_span_metrics_calls_total, service_name)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "refresh": 2,
+        "query": {
+          "qryType": 1,
+          "query": "label_values(traces_span_metrics_calls_total, service_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "sort": 1,
+        "type": "query",
+        "allValue": ".*"
+      },
+      {
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\"}, span_name)",
+        "includeAll": true,
+        "label": "Dependency",
+        "multi": true,
+        "name": "dependency",
+        "description": "Client span names, formatted 'METHOD host'.",
+        "options": [],
+        "refresh": 2,
+        "query": {
+          "qryType": 1,
+          "query": "label_values(traces_span_metrics_calls_total{span_kind=\"SPAN_KIND_CLIENT\"}, span_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "sort": 1,
+        "type": "query",
+        "allValue": ".*"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ADSP Service Dependencies",
+  "uid": "adsp-service-dependencies",
+  "weekStart": ""
+}

--- a/.openshift/observability/dashboards/adsp-service-overview.json
+++ b/.openshift/observability/dashboards/adsp-service-overview.json
@@ -1,0 +1,1192 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Starting dashboard for ADSP services instrumented by the SDK with OpenTelemetry metrics and Tempo traces.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": true,
+      "title": "Open Tempo Explore",
+      "type": "link",
+      "url": "/explore?left={\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{service.name=\\\"$service\\\"}\",\"queryType\":\"traceqlSearch\",\"refId\":\"A\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!~\"^/$\"}[5m]))",
+          "legendFormat": "RPS",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (sum(rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!~\"^/$\", http_response_status_code=~\"5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!~\"^/$\"}[5m])), 1e-9)",
+          "legendFormat": "Error rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate",
+      "type": "stat",
+      "description": "Derived from http_server_request_count_total by status code. http_server_request_errors_total is only exported once a 5xx has occurred, so a panel built on it reads \"No data\" when healthy - indistinguishable from broken."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_milliseconds_bucket{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m]) unless rate(http_server_request_duration_milliseconds_bucket{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=\"/\", http_request_method=\"GET\"}[5m])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Latency",
+      "type": "stat",
+      "description": ""
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(http_server_request_active{service_name=~\"${service:pipe}\", http_request_method=~\"${method:pipe}\"} unless http_server_request_active{service_name=~\"${service:pipe}\", http_request_method=\"GET\", http_route=\"/\"})",
+          "legendFormat": "Active",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (http_route, http_request_method) (rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\"}[5m])))",
+          "legendFormat": "{{http_request_method}} {{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Routes by Throughput",
+      "type": "timeseries",
+      "description": "Excludes <unmatched>, the label the SDK gives requests that matched no route (mostly internet scanners). Previously that traffic landed on \"/\" and was excluded by path."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ms",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (http_route, http_request_method, le) (rate(http_server_request_duration_milliseconds_bucket{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\"}[5m]))) and on (http_route, http_request_method) (sum by (http_route, http_request_method) (rate(http_server_request_duration_milliseconds_count{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\"}[5m])) > 0))",
+          "legendFormat": "{{http_request_method}} {{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Routes by P95 Latency",
+      "type": "timeseries",
+      "description": "Routes with no requests in the window are excluded: their bucket rates are all zero, and histogram_quantile returns NaN for those, which renders as gaps. Excludes <unmatched>, the label the SDK gives requests that matched no route (mostly internet scanners). Previously that traffic landed on \"/\" and was excluded by path."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "errors/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, 100 * sum by (http_route)(rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\", http_response_status_code=~\"5..\"}[5m])) / clamp_min(sum by (http_route)(rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\"}[5m])), 1e-9))",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Routes by 5xx Rate",
+      "type": "timeseries",
+      "description": "Empty when no route is returning 5xx, which is the healthy state. The Error Rate tile above reads 0% rather than \"No data\". Excludes <unmatched>, the label the SDK gives requests that matched no route (mostly internet scanners). Previously that traffic landed on \"/\" and was excluded by path."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "dependency"
+          }
+        ]
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (dependency) (rate(platform_healthcheck_dependency_status_sum{service_name=~\"${service:pipe}\", dependency=~\"${dependency:pipe}\"}[15m])) / clamp_min(sum by (dependency) (rate(platform_healthcheck_dependency_status_count{service_name=~\"${service:pipe}\", dependency=~\"${dependency:pipe}\"}[15m])), 0.0001)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{dependency}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Dependency Health Score",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Value": 1,
+              "dependency": 0
+            },
+            "renameByName": {
+              "Value": "health"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "failures",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (dependency) (increase(platform_healthcheck_dependency_failures_total{service_name=~\"${service:pipe}\", dependency=~\"${dependency:pipe}\"}[1h]))",
+          "legendFormat": "{{dependency}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dependency Failures (1h Increase)",
+      "type": "timeseries",
+      "description": "Uses the real failures counter. It records 0 on the healthy path as of PR #5799, so the series exists before the first failure -- previously it was never exported and this panel derived failures from the status histogram."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ms",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (service_name, le) (rate(platform_healthcheck_duration_milliseconds_bucket{service_name=~\"${service:pipe}\"}[15m])))",
+          "legendFormat": "{{service_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Health Check P95 by Service",
+      "type": "timeseries",
+      "description": "platform_healthcheck_duration_milliseconds carries no \"dependency\" label (only cache_hit), so this is per-service rather than per-dependency."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "requests",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!~\"^/$\"}[5m]))",
+          "legendFormat": "{{http_response_status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Response Codes",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 12,
+      "options": {
+        "content": "# Trace Drill-Down\n\nUse the dashboard link at the top to open Tempo Explore for the selected service.\n\nRecommended next view in Grafana:\n- Tempo service graph filtered to `service.name = $service`\n- Trace search over the current time range\n- Correlate spikes from the panels above with slow traces and dependency edges\n\nThis dashboard assumes the provisioned datasource UIDs from the ADSP observability stack:\n- Prometheus: `prometheus`\n- Tempo: `tempo`",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.5.2",
+      "title": "Tempo Drill-Down",
+      "type": "text"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "adsp",
+    "otel",
+    "prometheus",
+    "tempo"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total, service_name)",
+        "includeAll": true,
+        "label": "Service",
+        "name": "service",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total, service_name)",
+          "refId": "Prometheus-service"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total{service_name=~\"$service\"}, adsp_tenant_name)",
+        "includeAll": true,
+        "label": "Tenant",
+        "name": "tenant",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total{service_name=~\"${service:pipe}\"}, adsp_tenant)",
+          "refId": "Prometheus-tenant"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "description": "Combined \"name id\" label. Interpolated with :pipe, not :regex - the regex formatter escapes metacharacters and PromQL rejects escapes like \\( and \\/. All uses \".*\" so untenanted requests stay included."
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total{service_name=~\"$service\", adsp_tenant_name=~\"${tenant:pipe}\", http_route!=\"/\"}, http_route)",
+        "includeAll": true,
+        "label": "Route",
+        "name": "route",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\", http_route!=\"/\"}, http_route)",
+          "refId": "Prometheus-route"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total{service_name=~\"$service\", adsp_tenant_name=~\"${tenant:pipe}\"}, http_request_method)",
+        "includeAll": true,
+        "label": "Method",
+        "name": "method",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total{service_name=~\"${service:pipe}\", adsp_tenant=~\"${tenant:pipe}\"}, http_request_method)",
+          "refId": "Prometheus-method"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(platform_healthcheck_dependency_failures_total{service_name=~\"$service\"}, dependency)",
+        "includeAll": true,
+        "label": "Dependency",
+        "name": "dependency",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(platform_healthcheck_dependency_status_count{service_name=~\"${service:pipe}\"}, dependency)",
+          "refId": "Prometheus-dependency"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ADSP Service Overview",
+  "uid": "adsp-service-overview",
+  "weekStart": ""
+}

--- a/.openshift/observability/dashboards/configuration-service-performance.json
+++ b/.openshift/observability/dashboards/configuration-service-performance.json
@@ -1,0 +1,1165 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Performance dashboard for configuration-service using ADSP SDK HTTP metrics, benchmark histograms, and Tempo traces.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": true,
+      "title": "Open Tempo Explore",
+      "type": "link",
+      "url": "/explore?left={\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{service.name=\\\"configuration-service\\\"}\",\"queryType\":\"traceqlSearch\",\"refId\":\"A\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m]))",
+          "legendFormat": "RPS",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (sum(rate(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_response_status_code=~\"5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m])), 1e-9)",
+          "legendFormat": "Error rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Error Rate",
+      "type": "stat",
+      "description": "Derived from http_server_request_count_total by status code. http_server_request_errors_total is only exported once a 5xx has occurred, so a panel built on it reads \"No data\" when healthy - indistinguishable from broken."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 750
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_milliseconds_bucket{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Request Latency",
+      "type": "stat",
+      "description": ""
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(http_server_request_active{service_name=\"configuration-service\", http_request_method=~\"${method:pipe}\"})",
+          "legendFormat": "Active",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_request_method) (rate(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m]))",
+          "legendFormat": "{{http_request_method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Throughput by Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ms",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (http_request_method, le) (rate(http_server_request_duration_milliseconds_bucket{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m])))",
+          "legendFormat": "{{http_request_method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Latency by Method",
+      "type": "timeseries",
+      "description": ""
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(8, sum by (http_route, http_request_method) (rate(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\"}[5m])))",
+          "legendFormat": "{{http_request_method}} {{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Routes by Throughput",
+      "type": "timeseries",
+      "description": "Excludes <unmatched>, the label the SDK gives requests that matched no route (mostly internet scanners). Previously that traffic landed on \"/\" and was excluded by path."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ms",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(8, histogram_quantile(0.95, sum by (http_route, http_request_method, le) (rate(http_server_request_duration_milliseconds_bucket{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\", http_route!=\"<unmatched>\"}[5m]))))",
+          "legendFormat": "{{http_request_method}} {{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Routes by P95 Latency",
+      "type": "timeseries",
+      "description": "Excludes <unmatched>, the label the SDK gives requests that matched no route (mostly internet scanners). Previously that traffic landed on \"/\" and was excluded by path."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "requests",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m]))",
+          "legendFormat": "{{http_response_status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Response Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ms",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (benchmark_name, le) (rate(adsp_benchmark_duration_milliseconds_bucket{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", benchmark_name=~\"${benchmark:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[5m])))",
+          "legendFormat": "{{benchmark_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Internal Benchmark P95",
+      "type": "timeseries",
+      "description": ""
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "avg_ms"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (benchmark_name) (rate(adsp_benchmark_duration_milliseconds_sum{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", benchmark_name=~\"${benchmark:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[15m])) / clamp_min(sum by (benchmark_name) (rate(adsp_benchmark_duration_milliseconds_count{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\", benchmark_name=~\"${benchmark:pipe}\", http_route=~\"${route:pipe}\", http_request_method=~\"${method:pipe}\"}[15m])), 0.0001)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{benchmark_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Internal Benchmark Avg (15m)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Value": 1,
+              "benchmark_name": 0
+            },
+            "renameByName": {
+              "Value": "avg_ms"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 12,
+      "options": {
+        "content": "# Trace Drill-Down\n\nUse the dashboard link at the top to open Tempo Explore for `configuration-service`.\n\nRecommended trace filters:\n- `service.name = \"configuration-service\"`\n- `span.http.target` or `span.http.url` containing the slow route from the route panels\n- `status = error` when the 5xx panel spikes\n\nMost useful correlations in this service:\n- High request P95 with high `get-entity-time`: repository reads or definition loading are the likely bottleneck\n- High write latency with high `operation-handler-time`: revision update, event emission, or persistence path is slow\n- High request P95 without benchmark growth: investigate middleware, auth, tenant resolution, or downstream HTTP calls\n\nThis dashboard assumes the ADSP observability stack datasource UIDs:\n- Prometheus: `prometheus`\n- Tempo: `tempo`",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.5.2",
+      "title": "How To Read It",
+      "type": "text"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "adsp",
+    "configuration-service",
+    "otel",
+    "prometheus",
+    "tempo"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total{service_name=\"configuration-service\"}, adsp_tenant_name)",
+        "includeAll": true,
+        "label": "Tenant",
+        "name": "tenant",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total{service_name=\"configuration-service\"}, adsp_tenant)",
+          "refId": "Prometheus-tenant"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "description": "Combined \"name id\" label. Interpolated with :pipe, not :regex - the regex formatter escapes metacharacters and PromQL rejects escapes like \\( and \\/. All uses \".*\" so untenanted requests stay included."
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant_name=~\"${tenant:pipe}\"}, http_route)",
+        "includeAll": true,
+        "label": "Route",
+        "name": "route",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\"}, http_route)",
+          "refId": "Prometheus-route"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant_name=~\"${tenant:pipe}\"}, http_request_method)",
+        "includeAll": true,
+        "label": "Method",
+        "name": "method",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_request_count_total{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\"}, http_request_method)",
+          "refId": "Prometheus-method"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(adsp_benchmark_duration_milliseconds_count{service_name=\"configuration-service\", adsp_tenant_name=~\"${tenant:pipe}\"}, benchmark_name)",
+        "includeAll": true,
+        "label": "Benchmark",
+        "name": "benchmark",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(adsp_benchmark_duration_milliseconds_count{service_name=\"configuration-service\", adsp_tenant=~\"${tenant:pipe}\"}, benchmark_name)",
+          "refId": "Prometheus-benchmark"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Configuration Service Performance",
+  "uid": "configuration-service-performance",
+  "weekStart": ""
+}

--- a/.openshift/observability/observability-stack.yml
+++ b/.openshift/observability/observability-stack.yml
@@ -407,7 +407,9 @@ objects:
         component: observability
         environment: ${ENVIRONMENT_NAME}
     spec:
-      minAvailable: 1
+      # Single replica: minAvailable: 1 here would make the pod ineligible for voluntary
+      # eviction and stall node drains.
+      maxUnavailable: 1
       selector:
         matchLabels:
           app: ${TEMPO_NAME}
@@ -457,8 +459,10 @@ objects:
         processors:
           memory_limiter:
             check_interval: 1s
-            limit_mib: 1024
-            spike_limit_mib: 256
+            # Keep limit_mib at roughly 80% of the container memory limit below. Set above it and
+            # the soft limiter never engages -- the kernel OOM-kills first.
+            limit_mib: 800
+            spike_limit_mib: 200
           filter/drop-low-value-http-spans:
             error_mode: ignore
             traces:
@@ -500,6 +504,9 @@ objects:
               - http.status_code
             store:
               ttl: 2s
+          # NOTE: these buckets and dimensions multiply the spanmetrics series count. Do not apply
+          # them to an environment until every service runs an adsp-service-sdk with bounded span
+          # names (the route-template fix), or Prometheus will OOM on span_name cardinality.
           spanmetrics:
             histogram:
               explicit:
@@ -514,6 +521,16 @@ objects:
 
         service:
           extensions: [health_check]
+          # Without this the collector's own queue depth, refused spans and export failures are
+          # not reported anywhere, so dropped telemetry is invisible.
+          telemetry:
+            metrics:
+              readers:
+                - pull:
+                    exporter:
+                      prometheus:
+                        host: 0.0.0.0
+                        port: 8888
           pipelines:
             traces:
               receivers: [otlp]
@@ -575,6 +592,9 @@ objects:
                 - containerPort: 8889
                   name: metrics
                   protocol: TCP
+                - containerPort: 8888
+                  name: internal
+                  protocol: TCP
                 - containerPort: 13133
                   name: health
                   protocol: TCP
@@ -596,7 +616,8 @@ objects:
                   memory: 256Mi
                 limits:
                   cpu: 500m
-                  memory: 512Mi
+                  # Paired with memory_limiter.limit_mib in the ConfigMap above; change together.
+                  memory: 1Gi
               volumeMounts:
                 - name: config
                   mountPath: /conf
@@ -641,9 +662,38 @@ objects:
           port: 8889
           targetPort: metrics
           protocol: TCP
+        - name: internal
+          port: 8888
+          targetPort: internal
+          protocol: TCP
         - name: health
           port: 13133
           targetPort: health
+          protocol: TCP
+  # Headless sibling of the service above, used only as a Prometheus DNS-SD target. The ClusterIP
+  # service load-balances, which is correct for OTLP ingest and wrong for scraping: each replica
+  # holds its own spanmetrics and servicegraph counters, so a load-balanced scrape captures a
+  # random subset of the series.
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${COLLECTOR_NAME}-metrics
+      labels:
+        app: ${COLLECTOR_NAME}
+        component: observability
+        environment: ${ENVIRONMENT_NAME}
+    spec:
+      clusterIP: None
+      selector:
+        app: ${COLLECTOR_NAME}
+      ports:
+        - name: metrics
+          port: 8889
+          targetPort: metrics
+          protocol: TCP
+        - name: internal
+          port: 8888
+          targetPort: internal
           protocol: TCP
 
   - apiVersion: v1
@@ -662,16 +712,37 @@ objects:
 
         scrape_configs:
           - job_name: otel-collector
-            static_configs:
-              - targets: ['${COLLECTOR_NAME}:8889']
+            # Guardrail. A misbehaving service can otherwise grow the collector's exported series
+            # without bound; a failed scrape is visible and recoverable, an OOMKill loses the
+            # whole TSDB head.
+            sample_limit: 150000
+            label_limit: 40
+            label_value_length_limit: 512
+            dns_sd_configs:
+              - names: ['${COLLECTOR_NAME}-metrics']
+                type: A
+                port: 8889
+
+          - job_name: otel-collector-internal
+            dns_sd_configs:
+              - names: ['${COLLECTOR_NAME}-metrics']
+                type: A
+                port: 8888
 
           - job_name: prometheus
             static_configs:
               - targets: ['127.0.0.1:9090']
 
+          # Per-node RabbitMQ metrics. Targets the headless service so all cluster nodes are
+          # scraped -- queue depth and memory are per-node, and the balancer service would return
+          # one node at random. Requires rabbitmq_prometheus in the broker's enabled_plugins (see
+          # .openshift/managed/event-service.yml); until that is enabled this job finds no targets.
+          # The port comes from the scrape config and DNS-SD resolves to pod IPs, so the broker does
+          # not need a containerPort or Service port declared for 15692.
           - job_name: rabbitmq
             dns_sd_configs:
-              - names: ['event-service-rabbitmq.default.svc.cluster.local']
+              - names: ['event-service-rabbitmq']
+                type: A
                 port: 15692
   - apiVersion: v1
     kind: PersistentVolumeClaim
@@ -755,7 +826,9 @@ objects:
                   memory: 256Mi
                 limits:
                   cpu: 500m
-                  memory: 1Gi
+                  # 2Gi in dev and uat. The template previously said 1Gi, so applying it would have
+                  # halved the limit on a Prometheus that has been OOMKilling at 2Gi.
+                  memory: 2Gi
               volumeMounts:
                 - name: config
                   mountPath: /etc/prometheus
@@ -777,7 +850,9 @@ objects:
         component: observability
         environment: ${ENVIRONMENT_NAME}
     spec:
-      minAvailable: 1
+      # Single replica: minAvailable: 1 here would make the pod ineligible for voluntary
+      # eviction and stall node drains.
+      maxUnavailable: 1
       selector:
         matchLabels:
           app: ${PROMETHEUS_NAME}
@@ -798,6 +873,33 @@ objects:
           targetPort: http
           protocol: TCP
 
+  # Tells Grafana to load dashboards from a directory. The dashboard JSON itself lives in the
+  # ${GRAFANA_NAME}-dashboards ConfigMap, built from .openshift/observability/dashboards/ by
+  # tools/observability/apply-dashboards.sh -- keeping ~100KB of JSON out of this template.
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${GRAFANA_NAME}-dashboard-provider
+      labels:
+        app: ${GRAFANA_NAME}
+        component: observability
+        environment: ${ENVIRONMENT_NAME}
+    data:
+      dashboards.yaml: |
+        apiVersion: 1
+        providers:
+          - name: adsp
+            orgId: 1
+            type: file
+            # UI edits are allowed so panels can be iterated on, but the ConfigMap is reloaded on
+            # pod restart and on updateIntervalSeconds, so anything not exported back to the repo
+            # is eventually overwritten. See the README for the export workflow.
+            allowUiUpdates: true
+            disableDeletion: false
+            updateIntervalSeconds: 60
+            options:
+              path: /etc/grafana/dashboards
+              foldersFromFilesStructure: false
   - apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -969,12 +1071,25 @@ objects:
               volumeMounts:
                 - name: datasources
                   mountPath: /etc/grafana/provisioning/datasources
+                - name: dashboard-provider
+                  mountPath: /etc/grafana/provisioning/dashboards
+                - name: dashboards
+                  mountPath: /etc/grafana/dashboards
                 - name: storage
                   mountPath: /var/lib/grafana
           volumes:
             - name: datasources
               configMap:
                 name: ${GRAFANA_NAME}-datasources
+            - name: dashboard-provider
+              configMap:
+                name: ${GRAFANA_NAME}-dashboard-provider
+            - name: dashboards
+              configMap:
+                name: ${GRAFANA_NAME}-dashboards
+                # Optional so Grafana still starts before the dashboard ConfigMap is created, and
+                # so a missing ConfigMap degrades to "no dashboards" rather than a crash loop.
+                optional: true
             - name: storage
               persistentVolumeClaim:
                 claimName: ${GRAFANA_NAME}-storage
@@ -987,7 +1102,9 @@ objects:
         component: observability
         environment: ${ENVIRONMENT_NAME}
     spec:
-      minAvailable: 1
+      # Single replica: minAvailable: 1 here would make the pod ineligible for voluntary
+      # eviction and stall node drains.
+      maxUnavailable: 1
       selector:
         matchLabels:
           app: ${GRAFANA_NAME}

--- a/tools/observability/apply-dashboards.sh
+++ b/tools/observability/apply-dashboards.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Create or update the Grafana dashboard ConfigMap from the JSON files in the repo.
+#
+# The dashboards are ~100KB of JSON, so they are not inlined in observability-stack.yml. This builds the
+# ConfigMap that observability-stack.yml's Grafana deployment mounts at /etc/grafana/dashboards, where the
+# provisioning provider picks them up.
+#
+# Usage: tools/observability/apply-dashboards.sh <namespace> [configmap-name]
+set -euo pipefail
+
+NAMESPACE="${1:-}"
+NAME="${2:-grafana-dashboards}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.openshift/observability/dashboards" && pwd)"
+
+if [ -z "$NAMESPACE" ]; then
+  echo "usage: $(basename "$0") <namespace> [configmap-name]" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+files=("$DIR"/*.json)
+if [ ${#files[@]} -eq 0 ]; then
+  echo "no dashboard JSON found in $DIR" >&2
+  exit 1
+fi
+
+# Fail loudly rather than shipping a dashboard Grafana will reject, and enforce the repo
+# conventions documented in .openshift/observability/README.md.
+for f in "${files[@]}"; do
+  python3 - "$f" <<'PY'
+import json, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+try:
+    d = json.loads(path.read_text())
+except Exception as err:
+    sys.exit(f"{path.name}: invalid JSON -- {err}")
+if not d.get('uid'):
+    sys.exit(f"{path.name}: no uid")
+if path.stem != d['uid']:
+    sys.exit(f"{path.name}: filename does not match uid '{d['uid']}'")
+if d.get('id') is not None:
+    sys.exit(f"{path.name}: id must be null (it is {d['id']!r}); run normalize-dashboard.mjs")
+if 'version' in d:
+    sys.exit(f"{path.name}: remove the version key; run normalize-dashboard.mjs")
+PY
+done
+
+echo "applying ${#files[@]} dashboards to ${NAMESPACE}/${NAME}:"
+for f in "${files[@]}"; do echo "  $(basename "$f")"; done
+
+args=()
+for f in "${files[@]}"; do args+=("--from-file=$(basename "$f")=$f"); done
+
+oc create configmap "$NAME" "${args[@]}" \
+  --dry-run=client -o yaml \
+  | oc label -f - --local -o yaml \
+      app=grafana component=observability \
+  | oc apply -n "$NAMESPACE" -f -

--- a/tools/observability/normalize-dashboard.mjs
+++ b/tools/observability/normalize-dashboard.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Normalise a Grafana dashboard export for storage in the repo.
+//
+// Grafana's UI export is not directly committable: the filename carries an export timestamp and
+// spaces, `id` holds the exporting instance's local numeric id (which collides on import into a
+// different Grafana), and `version` increments on every save so it churns the diff.
+//
+// Usage: node tools/observability/normalize-dashboard.mjs <exported-file> [...]
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const OUT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../.openshift/observability/dashboards');
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('usage: node tools/observability/normalize-dashboard.mjs <exported-file> [...]');
+  process.exit(1);
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+let failed = false;
+for (const file of files) {
+  let dashboard;
+  try {
+    dashboard = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (err) {
+    console.error(`${file}: not readable as JSON -- ${err.message}`);
+    failed = true;
+    continue;
+  }
+
+  if (!dashboard.uid) {
+    console.error(`${file}: no uid, so there is no stable filename to use. Set one in Grafana first.`);
+    failed = true;
+    continue;
+  }
+
+  dashboard.id = null;
+  delete dashboard.version;
+
+  const out = join(OUT_DIR, `${dashboard.uid}.json`);
+  writeFileSync(out, `${JSON.stringify(dashboard, null, 2)}\n`);
+  console.log(`${dashboard.title} -> ${out}`);
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Companion to the SDK instrumentation fixes (#5795, #5798, #5799). Those made the telemetry correct; this makes the collector stack correct and puts the dashboards in the repo.

**Applied to `adsp-dev` and verified** — see the bottom section.

## Collector stack

Found while investigating why dashboards disagreed with reality in uat and dev.

| Defect | Evidence |
|---|---|
| `memory_limiter` at 1024 MiB against a **512Mi** container limit — the soft limiter could never engage before the kernel OOM-killed | both replicas had been OOMKilled |
| Prometheus scraped the collector via **ClusterIP with 2 replicas**, capturing a random one per scrape | the two pods held **12,697 vs 15,428** different spanmetrics series |
| RabbitMQ scrape job pointed at namespace `default` (hardcoded) and port 15692, which the broker didn't expose | job silently resolved to **zero targets** — read as coverage that didn't exist |
| No collector self-telemetry, so dropped spans and queue saturation were invisible | **28** `otelcol_*` metrics now, previously none |
| Prometheus memory limit `1Gi` in the template, `2Gi` in both dev and uat | applying the template would have **halved** the limit on the Prometheus that was OOMKilling |
| PDBs with `minAvailable: 1` on single-replica deployments | makes those pods ineligible for voluntary eviction, **stalling node drains** |

Fixes: limiter paired to a 1Gi container, headless `<collector>-metrics` service + DNS-SD so every replica is scraped, `sample_limit` as a guardrail, self-telemetry on `:8888`, RabbitMQ job pointed in-namespace, Prometheus at 2Gi, and `maxUnavailable: 1` on the single-replica PDBs.

The split-scrape one is worth dwelling on: it made every `rate()` and `increase()` unreliable, because alternating between two replicas' counters reads as constant resets. It's what made 102 requests look like 6,147/hour during one investigation.

## Dashboards as code

Grafana now provisions from ConfigMaps instead of relying on manual import. `grafana-dashboard-provider` holds the provider config inline; `grafana-dashboards` holds the JSON, built from `dashboards/` by `tools/observability/apply-dashboards.sh` — not inlined, because ~130KB of JSON would make the template unreadable. The volume is `optional: true` so Grafana starts before it exists.

Four dashboards, each answering one question:

| Dashboard | Question |
|---|---|
| `adsp-service-overview` | Is a service healthy, which routes are slow or failing? |
| `configuration-service-performance` | The same for configuration-service, plus its benchmark phases. |
| `adsp-service-dependencies` | What is a service waiting on? Only possible now that client span names are bounded rather than full URLs. |
| `adsp-event-bus-rabbitmq` | Is the event bus about to block, and are domain events flowing without loss? |

**Every query validated against `adsp-dev`: 61 queries, 0 parse errors, 0 NaN.**

### Two lessons encoded in the files and README

**Interpolate with `${var:pipe}`, never `${var:regex}`.** The regex formatter escapes regex metacharacters and PromQL rejects escapes like `\(` and `\.`, so a label value containing a bracket or a dot makes the panel *fail to parse*. This cost two debugging rounds. `allValue` is `.*` so "All" still matches series where the label is absent.

**Error panels derive 5xx from `http_server_request_count_total` by status code, with `or vector(0)`.** A healthy service then reads **0%** rather than "No data", which is otherwise indistinguishable from broken instrumentation.

### RabbitMQ dashboard framing

Ordered around **resource alarms first**, because a tripped watermark makes RabbitMQ block publishers and services then hang on publish *with no error returned* — the symptom elsewhere is hung requests, not failures. Then message loss (unroutable and every dead-letter reason), then flow and backlog, then capacity expressed as % of each limit so one axis works and **100% is where the alarm fires**.

Two deliberate omissions, documented on the dashboard so they aren't "fixed" later:
- **No per-queue breakdown.** `prometheus.return_per_object_metrics` is off and should stay off — per-object series scale with queues × channels × connections. The dashboard can show *that* the bus is backing up, not *which queue*.
- **No consumer-utilisation panel.** `rabbitmq_queue_consumer_utilisation` on the aggregated endpoint is the sum of per-queue ratios per node — observed 9, 14, 23 rather than 0–1 — so it has no useful meaning.

## RabbitMQ manifest

`rabbitmq_prometheus` enabled (it ships with the 4.1.6 image), `disk_free_limit.absolute` corrected to `2GB` to match both environments, and the metrics port documented.

Also comments recording that **this template must not be applied wholesale**: its three `generate: expression` credentials rotate on every render, which would break cluster formation and every service's AMQP auth, and `volumeClaimTemplates` is immutable at 5Gi live against 10Gi here, so a StatefulSet apply is rejected outright. Confirmed by server-side dry-run.

## Tooling and naming

- `normalize-dashboard.mjs` — strips the instance-local `id` and the churning `version` from a Grafana export, writes `dashboards/<uid>.json`. Idempotent.
- `apply-dashboards.sh` — builds the ConfigMap, validating conventions first so a malformed dashboard fails locally rather than in the cluster.
- `stack.yml` → `observability-stack.yml`, so the filename matches the template's `metadata.name` — the convention every template under `.openshift/managed/` follows. It stays in its own directory rather than moving to `managed/`, because that directory has a real contract: CI keys it on Nx app names and applies with an `apply-<env>=true` selector.

## Verified in adsp-dev

Applied before opening this. All four dashboards present; the three previously hand-imported ones were **updated in place rather than duplicated** (`version 1 → 2`), and their panel expressions are byte-identical to these files. Collector self-telemetry, per-replica scraping and the RabbitMQ job are all live and healthy.

One correction to an expectation I had: the dashboards report `provisioned=False`. That's because `allowUiUpdates: true` — Grafana doesn't apply provisioning ownership or the read-only lock when UI edits are permitted. Provisioning works regardless; the practical effect is that a UI edit persists until the next ConfigMap reload (60s poll or pod restart), then the file wins. Set `allowUiUpdates: false` if you'd rather have the badge and the lock.

## Not included

`prometheus.yml` has no `rule_files` and there is no Alertmanager, so none of this alerts — it only surfaces in the UI. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
