### PR TITLE
fix(form-admin-app): CS-5332 highlight the current side menu item

### DIFF
--- a/apps/form-admin-app/src/app/containers/NavigationMenu.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/NavigationMenu.spec.tsx
@@ -26,16 +26,17 @@ const createState = (selectedDefinition: string = null) => ({
   },
 });
 
-const renderMenu = (selectedDefinition: string = null) =>
-  render(
-    <Provider store={mockStore(createState(selectedDefinition))}>
-      <MemoryRouter initialEntries={[`/${tenantName}/definitions`]}>
-        <Routes>
-          <Route path="/:tenant/*" element={<NavigationMenu type="side" />} />
-        </Routes>
-      </MemoryRouter>
-    </Provider>,
-  );
+const menu = (selectedDefinition: string = null) => (
+  <Provider store={mockStore(createState(selectedDefinition))}>
+    <MemoryRouter initialEntries={[`/${tenantName}/definitions`]}>
+      <Routes>
+        <Route path="/:tenant/*" element={<NavigationMenu type="side" />} />
+      </Routes>
+    </MemoryRouter>
+  </Provider>
+);
+
+const renderMenu = (selectedDefinition: string = null) => render(menu(selectedDefinition));
 
 const menuLinks = (baseElement: Element) => Array.from(baseElement.querySelectorAll('goa-side-menu a'));
 
@@ -60,6 +61,17 @@ describe('NavigationMenu', () => {
     const { queryByText } = renderMenu(definitionId);
 
     expect(queryByText('Affordability Example')).toBeNull();
+  });
+
+  it('should recreate the side menu when the selected definition changes', () => {
+    // goa-side-menu only collects its links on mount, so it has to be a new element for the
+    // definition scoped links to be highlighted when they are the current page.
+    const { baseElement, rerender } = renderMenu();
+    const before = baseElement.querySelector('goa-side-menu');
+
+    rerender(menu(definitionId));
+
+    expect(baseElement.querySelector('goa-side-menu')).not.toBe(before);
   });
 
   it('should link responses and configuration under the selected definition', () => {

--- a/apps/form-admin-app/src/app/containers/NavigationMenu.tsx
+++ b/apps/form-admin-app/src/app/containers/NavigationMenu.tsx
@@ -67,7 +67,12 @@ export const NavigationMenu: FunctionComponent<NavigationMenuProps> = ({ type })
         </span>
       )}
       <Nav type={type}>
-        <GoabSideMenu data-side-nav={true}>
+        {/*
+          goa-side-menu reads its links once when it mounts and never looks again, so links added
+          later are never marked as current. Key it on the definition to recreate it whenever the
+          definition scoped links come and go.
+        */}
+        <GoabSideMenu key={definition?.id ?? 'no-definition'} data-side-nav={true}>
           <GoabSideMenuHeading icon="documents">Form definitions</GoabSideMenuHeading>
           <a
             href={`/${tenantName}/definitions`}


### PR DESCRIPTION
[CS-5332](https://goa-dio.atlassian.net/browse/CS-5332)

`goa-side-menu` snapshots its slotted anchors once, in `onMount`, and never re-reads them. The **Responses** and **Configuration** links only render after a definition is selected, so they were never registered — the component's `current` class went to **Definitions** (the only link it knew about) no matter which page you were on.

Keying `GoabSideMenu` on the definition id recreates the element when the definition-scoped links appear or disappear, so the web component re-collects the full set and highlights the right one.

Regression test added to `NavigationMenu.spec.tsx` — it fails without the key.