### PR TITLE
fix(tenant-management-webapp): CS-5325 save the notice dates that were entered

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/timeUtil.spec.ts
+++ b/apps/tenant-management-webapp/src/app/lib/timeUtil.spec.ts
@@ -1,4 +1,4 @@
-import { getTimeFromGMT, getDateTime, getLocalISOString } from './timeUtil';
+import { getTimeFromGMT, getDateTime, getLocalISOString, parseLocalDate, toDateInputValue } from './timeUtil';
 
 describe('getTimeFromGMT', () => {
   it('should format the time correctly for times with double-digit hours and minutes', () => {
@@ -67,5 +67,52 @@ describe('getLocalISOString', () => {
 
     expect(resultPositive).toBe(expectedPositive);
     expect(resultNegative).toBe(expectedNegative);
+  });
+});
+
+describe('date only handling', () => {
+  // Tests run with TZ=UTC (jest.preset.js), so these pin down the local time semantics the browser relies on:
+  // a date only string is the day the user picked, not that day at UTC midnight.
+  it('parses a date only string as local midnight rather than UTC midnight', () => {
+    const parsed = parseLocalDate('2026-08-20');
+    const offsetMs = parsed.getTimezoneOffset() * 60000;
+
+    expect(parsed.getTime()).toBe(Date.parse('2026-08-20T00:00:00.000Z') + offsetMs);
+    expect(parsed.getDate()).toBe(20);
+    expect(parsed.getHours()).toBe(0);
+  });
+
+  it('parses other date formats the way the Date constructor does', () => {
+    expect(parseLocalDate('10/02/2023').getDate()).toBe(2);
+    expect(isNaN(parseLocalDate('not a date').getTime())).toBe(true);
+  });
+
+  it('returns the date it is given', () => {
+    const date = new Date(2026, 7, 20, 20, 0);
+
+    expect(parseLocalDate(date)).toBe(date);
+  });
+
+  it('formats a date input value from the local date', () => {
+    expect(toDateInputValue(new Date(2026, 7, 20, 20, 0))).toBe('2026-08-20');
+    expect(toDateInputValue(new Date(2026, 0, 5))).toBe('2026-01-05');
+    expect(toDateInputValue(new Date('not a date'))).toBe('');
+  });
+
+  it('combines a date only string with a local time', () => {
+    const result = getDateTime('2026-08-20', '00:00');
+
+    expect(result.getDate()).toBe(20);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it('keeps the entered day through a date input round trip', () => {
+    const result = getDateTime(parseLocalDate('2026-08-20'), '12:30:45');
+
+    expect(toDateInputValue(result)).toBe('2026-08-20');
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(30);
+    expect(result.getSeconds()).toBe(45);
   });
 });

--- a/apps/tenant-management-webapp/src/app/lib/timeUtil.ts
+++ b/apps/tenant-management-webapp/src/app/lib/timeUtil.ts
@@ -39,12 +39,44 @@ export const getTimeFromGMT = (date: Date): string => {
   return `${formattedHours}:${formattedMinutes}`;
 };
 
-export const getDateTime = (date, time) => {
-  const newDate = new Date(date);
-  const combinedDateTime = new Date(
-    newDate.getMonth() + 1 + '/' + newDate.getDate() + '/' + newDate.getFullYear() + ' ' + time
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{1,2})-(\d{1,2})$/;
+
+// The Date constructor reads a date only string (yyyy-mm-dd) as UTC midnight, which lands on the previous
+// day in negative offset timezones like Alberta's; parse the parts so the date stays the one that was entered.
+export const parseLocalDate = (date: string | Date): Date => {
+  if (date instanceof Date) {
+    return date;
+  }
+
+  const parts = DATE_ONLY_PATTERN.exec((date || '').trim());
+  if (!parts) {
+    return new Date(date);
+  }
+
+  const [, year, month, day] = parts;
+  return new Date(Number(year), Number(month) - 1, Number(day));
+};
+
+// Value for a date input, using the local date so it matches what the user sees in the rest of the form.
+export const toDateInputValue = (date: Date): string => {
+  if (!date || isNaN(date.getTime())) {
+    return '';
+  }
+
+  return `${date.getFullYear()}-${padZero(date.getMonth() + 1)}-${padZero(date.getDate())}`;
+};
+
+export const getDateTime = (date: string | Date, time: string): Date => {
+  const newDate = parseLocalDate(date);
+  const [hours, minutes, seconds] = (time || '').split(':').map(Number);
+  return new Date(
+    newDate.getFullYear(),
+    newDate.getMonth(),
+    newDate.getDate(),
+    hours || 0,
+    minutes || 0,
+    seconds || 0
   );
-  return combinedDateTime;
 };
 
 export const getLocalISOString = (date: Date): string => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { fireEvent, render } from '@testing-library/react';
+
+import NoticeModal from './noticeModal';
+import { SAVE_NOTICE_ACTION } from '@store/notice/actions';
+
+describe('NoticeModal', () => {
+  const mockStore = configureStore([]);
+
+  // The notice being edited starts at midnight on Aug 19 and ends at noon on Aug 27, local time.
+  const notice = {
+    id: '1',
+    message: 'howard-test',
+    tennantServRef: [{ id: '99', name: 'Autotest' }],
+    startDate: new Date(2026, 7, 19, 0, 0).toISOString(),
+    endDate: new Date(2026, 7, 27, 12, 0).toISOString(),
+    isAllApplications: false,
+  };
+
+  const createStore = () =>
+    mockStore({
+      serviceStatus: {
+        applications: [{ appKey: '99', name: 'Autotest', monitorOnly: false }],
+      },
+      notice: { notices: [notice] },
+    });
+
+  const renderModal = (store, noticeId?: string) =>
+    render(
+      <Provider store={store}>
+        <NoticeModal title={noticeId ? 'Edit notice' : 'Add notice'} isOpen={true} noticeId={noticeId} />
+      </Provider>
+    );
+
+  const changeValue = (baseElement: Element, selector: string, value: string) => {
+    const element = baseElement.querySelector(selector);
+    fireEvent(element, new CustomEvent('_change', { detail: { value } }));
+  };
+
+  const savedNotice = (store) => store.getActions().find((action) => action.type === SAVE_NOTICE_ACTION)?.payload;
+
+  it('saves the dates that were entered', () => {
+    const store = createStore();
+    const { baseElement } = renderModal(store);
+
+    changeValue(baseElement, "goa-textarea[testId='notice-form-description']", 'howard-test');
+    changeValue(baseElement, "goa-dropdown[testId='application-dropdown-list']", 'Autotest');
+    changeValue(baseElement, "goa-input[testId='notice-form-start-date-picker']", '2026-08-20');
+    changeValue(baseElement, "goa-input[testId='notice-form-start-time']", '00:00');
+    changeValue(baseElement, "goa-input[testId='notice-form-end-date-picker']", '2026-08-27');
+
+    fireEvent(baseElement.querySelector("goa-button[data-testid='notice-form-submit']"), new CustomEvent('_click'));
+
+    const saved = savedNotice(store);
+    expect(saved.startDate.getDate()).toBe(20);
+    expect(saved.startDate.getHours()).toBe(0);
+    expect(saved.endDate.getDate()).toBe(27);
+  });
+
+  it('shows the local dates of the notice being edited', () => {
+    const { baseElement } = renderModal(createStore(), notice.id);
+
+    expect(baseElement.querySelector("goa-input[testId='notice-form-start-date-picker']").getAttribute('value')).toBe(
+      '2026-08-19'
+    );
+    expect(baseElement.querySelector("goa-input[testId='notice-form-end-date-picker']").getAttribute('value')).toBe(
+      '2026-08-27'
+    );
+  });
+
+  it('saves the dates that were changed on an existing notice', () => {
+    const store = createStore();
+    const { baseElement } = renderModal(store, notice.id);
+
+    changeValue(baseElement, "goa-input[testId='notice-form-start-date-picker']", '2026-08-10');
+    changeValue(baseElement, "goa-input[testId='notice-form-end-date-picker']", '2026-08-22');
+
+    fireEvent(baseElement.querySelector("goa-button[data-testid='notice-form-submit']"), new CustomEvent('_click'));
+
+    const saved = savedNotice(store);
+    expect(saved.id).toBe(notice.id);
+    expect(saved.startDate.getDate()).toBe(10);
+    expect(saved.endDate.getDate()).toBe(22);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
@@ -15,7 +15,7 @@ import {
   GoabDropdownItem,
   GoabGrid,
 } from '@abgov/react-components';
-import { getTimeFromGMT, getDateTime } from '@lib/timeUtil';
+import { getTimeFromGMT, getDateTime, parseLocalDate, toDateInputValue } from '@lib/timeUtil';
 import { HelpTextComponent } from '@components/HelpTextComponent';
 import {
   GoabTextAreaOnChangeDetail,
@@ -142,10 +142,16 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
     setEndTime('14:00');
     setSelectedApplications([]);
   }
-  const isValidDateString = (dateString) => {
-    const date = new Date(dateString);
-    return !isNaN(date.getTime());
-  };
+  function onDateChange(value: string, setDate: (date: Date) => void, errorMessage: string) {
+    const date = parseLocalDate(value);
+    if (isNaN(date.getTime())) {
+      setErrors({ date: errorMessage });
+      return;
+    }
+
+    setErrors({});
+    setDate(date);
+  }
 
   return (
     <GoabModal
@@ -218,16 +224,11 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
           <GoabInput size="compact"
             type="date"
             name="StartDate"
-            value={startDate.toISOString().slice(0, 10)}
+            value={toDateInputValue(startDate)}
             width="100%"
             testId="notice-form-start-date-picker"
             onChange={(detail: GoabInputOnChangeDetail) => {
-              if (isValidDateString(detail.value)) {
-                setErrors({});
-                setStartDate(new Date(detail.value));
-              } else {
-                setErrors({ date: 'Please input right start date format!' });
-              }
+              onDateChange(detail.value, setStartDate, 'Please input right start date format!');
             }}
           />
         </GoabFormItem>
@@ -249,16 +250,11 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
           <GoabInput size="compact"
             type="date"
             name="EndDate"
-            value={endDate.toISOString().slice(0, 10)}
+            value={toDateInputValue(endDate)}
             width="100%"
             testId="notice-form-end-date-picker"
             onChange={(detail: GoabInputOnChangeDetail) => {
-              if (isValidDateString(detail.value)) {
-                setErrors({});
-                setEndDate(new Date(detail.value));
-              } else {
-                setErrors({ date: 'Please input right end date format!' });
-              }
+              onDateChange(detail.value, setEndDate, 'Please input right end date format!');
             }}
           />
         </GoabFormItem>


### PR DESCRIPTION


https://github.com/user-attachments/assets/fa3eab55-c464-405a-aacb-7d5673662aa3


The status notice modal parsed the date pickers' `yyyy-mm-dd` values with `new Date(value)`, which reads them as UTC midnight. `getDateTime` then took the local calendar day off that instant — the previous day in Alberta — so notices saved a day early, on both add and edit.

- `timeUtil`: added `parseLocalDate` and `toDateInputValue`, and `getDateTime` now builds its result from date/time components.
- `noticeModal`: both pickers display and parse local dates through those helpers.
- Tests for the helpers, plus a new `noticeModal` spec covering add, edit prefill, and edit save.