### PR TITLE
fix(observability): expire idle spanmetrics series, widen the service graph pairing window

### DIFF
--- a/.openshift/observability/observability-stack.yml
+++ b/.openshift/observability/observability-stack.yml
@@ -503,11 +503,23 @@ objects:
               - http.method
               - http.status_code
             store:
-              ttl: 2s
+              # The connector holds a span here waiting for its pair. The batch processor above uses a
+              # 5s timeout, so a client span and its server span can legitimately arrive up to ~5s
+              # apart from two different services -- at the 2s default the edge expired unpaired,
+              # which is one reason edges show a callee of "unknown". Bounded by max_items so a burst
+              # of unpaired spans cannot grow the collector's heap without limit.
+              ttl: 10s
+              max_items: 10000
           # NOTE: these buckets and dimensions multiply the spanmetrics series count. Do not apply
           # them to an environment until every service runs an adsp-service-sdk with bounded span
           # names (the route-template fix), or Prometheus will OOM on span_name cardinality.
           spanmetrics:
+            # Without this the connector exports every span name it has ever seen, forever. Measured
+            # before the change: 113 of 127 span names in dev (89%) and 245 of 319 in uat (77%) had
+            # seen no call in 15 minutes yet were still being scraped every interval -- so they never
+            # went stale in Prometheus and retention never expired them. Series that go quiet now
+            # stop being exported and age out normally.
+            metrics_expiration: 15m
             histogram:
               explicit:
                 buckets: [2ms, 5ms, 10ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s]


### PR DESCRIPTION
Two collector connector settings, both found while investigating why cleaning up old metric data appeared impossible.

**Applied to `adsp-dev` and `adsp-uat`** before opening this.

## spanmetrics kept every span name forever

There was no `metrics_expiration`, so the connector exported every span name it had ever seen for the lifetime of the process:

| | span names exported | saw a call in 15m | idle |
|---|---|---|---|
| dev | 127 | 14 | **113 (89%)** |
| uat | 319 | 74 | **245 (77%)** |

The consequence is the non-obvious part: because those series were still being *written*, Prometheus never marked them stale — measured staleness was **0%** — so retention never expired them, and **no cleanup could stick.** Anything deleted was re-exported within a scrape interval. Head series had reached 33k in dev and 96k in uat.

`metrics_expiration: 15m` lets quiet series stop being exported, go stale normally, and age out with retention. Roughly a fivefold reduction in spanmetrics series on these numbers.

Trade-off worth knowing: a series that later resumes restarts its counter, which reads as a reset. Prometheus handles resets in `rate()`/`increase()`, and it is clearly preferable to unbounded growth — but it does mean more reset events, not fewer.

## servicegraph pairing window was too short

`store.ttl` was the `2s` default. The connector holds a span waiting for its pair, and the `batch` processor above it uses a **5s** timeout — so a client span and its server span can legitimately arrive ~5s apart from two different services. At 2s the edge expired unpaired, which is one reason edges show a callee of `unknown`:

```
dev  8 of 18 edges  server=unknown
uat  9 of 24 edges  server=unknown
```

Raised to `10s`, bounded with `max_items: 10000` so a burst of unpaired spans cannot grow the heap without limit — relevant given the `memory_limiter` mismatch fixed in #5800.

## Validation

`otelcol validate` against `contrib:0.125.0` passes, **and** a control run with a deliberately bogus key inside the same blocks fails — so the validator is genuinely checking these settings rather than ignoring unknown fields.

## Blast radius

Only the collector ConfigMap changes:

- No SDK change, no service change, **no service redeploy**.
- No Prometheus reload needed.
- Collector rollout is two replicas one at a time, ingestion continuing on the survivor.
- All four replicas across both environments came up healthy, zero restarts, 31Mi against the 1Gi limit.

## One thing to expect afterwards

Head series **ticks up** briefly on a collector restart, because per-replica scraping keys `instance` on the pod IP and new pods mint new series. Those are self-correcting — the dead targets go stale immediately and age out.

That is the better failure mode than the previous shared ClusterIP label, where a restart silently reset counters behind a stable series and corrupted every `rate()` spanning the boundary. That artifact has repeatedly produced nonsense during this work — 102 requests reading as 6,147/hour, and a probe endpoint at a genuine 0.43/s reading as 190/s. Raw counter deltas remain the trustworthy read across a deploy boundary; `rate()` does not.

## Follow-up

`prometheus.yml` still has no `rule_files` and there is no Alertmanager, so none of this alerts. Given how much of this work has been "nobody noticed until someone looked", that remains the largest gap in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
