### PR TITLE
fix(form-editor-common): CS-5329 say which list to keep small

### DIFF
--- a/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.spec.tsx
+++ b/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.spec.tsx
@@ -49,6 +49,12 @@ describe('ReviewConfigurationTab', () => {
     expect(screen.getByTestId('review-config-empty').textContent).toContain('No fields selected');
   });
 
+  it('directs the author to keep the number of columns small', () => {
+    render(<ReviewConfigurationTab schema={schema} onChange={jest.fn()} />);
+
+    expect(screen.getByText(/Keep the number of columns small so the table stays manageable\./)).toBeTruthy();
+  });
+
   it('adds a selected field to the configuration', () => {
     const onChange = jest.fn();
     const { container } = render(<ReviewConfigurationTab schema={schema} onChange={onChange} />);

--- a/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.tsx
+++ b/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.tsx
@@ -54,8 +54,8 @@ export const ReviewConfigurationTab: FunctionComponent<ReviewConfigurationTabPro
             order.
           </p>
           <p>
-            Pick values that help reviewers identify a submission quickly, for example first and last name. Keep the list
-            small so the table stays manageable.
+            Pick values that help reviewers identify a submission quickly, for example first and last name. Keep the
+            number of columns small so the table stays manageable.
           </p>
         </ReviewDescription>
       </GoabAccordion>


### PR DESCRIPTION
Per [CS-5329](https://goa-dio.atlassian.net/browse/CS-5329), the guidance on the form editor's Review tab now reads:

> Keep the **number of columns** small so the table stays manageable.

"Keep the list small" could be read as the list of responses rather than the columns being chosen on the tab.

The wording is the whole deliverable here, so there's a test asserting the sentence — the existing spec only checked that the description block rendered.

One thing left alone: the callout further down that appears once many columns are selected already says "Keep the list of columns small so the Form Admin submission table stays easy to scan." It isn't the sentence the ticket quotes and isn't ambiguous in the same way, so I didn't touch it — say if you'd like the two aligned.