### PR TITLE
feat(adsp-sdk-mcp-server): add HTTP transport and OpenShift deployment

### DIFF
--- a/.openshift/adsp-sdk-mcp-server/deploy.yml
+++ b/.openshift/adsp-sdk-mcp-server/deploy.yml
@@ -1,0 +1,122 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: adsp-sdk-mcp-server
+  labels:
+    app: adsp-sdk-mcp-server
+spec: {}
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: adsp-sdk-mcp-server
+  labels:
+    app: adsp-sdk-mcp-server
+    apply-build: "true"
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: adsp-sdk-mcp-server:latest
+  resources:
+    limits:
+      cpu: "300m"
+      memory: "1Gi"
+    requests:
+      cpu: "100m"
+      memory: "200Mi"
+  runPolicy: Serial
+  source:
+    binary: {}
+    type: Binary
+  strategy:
+    dockerStrategy:
+      dockerfilePath: Dockerfile
+    type: Docker
+  triggers: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adsp-sdk-mcp-server
+  labels:
+    app: adsp-sdk-mcp-server
+  annotations:
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"adsp-sdk-mcp-server:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"adsp-sdk-mcp-server\")].image"}]'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: adsp-sdk-mcp-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: "25%"
+      maxUnavailable: "25%"
+  template:
+    metadata:
+      labels:
+        name: adsp-sdk-mcp-server
+    spec:
+      containers:
+        - name: adsp-sdk-mcp-server
+          image: adsp-sdk-mcp-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3333
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "3333"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3333
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3333
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+            requests:
+              cpu: "20m"
+              memory: "64Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: adsp-sdk-mcp-server
+  labels:
+    app: adsp-sdk-mcp-server
+spec:
+  ports:
+    - name: http
+      port: 3333
+      protocol: TCP
+      targetPort: 3333
+  selector:
+    name: adsp-sdk-mcp-server
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: adsp-sdk-mcp-server
+  labels:
+    app: adsp-sdk-mcp-server
+spec:
+  to:
+    kind: Service
+    name: adsp-sdk-mcp-server
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/libs/adsp-sdk-mcp-server/Dockerfile
+++ b/libs/adsp-sdk-mcp-server/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi9/nodejs-24
+
+ENV NODE_ENV=production
+ENV PORT=3333
+
+WORKDIR /opt/app-root/src
+
+COPY --chown=1001:0 . .
+
+RUN npm install --omit=dev --no-package-lock
+
+USER 1001
+
+EXPOSE 3333
+
+CMD ["node", "src/main-http.js"]

--- a/libs/adsp-sdk-mcp-server/src/main-http.spec.ts
+++ b/libs/adsp-sdk-mcp-server/src/main-http.spec.ts
@@ -1,0 +1,111 @@
+import { EventEmitter } from 'events';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+// Captured by the http mock factory when main-http.ts calls createServer(handler)
+const captured: { handler: ((req: IncomingMessage, res: ServerResponse) => void) | null } = {
+  handler: null,
+};
+
+const mockHandleRequest = jest.fn().mockResolvedValue(undefined);
+const mockConnect = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('http', () => ({
+  createServer: jest.fn((h: (req: IncomingMessage, res: ServerResponse) => void) => {
+    captured.handler = h;
+    return { listen: jest.fn() };
+  }),
+}));
+
+jest.mock('./docs/docsRepository', () => ({
+  DocsRepository: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('./server', () => ({
+  createAdspMcpServer: jest.fn().mockReturnValue({ connect: mockConnect }),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: jest.fn().mockImplementation(() => ({
+    handleRequest: mockHandleRequest,
+  })),
+}));
+
+function makeReq(method: string, url: string): IncomingMessage {
+  const req = new EventEmitter() as unknown as IncomingMessage;
+  Object.assign(req, { method, url, headers: {} });
+  return req;
+}
+
+interface MockRes {
+  writeHead: jest.Mock;
+  setHeader: jest.Mock;
+  end: jest.Mock;
+  headersSent: boolean;
+}
+
+function makeRes(): MockRes {
+  return { writeHead: jest.fn(), setHeader: jest.fn(), end: jest.fn(), headersSent: false };
+}
+
+describe('main-http', () => {
+  beforeAll(() => {
+    // require (not import) so module runs after mock factories are installed
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('./main-http');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleRequest.mockResolvedValue(undefined);
+    mockConnect.mockResolvedValue(undefined);
+  });
+
+  it('captures the request handler from createServer', () => {
+    expect(captured.handler).toBeInstanceOf(Function);
+  });
+
+  it('OPTIONS /mcp returns 204 with CORS headers', () => {
+    const res = makeRes();
+    captured.handler!(makeReq('OPTIONS', '/mcp'), res as unknown as ServerResponse);
+
+    expect(res.writeHead).toHaveBeenCalledWith(
+      204,
+      expect.objectContaining({ 'Access-Control-Allow-Origin': '*' })
+    );
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('GET /health returns 200 with status ok', () => {
+    const res = makeRes();
+    captured.handler!(makeReq('GET', '/health'), res as unknown as ServerResponse);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({ 'Content-Type': 'application/json' }));
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ status: 'ok' }));
+  });
+
+  it('/health sets CORS headers', () => {
+    const res = makeRes();
+    captured.handler!(makeReq('GET', '/health'), res as unknown as ServerResponse);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+  });
+
+  it('POST /mcp creates a fresh transport and server per request then calls handleRequest', async () => {
+    const req = makeReq('POST', '/mcp');
+    const res = makeRes();
+    captured.handler!(req, res as unknown as ServerResponse);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockHandleRequest).toHaveBeenCalledWith(req, res);
+  });
+
+  it('GET /unknown returns 404', () => {
+    const res = makeRes();
+    captured.handler!(makeReq('GET', '/unknown'), res as unknown as ServerResponse);
+
+    expect(res.writeHead).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalled();
+  });
+});

