### PR TITLE
fix(tenant-management-webapp): CS-5325 keep the notice year being typed

### DIFF
--- a/apps/tenant-management-webapp/src/app/lib/timeUtil.spec.ts
+++ b/apps/tenant-management-webapp/src/app/lib/timeUtil.spec.ts
@@ -115,4 +115,32 @@ describe('date only handling', () => {
     expect(result.getMinutes()).toBe(30);
     expect(result.getSeconds()).toBe(45);
   });
+
+  // A date input reports every keystroke in the year, so typing 2020 arrives as 0002, 0020, 0202 and
+  // then 2020. Each of those has to survive the round trip, or the value written back to the input
+  // replaces what the user is typing.
+  it('keeps a year in the first two centuries out of the 1900s', () => {
+    expect(parseLocalDate('0020-08-20').getFullYear()).toBe(20);
+    expect(parseLocalDate('0002-08-20').getFullYear()).toBe(2);
+    expect(parseLocalDate('0202-08-20').getFullYear()).toBe(202);
+  });
+
+  it('pads a short year to the four digits a date input needs', () => {
+    expect(toDateInputValue(parseLocalDate('0020-08-20'))).toBe('0020-08-20');
+    expect(toDateInputValue(parseLocalDate('0002-08-20'))).toBe('0002-08-20');
+    expect(toDateInputValue(parseLocalDate('0202-08-20'))).toBe('0202-08-20');
+  });
+
+  it('round trips each year a date input reports while 2020 is typed', () => {
+    ['0002-08-20', '0020-08-20', '0202-08-20', '2020-08-20'].forEach((entered) => {
+      expect(toDateInputValue(parseLocalDate(entered))).toBe(entered);
+    });
+  });
+
+  it('keeps a short year when the date is combined with a time', () => {
+    const result = getDateTime('0020-08-20', '12:30');
+
+    expect(result.getFullYear()).toBe(20);
+    expect(toDateInputValue(result)).toBe('0020-08-20');
+  });
 });

--- a/apps/tenant-management-webapp/src/app/lib/timeUtil.ts
+++ b/apps/tenant-management-webapp/src/app/lib/timeUtil.ts
@@ -41,6 +41,14 @@ export const getTimeFromGMT = (date: Date): string => {
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{1,2})-(\d{1,2})$/;
 
+// The Date constructor maps years 0 to 99 onto 1900 to 1999, so a year still being typed into a date
+// input arrives in the wrong century: 0020 becomes 1920. Set the year explicitly to keep it as entered.
+const localDate = (year: number, month: number, day: number, hours = 0, minutes = 0, seconds = 0): Date => {
+  const date = new Date(year, month, day, hours, minutes, seconds);
+  date.setFullYear(year);
+  return date;
+};
+
 // The Date constructor reads a date only string (yyyy-mm-dd) as UTC midnight, which lands on the previous
 // day in negative offset timezones like Alberta's; parse the parts so the date stays the one that was entered.
 export const parseLocalDate = (date: string | Date): Date => {
@@ -54,22 +62,24 @@ export const parseLocalDate = (date: string | Date): Date => {
   }
 
   const [, year, month, day] = parts;
-  return new Date(Number(year), Number(month) - 1, Number(day));
+  return localDate(Number(year), Number(month) - 1, Number(day));
 };
 
 // Value for a date input, using the local date so it matches what the user sees in the rest of the form.
+// The year is padded to four digits because a date input rejects anything else, and a rejected value
+// wipes out the year the user is part way through typing.
 export const toDateInputValue = (date: Date): string => {
   if (!date || isNaN(date.getTime())) {
     return '';
   }
 
-  return `${date.getFullYear()}-${padZero(date.getMonth() + 1)}-${padZero(date.getDate())}`;
+  return `${padYear(date.getFullYear())}-${padZero(date.getMonth() + 1)}-${padZero(date.getDate())}`;
 };
 
 export const getDateTime = (date: string | Date, time: string): Date => {
   const newDate = parseLocalDate(date);
   const [hours, minutes, seconds] = (time || '').split(':').map(Number);
-  return new Date(
+  return localDate(
     newDate.getFullYear(),
     newDate.getMonth(),
     newDate.getDate(),
@@ -94,3 +104,5 @@ const getTimezoneOffsetString = (date: Date): string => {
 };
 
 const padZero = (num: number): string => (num < 10 ? `0${num}` : `${num}`);
+
+const padYear = (year: number): string => `${year}`.padStart(4, '0');

--- a/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/services/status/notices/noticeModal.spec.tsx
@@ -85,4 +85,17 @@ describe('NoticeModal', () => {
     expect(saved.startDate.getDate()).toBe(10);
     expect(saved.endDate.getDate()).toBe(22);
   });
+
+  // The date input reports the year on every keystroke, so typing 2020 arrives a digit at a time. The
+  // value put back into the input has to match what was reported, or it replaces what is being typed.
+  it('leaves the year alone while it is being typed', () => {
+    const { baseElement } = renderModal(createStore());
+    const startDate = "goa-input[testId='notice-form-start-date-picker']";
+
+    ['0002-08-20', '0020-08-20', '0202-08-20', '2020-08-20'].forEach((entered) => {
+      changeValue(baseElement, startDate, entered);
+
+      expect(baseElement.querySelector(startDate).getAttribute('value')).toBe(entered);
+    });
+  });
 });


### PR DESCRIPTION
[CS-5325](https://goa-dio.atlassian.net/browse/CS-5325) — follow-up to #5804, from Howard's comment: dates save correctly now, but keyboard entry of the year broke ("it takes 20 as 1920 and the second 20 as 0000").

A date input reports its value on every keystroke, so typing `2020` into the year arrives as `0002`, `0020`, `0202`, `2020`. Two things then went wrong in `timeUtil`:

- `new Date(year, month, day)` maps years 0-99 onto 1900-1999, so `0020-08-20` parsed as **1920**-08-20.
- `toDateInputValue` did not pad the year, so a year under 1000 came back as `20-08-20`, which a date input will not take.

Either way the value written back into the controlled input differed from what the browser reported, which replaces the year mid-edit and loses the digits typed so far.

`parseLocalDate` and `getDateTime` now set the year explicitly via a shared `localDate` helper, and `toDateInputValue` pads it to four digits, so every intermediate year round trips unchanged.

Tests cover the whole `0002 → 0020 → 0202 → 2020` sequence in `timeUtil.spec.ts` and at the modal level in `noticeModal.spec.tsx`; both fail without the fix, reproducing the 1920.