### PR TITLE
feat(tenant-management-webapp): CS-5331 add full page mode to the ADSP editors

### DIFF
--- a/apps/tenant-management-webapp/src/app/components/FullPagePane.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/components/FullPagePane.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FullPagePane } from './FullPagePane';
+
+const toggle = (baseElement: Element) => baseElement.querySelector("goa-icon-button[testid='pdf-body-toggle']");
+
+const renderPane = () =>
+  render(
+    <FullPagePane label="Body" testId="pdf-body" height="calc(100vh - 356px)">
+      <div>Editor</div>
+    </FullPagePane>,
+  );
+
+describe('FullPagePane', () => {
+  it('starts at regular size with the height it was given', () => {
+    // Arrange
+    const { baseElement, getByTestId } = renderPane();
+
+    // Act
+    const pane = getByTestId('pdf-body');
+
+    // Assert
+    expect(pane).toHaveStyle('height: calc(100vh - 356px)');
+    expect(toggle(baseElement)).toHaveAttribute('icon', 'expand');
+  });
+
+  it('puts the editor into full page mode', () => {
+    // Arrange
+    const { baseElement, getByTestId } = renderPane();
+
+    // Act
+    fireEvent(toggle(baseElement), new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('pdf-body')).toHaveAttribute('data-full-page', 'true');
+    expect(toggle(baseElement)).toHaveAttribute('icon', 'contract');
+  });
+
+  it('returns the editor to regular size', () => {
+    // Arrange
+    const { baseElement, getByTestId } = renderPane();
+    fireEvent(toggle(baseElement), new CustomEvent('_click'));
+
+    // Act
+    fireEvent(toggle(baseElement), new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('pdf-body')).toHaveAttribute('data-full-page', 'false');
+    expect(getByTestId('pdf-body')).toHaveStyle('height: calc(100vh - 356px)');
+  });
+
+  it('returns the editor to regular size on escape', () => {
+    // Arrange
+    const { baseElement, getByTestId } = renderPane();
+    fireEvent(toggle(baseElement), new CustomEvent('_click'));
+
+    // Act
+    fireEvent.keyDown(getByTestId('pdf-body'), { key: 'Escape' });
+
+    // Assert
+    expect(getByTestId('pdf-body')).toHaveAttribute('data-full-page', 'false');
+  });
+
+  it('keeps the editor mounted through the switch to full page', () => {
+    // Arrange
+    const { baseElement, getByText } = renderPane();
+    const editor = getByText('Editor');
+
+    // Act
+    fireEvent(toggle(baseElement), new CustomEvent('_click'));
+
+    // Assert
+    expect(getByText('Editor')).toBe(editor);
+  });
+
+  it('puts an optional heading on the same row as the toggle', () => {
+    // Arrange
+    const { baseElement, getByText } = render(
+      <FullPagePane label="Body" heading="Body" testId="pdf-body">
+        <div>Editor</div>
+      </FullPagePane>,
+    );
+
+    // Act
+    const heading = getByText('Body');
+
+    // Assert
+    expect(heading.parentElement).toContainElement(toggle(baseElement) as HTMLElement);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/components/FullPagePane.tsx
+++ b/apps/tenant-management-webapp/src/app/components/FullPagePane.tsx
@@ -1,0 +1,106 @@
+import React, { FunctionComponent, KeyboardEvent, ReactNode, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { GoabIconButton } from '@abgov/react-components';
+
+// Above the editor modal (z-index 10000) so the pane covers the preview and the editor chrome.
+const FULL_PAGE_Z_INDEX = 10001;
+
+const Pane = styled.div<{ $fullPage: boolean }>`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+
+  ${({ $fullPage }) =>
+    $fullPage &&
+    css`
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: ${FULL_PAGE_Z_INDEX};
+      height: 100%;
+      box-sizing: border-box;
+      padding: var(--goa-space-s);
+      background: var(--goa-color-greyscale-white);
+    `}
+`;
+
+const PaneActions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--goa-space-s);
+`;
+
+// Matches the label a GoabFormItem renders, so a heading passed here reads as the field's own label.
+const PaneHeading = styled.span`
+  font: var(--goa-form-item-label-typography);
+`;
+
+const PaneContent = styled.div`
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+
+  > * {
+    box-sizing: border-box;
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+  }
+`;
+
+interface FullPagePaneProps {
+  /** Names the editor the toggle acts on (e.g. 'Body') so each tab's control reads distinctly. */
+  label: string;
+  /** Rendered on the toggle's row, for hosts that would otherwise label the editor on its own line. */
+  heading?: ReactNode;
+  testId: string;
+  /** Height of the pane at regular size; in full page mode the pane fills the viewport instead. */
+  height?: string | number;
+  children: ReactNode;
+}
+
+/**
+ * Wraps an editor so the user can lift it out of the page into a full page view and put it back.
+ * The pane stays mounted either way, so the editor keeps its content, cursor and undo history.
+ */
+export const FullPagePane: FunctionComponent<FullPagePaneProps> = ({ label, heading, testId, height, children }) => {
+  const [fullPage, setFullPage] = useState(false);
+  const toggleLabel = fullPage ? `Return ${label} editor to regular size` : `Edit ${label} in full page`;
+
+  // Escape is the conventional way out of a full page view. Monaco stops propagation for the escapes
+  // it handles itself (closing the suggestion widget, leaving find), so only the rest reach us here.
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (fullPage && event.key === 'Escape') {
+      setFullPage(false);
+    }
+  };
+
+  return (
+    <Pane
+      $fullPage={fullPage}
+      style={fullPage ? undefined : { height }}
+      onKeyDown={handleKeyDown}
+      data-testid={testId}
+      data-full-page={fullPage}
+    >
+      <PaneActions>
+        <PaneHeading>{heading}</PaneHeading>
+        <GoabIconButton
+          icon={fullPage ? 'contract' : 'expand'}
+          size="small"
+          title={toggleLabel}
+          ariaLabel={toggleLabel}
+          testId={`${testId}-toggle`}
+          onClick={() => setFullPage((current) => !current)}
+        />
+      </PaneActions>
+      <PaneContent>{children}</PaneContent>
+    </Pane>
+  );
+};

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.spec.tsx
@@ -36,6 +36,7 @@ jest.mock('@store/file/actions', () => ({
 const ACCORDION_SELECTOR = "goa-accordion[testid='email-template-properties']";
 const ERROR_BADGE_SELECTOR = "goa-badge[testid='email-template-properties-error']";
 const PREVIEW_BUTTON_SELECTOR = "goa-button[testid='toggle-email-preview']";
+const FULL_PAGE_BUTTON_SELECTOR = "goa-icon-button[testid='notification-body-editor-toggle']";
 
 const mockStore = configureStore([]);
 
@@ -162,5 +163,30 @@ describe('TemplateEditor properties section', () => {
     fireEvent(baseElement.querySelector(PREVIEW_BUTTON_SELECTOR), new CustomEvent('_click'));
 
     expect(onTogglePreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('puts the body editor into full page mode', () => {
+    // Arrange
+    const { baseElement, getByTestId } = renderEditor();
+    const toggleButton = baseElement.querySelector(FULL_PAGE_BUTTON_SELECTOR);
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('notification-body-editor')).toHaveAttribute('data-full-page', 'true');
+  });
+
+  it('returns the body editor to its regular size', () => {
+    // Arrange
+    const { baseElement, getByTestId } = renderEditor();
+    const toggleButton = baseElement.querySelector(FULL_PAGE_BUTTON_SELECTOR);
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('notification-body-editor')).toHaveAttribute('data-full-page', 'false');
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/TemplateEditor.tsx
@@ -24,6 +24,7 @@ import { Attachment } from '@core-services/app-common';
 import { AnyAction } from 'redux';
 
 import MonacoEditor, { useMonaco } from '@monaco-editor/react';
+import { FullPagePane } from '@components/FullPagePane';
 import { languages } from 'monaco-editor';
 import { buildSuggestions, triggerInScope } from '@lib/autoComplete';
 import { Template, baseTemplate } from '@store/notification/models';
@@ -310,6 +311,10 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
         >
           {radioOptions.map((item, key) => {
             const isPropertiesOpen = propertiesOpenMap[item.name] ?? true;
+            // The body editor takes the space the properties section is not using.
+            const bodyEditorHeight = isPropertiesOpen
+              ? 'max(200px, calc(100vh - 450px))'
+              : 'max(200px, calc(100vh - 340px))';
 
             return (
               <Tab
@@ -460,17 +465,24 @@ export const TemplateEditor: FunctionComponent<TemplateEditorProps> = ({
                       })()}
                   </GoabAccordion>
 
-                  <GoabFormItem error={errors['body'] ?? ''} mb={'s'} label="Body">
-                    <MonacoDivBody data-testid="templated-editor-body" $compact={!isPropertiesOpen}>
-                      <MonacoEditor
-                        language={item.name === 'slack' ? 'markdown' : 'handlebars'}
-                        value={templates[item.name]?.body}
-                        onChange={(value, event) => {
-                          onBodyChange(value, item.name);
-                        }}
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
+                  <GoabFormItem error={errors['body'] ?? ''} mb={'s'} label="">
+                    <FullPagePane
+                      label="Body"
+                      heading="Body"
+                      testId="notification-body-editor"
+                      height={bodyEditorHeight}
+                    >
+                      <MonacoDivBody data-testid="templated-editor-body">
+                        <MonacoEditor
+                          language={item.name === 'slack' ? 'markdown' : 'handlebars'}
+                          value={templates[item.name]?.body}
+                          onChange={(value, event) => {
+                            onBodyChange(value, item.name);
+                          }}
+                          {...bodyEditorConfig}
+                        />
+                      </MonacoDivBody>
+                    </FullPagePane>
                   </GoabFormItem>
                 </>
               </Tab>

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MonacoDivBody } from './styled-components';
+
+describe('MonacoDivBody', () => {
+  it('fills the pane that owns its height', () => {
+    // Arrange
+    const { getByTestId } = render(<MonacoDivBody data-testid="templated-editor-body" />);
+
+    // Act
+    const body = getByTestId('templated-editor-body');
+
+    // Assert
+    expect(body).toHaveStyle('height: 100%');
+  });
+
+  it('stays usable when the pane is short', () => {
+    // Arrange
+    const { getByTestId } = render(<MonacoDivBody data-testid="templated-editor-body" />);
+
+    // Act
+    const body = getByTestId('templated-editor-body');
+
+    // Assert
+    expect(body).toHaveStyle('min-height: 200px');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/notifications/previewEditor/styled-components.ts
@@ -54,12 +54,12 @@ export const MonacoDiv = styled.div`
   border-radius: 3px;
   padding: 0.15rem 0.15rem;
 `;
-export const MonacoDivBody = styled.div<{ $compact?: boolean }>`
+export const MonacoDivBody = styled.div`
   display: flex;
   border: 1px solid var(--color-gray-700);
   border-radius: 3px;
   padding: 0.15rem 0.15rem;
-  height: ${({ $compact }) => ($compact ? 'max(200px, calc(100vh - 340px))' : 'max(200px, calc(100vh - 450px))')};
+  height: 100%;
   min-height: 200px;
 `;
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.spec.tsx
@@ -146,4 +146,37 @@ describe('Pdf Component', () => {
     // Assert
     expect(toggleLabel).toBeInTheDocument();
   });
+
+  it('puts the template editor into full page mode', () => {
+    // Arrange
+    const { baseElement, getByTestId } = render(
+      <Provider store={store}>
+        <TemplateEditor previewVisible onTogglePreview={jest.fn()} />
+      </Provider>,
+    );
+    const toggleButton = baseElement.querySelector("goa-icon-button[testid='pdf-header-editor-toggle']");
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('pdf-header-editor')).toHaveAttribute('data-full-page', 'true');
+  });
+
+  it('returns the template editor to its regular size', () => {
+    // Arrange
+    const { baseElement, getByTestId } = render(
+      <Provider store={store}>
+        <TemplateEditor previewVisible onTogglePreview={jest.fn()} />
+      </Provider>,
+    );
+    const toggleButton = baseElement.querySelector("goa-icon-button[testid='pdf-header-editor-toggle']");
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('pdf-header-editor')).toHaveAttribute('data-full-page', 'false');
+  });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/TemplateEditor.tsx
@@ -44,6 +44,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useDebounce } from '@lib/useDebounce';
 import { selectPdfTemplateById, selectCorePdfTemplateById } from '@store/pdf/selectors';
 import { CustomLoader } from '@components/CustomLoader';
+import { FullPagePane } from '@components/FullPagePane';
 import useWindowDimensions from '@lib/useWindowDimensions';
 import { v4 as uuid } from 'uuid';
 
@@ -308,92 +309,102 @@ export const TemplateEditor = ({
                   <GoabFormItem error={errors?.header ?? ''} label="">
                     <div>
                       {pdfTemplate && (
-                        <MonacoDivBody>
-                          <MonacoEditor
-                            height={monacoHeight}
-                            language={'handlebars'}
-                            value={tmpTemplate?.header}
-                            data-testid="templateForm-header"
-                            onChange={(value) => {
-                              setTmpTemplate({ ...tmpTemplate, header: value });
-                            }}
-                            {...bodyEditorConfig}
-                          />
-                        </MonacoDivBody>
+                        <FullPagePane label="Header" testId="pdf-header-editor" height={monacoHeight}>
+                          <MonacoDivBody>
+                            <MonacoEditor
+                              height="100%"
+                              language={'handlebars'}
+                              value={tmpTemplate?.header}
+                              data-testid="templateForm-header"
+                              onChange={(value) => {
+                                setTmpTemplate({ ...tmpTemplate, header: value });
+                              }}
+                              {...bodyEditorConfig}
+                            />
+                          </MonacoDivBody>
+                        </FullPagePane>
                       )}
                     </div>
                   </GoabFormItem>
                 </Tab>
                 <Tab testId={`pdf-edit-body`} label={<PdfEditorLabelWrapper>Body</PdfEditorLabelWrapper>}>
                   <GoabFormItem error={errors?.body ?? null} label="">
-                    <MonacoDivBody>
-                      <MonacoEditor
-                        height={monacoHeight}
-                        language={'handlebars'}
-                        value={tmpTemplate?.template}
-                        data-testid="templateForm-body"
-                        onChange={(value) => {
-                          setTmpTemplate({ ...tmpTemplate, template: value });
-                        }}
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
+                    <FullPagePane label="Body" testId="pdf-body-editor" height={monacoHeight}>
+                      <MonacoDivBody>
+                        <MonacoEditor
+                          height="100%"
+                          language={'handlebars'}
+                          value={tmpTemplate?.template}
+                          data-testid="templateForm-body"
+                          onChange={(value) => {
+                            setTmpTemplate({ ...tmpTemplate, template: value });
+                          }}
+                          {...bodyEditorConfig}
+                        />
+                      </MonacoDivBody>
+                    </FullPagePane>
                   </GoabFormItem>
                 </Tab>
                 <Tab testId={`pdf-edit-footer`} label={<PdfEditorLabelWrapper>Footer</PdfEditorLabelWrapper>}>
                   <GoabFormItem error={errors?.footer ?? ''} label="">
-                    <MonacoDivBody style={{ height: monacoHeight }}>
-                      <MonacoEditor
-                        language={'handlebars'}
-                        value={tmpTemplate?.footer}
-                        data-testid="templateForm-footer"
-                        onChange={(value) => {
-                          setTmpTemplate({ ...tmpTemplate, footer: value });
-                        }}
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
+                    <FullPagePane label="Footer" testId="pdf-footer-editor" height={monacoHeight}>
+                      <MonacoDivBody>
+                        <MonacoEditor
+                          language={'handlebars'}
+                          value={tmpTemplate?.footer}
+                          data-testid="templateForm-footer"
+                          onChange={(value) => {
+                            setTmpTemplate({ ...tmpTemplate, footer: value });
+                          }}
+                          {...bodyEditorConfig}
+                        />
+                      </MonacoDivBody>
+                    </FullPagePane>
                   </GoabFormItem>
                 </Tab>
                 <Tab testId={`pdf-edit-css`} label={<PdfEditorLabelWrapper>CSS</PdfEditorLabelWrapper>}>
                   <GoabFormItem error={errors?.body ?? null} label="">
-                    <MonacoDivBody style={{ height: monacoHeight }}>
-                      <MonacoEditor
-                        language={'handlebars'}
-                        value={tmpTemplate?.additionalStyles}
-                        data-testid="templateForm-css"
-                        onChange={(value) => {
-                          setTmpTemplate({ ...tmpTemplate, additionalStyles: value });
-                        }}
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
+                    <FullPagePane label="CSS" testId="pdf-css-editor" height={monacoHeight}>
+                      <MonacoDivBody>
+                        <MonacoEditor
+                          language={'handlebars'}
+                          value={tmpTemplate?.additionalStyles}
+                          data-testid="templateForm-css"
+                          onChange={(value) => {
+                            setTmpTemplate({ ...tmpTemplate, additionalStyles: value });
+                          }}
+                          {...bodyEditorConfig}
+                        />
+                      </MonacoDivBody>
+                    </FullPagePane>
                   </GoabFormItem>
                 </Tab>
                 <Tab testId={`pdf-test-generator`} label={<PdfEditorLabelWrapper>Test data</PdfEditorLabelWrapper>}>
                   <GoabFormItem error={errors?.body ?? EditorError?.testData ?? null} label="">
-                    <MonacoDivBody style={{ height: monacoHeight }}>
-                      <MonacoEditor
-                        data-testid="form-schema"
-                        value={tmpTemplate?.variables}
-                        onChange={(value) => {
-                          setTmpTemplate({ ...tmpTemplate, variables: value });
-                        }}
-                        onValidate={(makers) => {
-                          if (makers.length !== 0) {
-                            setEditorError({
-                              testData: `Invalid JSON: col ${makers[0]?.endColumn}, line: ${makers[0]?.endLineNumber}, ${makers[0]?.message}`,
-                            });
-                          } else {
-                            setEditorError({
-                              testData: null,
-                            });
-                          }
-                        }}
-                        language="json"
-                        {...bodyEditorConfig}
-                      />
-                    </MonacoDivBody>
+                    <FullPagePane label="Test data" testId="pdf-test-data-editor" height={monacoHeight}>
+                      <MonacoDivBody>
+                        <MonacoEditor
+                          data-testid="form-schema"
+                          value={tmpTemplate?.variables}
+                          onChange={(value) => {
+                            setTmpTemplate({ ...tmpTemplate, variables: value });
+                          }}
+                          onValidate={(makers) => {
+                            if (makers.length !== 0) {
+                              setEditorError({
+                                testData: `Invalid JSON: col ${makers[0]?.endColumn}, line: ${makers[0]?.endLineNumber}, ${makers[0]?.message}`,
+                              });
+                            } else {
+                              setEditorError({
+                                testData: null,
+                              });
+                            }
+                          }}
+                          language="json"
+                          {...bodyEditorConfig}
+                        />
+                      </MonacoDivBody>
+                    </FullPagePane>
                   </GoabFormItem>
                 </Tab>
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/config.spec.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/config.spec.ts
@@ -1,0 +1,14 @@
+import { bodyEditorConfig } from './config';
+
+describe('bodyEditorConfig', () => {
+  it('lets Monaco relayout itself when the editor pane changes size', () => {
+    // Arrange
+    const { options } = bodyEditorConfig;
+
+    // Act
+    const automaticLayout = options?.automaticLayout;
+
+    // Assert
+    expect(automaticLayout).toBe(true);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/config.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/pdf/templates/previewEditor/config.ts
@@ -2,6 +2,8 @@ import { EditorProps } from '@monaco-editor/react';
 
 export const bodyEditorConfig: EditorProps = {
   options: {
+    // The editor pane changes size when it goes full page, so Monaco has to relayout itself.
+    automaticLayout: true,
     tabSize: 2,
     minimap: { enabled: false },
     overviewRulerBorder: false,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/config.spec.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/config.spec.ts
@@ -1,0 +1,14 @@
+import { scriptEditorConfig } from './config';
+
+describe('scriptEditorConfig', () => {
+  it('lets Monaco relayout itself when the editor pane changes size', () => {
+    // Arrange
+    const { options } = scriptEditorConfig;
+
+    // Act
+    const automaticLayout = options.automaticLayout;
+
+    // Assert
+    expect(automaticLayout).toBe(true);
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/config.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/config.ts
@@ -1,6 +1,8 @@
 export const scriptEditorConfig = {
   'data-testid': 'templateForm-body',
   options: {
+    // The editor pane changes size when it goes full page, so Monaco has to relayout itself.
+    automaticLayout: true,
     tabSize: 2,
     minimap: { enabled: false },
     overviewRulerBorder: false,

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { ScriptEditor, ScriptEditorProps } from './scriptEditor';
 import { ScriptItem } from '@store/script/models';
 import { Provider } from 'react-redux';
@@ -141,5 +142,27 @@ describe('ScriptEditor Component', () => {
     await waitFor(() => {
       expect(require('react-router-dom').useHistory().push).not.toHaveBeenCalled();
     });
+  });
+
+  test('puts the lua script editor into full page mode and back', () => {
+    // Arrange
+    const { baseElement, getByTestId } = render(
+      <Provider store={store}>
+        <ScriptEditor {...mockScriptEditorProps} />
+      </Provider>
+    );
+    const toggleButton = baseElement.querySelector("goa-icon-button[testid='script-editor-toggle']");
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('script-editor')).toHaveAttribute('data-full-page', 'true');
+
+    // Act
+    fireEvent(toggleButton, new CustomEvent('_click'));
+
+    // Assert
+    expect(getByTestId('script-editor')).toHaveAttribute('data-full-page', 'false');
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/script/editor/scriptEditor.tsx
@@ -17,6 +17,7 @@ import {
 import { TombStone } from './tombstone';
 
 import MonacoEditor, { useMonaco } from '@monaco-editor/react';
+import { FullPagePane } from '@components/FullPagePane';
 import { languages } from 'monaco-editor';
 import { SaveFormModal } from '@components/saveModal';
 import { ScriptItem } from '@store/script/models';
@@ -356,17 +357,19 @@ export const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
             </div>
             <Tabs activeIndex={activeIndex} data-testid="editor-tabs">
               <Tab label="Lua script" data-testid="script-editor-tab">
-                <MonacoDivBody data-testid="templated-editor-body">
-                  <MonacoEditor
-                    height={monacoHeight}
-                    language={'lua'}
-                    value={scriptStr}
-                    {...scriptEditorConfig}
-                    onChange={(value) => {
-                      onScriptChange(value);
-                    }}
-                  />
-                </MonacoDivBody>
+                <FullPagePane label="Lua script" testId="script-editor" height={monacoHeight}>
+                  <MonacoDivBody data-testid="templated-editor-body">
+                    <MonacoEditor
+                      height="100%"
+                      language={'lua'}
+                      value={scriptStr}
+                      {...scriptEditorConfig}
+                      onChange={(value) => {
+                        onScriptChange(value);
+                      }}
+                    />
+                  </MonacoDivBody>
+                </FullPagePane>
               </Tab>
               <Tab label="Roles" data-testid="script-roles-tab">
                 <MonacoDivTabBody data-testid="roles-editor-body">

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -25,6 +25,7 @@ import { ClientRoleTable } from '@components/RoleTable';
 import { SaveFormModal } from '@components/saveModal';
 import { Tab, Tabs } from '@components/Tabs';
 import { PageIndicator } from '@components/Indicator';
+import { FullPagePane } from '@components/FullPagePane';
 import DataTable from '@components/DataTable';
 import { DeleteModal } from '@components/DeleteModal';
 import { CustomLoader } from '@components/CustomLoader';
@@ -548,102 +549,106 @@ export function AddEditFormDefinitionEditor({
                       error={errors?.body ?? editorErrors?.dataSchemaJSON ?? editorErrors?.dataSchemaJSONSchema ?? null}
                       label=""
                     >
-                      <EditorPadding>
-                        <MonacoEditor
-                          data-testid="form-data-schema"
-                          height={EditorHeight}
-                          value={tempDataSchema}
-                          onMount={handleEditorDidMountData}
-                          onChange={(value) => {
-                            const jsonSchemaValidResult = JSONSchemaValidator(value);
-                            dispatch(setDraftDataSchema(value));
+                      <FullPagePane label="Data schema" testId="form-data-schema-editor" height={EditorHeight}>
+                        <EditorPadding>
+                          <MonacoEditor
+                            data-testid="form-data-schema"
+                            height="100%"
+                            value={tempDataSchema}
+                            onMount={handleEditorDidMountData}
+                            onChange={(value) => {
+                              const jsonSchemaValidResult = JSONSchemaValidator(value);
+                              dispatch(setDraftDataSchema(value));
 
-                            if (jsonSchemaValidResult === '') {
+                              if (jsonSchemaValidResult === '') {
+                                setEditorErrors({
+                                  ...editorErrors,
+                                  dataSchemaJSONSchema: null,
+                                });
+                              } else {
+                                setEditorErrors({
+                                  ...editorErrors,
+                                  dataSchemaJSONSchema: jsonSchemaValidResult,
+                                });
+                              }
+                            }}
+                            onValidate={(makers) => {
+                              if (makers.length === 0) {
+                                setEditorErrors({
+                                  ...editorErrors,
+                                  dataSchemaJSON: null,
+                                });
+                                return;
+                              }
                               setEditorErrors({
                                 ...editorErrors,
-                                dataSchemaJSONSchema: null,
+                                dataSchemaJSON: `Invalid JSON: col ${makers[0]?.endColumn}, line: ${makers[0]?.endLineNumber}, ${makers[0]?.message}`,
                               });
-                            } else {
-                              setEditorErrors({
-                                ...editorErrors,
-                                dataSchemaJSONSchema: jsonSchemaValidResult,
-                              });
-                            }
-                          }}
-                          onValidate={(makers) => {
-                            if (makers.length === 0) {
-                              setEditorErrors({
-                                ...editorErrors,
-                                dataSchemaJSON: null,
-                              });
-                              return;
-                            }
-                            setEditorErrors({
-                              ...editorErrors,
-                              dataSchemaJSON: `Invalid JSON: col ${makers[0]?.endColumn}, line: ${makers[0]?.endLineNumber}, ${makers[0]?.message}`,
-                            });
-                          }}
-                          language="json"
-                          options={{
-                            autoClosingQuotes: 'never',
-                            automaticLayout: true,
-                            scrollBeyondLastLine: false,
-                            lineNumbersMinChars: 2,
-                            tabSize: 2,
-                            padding: {
-                              top: 8,
-                            },
-                            minimap: { enabled: isUseMiniMap },
-                            folding: true,
-                            foldingStrategy: 'auto',
-                            showFoldingControls: 'always',
-                          }}
-                        />
-                      </EditorPadding>
+                            }}
+                            language="json"
+                            options={{
+                              autoClosingQuotes: 'never',
+                              automaticLayout: true,
+                              scrollBeyondLastLine: false,
+                              lineNumbersMinChars: 2,
+                              tabSize: 2,
+                              padding: {
+                                top: 8,
+                              },
+                              minimap: { enabled: isUseMiniMap },
+                              folding: true,
+                              foldingStrategy: 'auto',
+                              showFoldingControls: 'always',
+                            }}
+                          />
+                        </EditorPadding>
+                      </FullPagePane>
                     </GoabFormItem>
                   </Tab>
                   <Tab label="UI schema" data-testid="form-editor-ui-schema-tab" isTightContent={true}>
                     <GoabFormItem error={errors?.body ?? editorErrors?.uiSchema ?? null} label="">
-                      <EditorPadding>
-                        <MonacoEditor
-                          data-testid="form-ui-schema"
-                          height={EditorHeight}
-                          value={tempUiSchema}
-                          {...formEditorJsonConfig}
-                          onValidate={(makers) => {
-                            if (makers.length === 0) {
+                      <FullPagePane label="UI schema" testId="form-ui-schema-editor" height={EditorHeight}>
+                        <EditorPadding>
+                          <MonacoEditor
+                            data-testid="form-ui-schema"
+                            height="100%"
+                            value={tempUiSchema}
+                            {...formEditorJsonConfig}
+                            onValidate={(makers) => {
+                              if (makers.length === 0) {
+                                setEditorErrors({
+                                  ...editorErrors,
+                                  uiSchema: null,
+                                });
+                                return;
+                              }
                               setEditorErrors({
                                 ...editorErrors,
-                                uiSchema: null,
+                                uiSchema: `Invalid JSON: col ${makers[0]?.endColumn}, line: ${makers[0]?.endLineNumber}, ${makers[0]?.message}`,
                               });
-                              return;
-                            }
-                            setEditorErrors({
-                              ...editorErrors,
-                              uiSchema: `Invalid JSON: col ${makers[0]?.endColumn}, line: ${makers[0]?.endLineNumber}, ${makers[0]?.message}`,
-                            });
-                          }}
-                          onMount={handleEditorDidMountUi}
-                          onChange={(value) => {
-                            dispatch(setDraftUISchema(value));
-                          }}
-                          language="json"
-                          options={{
-                            autoClosingQuotes: 'never',
-                            automaticLayout: true,
-                            scrollBeyondLastLine: false,
-                            wordWrap: 'on',
-                            tabSize: 2,
-                            padding: {
-                              top: 8,
-                            },
-                            minimap: { enabled: isUseMiniMap },
-                            folding: true,
-                            foldingStrategy: 'auto',
-                            showFoldingControls: 'always',
-                          }}
-                        />
-                      </EditorPadding>
+                            }}
+                            onMount={handleEditorDidMountUi}
+                            onChange={(value) => {
+                              dispatch(setDraftUISchema(value));
+                            }}
+                            language="json"
+                            options={{
+                              autoClosingQuotes: 'never',
+                              automaticLayout: true,
+                              scrollBeyondLastLine: false,
+                              wordWrap: 'on',
+                              tabSize: 2,
+                              padding: {
+                                top: 8,
+                              },
+                              minimap: { enabled: isUseMiniMap },
+                              folding: true,
+                              foldingStrategy: 'auto',
+                              showFoldingControls: 'always',
+                            }}
+                          />
+                        </EditorPadding>
+                      </FullPagePane>
                     </GoabFormItem>
                   </Tab>
                   {formAIEnabled && (

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -25,7 +25,7 @@ import { ClientRoleTable } from '@components/RoleTable';
 import { SaveFormModal } from '@components/saveModal';
 import { Tab, Tabs } from '@components/Tabs';
 import { PageIndicator } from '@components/Indicator';
-import { FullPagePane } from '@components/FullPagePane';
+import { FullPagePane } from '@components/FullPagePane'; // clean-code-ignore: RULE-19 — see the note at the top of this file.
 import DataTable from '@components/DataTable';
 import { DeleteModal } from '@components/DeleteModal';
 import { CustomLoader } from '@components/CustomLoader';


### PR DESCRIPTION
Adds a full page toggle to the ADSP template editors, so the Monaco editor is not constricted by the surrounding page.

- New `FullPagePane` wraps an editor with an expand icon that lifts it to a full viewport overlay, and a contract icon (or Escape) that returns it to its place. The pane stays mounted, so content, cursor and undo history survive the switch.
- Applied to the PDF template tabs (header, body, footer, CSS, test data), the form data and UI schema editors, the notification email body and the Lua script editor.
- Each host now passes its height to the pane rather than to Monaco, so full page mode can override it; `automaticLayout` turned on where it was missing.
- The notification body's "Body" label moved onto the toggle row via the pane's optional `heading`.

Tests: new `FullPagePane.spec.tsx`, plus toggle round trips in the PDF, notification and script editor specs.