### PR TITLE
fix(jsonforms-components): CS-5333 land on the task list instead of the first page

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -328,6 +328,123 @@ describe('JsonFormsStepperContext', () => {
     });
   });
 
+  // CS-5333: a pages variant form opens on the task list, and the recompute that runs on mount and
+  // on every data change afterwards must not move the user off it.
+  describe('task list landing', () => {
+    const taskListUischema = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Category',
+          label: 'Personal details',
+          elements: [{ type: 'Control', scope: '#/properties/firstName' }],
+        },
+        {
+          type: 'Category',
+          label: 'Contact details',
+          elements: [{ type: 'Control', scope: '#/properties/lastName' }],
+        },
+      ],
+      options: { variant: 'pages', showNavButtons: true },
+    };
+
+    const ActiveIdProbe = (): JSX.Element => {
+      const ctx = useContext(JsonFormsStepperContext) as JsonFormsStepperContextProps;
+      const { activeId, categories } = ctx.selectStepperState();
+
+      return (
+        <div>
+          <div data-testid="active-id">{activeId}</div>
+          {/* The task list is rendered for the sentinel id one past the last page. */}
+          <div data-testid="is-task-list">{(activeId === categories.length + 1).toString()}</div>
+          <button data-testid="open-page-1" onClick={() => ctx.goToPage(1)}>
+            open
+          </button>
+        </div>
+      );
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const renderTaskListStepper = (data: any, uischema: unknown = taskListUischema) => (
+      <JsonFormsStepperContextProvider
+        StepperProps={
+          {
+            ...stepperBaseProps,
+            uischema,
+            data,
+          } as unknown as CategorizationStepperLayoutRendererProps
+        }
+      >
+        <ActiveIdProbe />
+      </JsonFormsStepperContextProvider>
+    );
+
+    test('opens on the task list rather than the first page', () => {
+      // Arrange / Act
+      render(renderTaskListStepper({}));
+
+      // Assert
+      expect(screen.getByTestId('is-task-list').textContent).toBe('true');
+      expect(screen.getByTestId('active-id').textContent).toBe('3');
+    });
+
+    test('stays on the task list when saved data arrives after mount', () => {
+      // Arrange
+      const { rerender } = render(renderTaskListStepper({}));
+
+      // Act: the form loads its draft, which re-runs the recompute.
+      act(() => {
+        rerender(renderTaskListStepper({ firstName: 'Alex' }));
+      });
+
+      // Assert
+      expect(screen.getByTestId('is-task-list').textContent).toBe('true');
+    });
+
+    test('stays on the task list when a page count change shifts the sentinel', () => {
+      // Arrange
+      const { rerender } = render(renderTaskListStepper({}));
+
+      // Act: a conditional page appears, so the sentinel is no longer the id it was on mount.
+      const withExtraPage = {
+        ...taskListUischema,
+        elements: [
+          ...taskListUischema.elements,
+          {
+            type: 'Category',
+            label: 'Extra details',
+            elements: [{ type: 'Control', scope: '#/properties/lastName' }],
+          },
+        ],
+      };
+      act(() => {
+        rerender(renderTaskListStepper({ firstName: 'Alex' }, withExtraPage));
+      });
+
+      // Assert: the review page would be id 3, so the sentinel has to move to 4 with it.
+      expect(screen.getByTestId('is-task-list').textContent).toBe('true');
+      expect(screen.getByTestId('active-id').textContent).toBe('4');
+    });
+
+    test('keeps the user on the page they opened when data changes', () => {
+      // Arrange
+      const { rerender } = render(renderTaskListStepper({}));
+      act(() => {
+        fireEvent.click(screen.getByTestId('open-page-1'));
+      });
+      expect(screen.getByTestId('active-id').textContent).toBe('1');
+
+      // Act
+      act(() => {
+        rerender(renderTaskListStepper({ lastName: 'Smith' }));
+      });
+
+      // Assert
+      expect(screen.getByTestId('active-id').textContent).toBe('1');
+      expect(screen.getByTestId('is-task-list').textContent).toBe('false');
+    });
+  });
+
   test('handles missing context gracefully', () => {
     // Arrange
     const MissingContextComponent = (): JSX.Element => {

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.tsx
@@ -293,13 +293,22 @@ export const JsonFormsStepperContextProvider = ({
   useEffect(() => {
     if (context?.isProvided === true) {
       /* The block is used to cache the state for the tenant web app review editor  */
+      // The task list is the sentinel id past the last page, which sits above maxReachedStep until
+      // the user opens something, so clamping would drop them onto the first page on the recompute
+      // that follows mount. Real pages survive the clamp only because the goToPage pair below puts
+      // them back, and that is deliberately skipped while the task list is showing.
+      const isOnTaskList = stepperState.activeId === stepperState.categories.length + 1;
+
       stepperDispatch({
         type: 'update/uischema',
         payload: {
           state: createStepperContextInitData(
             {
               ...StepperProps,
-              activeId: Math.min(stepperState?.activeId, stepperState.maxReachedStep),
+              // Leaving activeId out lets init recompute the sentinel from the categories this
+              // recompute produced, so a conditional page appearing or disappearing still lands on
+              // the task list rather than on the review page.
+              activeId: isOnTaskList ? undefined : Math.min(stepperState?.activeId, stepperState.maxReachedStep),
             },
             {
               visitedIds: new Set([
@@ -312,7 +321,7 @@ export const JsonFormsStepperContextProvider = ({
         },
       });
 
-      if (stepperState.activeId !== stepperState.categories.length + 1) {
+      if (!isOnTaskList) {
         context.goToPage(stepperState.maxReachedStep);
         context.goToPage(stepperState.activeId);
       }


### PR DESCRIPTION
Fixes the regression the nightly form-app e2e run caught: a pages variant form opened on step 1 instead of its task list.

The recompute that runs on mount (and on every data change after it) passed `activeId: Math.min(activeId, maxReachedStep)`. The task list is the sentinel id one past the last page, and `maxReachedStep` starts at 0, so it was clamped to 0. Real pages survive that clamp only because the `goToPage` pair below the dispatch puts them back, and that is deliberately skipped while the task list is showing — so nothing restored it. Introduced in 1a2abeac0.

The clamp is now skipped on the task list, and `activeId` is left out so init recomputes the sentinel from the categories that recompute produced — a conditional page appearing or disappearing keeps it on the task list rather than the review page.

Tests: four cases in `StepperContext.spec.tsx` (opens on the task list, survives data arriving after mount, survives a page count change, and still keeps the user on a page they opened). The first three fail without the fix. Full jsonforms-components suite (1448) and form-app unit tests pass. Not manually run against a tenant; the nightly e2e covers the acceptance criteria.