### PR TITLE
feat(tenant-management-webapp): CS-5316 mark reports as beta

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.spec.tsx
@@ -8,4 +8,9 @@ describe('Reports', () => {
 
     expect(getByTestId('reports-title')).toHaveTextContent('Reports');
   });
+  it('marks the page as beta', () => {
+    const { getByAltText } = render(<Reports />);
+
+    expect(getByAltText('Reports beta')).toBeInTheDocument();
+  });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.tsx
@@ -1,12 +1,17 @@
 import { Main } from '@components/Html';
+import BetaBadge from '@icons/beta-badge.svg';
 import React, { FunctionComponent } from 'react';
 import { ServiceColumnLayoutWithMargin } from '../../admin';
+import { HeadingDiv } from '../services/styled-components';
 
 export const Reports: FunctionComponent = () => {
   return (
     <Main>
       <ServiceColumnLayoutWithMargin>
-        <h1 data-testid="reports-title">Reports</h1>
+        <HeadingDiv>
+          <h1 data-testid="reports-title">Reports</h1>
+          <img src={BetaBadge} alt="Reports beta" />
+        </HeadingDiv>
       </ServiceColumnLayoutWithMargin>
     </Main>
   );

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
@@ -75,4 +75,15 @@ describe('Sidebar', () => {
 
     expect(() => fireEvent.click(getByTestId('menu-task'))).not.toThrow();
   });
+  it('marks the reports menu item as beta', () => {
+    const { getByTestId } = renderSidebar();
+
+    expect(getByTestId('menu-reports').querySelector('img')).toHaveAttribute('alt', 'Reports beta');
+  });
+
+  it('names the service each beta badge belongs to', () => {
+    const { getByTestId } = renderSidebar();
+
+    expect(getByTestId('menu-task').querySelector('img')).toHaveAttribute('alt', 'Task beta');
+  });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
@@ -34,10 +34,10 @@ const Sidebar = ({ type }: SidebarProps) => {
         state.session?.resourceAccess?.['urn:ads:platform:tenant-service']?.roles?.includes(tenantAdminRole),
     };
   });
-  const betaBadge = () => {
+  const betaBadge = (label: string) => {
     return (
       <BetaBadgeStyle>
-        <img src={BetaBadge} alt="Files Service" />
+        <img src={BetaBadge} alt={`${label} beta`} />
       </BetaBadgeStyle>
     );
   };
@@ -92,6 +92,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                     data-testid="menu-reports"
                   >
                     <span>Reports</span>
+                    {betaBadge('Reports')}
                   </NavLink>
                   <NavLink
                     to="/admin"
@@ -119,7 +120,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                     data-testid={`menu-${service.name.toLowerCase()}`}
                   >
                     <span>{service.name}</span>
-                    {service.beta && betaBadge()}
+                    {service.beta && betaBadge(service.name)}
                     {service.alpha && alphaBadge()}
                   </NavLink>
                 ))}


### PR DESCRIPTION

<img width="493" height="238" alt="image" src="https://github.com/user-attachments/assets/f8069582-9123-474a-8ac5-bd6b34a4bf8d" />


Follow-up to #5812, per the thread on that PR — Roy confirmed the Reports feature should carry a beta badge.

- Beta badge on the Reports side menu item, matching how beta services are marked
- Beta badge beside the Reports page heading, matching the service pages

The sidebar's `betaBadge` now takes the name of the item it marks, so its `alt` reads "Task beta" rather than "Files Service" on every badge — a copy-paste that predates this change.

Not included: the feature flag Thang raised. Roy's reply confirmed the badge only, so that's left for a separate decision.