### PR TITLE
feat(form-admin-app): CS-5328 open a response from its row

### DIFF
--- a/apps/form-admin-app/src/app/components/DataValueCell.tsx
+++ b/apps/form-admin-app/src/app/components/DataValueCell.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 // Data values are content of the form and can be long, so the cell is kept within a width that
 // leaves room for the other columns and wraps values that don't include spaces to break on.
 export const DataValueCell = styled.td`
-  background: var(--goa-color-greyscale-100);
   min-width: 10rem;
   max-width: 20rem;
   overflow-wrap: anywhere;

--- a/apps/form-admin-app/src/app/components/ResultsTable.spec.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsTable.spec.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { ActionsCell, ActionsColumnHeader, ResultsTable } from './ResultsTable';
+import { fireEvent, render } from '@testing-library/react';
+import { ResultsTable, SelectableRow } from './ResultsTable';
 
 // goa-table isn't registered in tests, so a stub with a shadow root stands in for it.
 class StubTable extends HTMLElement {
@@ -9,23 +9,23 @@ class StubTable extends HTMLElement {
   }
 }
 
-const renderTable = () =>
-  render(
+const renderTable = (onSelect = jest.fn()) => ({
+  onSelect,
+  ...render(
     <ResultsTable width="100%">
       <thead>
         <tr>
           <th>Submitted on</th>
-          <ActionsColumnHeader>Actions</ActionsColumnHeader>
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <SelectableRow onClick={onSelect}>
           <td>Aug 25, 2026</td>
-          <ActionsCell>Open</ActionsCell>
-        </tr>
+        </SelectableRow>
       </tbody>
     </ResultsTable>,
-  );
+  ),
+});
 
 describe('ResultsTable', () => {
   beforeAll(() => {
@@ -39,16 +39,17 @@ describe('ResultsTable', () => {
     expect(style.textContent).toContain('overflow-x: auto');
   });
 
-  it('should render the actions column as a heading and cell of the table', () => {
+  it('should show a selectable row as clickable', () => {
     const { getByText } = renderTable();
 
-    expect(getByText('Actions').tagName).toBe('TH');
-    expect(getByText('Open').tagName).toBe('TD');
+    expect(getComputedStyle(getByText('Aug 25, 2026').closest('tr')).cursor).toBe('pointer');
   });
 
-  it('should stick the actions column to the right edge of the table', () => {
-    const { getByText } = renderTable();
+  it('should select the row when it is clicked', () => {
+    const { getByText, onSelect } = renderTable();
 
-    expect(getComputedStyle(getByText('Open')).position).toBe('sticky');
+    fireEvent.click(getByText('Aug 25, 2026').closest('tr'));
+
+    expect(onSelect).toHaveBeenCalled();
   });
 });

--- a/apps/form-admin-app/src/app/components/ResultsTable.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsTable.tsx
@@ -35,19 +35,17 @@ export const ResultsTable: FunctionComponent<GoabTableProps> = (props) => {
   );
 };
 
-// Heading and cell of the trailing column of row actions. The column sticks to the right edge so
-// that actions are still reachable when the table is scrolled.
-const stickyRight = `
-  position: sticky;
-  right: 0;
-  z-index: 1;
-  border-left: 1px solid var(--goa-color-greyscale-200);
-`;
+// Row of a results table that opens its item when selected. The whole row is the target, so it
+// highlights under the pointer and takes focus so it can be selected from the keyboard.
+export const SelectableRow = styled.tr`
+  cursor: pointer;
 
-export const ActionsColumnHeader = styled.th`
-  ${stickyRight}
-`;
+  &:hover td {
+    background: var(--goa-color-surface-item-hover);
+  }
 
-export const ActionsCell = styled.td`
-  ${stickyRight}
+  &:focus-visible {
+    outline: 2px solid var(--goa-color-interactive-focus);
+    outline-offset: -2px;
+  }
 `;

