### PR TITLE
fix(tenant-management-webapp): CS-5326 clear the add notice modal on open

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.spec.tsx
@@ -28,12 +28,13 @@ describe('NoticeModal', () => {
       notice: { notices: [notice] },
     });
 
-  const renderModal = (store, noticeId?: string) =>
-    render(
-      <Provider store={store}>
-        <NoticeModal title={noticeId ? 'Edit notice' : 'Add notice'} isOpen={true} noticeId={noticeId} />
-      </Provider>
-    );
+  const modal = (store, isOpen: boolean, noticeId?: string) => (
+    <Provider store={store}>
+      <NoticeModal title={noticeId ? 'Edit notice' : 'Add notice'} isOpen={isOpen} noticeId={noticeId} />
+    </Provider>
+  );
+
+  const renderModal = (store, noticeId?: string) => render(modal(store, true, noticeId));
 
   const changeValue = (baseElement: Element, selector: string, value: string) => {
     const element = baseElement.querySelector(selector);
@@ -68,6 +69,22 @@ describe('NoticeModal', () => {
     );
     expect(baseElement.querySelector("goa-input[testId='notice-form-end-date-picker']").getAttribute('value')).toBe(
       '2026-08-27'
+    );
+  });
+
+  it('clears the form when the add notice modal is reopened', () => {
+    const store = createStore();
+    const { baseElement, rerender } = renderModal(store);
+
+    changeValue(baseElement, "goa-textarea[testId='notice-form-description']", 'howard-test');
+    changeValue(baseElement, "goa-dropdown[testId='application-dropdown-list']", 'Autotest');
+
+    rerender(modal(store, false));
+    rerender(modal(store, true));
+
+    expect(baseElement.querySelector("goa-textarea[testId='notice-form-description']").getAttribute('value')).toBe('');
+    expect(baseElement.querySelector("goa-dropdown[testId='application-dropdown-list']").getAttribute('value')).toBe(
+      ''
     );
   });
 

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.tsx
@@ -49,29 +49,31 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
 
   const noMonitorOnlyApplications = applications.filter((application) => !application.monitorOnly);
 
+  // The modal stays mounted between uses, so reset it to the notice being edited, or to
+  // empty defaults when adding, every time it is opened.
   useEffect(() => {
-    if (props.noticeId) {
-      const notice = notices.find((nt) => props?.noticeId === nt.id);
-      const currentStartDate = new Date(notice.startDate);
-      const currentEndDate = new Date(notice.endDate);
-      setStartDate(currentStartDate);
-      setEndDate(currentEndDate);
-
-      setStartTime(getTimeFromGMT(currentStartDate));
-      setEndTime(getTimeFromGMT(currentEndDate));
-      setMessage(notice.message);
-
-      let parsedApplications = [];
-      try {
-        parsedApplications = notice.tennantServRef;
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setSelectedApplications(parsedApplications);
-        setIsAllApplications(notice.isAllApplications);
-      }
+    if (!props.isOpen) {
+      return;
     }
-  }, [props.noticeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const notice = props.noticeId && notices.find((nt) => props.noticeId === nt.id);
+    if (!notice) {
+      setNoticeDefaults();
+      return;
+    }
+
+    const currentStartDate = new Date(notice.startDate);
+    const currentEndDate = new Date(notice.endDate);
+    setStartDate(currentStartDate);
+    setEndDate(currentEndDate);
+
+    setStartTime(getTimeFromGMT(currentStartDate));
+    setEndTime(getTimeFromGMT(currentEndDate));
+    setMessage(notice.message);
+    setErrors({});
+    setSelectedApplications(notice.tennantServRef ?? []);
+    setIsAllApplications(notice.isAllApplications);
+  }, [props.isOpen, props.noticeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function validDateRangeErrors() {
     if (getDateTime(endDate, endTime) < getDateTime(startDate, startTime)) {
@@ -122,7 +124,6 @@ function NoticeModal(props: NoticeModalProps): JSX.Element {
   }
 
   function cancel() {
-    setNoticeDefaults();
     if (props.onCancel) props.onCancel();
   }
 


### PR DESCRIPTION
[CS-5326](https://goa-dio.atlassian.net/browse/CS-5326)

The notice modal stays mounted between uses and only toggles `isOpen`, so saving left the previous entry in state and the next **Add notice** opened pre-populated. The effect that loaded a notice now runs on open and resets to empty defaults when there is no `noticeId`, so `cancel()` no longer has to do it.

Regression test added to `noticeModal.spec.tsx` — it fails without the fix.