### PR TITLE
feat(form-service): trace mongoose operations with auto-instrumentation

### DIFF
--- a/apps/form-service/src/main.ts
+++ b/apps/form-service/src/main.ts
@@ -1,3 +1,6 @@
+// Must stay first: it patches mongoose via require-hook, and ./mongo below loads mongoose
+// during the import phase.
+import './tracing';
 import * as express from 'express';
 import { readFile } from 'fs';
 import { promisify } from 'util';

--- a/apps/form-service/src/tracing.ts
+++ b/apps/form-service/src/tracing.ts
@@ -1,0 +1,23 @@
+// Registers OpenTelemetry auto-instrumentation for this service's data store.
+//
+// MUST be the first import in main.ts. The instrumentation patches mongoose by hooking `require`,
+// which only works if it runs before mongoose is loaded -- and `./mongo` is a top-level import of
+// main.ts, so mongoose is pulled in during the import phase, not inside main().
+//
+// No TracerProvider is passed. At this point initializePlatform has not run, so the instrumentation
+// caches the API's ProxyTracer, which resolves its delegate lazily on every startSpan. Once
+// initializePlatform calls tracerProvider.register(), spans start flowing; before that they are
+// no-ops, so this is also safe when tracing is disabled.
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { MongooseInstrumentation } from '@opentelemetry/instrumentation-mongoose';
+
+registerInstrumentations({
+  instrumentations: [
+    new MongooseInstrumentation({
+      // Statements can carry form content, which may include personal information. Record the
+      // operation and collection only -- the span name and db attributes are enough to see which
+      // query is slow.
+      dbStatementSerializer: () => undefined,
+    }),
+  ],
+});


### PR DESCRIPTION
Database operations in form-service now appear as child spans of the request instead of as unaccounted self time. First service to get storage instrumentation — a trial before rolling the pattern out further.

## The gap this closes

Measured on a real `GET /form/v1/definitions` trace in `adsp-dev`:

```
GET /form/v1/definitions                     SERVER  1211.1ms
  POST .../openid-connect/token              CLIENT    20.1ms
  GET  .../api/tenant/v2/tenants             CLIENT   141.3ms
  GET  .../.well-known/openid-configuration  CLIENT   142.5ms
  GET  .../configuration/v2/configuration    CLIENT   652.7ms
                                             --------------------
  outbound HTTP accounted for                         957.0ms
  attributable to no span at all                      254.4ms
```

The SDK benchmark phases explained **4.5ms** of that 254ms. The two largest blind windows — **61.4ms** and **92.8ms** — are database work, which had no instrumentation at all.

## Registration order is load-bearing

The instrumentation patches mongoose by hooking `require`, so it only works if it runs **before** mongoose is loaded. `./mongo` is a top-level import of `main.ts` (line 44), so mongoose is pulled in during the import phase, not inside `main()`. Hence a dedicated `tracing.ts` imported first.

Both files carry a comment saying so, because a tidy-up that reorders imports would **silently disable this with no error** — no spans, no warning.

No `TracerProvider` is passed at registration. `initializePlatform` has not run at that point, so the instrumentation caches the API's `ProxyTracer`, which resolves its delegate lazily on every `startSpan` (`ProxyTracer.js:42-51`) and begins producing real spans once `tracerProvider.register()` is called. Before that they are no-ops, so this is also safe when tracing is disabled.

## Verified rather than assumed

I had earlier concluded — wrongly — that require-hook instrumentation could not work here because services are bundled. Nx actually **externalizes** `package.json` dependencies, so mongoose is a genuine runtime require from `node_modules`. Confirmed by running the real packages in this repo's dependency tree, registering the instrumentation first and the provider second:

```
name="findOne widgets"  kind=CLIENT
attrs={"db.collection.name":"widgets","db.operation.name":"findOne","db.system.name":"mongodb"}
```

## Privacy

`dbStatementSerializer` returns `undefined`, so query statements are **not** recorded. Form queries can carry personal information, and the operation plus collection is enough to identify a slow query.

## No dashboard change needed

Spans are `SpanKind.CLIENT` named `<operation> <collection>`, and **ADSP Service Dependencies** already filters client spans and groups by `span_name` with `topk(8)`. Its outbound rate and P95 panels pick these up unchanged — which fits, since that dashboard's question is "what is this service waiting on?" and Mongo is a dependency. Cardinality is bounded by operation × collection.

Two cosmetic follow-ups once this has been seen working, neither worth a new dashboard:

- Those panel descriptions say dependency names are `METHOD host` and point at `http.url` for detail. True for HTTP, not for `findOne forms`.
- HTTP and DB dependencies share one `topk(8)`. If the mixing turns out to be annoying, adding `db.system.name` as a `spanmetrics` dimension in `observability-stack.yml` allows a separate DB panel, at the cost of one near-zero-cardinality label.

Mongo spans will also carry **empty** `http_method` and `http_status_code` labels, since those are the configured spanmetrics dimensions and do not apply. Harmless, just odd in a label dump.

## Verification

- form-service 460/460 tests pass, lint clean, builds.
- Rebased on `main` at `83646c838` (which touched `form/router/form.ts`, no overlap with these files).
- The dependencies were already added in #5799; this only adds the registration.

## If this works out

The same shape applies to `pg` in task, calendar, comment and value-service — `@opentelemetry/instrumentation-pg` is already in `package.json`, and the equivalent change is one `tracing.ts` per service plus a first-line import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