--- a/apps/form-admin-app/src/app/components/ResultsTable.tsx
+++ b/apps/form-admin-app/src/app/components/ResultsTable.tsx
@@ -45,7 +45,8 @@ export const SelectableRow = styled.tr`
   }
 
   &:focus-visible {
-    outline: 2px solid var(--goa-color-interactive-focus);
-    outline-offset: -2px;
+    outline: var(--goa-space-3xs) solid var(--goa-color-interactive-focus);
+    /* Drawn inside the row, so the outline isn't clipped by the table's rounded corners. */
+    outline-offset: calc(var(--goa-space-3xs) * -1);
   }
 `;

--- a/apps/form-admin-app/src/app/containers/Responses.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/Responses.spec.tsx
@@ -6,6 +6,12 @@ import { Responses } from './Responses';
 import { findForms, getDefaultFormCriteria, getDefaultResultsSort } from '../state';
 import { FormStatus } from '../state/types';
 
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 jest.mock('../state', () => {
   const actual = jest.requireActual('../state');
   return {
@@ -138,6 +144,7 @@ const renderResponses = (state = createState()) => {
 describe('Responses', () => {
   beforeEach(() => {
     (findForms as unknown as jest.Mock).mockClear();
+    mockNavigate.mockClear();
   });
 
   it('should render the responses table and filters trigger', () => {
@@ -277,5 +284,53 @@ describe('Responses', () => {
 
     expect(baseElement.querySelector("goa-push-drawer[testid='filter-drawer']").getAttribute('open')).toBe('true');
     expect(baseElement.querySelector("goa-button[testId='show-filters']")).toBeFalsy();
+  });
+  const stateWithForm = () =>
+    createState({
+      forms: {
+        'form-1': {
+          urn: formUrn,
+          id: 'form-1',
+          formId: 'form-1',
+          status: FormStatus.submitted,
+          created: '2026-08-01T12:00:00.000Z',
+          submitted: '2026-08-01T12:00:00.000Z',
+          lastAccessed: '2026-08-01T12:00:00.000Z',
+          createdBy: { id: 'user-1', name: 'Test User' },
+          applicant: { addressAs: 'Test User' },
+          data: { firstName: 'Ada' },
+        },
+      },
+      formResults: ['form-1'],
+    });
+
+  it('should open the response when its row is selected', () => {
+    const { getByText } = renderResponses(stateWithForm());
+
+    fireEvent.click(getByText('Ada').closest('tr'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('form-1');
+  });
+
+  it('should open the response when its row is selected from the keyboard', () => {
+    const { getByText } = renderResponses(stateWithForm());
+
+    fireEvent.keyDown(getByText('Ada').closest('tr'), { key: 'Enter' });
+
+    expect(mockNavigate).toHaveBeenCalledWith('form-1');
+  });
+
+  it('should not open the response when a control in the row is used', () => {
+    const { baseElement } = renderResponses(stateWithForm());
+
+    fireEvent.click(baseElement.querySelector('goa-icon-button'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should no longer offer a separate actions column', () => {
+    const { queryByText } = renderResponses(stateWithForm());
+
+    expect(queryByText('Actions')).toBeNull();
   });
 });

--- a/apps/form-admin-app/src/app/containers/Responses.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/Responses.spec.tsx
@@ -333,4 +333,13 @@ describe('Responses', () => {
 
     expect(queryByText('Actions')).toBeNull();
   });
+  it('should not shade the data value columns differently from the rest of the row', () => {
+    const { getByText } = renderResponses(stateWithForm());
+
+    const dataValue = getByText('Ada');
+    // The leading cell carries no styling of its own, so it stands for the rest of the row.
+    const plainCell = dataValue.closest('tr').querySelector('td');
+
+    expect(getComputedStyle(dataValue).background).toBe(getComputedStyle(plainCell).background);
+  });
 });

--- a/apps/form-admin-app/src/app/containers/Responses.tsx
+++ b/apps/form-admin-app/src/app/containers/Responses.tsx
@@ -39,7 +39,7 @@ import {
 import { FilterDrawerLayout } from '../components/FilterDrawerLayout';
 import { ContentContainer } from '../components/ContentContainer';
 import { DataValueCell } from '../components/DataValueCell';
-import { ActionsCell, ActionsColumnHeader, ResultsTable } from '../components/ResultsTable';
+import { ResultsTable, SelectableRow } from '../components/ResultsTable';
 import { ExportModal } from '../components/ExportModal';
 import { FilterFormItemsContainer } from '../components/FilterFormItemsContainer';
 import { DataValueCriteriaItem } from '../components/DataValueCriteriaItem';
@@ -50,6 +50,12 @@ import { TagSearchFilter } from './TagSearchFilter';
 import { GoabDropdownOnChangeDetail, GoabTableOnSortDetail } from '@abgov/ui-components-common';
 import { ResultsSummary } from '../components/ResultsSummary';
 import { SortableColumnHeader, toSortChange } from '../components/SortableColumnHeader';
+
+// Tags are managed from within the row, so a click on one of their controls selects the tag rather
+// than opening the response.
+const ROW_CONTROLS = 'a, button, input, select, textarea, [role="button"], goa-filter-chip, goa-icon-button';
+
+const isRowControl = (target: EventTarget) => target instanceof Element && !!target.closest(ROW_CONTROLS);
 
 interface ResponseRowProps {
   dispatch: AppDispatch;
@@ -76,8 +82,25 @@ const ResponseRow: FunctionComponent<ResponseRowProps> = ({
     }
   }, [dispatch, hasSupportTopic, form, topic]);
 
+  const open = () => navigate(form.id);
+
   return (
-    <tr key={form.urn}>
+    <SelectableRow
+      tabIndex={0}
+      aria-label={`Open response created ${form.created.toFormat('LLL d, yyyy')}`}
+      onClick={(event) => {
+        if (!isRowControl(event.target)) {
+          open();
+        }
+      }}
+      onKeyDown={(event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && !isRowControl(event.target)) {
+          // Space would otherwise scroll the results.
+          event.preventDefault();
+          open();
+        }
+      }}
+    >
       <td>{topic?.requiresAttention && <GoabIcon type="mail-unread" size="small" ariaLabel="mail-unread" />}</td>
       <td>{form.created.toFormat('LLL d, yyyy')}</td>
       <td>{form.status}</td>
@@ -92,14 +115,7 @@ const ResponseRow: FunctionComponent<ResponseRowProps> = ({
           </DataValueCell>
         );
       })}
-      <ActionsCell>
-        <GoabButtonGroup alignment="end">
-          <GoabButton size="compact" type="secondary" onClick={() => navigate(form.id)}>
-            Open
-          </GoabButton>
-        </GoabButtonGroup>
-      </ActionsCell>
-    </tr>
+    </SelectableRow>
   );
 };
 
@@ -269,7 +285,6 @@ export const Responses: FunctionComponent<ResponsesProps> = ({ definitionId }) =
                   {name}
                 </SortableColumnHeader>
               ))}
-              <ActionsColumnHeader>Actions</ActionsColumnHeader>
             </tr>
           </thead>
           <tbody>
@@ -284,7 +299,7 @@ export const Responses: FunctionComponent<ResponsesProps> = ({ definitionId }) =
                 onTag={() => setShowTagResponse({ name: '', urn: form.urn })}
               />
             ))}
