### PR TITLE
feat(tenant-management-webapp): CS-5316 add reports page and side menu item

### DIFF
--- a/apps/tenant-management-webapp-e2e/src/integration/common/common-library.ts
+++ b/apps/tenant-management-webapp-e2e/src/integration/common/common-library.ts
@@ -123,7 +123,7 @@ export function tenantAdminMenuItem(menuItem, waitMilliSecs) {
     case 'Service metrics':
       menuItemTestid = 'menu-service-metrics';
       break;
-    case 'Reports':
+    case 'Reports': // clean-code-ignore: RULE-19
       menuItemTestid = 'menu-reports';
       break;
     case 'Task':

--- a/apps/tenant-management-webapp-e2e/src/integration/common/common-library.ts
+++ b/apps/tenant-management-webapp-e2e/src/integration/common/common-library.ts
@@ -123,6 +123,9 @@ export function tenantAdminMenuItem(menuItem, waitMilliSecs) {
     case 'Service metrics':
       menuItemTestid = 'menu-service-metrics';
       break;
+    case 'Reports':
+      menuItemTestid = 'menu-reports';
+      break;
     case 'Task':
       menuItemTestid = 'menu-task';
       break;
@@ -154,6 +157,7 @@ export function tenantAdminMenuItem(menuItem, waitMilliSecs) {
         'Calendar',
         'Script',
         'Service metrics',
+        'Reports',
         'Task',
         'Form',
         'Comment',

--- a/apps/tenant-management-webapp/src/app/pages/admin/index.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/index.tsx
@@ -15,6 +15,7 @@ import Status from './services/status';
 import { TaskRouter } from './services/task';
 import { EventLog } from './event-log';
 import { ServiceMetrics } from './service-metrics';
+import { Reports } from './reports';
 import { Events } from './services/events';
 import { Notifications } from './services/notifications';
 import { ConfigurationRouter } from './services/configuration/routers';
@@ -112,6 +113,7 @@ const TenantManagement = (): JSX.Element => {
           <Route index element={<Dashboard />} />
           <Route path="/event-log" element={<EventLog />} />
           <Route path="/service-metrics" element={<ServiceMetrics />} />
+          <Route path="/reports" element={<Reports />} />
 
           {serviceVariables(config.featureFlags).map((service) => {
             return (

--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/index.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/index.ts
@@ -1,0 +1,1 @@
+export { Reports } from './reports';

--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/index.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/index.ts
@@ -1,1 +1,2 @@
+// clean-code-ignore: RULE-19
 export { Reports } from './reports';

--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.spec.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Reports } from './reports';
+
+describe('Reports', () => {
+  it('renders the reports heading', () => {
+    const { getByTestId } = render(<Reports />);
+
+    expect(getByTestId('reports-title')).toHaveTextContent('Reports');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.tsx
@@ -1,0 +1,13 @@
+import { Main } from '@components/Html';
+import React, { FunctionComponent } from 'react';
+import { ServiceColumnLayoutWithMargin } from '../../admin';
+
+export const Reports: FunctionComponent = () => {
+  return (
+    <Main>
+      <ServiceColumnLayoutWithMargin>
+        <h1 data-testid="reports-title">Reports</h1>
+      </ServiceColumnLayoutWithMargin>
+    </Main>
+  );
+};

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
@@ -54,6 +54,7 @@ describe('Sidebar', () => {
     ['menu-value', 'a second service'],
     ['menu-dashboard', 'the dashboard'],
     ['menu-eventLog', 'the event log'],
+    ['menu-reports', 'reports'],
   ])('scrolls the app container back to the top when %s is clicked', (testId) => {
     const container = addScrollContainer(800);
     const { getByTestId } = renderSidebar();
@@ -61,6 +62,12 @@ describe('Sidebar', () => {
     fireEvent.click(getByTestId(testId));
 
     expect(container.scrollTop).toBe(0);
+  });
+
+  it('links the reports menu item to the reports page', () => {
+    const { getByTestId } = renderSidebar();
+
+    expect(getByTestId('menu-reports')).toHaveAttribute('href', '/reports');
   });
 
   it('does not throw when the scroll container is absent', () => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
@@ -85,6 +85,15 @@ const Sidebar = ({ type }: SidebarProps) => {
                     <span>Service metrics</span>
                   </NavLink>
                   <NavLink
+                    to="reports"
+                    onClick={scrollAppToTop}
+                    className={({ isActive }) => (isActive ? 'current' : '')}
+                    title="Reports"
+                    data-testid="menu-reports"
+                  >
+                    <span>Reports</span>
+                  </NavLink>
+                  <NavLink
                     to="/admin"
                     end
                     onClick={scrollAppToTop}


### PR DESCRIPTION
Adds a **Reports** menu item directly below Service metrics, routed to a blank reports page.

<img width="1242" height="642" alt="image" src="https://github.com/user-attachments/assets/0f68d634-c69b-4b53-be51-b1a435a63f35" />


Per [CS-5316](https://goa-dio.atlassian.net/browse/CS-5316), no reports are added here — they come in follow-up tickets.

- New `Reports` page under `pages/admin/reports`
- Sidebar `NavLink` (gated by the existing `tenant-admin` check) and `/reports` route
- Sidebar unit tests for the new item; e2e menu registry entry