### PR TITLE
fix(value-service): strip null characters before writing to timescale

### DIFF
--- a/apps/value-service/src/timescale/index.ts
+++ b/apps/value-service/src/timescale/index.ts
@@ -65,6 +65,6 @@ export const createRepositories = async ({
         return false;
       }
     },
-    valueRepository: new TimescaleValuesRepository(knex),
+    valueRepository: new TimescaleValuesRepository(knex, logger),
   };
 };

--- a/apps/value-service/src/timescale/sanitize.spec.ts
+++ b/apps/value-service/src/timescale/sanitize.spec.ts
@@ -1,0 +1,50 @@
+import { stripNul } from './sanitize';
+
+const NUL = '\u0000';
+
+describe('stripNul', () => {
+  it('can remove a nul from a string', () => {
+    expect(stripNul(`before${NUL}after`)).toBe('beforeafter');
+  });
+
+  it('can remove the nul that a six-digit escape decodes to', () => {
+    // `\u000027` is `\u0027` written with two extra zeros. JSON reads four hex digits, so it decodes
+    // to U+0000 followed by a literal "27". This is the shape found in adsp-dev.
+    const decoded = JSON.parse('"We\\u000027re here"');
+
+    expect(decoded).toContain(NUL);
+    expect(stripNul(decoded)).toBe('We27re here');
+  });
+
+  it('can clean nested objects and arrays', () => {
+    const input = { a: [`x${NUL}`, { b: `y${NUL}z` }], c: 1, d: null };
+
+    expect(stripNul(input)).toEqual({ a: ['x', { b: 'yz' }], c: 1, d: null });
+  });
+
+  it('can clean object keys', () => {
+    const input = { [`key${NUL}`]: 'value' };
+
+    expect(Object.keys(stripNul(input))).toEqual(['key']);
+  });
+
+  it('can return the same reference when there is nothing to strip', () => {
+    // Callers rely on reference equality to decide whether to warn, and to avoid copying.
+    const input = { a: ['x', { b: 'y' }], c: 1 };
+
+    expect(stripNul(input)).toBe(input);
+  });
+
+  it('can leave non-string primitives alone', () => {
+    expect(stripNul(42)).toBe(42);
+    expect(stripNul(true)).toBe(true);
+    expect(stripNul(null)).toBeNull();
+    expect(stripNul(undefined)).toBeUndefined();
+  });
+
+  it('can leave a Date intact', () => {
+    const date = new Date('2026-08-27T00:00:00Z');
+
+    expect(stripNul(date)).toBe(date);
+  });
+});

--- a/apps/value-service/src/timescale/sanitize.ts
+++ b/apps/value-service/src/timescale/sanitize.ts
@@ -1,0 +1,54 @@
+// PostgreSQL text -- and therefore jsonb, which stores text -- cannot represent U+0000. An insert
+// carrying one fails with "unsupported Unicode escape sequence", and for the event log that means the
+// entry is retried once and then dead-lettered rather than recorded.
+//
+// Publishers cannot be relied on to exclude it. Observed in adsp-dev: stored PDF and email templates
+// contained six-hex-digit escapes -- `\u0000b7` where `\u00b7` (a middle dot) was meant, likewise
+// `\u000026`, `\u000027` and `\u00002d`. JSON reads exactly four hex digits after `\u`, so each of those
+// decodes to U+0000 followed by the leftover digits as literal text. Stripping at the storage
+// boundary is the only place that covers every publisher.
+const NUL = '\u0000';
+
+function stripFromString(value: string): string {
+  return value.includes(NUL) ? value.split(NUL).join('') : value;
+}
+
+/**
+ * Remove U+0000 from every string in a value, including object keys.
+ *
+ * Returns the **same reference** when nothing needed removing, so a caller can detect whether
+ * anything was altered with `result !== input` -- avoiding both a second traversal and a needless
+ * copy on the common path.
+ */
+export function stripNul<T>(value: T): T {
+  if (typeof value === 'string') {
+    return stripFromString(value) as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const cleaned = stripNul(item);
+      changed = changed || cleaned !== item;
+      return cleaned;
+    });
+
+    return (changed ? next : value) as unknown as T;
+  }
+
+  // Dates and other non-plain objects would be flattened by Object.entries, so leave them alone.
+  if (value === null || typeof value !== 'object' || value instanceof Date) {
+    return value;
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    const cleanedKey = stripFromString(key);
+    const cleaned = stripNul(item);
+    changed = changed || cleanedKey !== key || cleaned !== item;
+    next[cleanedKey] = cleaned;
+  }
+
+  return (changed ? next : value) as unknown as T;
+}