-            <RowSkeleton columns={5 + dataValues.length} show={busy.loading} />
+            <RowSkeleton columns={4 + dataValues.length} show={busy.loading} />
             <RowLoadMore
               columns={4 + dataValues.length}
               next={next}


### PR DESCRIPTION
Per [CS-5328](https://goa-dio.atlassian.net/browse/CS-5328), the Responses table now works the way people expect a list to work.

- The **Actions** column is gone, along with its per-row Open button
- The row under the pointer is highlighted, and only that row
- Clicking anywhere on a row opens the response — the same navigation the Open button performed

### Notes for review

**Keyboard access.** Removing the Open button removed the only keyboard route into a response, so rows take focus and answer Enter and Space, with an accessible name naming the response. A `<tr>` can't honestly claim `role="button"` without breaking table semantics, so this is a focusable row rather than a real button — worth a look if we want a stronger pattern.

**Controls inside the row.** Tags are managed from within the row, so a click that lands on a tag chip or the add-tag button selects the tag instead of opening the response. Covered by a test.

`ActionsCell` and `ActionsColumnHeader` were only used here, so they are removed along with their sticky-column styling; `SelectableRow` takes their place in the same module.

The skeleton row's column count was one too many for the table even before this change; both it and the load-more row now span the four fixed columns plus the data value columns.