--- a/libs/adsp-sdk-mcp-server/src/main-http.ts
+++ b/libs/adsp-sdk-mcp-server/src/main-http.ts
@@ -1,0 +1,56 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { join } from 'path';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { DocsRepository } from './docs/docsRepository';
+import { createAdspMcpServer } from './server';
+
+const PORT = parseInt(process.env['PORT'] ?? '3333', 10);
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Accept, Mcp-Session-Id',
+  'Access-Control-Expose-Headers': 'Mcp-Session-Id',
+};
+
+// Load docs once at startup; share across per-request server instances.
+const sharedDocs = new DocsRepository(join(__dirname, '..', 'assets', 'docs'));
+
+const httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, CORS_HEADERS);
+    res.end();
+    return;
+  }
+
+  Object.entries(CORS_HEADERS).forEach(([k, v]) => res.setHeader(k, v));
+
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
+  if (req.url?.startsWith('/mcp')) {
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    const mcpServer = createAdspMcpServer({ docs: sharedDocs });
+    mcpServer
+      .connect(transport)
+      .then(() => transport.handleRequest(req, res))
+      .catch((err: unknown) => {
+        process.stderr.write(`MCP request error: ${err instanceof Error ? err.stack : String(err)}\n`);
+        if (!res.headersSent) {
+          res.writeHead(500);
+          res.end();
+        }
+      });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+httpServer.listen(PORT, () => {
+  process.stderr.write(`ADSP MCP Server HTTP listening on port ${PORT}\n`);
+});

--- a/libs/adsp-sdk-mcp-server/src/server.ts
+++ b/libs/adsp-sdk-mcp-server/src/server.ts
@@ -11,12 +11,14 @@ import { createSdkTools } from './tools/registerSdkTools';
 export interface CreateAdspMcpServerOptions {
   /** Root directory of bundled ADSP docs. Defaults to the assets copied alongside the built package. */
   docsRoot?: string;
+  /** Pre-built docs repository. When provided, docsRoot is ignored. */
+  docs?: DocsRepository;
 }
 
 export function createAdspMcpServer(options: CreateAdspMcpServerOptions = {}): Server {
   // Compiled output places this file under dist/.../src/, while the docs asset copy lands one level up at dist/.../assets/docs.
   const docsRoot = options.docsRoot ?? join(__dirname, '..', 'assets', 'docs');
-  const docs = new DocsRepository(docsRoot);
+  const docs = options.docs ?? new DocsRepository(docsRoot);
 
   const tools = [
     ...createDocsTools(docs),


### PR DESCRIPTION
## Summary
- Adds `src/main-http.ts` — Streamable HTTP entry point so the MCP server runs as a persistent OpenShift service alongside the existing stdio mode used by local clients (Claude Desktop, Cursor, etc.)
- Adds `Dockerfile` for a self-contained production image (`npm install --omit=dev` pulls runtime deps during OC build)
- Adds `.openshift/adsp-sdk-mcp-server/deploy.yml` — ImageStream, BuildConfig (binary/Docker strategy), Deployment, Service, Route (edge TLS)
- Adds optional `docs` field to `CreateAdspMcpServerOptions` in `server.ts` to accept a pre-built `DocsRepository`

## Key decisions
- **Per-request transport + Server**: `StreamableHTTPServerTransport` is single-use — a shared instance breaks after the first response. Each `/mcp` request creates a fresh transport + Server pair.
- **Shared `DocsRepository`**: 182 markdown files + search index loaded once at startup and injected via the new `docs` option, avoiding repeated disk reads per request.
- **CORS headers** on all responses so browser-based MCP clients (MCP Inspector) connect without preflight failures.

## Deployed at
`https://adsp-sdk-mcp-server-sds-dev.apps.aro-01.int.gov.ab.ca/mcp` (sds-dev, Streamable HTTP stateless)

## Build steps for new environments
```bash
npx nx build adsp-sdk-mcp-server
oc apply -f .openshift/adsp-sdk-mcp-server/deploy.yml -n <namespace>
oc start-build adsp-sdk-mcp-server --from-dir=dist/libs/adsp-sdk-mcp-server --follow -n <namespace>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)