--- a/apps/value-service/src/timescale/value.ts
+++ b/apps/value-service/src/timescale/value.ts
@@ -1,12 +1,37 @@
 import { Knex } from 'knex';
 import { decodeAfter, encodeNext, InvalidOperationError, Results } from '@core-services/core-common';
+import { Logger } from 'winston';
 import { Value, ValueCriteria, ValuesRepository, MetricValue, Metric, MetricCriteria, Page } from '../values';
 import { AdspId } from '@abgov/adsp-service-sdk';
+import { stripNul } from './sanitize';
 
 type ValueRecord = Value & { namespace: string; name: string; tenant: string };
 
 export class TimescaleValuesRepository implements ValuesRepository {
-  constructor(private knex: Knex) {}
+  constructor(
+    private knex: Knex,
+    private logger?: Logger
+  ) {}
+
+  /**
+   * Strip U+0000 before it reaches a text or jsonb column, where PostgreSQL cannot represent it.
+   *
+   * stripNul returns the same reference when nothing changed, so the warning fires only when a
+   * payload was actually altered -- which is worth surfacing, since the stored value then differs
+   * from what the publisher sent.
+   */
+  private sanitize<T>(namespace: string, name: string, value: T): T {
+    const sanitized = stripNul(value);
+    if (sanitized !== value) {
+      this.logger?.warn(
+        `Removed null characters from value ${namespace}:${name} before write; ` +
+          'the stored value differs from what was submitted.',
+        { context: 'TimescaleValuesRepository' }
+      );
+    }
+
+    return sanitized;
+  }
 
   async writeValues(
     namespace: string,
@@ -22,9 +47,9 @@ export class TimescaleValuesRepository implements ValuesRepository {
             name,
             timestamp,
             tenant: tenantId?.toString(),
-            correlationId: correlationId,
-            context: context || {},
-            value,
+            correlationId: this.sanitize(namespace, name, correlationId),
+            context: this.sanitize(namespace, name, context || {}),
+            value: this.sanitize(namespace, name, value),
           }))
         )
         .returning('*');
@@ -355,7 +380,7 @@ export class TimescaleValuesRepository implements ValuesRepository {
           namespace,
           name,
           tenant: tenantId?.toString(),
-          metric,
+          metric: this.sanitize(namespace, name, metric),
           timestamp,
           value,
         }))

--- a/libs/core-common/src/errors/handler.spec.ts
+++ b/libs/core-common/src/errors/handler.spec.ts
@@ -79,6 +79,19 @@ describe('createErrorHandler', () => {
     expect(loggerMock.warn).not.toHaveBeenCalledWith(expect.stringContaining('(status: 200)'));
   });
 
+  it('keeps a status the handler set before failing', () => {
+    // res.status(409) sets the code without sending headers. The client still receives 500 because
+    // sendStatus overrides it, but the 409 says where the handler got to.
+    const res = createRes();
+    res.statusCode = 409;
+
+    createErrorHandler(loggerMock)(new Error('boom'), req as never, res as never, jest.fn());
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining('(status: 500) (handler had set 409)')
+    );
+  });
+
   it('logs the real status when headers were already sent', () => {
     const res = createRes();
     res.headersSent = true;

--- a/libs/core-common/src/errors/handler.spec.ts
+++ b/libs/core-common/src/errors/handler.spec.ts
@@ -12,6 +12,9 @@ describe('createErrorHandler', () => {
   const createRes = () => {
     const res = {
       headersSent: false,
+      // Express leaves this at the default until something sets it, which is the bug the status
+      // logging tests below pin down.
+      statusCode: 200,
       status: jest.fn(() => res),
       json: jest.fn(() => res),
       sendStatus: jest.fn(() => res),
@@ -63,6 +66,28 @@ describe('createErrorHandler', () => {
     createErrorHandler(loggerMock)(err, req as never, res as never, jest.fn());
 
     expect(res.status).toHaveBeenCalledWith(HttpStatusCodes.BAD_REQUEST);
+  });
+
+  it('logs the status it is actually sending, not the unset default', () => {
+    // res.statusCode is still 200 when the handler runs, so logging it directly reported every
+    // unhandled error as a success and misled anyone triaging from logs.
+    const res = createRes();
+
+    createErrorHandler(loggerMock)(new Error('boom'), req as never, res as never, jest.fn());
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(expect.stringContaining('(status: 500)'));
+    expect(loggerMock.warn).not.toHaveBeenCalledWith(expect.stringContaining('(status: 200)'));
+  });
+
+  it('logs the real status when headers were already sent', () => {
+    const res = createRes();
+    res.headersSent = true;
+    res.statusCode = 206;
+
+    createErrorHandler(loggerMock)(new Error('boom'), req as never, res as never, jest.fn());
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(expect.stringContaining('(status: 206)'));
+    expect(res.end).toHaveBeenCalled();
   });
 
   it('does not treat an ordinary SyntaxError as a body parse failure', () => {

--- a/libs/core-common/src/errors/handler.ts
+++ b/libs/core-common/src/errors/handler.ts
@@ -39,13 +39,14 @@ export const createErrorHandler =
         errorMessage: `Malformed request body: ${err.message}`,
       });
     } else {
-      logger.warn(
-        `Unexpected error encountered in handler for request ${req.path} ${
-          res.statusCode ? `(status: ${res.statusCode})` : ''
-        }. ${err}`
-      );
+      // res.statusCode is still the default 200 at this point, so logging it here reported every
+      // unhandled error as "(status: 200)" -- which reads as a success and misleads anyone
+      // triaging from logs. Log the status actually being sent instead.
+      const sending = res.headersSent ? res.statusCode : HttpStatusCodes.INTERNAL_SERVER_ERROR;
+      logger.warn(`Unexpected error encountered in handler for request ${req.path} (status: ${sending}). ${err}`);
+
       if (!res.headersSent) {
-        res.sendStatus(500);
+        res.sendStatus(HttpStatusCodes.INTERNAL_SERVER_ERROR);
       } else {
         res.end();
       }

--- a/libs/core-common/src/errors/handler.ts
+++ b/libs/core-common/src/errors/handler.ts
@@ -39,11 +39,20 @@ export const createErrorHandler =
         errorMessage: `Malformed request body: ${err.message}`,
       });
     } else {
-      // res.statusCode is still the default 200 at this point, so logging it here reported every
-      // unhandled error as "(status: 200)" -- which reads as a success and misleads anyone
-      // triaging from logs. Log the status actually being sent instead.
-      const sending = res.headersSent ? res.statusCode : HttpStatusCodes.INTERNAL_SERVER_ERROR;
-      logger.warn(`Unexpected error encountered in handler for request ${req.path} (status: ${sending}). ${err}`);
+      // Log the status the client actually receives. res.statusCode alone is misleading: for a
+      // plain throw it is still the default 200, which reads as a success, and sendStatus below
+      // overrides whatever it holds anyway.
+      const sent = res.headersSent ? res.statusCode : HttpStatusCodes.INTERNAL_SERVER_ERROR;
+
+      // A handler may have called res.status(...) and then failed -- res.status sets the code
+      // without sending headers. That intent does not survive into the response, but it says
+      // something about how far the request got, so keep it alongside rather than discarding it.
+      const preset =
+        !res.headersSent && res.statusCode !== HttpStatusCodes.OK ? ` (handler had set ${res.statusCode})` : '';
+
+      logger.warn(
+        `Unexpected error encountered in handler for request ${req.path} (status: ${sent})${preset}. ${err}`
+      );
 
       if (!res.headersSent) {
         res.sendStatus(HttpStatusCodes.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Symptom

Event log writes failing in `adsp-dev`:

```
insert into "values" ("context","correlationId","name","namespace","tenant","timestamp","value")
values ($1,...,$7) returning * - unsupported Unicode escape sequence
```

event-service retried once, then dead-lettered. Three messages had accumulated in `undelivered-event-log`.

## Root cause: a malformed escape, not a raw NUL

The payloads contained unicode escapes written with **six** hex digits instead of four:

| In the stored content | Intended | Character |
|---|---|---|
| `\u0000b7` | `\u00b7` | middle dot |
| `\u000026` | `\u0026` | ampersand |
| `\u000027` | `\u0027` | apostrophe |
| `\u00002d` | `\u002d` | hyphen |

JSON reads **exactly four** hex digits after `\u`, so `\u000027` decodes to **U+0000** followed by a literal `27`. PostgreSQL text -- and `jsonb`, which stores text -- cannot represent U+0000, so the insert is rejected.

The signature is `padStart(6, '0')` where `padStart(4, '0')` was meant.

## Where the bad data is

I peeked at the dead-lettered messages non-destructively (`ackmode=reject_requeue_true`):

| Message | Event | Content |
|---|---|---|
| 1 | `platform:pdf-service` config update | PDF footer template -- `Cascade Outfitters \u0000b7 Spring 2025` |
| 2 | `pdf-service:pdf-generation-failed` | a **Handlebars lexical error** caused by that same template |
| 3 | `platform:notification-service` config update | email template -- `We\u000027re excited` |

So the corruption is **at rest in stored configuration** for the `autotest` tenant. The `configuration-updated` events merely carry it, and message 2 shows pdf-service already failing on its own. I searched the repo for code producing six-digit escapes and found none, so it entered via whatever authored those templates -- the "Cascade Outfitters" / "Auto Test" naming suggests generated fixtures.

## The fix

Fixing the templates is necessary but not sufficient: **no publisher can be relied on to exclude a character the database cannot store.** So U+0000 is stripped at the storage boundary, covering every publisher:

- `value` and `context` -- jsonb columns
- `correlationId` and metric names -- text columns, equally unable to hold it

`stripNul` returns the **same reference** when nothing changed, so the repository warns only when a payload was genuinely altered -- worth surfacing, since the stored value then differs from what was submitted -- while avoiding a copy on the common path.

## Second fix: the error handler logged the wrong status

`libs/core-common/src/errors/handler.ts` read `res.statusCode` *before* setting it, so every unhandled error logged as `(status: 200)`. That is exactly what made the value-service warning read as a success, and it would mislead anyone triaging from logs across every service using this handler. It now logs the status actually being sent, or the real one when headers have already gone out.

## Correction to my initial read

I first described the dead-lettered entries as permanently lost. They are not. `undelivered-event-log` is durable, quorum-type, with no TTL, no max-length and no policies, so they persist and are replayable via the shovel plugin. The accurate statement is narrower: they are absent from the queryable event log until replayed.

## Verification

- value-service 42/42 and core-common 57/57 tests pass, with 7 new sanitizer cases and 2 pinning the status logging.
- One test decodes the actual six-digit escape through `JSON.parse` rather than asserting on a hand-made NUL, so it exercises the real failure shape.
- Lint clean on changed files (the one remaining warning in `timescale/index.ts:64` is a pre-existing unused `err`).
- `value-service`, `event-service` and `form-service` all build.

## Follow-ups not in this PR

1. **Fix the corrupted templates** for the autotest tenant and find the `padStart(6)` generator. Until then pdf generation for that template keeps failing.
2. **Replay the three dead-lettered messages** once this deploys.
3. **Alert on dead-lettering.** `rabbitmq_global_messages_dead_lettered_*` is on the RabbitMQ dashboard from #5800, but `prometheus.yml` still has no `rule_files` and there is no Alertmanager -- so a filling DLQ is only visible if someone looks.

Note that the per-node-aggregate limitation documented in #5800 means DLQ **depth** is not independently visible: these 3 messages are simply part of a cluster-wide ready count.

Generated with [Claude Code](https://claude.com/claude-code)
