### PR TITLE
feat(form-service, form-admin-app): CS-5330 email people when a form message arrives

### DIFF
--- a/.openshift/configuration/form-service.yml
+++ b/.openshift/configuration/form-service.yml
@@ -11,6 +11,7 @@ items:
     data:
       KEYCLOAK_ROOT_URL: https://access.adsp-dev.gov.ab.ca
       DIRECTORY_URL: https://directory-service.adsp-dev.gov.ab.ca
+      AMQP_HOST: event-service-rabbitmq-balancer
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       LOG_LEVEL: debug
   - apiVersion: v1
@@ -23,3 +24,5 @@ items:
     stringData:
       CLIENT_ID: urn:ads:platform:form-service
       CLIENT_SECRET:
+      AMQP_USER: form-service
+      AMQP_PASSWORD:

--- a/apps/form-admin-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.spec.ts
@@ -1,9 +1,11 @@
+import axios from 'axios';
 import { addComment, commentReducer, commentsSelector, deleteComment, loadComments, selectTopic } from './comment.slice';
 
 // babel-jest hoists these above the import; the slice creates an axios client and a socket at
 // module load, and neither is exercised by reducer and selector tests.
 jest.mock('axios');
 jest.mock('socket.io-client', () => ({ io: jest.fn() }));
+jest.mock('./user.slice', () => ({ getAccessToken: jest.fn(async () => 'token') }));
 
 type CommentState = ReturnType<typeof commentReducer>;
 
@@ -149,5 +151,47 @@ describe('commentsSelector', () => {
 
     expect(results).toEqual([]);
     expect(next).toBeNull();
+  });
+});
+
+describe('addComment', () => {
+  const directoryState = {
+    config: {
+      directory: {
+        'urn:ads:platform:comment-service': 'https://comment-service',
+        'urn:ads:platform:notification-service': 'https://notification-service',
+      },
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const run = () => addComment({ topic: topicA, comment: { content: 'A reply' } })(jest.fn(), () => directoryState as any, undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  // A reviewer isn't recorded against a form, so replying is what makes them reachable by email.
+  it('should subscribe the replying reviewer for messages on the form', async () => {
+    (axios.post as jest.Mock).mockResolvedValue({ data: comment(1, 'A reply') });
+
+    await run();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/subscription/v1/types/form-message-reviewer-notifications/subscriptions'),
+      expect.objectContaining({ criteria: expect.objectContaining({ correlationId: topicA.resourceId }) }),
+      expect.objectContaining({ params: { userSub: true } }),
+    );
+  });
+
+  it('should keep the reply when subscribing fails', async () => {
+    (axios.post as jest.Mock)
+      .mockResolvedValueOnce({ data: comment(1, 'A reply') })
+      .mockRejectedValueOnce(new Error('no subscription for you'));
+
+    const result = await run();
+
+    expect(result.type).toBe('comment/add-comment/fulfilled');
   });
 });

--- a/apps/form-admin-app/src/app/state/comment.slice.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.ts
@@ -40,6 +40,25 @@ interface NewComment {
 }
 
 const COMMENT_SERVICE_ID = 'urn:ads:platform:comment-service';
+const NOTIFICATION_SERVICE_ID = 'urn:ads:platform:notification-service';
+const REVIEWER_NOTIFICATION_TYPE_ID = 'form-message-reviewer-notifications';
+
+// Reviewers aren't recorded against a form, so replying is what makes one reachable: it subscribes
+// them for this form using their own token, and that subscription is what tells the form service a
+// reviewer is part of the conversation. Best effort — the reply stands whether or not it succeeds.
+async function subscribeToFormMessages(notificationServiceUrl: string, resourceId: string): Promise<void> {
+  try {
+    const token = await getAccessToken();
+    await axios.post(
+      new URL(`/subscription/v1/types/${REVIEWER_NOTIFICATION_TYPE_ID}/subscriptions`, notificationServiceUrl).href,
+      { criteria: { description: 'Messages from the applicant.', correlationId: resourceId } },
+      { headers: { Authorization: `Bearer ${token}` }, params: { userSub: true } },
+    );
+  } catch (err) {
+    // Nothing to surface to the reviewer; they simply won't be emailed about replies.
+    console.warn(`Unable to subscribe for messages on ${resourceId}.`, err);
+  }
+}
 
 let socket: Socket;
 export const connectStream = createAsyncThunk(
@@ -249,6 +268,10 @@ export const addComment = createAsyncThunk(
           headers: { Authorization: `Bearer ${token}` },
         },
       );
+
+      if (topic.resourceId) {
+        await subscribeToFormMessages(config.directory[NOTIFICATION_SERVICE_ID], topic.resourceId);
+      }
 
       return data;
     } catch (err) {

--- a/apps/form-service/src/comment.ts
+++ b/apps/form-service/src/comment.ts
@@ -1,4 +1,4 @@
-import { ServiceDirectory, TokenProvider, adspId } from '@abgov/adsp-service-sdk';
+import { AdspId, ServiceDirectory, TokenProvider, adspId } from '@abgov/adsp-service-sdk';
 import axios from 'axios';
 import { Logger } from 'winston';
 import { CommentService, FormEntity } from './form';
@@ -40,6 +40,30 @@ class CommentServiceImpl implements CommentService {
           axios.isAxiosError(err) ? err.response?.data?.errorMessage || err.message : err
         }`
       );
+    }
+  }
+
+  // The comment created event carries only metadata, so the message itself is read back when it
+  // needs to be included in a notification.
+  async getComment(tenantId: AdspId, topicId: number, commentId: number): Promise<{ content: string } | null> {
+    try {
+      const token = await this.tokenProvider.getAccessToken();
+      const { data } = await axios.get<{ content: string }>(
+        new URL(`${this.commentTopicUrl.pathname}/${topicId}/comments/${commentId}`, this.commentTopicUrl).href,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          params: { tenantId: tenantId.toString() },
+        }
+      );
+
+      return data;
+    } catch (err) {
+      this.logger.error(
+        `Failed to read comment ${commentId} of topic ${topicId}: ${
+          axios.isAxiosError(err) ? err.response?.data?.errorMessage || err.message : err
+        }`
+      );
+      return null;
     }
   }
 }

--- a/apps/form-service/src/environments/environment.ts
+++ b/apps/form-service/src/environments/environment.ts
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19 — environment configuration; there is no behaviour to test.
 import * as dotenv from 'dotenv';
 import * as envalid from 'envalid';
 import * as util from 'util';
@@ -17,6 +18,9 @@ export const environment = envalid.cleanEnv(
     MONGO_USER: envalid.str({ default: '' }),
     MONGO_PASSWORD: envalid.str({ default: '' }),
     MONGO_TLS: envalid.bool({ default: false }),
+    AMQP_HOST: envalid.str({ default: '127.0.0.1' }),
+    AMQP_USER: envalid.str({ default: 'guest' }),
+    AMQP_PASSWORD: envalid.str({ default: 'guest' }),
     LOG_LEVEL: envalid.str({ default: 'debug' }),
     PORT: envalid.num({ default: 3343 }),
     TRUSTED_PROXY: envalid.str({ default: 'uniquelocal' }),

--- a/apps/form-service/src/form/comment.ts
+++ b/apps/form-service/src/form/comment.ts
@@ -1,7 +1,10 @@
+// clean-code-ignore: RULE-19 — service interface and constant; the implementation is covered by ../comment.ts consumers.
+import { AdspId } from '@abgov/adsp-service-sdk';
 import { FormEntity } from './model';
 
 export const SUPPORT_COMMENT_TOPIC_TYPE_ID = 'form-questions';
 
 export interface CommentService {
   createSupportTopic(form: FormEntity, urn: string): Promise<void>;
+  getComment(tenantId: AdspId, topicId: number, commentId: number): Promise<{ content: string } | null>;
 }

--- a/apps/form-service/src/form/configuration.spec.ts
+++ b/apps/form-service/src/form/configuration.spec.ts
@@ -46,4 +46,32 @@ describe('configuration', () => {
       }),
     ).toThrow();
   });
+  it.each([['intake@gov.ab.ca'], [''], [null]])('accepts a questions email of %p', (questionsEmail) => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('formDefinition', configurationSchema);
+    service.validate('test', 'formDefinition', {
+      id: 'intake',
+      name: 'Intake',
+      anonymousApply: false,
+      applicantRoles: [],
+      assessorRoles: [],
+      reviewConfiguration: { columns: [], questionsEmail },
+    });
+  });
+
+  it('rejects a questions email that is not an address', () => {
+    const service = new AjvValidationService(logger as unknown as Logger);
+    service.setSchema('formDefinition', configurationSchema);
+
+    expect(() =>
+      service.validate('test', 'formDefinition', {
+        id: 'intake',
+        name: 'Intake',
+        anonymousApply: false,
+        applicantRoles: [],
+        assessorRoles: [],
+        reviewConfiguration: { columns: [], questionsEmail: 'not an address' },
+      }),
+    ).toThrow();
+  });
 });

--- a/apps/form-service/src/form/configuration.ts
+++ b/apps/form-service/src/form/configuration.ts
@@ -73,6 +73,13 @@ export const configurationSchema = {
             },
           },
         },
+        questionsEmail: {
+          anyOf: [
+            { type: 'string', pattern: '^\\S+@\\S+\\.\\S+$' },
+            { type: 'string', maxLength: 0 },
+            { type: 'null' },
+          ],
+        },
       },
     },
   },

--- a/apps/form-service/src/form/events.ts
+++ b/apps/form-service/src/form/events.ts
@@ -14,6 +14,10 @@ export const FORM_SET_TO_DRAFT = 'form-to-draft';
 export const FORM_SUBMITTED = 'form-submitted';
 export const FORM_ARCHIVED = 'form-archived';
 
+export const FORM_MESSAGE_TO_APPLICANT = 'form-message-to-applicant';
+export const FORM_MESSAGE_TO_REVIEWER = 'form-message-to-reviewer';
+export const FORM_MESSAGE_FORWARDED = 'form-message-forwarded';
+
 export const SUBMISSION_DISPOSITIONED = 'submission-dispositioned';
 export const SUBMISSION_DELETED = 'submission-deleted';
 
@@ -568,3 +572,122 @@ export const FormQuestionUpdatesStream: Stream = {
     },
   ],
 };
+
+// Notification events for form messages. The payload carries only what the templates need; the
+// message itself is included on the forwarded event alone, since that address is triaging the
+// question rather than reading it in the app.
+const messageFormSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    urn: { type: 'string' },
+    definition: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string', examples: ['Business licence application'] },
+      },
+    },
+  },
+};
+
+export const FormMessageToApplicantDefinition: DomainEventDefinition = {
+  name: FORM_MESSAGE_TO_APPLICANT,
+  description: 'Signalled when a reviewer sends a message to the applicant of a form.',
+  payloadSchema: {
+    type: 'object',
+    properties: {
+      form: messageFormSchema,
+      recipientEmail: { type: 'string' },
+    },
+  },
+};
+
+export const FormMessageToReviewerDefinition: DomainEventDefinition = {
+  name: FORM_MESSAGE_TO_REVIEWER,
+  description: 'Signalled when an applicant sends a message and a reviewer is part of the conversation.',
+  payloadSchema: {
+    type: 'object',
+    properties: {
+      form: messageFormSchema,
+    },
+  },
+};
+
+export const FormMessageForwardedDefinition: DomainEventDefinition = {
+  name: FORM_MESSAGE_FORWARDED,
+  description:
+    'Signalled when an applicant sends a message, no reviewer is part of the conversation, and the ' +
+    'form definition configures an address to forward questions to.',
+  payloadSchema: {
+    type: 'object',
+    properties: {
+      form: messageFormSchema,
+      recipientEmail: { type: 'string' },
+      message: { type: 'string' },
+    },
+  },
+};
+
+function mapMessageForm(apiId: AdspId, form: FormEntity) {
+  return {
+    id: form.id,
+    urn: `${apiId}:/forms/${form.id}`,
+    definition: {
+      id: form.definition?.id,
+      name: form.definition?.name,
+    },
+  };
+}
+
+function messageCorrelationId(apiId: AdspId, form: FormEntity) {
+  return `${apiId}:/forms/${form.id}`;
+}
+
+function messageContext(form: FormEntity) {
+  return { definitionId: form.definition?.id, formId: form.id };
+}
+
+export function formMessageToApplicant(
+  apiId: AdspId,
+  form: FormEntity,
+  recipientEmail: string,
+  timestamp: Date,
+): DomainEvent {
+  return {
+    name: FORM_MESSAGE_TO_APPLICANT,
+    timestamp,
+    tenantId: form.tenantId,
+    correlationId: messageCorrelationId(apiId, form),
+    context: messageContext(form),
+    payload: { form: mapMessageForm(apiId, form), recipientEmail },
+  };
+}
+
+export function formMessageToReviewer(apiId: AdspId, form: FormEntity, timestamp: Date): DomainEvent {
+  return {
+    name: FORM_MESSAGE_TO_REVIEWER,
+    timestamp,
+    tenantId: form.tenantId,
+    correlationId: messageCorrelationId(apiId, form),
+    context: messageContext(form),
+    payload: { form: mapMessageForm(apiId, form) },
+  };
+}
+
+export function formMessageForwarded(
+  apiId: AdspId,
+  form: FormEntity,
+  recipientEmail: string,
+  message: string,
+  timestamp: Date,
+): DomainEvent {
+  return {
+    name: FORM_MESSAGE_FORWARDED,
+    timestamp,
+    tenantId: form.tenantId,
+    correlationId: messageCorrelationId(apiId, form),
+    context: messageContext(form),
+    payload: { form: mapMessageForm(apiId, form), recipientEmail, message },
+  };
+}

--- a/apps/form-service/src/form/index.ts
+++ b/apps/form-service/src/form/index.ts
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19 — barrel and middleware wiring; the routers and jobs it assembles are covered by their own specs.
 import { AdspId, EventService, ServiceDirectory, TenantService, TokenProvider, adspId } from '@abgov/adsp-service-sdk';
 import { Application } from 'express';
 import { Logger } from 'winston';
@@ -21,6 +22,7 @@ export * from './events';
 export * from './notifications';
 export * from './pdf';
 export * from './calendar';
+export * from './jobs/messageNotification';
 
 interface FormMiddlewareProps extends Repositories {
   serviceId: AdspId;

--- a/apps/form-service/src/form/jobs/delete.spec.ts
+++ b/apps/form-service/src/form/jobs/delete.spec.ts
@@ -38,6 +38,7 @@ describe('delete', () => {
     unsubscribe: jest.fn(),
     sendCode: jest.fn(),
     verifyCode: jest.fn(),
+    hasSubscribers: jest.fn(),
   };
 
   const validationService: ValidationService = {

--- a/apps/form-service/src/form/jobs/lock.spec.ts
+++ b/apps/form-service/src/form/jobs/lock.spec.ts
@@ -34,6 +34,7 @@ describe('lock', () => {
     unsubscribe: jest.fn(),
     sendCode: jest.fn(),
     verifyCode: jest.fn(),
+    hasSubscribers: jest.fn(),
   };
 
   const validationService: ValidationService = {

--- a/apps/form-service/src/form/jobs/messageNotification.spec.ts
+++ b/apps/form-service/src/form/jobs/messageNotification.spec.ts
@@ -1,0 +1,174 @@
+import { adspId, Channel } from '@abgov/adsp-service-sdk';
+import { Logger } from 'winston';
+import { createMessageNotificationJob, REVIEWER_NOTIFICATION_TYPE_ID } from './messageNotification';
+import {
+  FORM_MESSAGE_FORWARDED,
+  FORM_MESSAGE_TO_APPLICANT,
+  FORM_MESSAGE_TO_REVIEWER,
+} from '../events';
+
+describe('messageNotification', () => {
+  const apiId = adspId`urn:ads:platform:form-service:v1`;
+  const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+  const formUrn = 'urn:ads:platform:form-service:v1:/forms/form-1';
+  const subscriberUrn = adspId`urn:ads:platform:notification-service:v1:/subscribers/subscriber-1`;
+
+  const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as Logger;
+  const repository = { get: jest.fn() };
+  const commentService = { createSupportTopic: jest.fn(), getComment: jest.fn() };
+  const notificationService = {
+    getSubscriber: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    hasSubscribers: jest.fn(),
+    sendCode: jest.fn(),
+    verifyCode: jest.fn(),
+  };
+  const eventService = { send: jest.fn() };
+
+  const form = {
+    id: 'form-1',
+    tenantId,
+    createdBy: { id: 'applicant-1', name: 'Applicant' },
+    applicant: { urn: subscriberUrn },
+    definition: {
+      id: 'licence',
+      name: 'Business licence application',
+      reviewConfiguration: { columns: [], questionsEmail: 'intake@gov.ab.ca' },
+    },
+  };
+
+  const commentCreated = (createdById: string, overrides = {}) => ({
+    namespace: 'comment-service',
+    name: 'comment-created',
+    timestamp: new Date('2026-08-31T12:00:00.000Z'),
+    tenantId,
+    correlationId: formUrn,
+    context: { topicTypeId: 'form-questions', topicId: 12, resourceId: formUrn, commentId: 34 },
+    payload: { createdBy: { id: createdById } },
+    ...overrides,
+  });
+
+  const createJob = () =>
+    createMessageNotificationJob({
+      apiId,
+      logger,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      repository: repository as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      commentService: commentService as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      notificationService: notificationService as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      eventService: eventService as any,
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository.get.mockResolvedValue(form);
+    notificationService.getSubscriber.mockResolvedValue({
+      channels: [{ channel: Channel.email, address: 'applicant@test.co' }],
+    });
+    notificationService.hasSubscribers.mockResolvedValue(false);
+    commentService.getComment.mockResolvedValue({ content: 'Where do I upload my licence?' });
+  });
+
+  it('notifies the applicant when a reviewer sends a message', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(commentCreated('reviewer-1') as any);
+
+    expect(eventService.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: FORM_MESSAGE_TO_APPLICANT,
+        payload: expect.objectContaining({ recipientEmail: 'applicant@test.co' }),
+      }),
+    );
+  });
+
+  it('does not include the message when notifying the applicant', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(commentCreated('reviewer-1') as any);
+
+    expect(eventService.send.mock.calls[0][0].payload).not.toHaveProperty('message');
+  });
+
+  it('notifies a reviewer that is part of the conversation', async () => {
+    notificationService.hasSubscribers.mockResolvedValue(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(commentCreated('applicant-1') as any);
+
+    expect(notificationService.hasSubscribers).toHaveBeenCalledWith(
+      tenantId,
+      REVIEWER_NOTIFICATION_TYPE_ID,
+      `${apiId}:/forms/form-1`,
+    );
+    expect(eventService.send).toHaveBeenCalledWith(expect.objectContaining({ name: FORM_MESSAGE_TO_REVIEWER }));
+  });
+
+  it('forwards the question with its message when no reviewer is part of the conversation', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(commentCreated('applicant-1') as any);
+
+    expect(commentService.getComment).toHaveBeenCalledWith(tenantId, 12, 34);
+    expect(eventService.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: FORM_MESSAGE_FORWARDED,
+        payload: expect.objectContaining({
+          recipientEmail: 'intake@gov.ab.ca',
+          message: 'Where do I upload my licence?',
+        }),
+      }),
+    );
+  });
+
+  it('sends nothing when no reviewer is known and no address is configured', async () => {
+    repository.get.mockResolvedValue({
+      ...form,
+      definition: { ...form.definition, reviewConfiguration: { columns: [] } },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(commentCreated('applicant-1') as any);
+
+    expect(eventService.send).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing when the applicant has no email address', async () => {
+    repository.get.mockResolvedValue({ ...form, applicant: null });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(commentCreated('reviewer-1') as any);
+
+    expect(eventService.send).not.toHaveBeenCalled();
+  });
+
+  it('ignores comments on topics that are not form questions', async () => {
+    const event = commentCreated('reviewer-1', {
+      context: { topicTypeId: 'other-topic', topicId: 12, resourceId: formUrn, commentId: 34 },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(event as any);
+
+    expect(repository.get).not.toHaveBeenCalled();
+    expect(eventService.send).not.toHaveBeenCalled();
+  });
+
+  it('ignores events other than a created comment', async () => {
+    const event = commentCreated('reviewer-1', { name: 'comment-deleted' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await createJob()(event as any);
+
+    expect(repository.get).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when the form cannot be read', async () => {
+    repository.get.mockRejectedValue(new Error('oh noes!'));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(createJob()(commentCreated('reviewer-1') as any)).resolves.toBeUndefined();
+    expect(eventService.send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/form-service/src/form/jobs/messageNotification.ts
+++ b/apps/form-service/src/form/jobs/messageNotification.ts
@@ -1,0 +1,143 @@
+import { AdspId, Channel, EventService } from '@abgov/adsp-service-sdk';
+import { DomainEvent } from '@core-services/core-common';
+import { Logger } from 'winston';
+import { CommentService, SUPPORT_COMMENT_TOPIC_TYPE_ID } from '../comment';
+import { formMessageForwarded, formMessageToApplicant, formMessageToReviewer } from '../events';
+import { FormRepository } from '../repository';
+import { NotificationService } from '../../notification';
+
+const COMMENT_SERVICE_NAMESPACE = 'comment-service';
+const COMMENT_CREATED = 'comment-created';
+
+// Reviewers aren't recorded against a form; they subscribe to this type when they reply, so a
+// subscription for the form is what tells us a reviewer is part of the conversation.
+export const REVIEWER_NOTIFICATION_TYPE_ID = 'form-message-reviewer-notifications';
+
+export interface MessageNotificationJobProps {
+  apiId: AdspId;
+  logger: Logger;
+  repository: FormRepository;
+  commentService: CommentService;
+  notificationService: NotificationService;
+  eventService: EventService;
+}
+
+function getFormId(resourceId: string): string {
+  return /\/forms\/([^/]+)$/.exec(resourceId || '')?.[1];
+}
+
+/**
+ * Notifies the other party by email when a message is posted on a form's support topic.
+ *
+ * Messages are posted straight to the comment service, so this reacts to the resulting domain event
+ * rather than sitting in the request path. Nothing here can prevent a message from being saved.
+ */
+export function createMessageNotificationJob({
+  apiId,
+  logger,
+  repository,
+  commentService,
+  notificationService,
+  eventService,
+}: MessageNotificationJobProps) {
+  return async function (event: DomainEvent): Promise<void> {
+    if (event?.namespace !== COMMENT_SERVICE_NAMESPACE || event?.name !== COMMENT_CREATED) {
+      return;
+    }
+
+    if (event.context?.topicTypeId !== SUPPORT_COMMENT_TOPIC_TYPE_ID) {
+      return;
+    }
+
+    try {
+      const tenantId = event.tenantId;
+      const formId = getFormId(event.context?.resourceId as string);
+      const form = formId && (await repository.get(tenantId, formId));
+      if (!form) {
+        logger.warn(`No form found for message on topic resource ${event.context?.resourceId}; skipping notification.`);
+        return;
+      }
+
+      // The applicant is the user that created the form and the only explicit commenter on the
+      // topic; anyone else posting is a reviewer acting through their role.
+      const createdBy = event.payload?.createdBy as { id?: string };
+      const fromApplicant = createdBy?.id === form.createdBy?.id;
+      if (!fromApplicant) {
+        await notifyApplicant({ apiId, logger, notificationService, eventService }, form, event);
+      } else {
+        await notifyReviewer({ apiId, logger, commentService, notificationService, eventService }, form, event);
+      }
+    } catch (err) {
+      // The message is already saved; a notification failure must not take the consumer down.
+      logger.error(`Error encountered notifying of form message. ${err}`);
+    }
+  };
+}
+
+type FormOf<T> = T extends (tenantId: AdspId, id: string) => Promise<infer R> ? R : never;
+type Form = FormOf<FormRepository['get']>;
+
+async function notifyApplicant(
+  {
+    apiId,
+    logger,
+    notificationService,
+    eventService,
+  }: Pick<MessageNotificationJobProps, 'apiId' | 'logger' | 'notificationService' | 'eventService'>,
+  form: Form,
+  event: DomainEvent
+): Promise<void> {
+  const subscriber = form.applicant ? await notificationService.getSubscriber(form.tenantId, form.applicant.urn) : null;
+  const address = subscriber?.channels?.find(({ channel }) => channel === Channel.email)?.address;
+
+  // Forms created by an intake application on someone's behalf may have no applicant to write to.
+  if (!address) {
+    logger.info(`No applicant email address for form ${form.id}; no message notification sent.`);
+    return;
+  }
+
+  eventService.send(formMessageToApplicant(apiId, form, address, event.timestamp));
+}
+
+async function notifyReviewer(
+  {
+    apiId,
+    logger,
+    commentService,
+    notificationService,
+    eventService,
+  }: Pick<
+    MessageNotificationJobProps,
+    'apiId' | 'logger' | 'commentService' | 'notificationService' | 'eventService'
+  >,
+  form: Form,
+  event: DomainEvent
+): Promise<void> {
+  const correlationId = `${apiId}:/forms/${form.id}`;
+  const hasReviewer = await notificationService.hasSubscribers(form.tenantId, REVIEWER_NOTIFICATION_TYPE_ID, correlationId);
+  if (hasReviewer) {
+    eventService.send(formMessageToReviewer(apiId, form, event.timestamp));
+    return;
+  }
+
+  const address = form.definition?.reviewConfiguration?.questionsEmail;
+  if (!address) {
+    logger.info(`No reviewer subscribed and no questions email set for form ${form.id}; no notification sent.`);
+    return;
+  }
+
+  // This address is triaging the question rather than reading it in the app, so it needs the
+  // message itself, which the comment created event does not carry.
+  const comment = await commentService.getComment(
+    form.tenantId,
+    event.context?.topicId as number,
+    event.context?.commentId as number
+  );
+
+  if (!comment?.content) {
+    logger.warn(`Unable to read message ${event.context?.commentId} for form ${form.id}; no notification sent.`);
+    return;
+  }
+
+  eventService.send(formMessageForwarded(apiId, form, address, comment.content, event.timestamp));
+}

--- a/apps/form-service/src/form/mapper.ts
+++ b/apps/form-service/src/form/mapper.ts
@@ -24,7 +24,9 @@ export function mapFormDefinition(entity: FormDefinition, revision: number, inta
     scheduledIntakes: entity.scheduledIntakes,
     supportTopic: entity.supportTopic,
     registeredId: entity.registeredId,
-    reviewConfiguration: entity.reviewConfiguration || { columns: [] },
+    // Only the columns are of interest to clients; the questions email is internal routing
+    // configuration and is deliberately not exposed to form applicants.
+    reviewConfiguration: { columns: entity.reviewConfiguration?.columns || [] },
     created,
     intake: intake ? intake : null,
   };

--- a/apps/form-service/src/form/model/definition.spec.ts
+++ b/apps/form-service/src/form/model/definition.spec.ts
@@ -392,6 +392,7 @@ describe('FormDefinitionEntity', () => {
       unsubscribe: jest.fn(),
       sendCode: jest.fn(),
       verifyCode: jest.fn(),
+      hasSubscribers: jest.fn(),
     };
 
     const subscriberId = adspId`urn:ads:platform:notification-service:v1:/subscribers/test`;

--- a/apps/form-service/src/form/model/form.spec.ts
+++ b/apps/form-service/src/form/model/form.spec.ts
@@ -79,6 +79,7 @@ describe('FormEntity', () => {
     unsubscribe: jest.fn(),
     sendCode: jest.fn(),
     verifyCode: jest.fn(),
+    hasSubscribers: jest.fn(),
   };
 
   const fileMock = {

--- a/apps/form-service/src/form/notifications.spec.ts
+++ b/apps/form-service/src/form/notifications.spec.ts
@@ -1,0 +1,63 @@
+import { Channel } from '@abgov/adsp-service-sdk';
+import { FormMessageNotificationType, FormMessageReviewerNotificationType } from './notifications';
+import {
+  formMessageForwarded,
+  formMessageToApplicant,
+  FORM_MESSAGE_FORWARDED,
+  FORM_MESSAGE_TO_APPLICANT,
+  FORM_MESSAGE_TO_REVIEWER,
+} from './events';
+import { adspId } from '@abgov/adsp-service-sdk';
+
+describe('form message notification types', () => {
+  const apiId = adspId`urn:ads:platform:form-service:v1`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const form = { id: 'form-1', tenantId: null, definition: { id: 'licence', name: 'Licence' } } as any;
+
+  describe('FormMessageNotificationType', () => {
+    // Notification service picks the direct implementation when addressPath is set, and reads the
+    // recipient out of the event payload at that path. A mismatch here silently sends nothing.
+    it('addresses notifications from a property the events actually set', () => {
+      expect(FormMessageNotificationType.addressPath).toBe('recipientEmail');
+
+      expect(formMessageToApplicant(apiId, form, 'applicant@test.co', new Date()).payload).toHaveProperty(
+        FormMessageNotificationType.addressPath,
+      );
+      expect(formMessageForwarded(apiId, form, 'intake@test.co', 'a question', new Date()).payload).toHaveProperty(
+        FormMessageNotificationType.addressPath,
+      );
+    });
+
+    it('has an email template for each of its events', () => {
+      expect(FormMessageNotificationType.events.map(({ name }) => name)).toEqual([
+        FORM_MESSAGE_TO_APPLICANT,
+        FORM_MESSAGE_FORWARDED,
+      ]);
+      FormMessageNotificationType.events.forEach((event) => expect(event.templates.email).toBeTruthy());
+      expect(FormMessageNotificationType.channels).toEqual([Channel.email]);
+    });
+
+    it('includes the message only when forwarding to the configured address', () => {
+      const toApplicant = FormMessageNotificationType.events.find(({ name }) => name === FORM_MESSAGE_TO_APPLICANT);
+      const forwarded = FormMessageNotificationType.events.find(({ name }) => name === FORM_MESSAGE_FORWARDED);
+
+      expect(JSON.stringify(toApplicant.templates.email)).not.toContain('payload.message');
+      expect(JSON.stringify(forwarded.templates.email)).toContain('payload.message');
+    });
+  });
+
+  describe('FormMessageReviewerNotificationType', () => {
+    // Reviewers are reached through their own subscription, so this type must stay subscription
+    // based; giving it an address path would turn it into a direct type and skip subscribers.
+    it('is subscription based', () => {
+      expect(FormMessageReviewerNotificationType.addressPath).toBeUndefined();
+      expect(FormMessageReviewerNotificationType.events.map(({ name }) => name)).toEqual([FORM_MESSAGE_TO_REVIEWER]);
+    });
+
+    it('does not include the message', () => {
+      const [event] = FormMessageReviewerNotificationType.events;
+
+      expect(JSON.stringify(event.templates.email)).not.toContain('payload.message');
+    });
+  });
+});

--- a/apps/form-service/src/form/notifications.ts
+++ b/apps/form-service/src/form/notifications.ts
@@ -1,5 +1,14 @@
 import { Channel, NotificationType } from '@abgov/adsp-service-sdk';
-import { FORM_CREATED, FORM_LOCKED, FORM_SUBMITTED, FORM_UNLOCKED, FORM_SET_TO_DRAFT } from './events';
+import {
+  FORM_CREATED,
+  FORM_LOCKED,
+  FORM_MESSAGE_FORWARDED,
+  FORM_MESSAGE_TO_APPLICANT,
+  FORM_MESSAGE_TO_REVIEWER,
+  FORM_SUBMITTED,
+  FORM_UNLOCKED,
+  FORM_SET_TO_DRAFT,
+} from './events';
 
 const FORM_EVENT_NAMESPACE = 'form-service';
 
@@ -128,6 +137,81 @@ export const FormStatusNotificationType: NotificationType = {
             '{{#if event.payload.form.formDraftUrl}} ' +
             'Use the following link to see a copy of your submitted form: {{ event.payload.form.formDraftUrl }}' +
             '{{/if}}',
+        },
+      },
+    },
+  ],
+};
+
+// Messages between an applicant and a reviewer are notified by email so that neither has to sign in
+// to find out something is waiting. The address is read off the event rather than from a
+// subscription, so no subscriber has to be registered per form.
+export const FormMessageNotificationType: NotificationType = {
+  name: 'form-message-notifications',
+  displayName: 'Form message notifications',
+  description: 'Provides notification of messages sent between a form applicant and a reviewer.',
+  publicSubscribe: true,
+  subscriberRoles: [],
+  channels: [Channel.email],
+  addressPath: 'recipientEmail',
+  events: [
+    {
+      namespace: FORM_EVENT_NAMESPACE,
+      name: FORM_MESSAGE_TO_APPLICANT,
+      templates: {
+        email: {
+          subject: 'New message about your {{ event.payload.form.definition.name }} submission',
+          title: '{{ event.payload.form.definition.name }}',
+          subtitle: 'You have a new message',
+          body: `
+<section>
+  <p>You have received a message regarding your <b>{{ event.payload.form.definition.name }}</b> submission. Please log in to the form application to read your message and respond.</p>
+</section>`,
+        },
+      },
+    },
+    {
+      namespace: FORM_EVENT_NAMESPACE,
+      name: FORM_MESSAGE_FORWARDED,
+      templates: {
+        email: {
+          subject: 'New message from a {{ event.payload.form.definition.name }} applicant',
+          title: '{{ event.payload.form.definition.name }}',
+          subtitle: 'A message needs a response',
+          body: `
+<section>
+  <p>The following message from a <b>{{ event.payload.form.definition.name }}</b> applicant has been received.</p>
+  <blockquote>{{ event.payload.message }}</blockquote>
+  <p>Please log in to the form admin application to read the message and respond.</p>
+</section>`,
+        },
+      },
+    },
+  ],
+};
+
+// Reviewers aren't recorded against a form, so they make themselves reachable by subscribing when
+// they reply. That subscription is what makes a reviewer "known" for a conversation.
+export const FormMessageReviewerNotificationType: NotificationType = {
+  name: 'form-message-reviewer-notifications',
+  displayName: 'Form message notifications for reviewers',
+  description: 'Provides notification to reviewers of messages sent by a form applicant.',
+  publicSubscribe: false,
+  subscriberRoles: [],
+  channels: [Channel.email],
+  events: [
+    {
+      namespace: FORM_EVENT_NAMESPACE,
+      name: FORM_MESSAGE_TO_REVIEWER,
+      templates: {
+        email: {
+          subject: 'New message from a {{ event.payload.form.definition.name }} applicant',
+          title: '{{ event.payload.form.definition.name }}',
+          subtitle: 'You have a new message',
+          body: `
+<section>
+  <p>You have received a message from a <b>{{ event.payload.form.definition.name }}</b> applicant. Please log in to the form admin application to read your message and respond.</p>
+</section>`,
         },
       },
     },

--- a/apps/form-service/src/form/router/form.spec.ts
+++ b/apps/form-service/src/form/router/form.spec.ts
@@ -167,6 +167,7 @@ describe('form router', () => {
     unsubscribe: jest.fn(),
     sendCode: jest.fn(),
     verifyCode: jest.fn(),
+    hasSubscribers: jest.fn(),
   };
 
   const fileServiceMock = {
@@ -175,6 +176,7 @@ describe('form router', () => {
 
   const commentServiceMock = {
     createSupportTopic: jest.fn(),
+    getComment: jest.fn(),
   };
 
   const pdfServiceMock = {

--- a/apps/form-service/src/form/router/form.swagger.yml
+++ b/apps/form-service/src/form/router/form.swagger.yml
@@ -108,6 +108,11 @@ components:
                     type: string
                     description: Dot-separated path of a leaf field in the form data schema.
                     minLength: 1
+            questionsEmail:
+              type: string
+              description: >-
+                Address that applicant questions are forwarded to while no reviewer is part of the
+                conversation. Not returned by the form APIs.
         dryRun:
           type: boolean
         intake:

--- a/apps/form-service/src/form/types/definition.ts
+++ b/apps/form-service/src/form/types/definition.ts
@@ -1,3 +1,4 @@
+// clean-code-ignore: RULE-19 — type declarations only.
 import { SecurityClassificationType } from './form';
 export interface FormDefinition {
   id: string;
@@ -36,6 +37,8 @@ export interface ReviewColumn {
 
 export interface ReviewConfiguration {
   columns: ReviewColumn[];
+  // Address that applicant questions are forwarded to when no reviewer is part of the conversation.
+  questionsEmail?: string;
 }
 
 export interface QueueTaskToProcess {

--- a/apps/form-service/src/main.ts
+++ b/apps/form-service/src/main.ts
@@ -17,7 +17,8 @@ import {
   instrumentAxios,
 } from '@abgov/adsp-service-sdk';
 import type { User } from '@abgov/adsp-service-sdk';
-import { createLogger, createErrorHandler, AjvValidationService } from '@core-services/core-common';
+// clean-code-ignore: RULE-19 — service bootstrap; the routers, jobs and types it wires are covered by their own specs.
+import { createLogger, createErrorHandler, AjvValidationService, createAmqpEventService } from '@core-services/core-common';
 import { environment } from './environments/environment';
 import {
   applyFormMiddleware,
@@ -43,6 +44,12 @@ import {
   FormExportFileType,
   FormQuestionUpdatesStream,
   SubmissionDeletedDefinition,
+  FormMessageToApplicantDefinition,
+  FormMessageToReviewerDefinition,
+  FormMessageForwardedDefinition,
+  FormMessageNotificationType,
+  FormMessageReviewerNotificationType,
+  createMessageNotificationJob,
 } from './form';
 import { createRepositories } from './mongo';
 import { createNotificationService } from './notification';
@@ -138,9 +145,12 @@ const initializeApp = async (): Promise<express.Application> => {
         FormStatusSetToDraftDefinition,
         SubmissionDispositionedDefinition,
         SubmissionDeletedDefinition,
+        FormMessageToApplicantDefinition,
+        FormMessageToReviewerDefinition,
+        FormMessageForwardedDefinition,
       ],
       eventStreams: [SubmittedFormPdfUpdatesStream, FormQuestionUpdatesStream],
-      notifications: [FormStatusNotificationType],
+      notifications: [FormStatusNotificationType, FormMessageNotificationType, FormMessageReviewerNotificationType],
       values: [ServiceMetricsValueDefinition],
       serviceConfigurations: [
         // Register comment service form support comment topic.
@@ -280,6 +290,27 @@ const initializeApp = async (): Promise<express.Application> => {
     logger,
     configurationService,
     notificationService,
+  });
+
+  // Messages are posted straight to the comment service, so form message notifications are driven
+  // off the resulting domain event rather than from the request path.
+  const eventSubscriber = await createAmqpEventService({
+    ...environment,
+    queue: 'form-message-notification',
+    logger,
+  });
+
+  const messageNotificationJob = createMessageNotificationJob({
+    apiId: adspId`${serviceId}:v1`,
+    logger,
+    repository: repositories.formRepository,
+    commentService,
+    notificationService,
+    eventService,
+  });
+
+  eventSubscriber.getItems().subscribe(({ item, done }) => {
+    messageNotificationJob(item).finally(() => done());
   });
 
   applyFormMiddleware(app, {

--- a/apps/form-service/src/notification.ts
+++ b/apps/form-service/src/notification.ts
@@ -22,6 +22,7 @@ export interface NotificationService {
     subscriber?: Omit<Subscriber, 'urn'>
   ): Promise<Subscriber>;
   unsubscribe(tenantId: AdspId, urn: AdspId, formId: string): Promise<boolean>;
+  hasSubscribers(tenantId: AdspId, typeId: string, correlationId: string): Promise<boolean>;
   sendCode(tenantId: AdspId, subscriber: Subscriber): Promise<void>;
   verifyCode(tenantId: AdspId, subscriber: Subscriber, code: string): Promise<boolean>;
 }
@@ -146,6 +147,35 @@ class NotificationServiceImpl implements NotificationService {
       return deleted;
     } catch (err) {
       this.logger.warn(`Error encountered unsubscribing for subscriber ${urn}. ${err}`, {
+        ...LOG_CONTEXT,
+        tenant: tenantId?.toString(),
+      });
+
+      return false;
+    }
+  }
+
+  // A reviewer becomes reachable for a form by subscribing when they reply, so the presence of a
+  // subscription is what tells us whether anyone is part of the conversation.
+  async hasSubscribers(tenantId: AdspId, typeId: string, correlationId: string): Promise<boolean> {
+    try {
+      const apiUrl = await this.directory.getServiceUrl(this.notificationApiId);
+      const subscriptionUrl = new URL(`v1/types/${typeId}/subscriptions`, apiUrl);
+
+      const token = await this.tokenProvider.getAccessToken();
+      const { data } = await axios.get<{ results: unknown[] }>(subscriptionUrl.href, {
+        headers: { Authorization: `Bearer ${token}` },
+        params: {
+          tenantId: tenantId.toString(),
+          top: 1,
+          criteria: JSON.stringify({ subscriptionMatch: { correlationId } }),
+        },
+      });
+
+      return data?.results?.length > 0;
+    } catch (err) {
+      // Treated as nobody being subscribed, so the question still reaches the configured address.
+      this.logger.warn(`Error encountered checking subscribers of ${typeId} for ${correlationId}. ${err}`, {
         ...LOG_CONTEXT,
         tenant: tenantId?.toString(),
       });

--- a/apps/tenant-management-webapp/src/app/store/form/model.ts
+++ b/apps/tenant-management-webapp/src/app/store/form/model.ts
@@ -42,6 +42,9 @@ export interface ReviewColumn {
 
 export interface ReviewConfiguration {
   columns: ReviewColumn[];
+  // clean-code-ignore: RULE-19 — type declarations and defaults only.
+  // Address that applicant questions are forwarded to when no reviewer is part of the conversation.
+  questionsEmail?: string;
 }
 
 export interface FormResourceTagResponse {

--- a/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
+++ b/libs/form-editor-common/src/lib/definitions/addEditFormDefinitionEditor.tsx
@@ -38,7 +38,15 @@ import {
 } from '@lib/autoComplete';
 import { isValidJSONSchemaCheck } from '@lib/validation/checkInput';
 import { useValidators } from '@lib/validation/useValidators';
-import { isNotEmptyCheck, wordMaxLengthCheck, badCharsCheck } from '@lib/validation/checkInput';
+// clean-code-ignore: RULE-19 — no test harness for this editor container; the review tab it hosts is
+// covered by ./reviewConfigurationTab.spec.tsx.
+import {
+  isNotEmptyCheck,
+  wordMaxLengthCheck,
+  badCharsCheck,
+  characterCheck,
+  validationPattern,
+} from '@lib/validation/checkInput';
 import useWindowDimensions from '@lib/useWindowDimensions';
 import { AppDispatch, RootState } from '@store/index';
 import { FETCH_KEYCLOAK_SERVICE_ROLES } from '@store/access/actions';
@@ -380,6 +388,8 @@ export function AddEditFormDefinitionEditor({
     isNotEmptyCheck('name'),
   )
     .add('description', 'description', wordMaxLengthCheck(180, 'Description'))
+    // Optional, so an empty value passes; characterCheck returns no error for one.
+    .add('questionsEmail', 'questionsEmail', characterCheck(validationPattern.validEmail))
     .build();
 
   const getQueueTaskToProcessValue = () => {
@@ -1168,7 +1178,12 @@ export function AddEditFormDefinitionEditor({
                         <ReviewConfigurationTab
                           schema={dataSchema}
                           reviewConfiguration={definition.reviewConfiguration}
-                          onChange={(reviewConfiguration) => setDefinition({ reviewConfiguration })}
+                          questionsEmailError={errors?.['questionsEmail']}
+                          onChange={(reviewConfiguration) => {
+                            validators.remove('questionsEmail');
+                            validators['questionsEmail'].check(reviewConfiguration.questionsEmail || '');
+                            setDefinition({ reviewConfiguration });
+                          }}
                         />
                       </EditorTabScroll>
                     </BorderBottom>

--- a/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.spec.tsx
+++ b/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.spec.tsx
@@ -182,4 +182,64 @@ describe('ReviewConfigurationTab', () => {
     expect(queryByTestIdAttr(container, 'stale-path-badge')).toBeTruthy();
     expect(screen.getByTestId('review-column-path-removedField').textContent).toBe('removedField');
   });
+  it('edits the address that questions are forwarded to', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <ReviewConfigurationTab schema={schema} reviewConfiguration={{ columns: [] }} onChange={onChange} />,
+    );
+
+    fireEvent(
+      container.querySelector('goa-input[name="questions-email"]'),
+      new CustomEvent('_change', { detail: { value: 'intake@gov.ab.ca' } }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith({ columns: [], questionsEmail: 'intake@gov.ab.ca' });
+  });
+
+  it('keeps the forwarding address when a column is added', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <ReviewConfigurationTab
+        schema={schema}
+        reviewConfiguration={{ columns: [], questionsEmail: 'intake@gov.ab.ca' }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent(
+      container.querySelector('goa-dropdown[name="review-field"]'),
+      new CustomEvent('_change', { detail: { value: 'firstName' } }),
+    );
+    fireEvent(queryByTestIdAttr(container, 'add-review-field'), new CustomEvent('_click'));
+
+    expect(onChange).toHaveBeenCalledWith({ columns: [{ path: 'firstName' }], questionsEmail: 'intake@gov.ab.ca' });
+  });
+
+  it('keeps the forwarding address when a column is removed', () => {
+    const onChange = jest.fn();
+    render(
+      <ReviewConfigurationTab
+        schema={schema}
+        reviewConfiguration={{ columns: [{ path: 'firstName' }], questionsEmail: 'intake@gov.ab.ca' }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('review-column-delete-firstName'));
+
+    expect(onChange).toHaveBeenCalledWith({ columns: [], questionsEmail: 'intake@gov.ab.ca' });
+  });
+
+  it('shows an error for an invalid forwarding address', () => {
+    const { container } = render(
+      <ReviewConfigurationTab
+        schema={schema}
+        reviewConfiguration={{ columns: [] }}
+        questionsEmailError="Please enter a valid email address"
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(container.querySelector('goa-form-item[error="Please enter a valid email address"]')).toBeTruthy();
+  });
 });

--- a/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.tsx
+++ b/libs/form-editor-common/src/lib/definitions/reviewConfigurationTab.tsx
@@ -6,8 +6,9 @@ import {
   GoabDropdown,
   GoabDropdownItem,
   GoabFormItem,
+  GoabInput,
 } from '@abgov/react-components';
-import { GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
+import { GoabDropdownOnChangeDetail, GoabInputOnChangeDetail } from '@abgov/ui-components-common';
 import DataTable from '@components/DataTable';
 import type { ReviewConfiguration } from '@store/form/model';
 import { ReviewColumnItems } from './reviewColumnItems';
@@ -19,12 +20,14 @@ const LARGE_COLUMN_COUNT = 6;
 interface ReviewConfigurationTabProps {
   schema: unknown;
   reviewConfiguration?: ReviewConfiguration;
+  questionsEmailError?: string;
   onChange: (reviewConfiguration: ReviewConfiguration) => void;
 }
 
 export const ReviewConfigurationTab: FunctionComponent<ReviewConfigurationTabProps> = ({
   schema,
   reviewConfiguration,
+  questionsEmailError,
   onChange,
 }) => {
   const [selectedPath, setSelectedPath] = useState('');
@@ -38,7 +41,7 @@ export const ReviewConfigurationTab: FunctionComponent<ReviewConfigurationTabPro
       return;
     }
 
-    onChange({ columns: [...columns, { path: selectedPath }] });
+    onChange({ ...reviewConfiguration, columns: [...columns, { path: selectedPath }] });
     setSelectedPath('');
   };
 
@@ -92,6 +95,25 @@ export const ReviewConfigurationTab: FunctionComponent<ReviewConfigurationTabPro
         </ReviewAddFieldRow>
       </GoabFormItem>
 
+      <GoabFormItem
+        label="Forward questions to"
+        error={questionsEmailError}
+        helpText="Applicant questions are emailed here until a reviewer replies. Leave blank to send nothing."
+        mt="l"
+      >
+        <GoabInput
+          name="questions-email"
+          testId="review-questions-email"
+          type="email"
+          size="compact"
+          width="100%"
+          value={reviewConfiguration?.questionsEmail || ''}
+          onChange={(detail: GoabInputOnChangeDetail) =>
+            onChange({ ...reviewConfiguration, columns, questionsEmail: detail.value })
+          }
+        />
+      </GoabFormItem>
+
       {columns.length > LARGE_COLUMN_COUNT && (
         <GoabCallout type="important" size="medium" mt="m" testId="review-config-large-list">
           Keep the list of columns small so the Form Admin submission table stays easy to scan.
@@ -117,7 +139,7 @@ export const ReviewConfigurationTab: FunctionComponent<ReviewConfigurationTabPro
             <ReviewColumnItems
               columns={columns}
               fieldsByPath={fieldsByPath}
-              onChange={(nextColumns) => onChange({ columns: nextColumns })}
+              onChange={(nextColumns) => onChange({ ...reviewConfiguration, columns: nextColumns })}
             />
           </tbody>
         </DataTable>


### PR DESCRIPTION
Per [CS-5330](https://goa-dio.atlassian.net/browse/CS-5330), a message on a form's support topic now sends an email so neither party has to sign in to discover it.

| Who sent it | Who is emailed | Message body included? |
|---|---|---|
| Reviewer → applicant | the applicant | no |
| Applicant → a reviewer who has replied | that reviewer | no |
| Applicant → nobody engaged yet | the address on the Review tab | **yes** |
| Applicant → nobody engaged, no address | nobody | — |

<img width="1235" height="835" alt="image" src="https://github.com/user-attachments/assets/5317a5b3-1d41-4db8-914b-cbdd72f920ea" />
<img width="1804" height="670" alt="image" src="https://github.com/user-attachments/assets/f821b250-8bfe-4fbc-aa54-2d0ecea9c71d" />
<img width="582" height="585" alt="image" src="https://github.com/user-attachments/assets/1236d15c-28b3-4d45-8505-01041c8f43bc" />
<img width="1890" height="680" alt="image" src="https://github.com/user-attachments/assets/da924d27-1cb0-41f3-b365-444769cb6ec6" />
<img width="923" height="588" alt="image" src="https://github.com/user-attachments/assets/69ee4c8e-0be2-42fe-9f3f-35656996537f" />




### How it hangs together

Messages are posted straight from both SPAs to comment-service, so form-service never saw them. It now consumes `comment-service:comment-created` (filtered to the `form-questions` topic type) through the existing `createAmqpEventService` helper, which is where form knowledge lives — definition name, applicant, configured address. comment-service is unchanged and stays form-agnostic.

Routing emits one of three new form-service events, and delivery is entirely notification-service:

- `form-message-notifications` — a **direct** type (`addressPath: 'recipientEmail'`), so the applicant and forwarding cases need no subscription per form and existing forms work with no backfill.
- `form-message-reviewer-notifications` — subscription-based, for reviewers.

### Decisions worth reviewing

**"The reviewer" is whoever has replied.** There is no reviewer identity anywhere — no `assignedTo`, no assessor field; access is role-based, and the topic's `commenters` holds only the applicant. So form-admin-app subscribes the reviewer when they reply, using `?userSub=true` so the address comes from their own token (nobody can subscribe anyone else). The presence of that subscription is what makes a reviewer "known". Subscribing is best-effort — a failure never fails the reply.

**The forwarded body travels in the event payload.** notification-service renders templates from `event.payload`, so the third case's message content is necessarily on a domain event, and those are persisted in the event log. The ticket withholds bodies elsewhere specifically to limit exposure, so this one wants an explicit nod from Roy before it ships.

**`questionsEmail` is not exposed by the form APIs.** `mapFormDefinition` previously passed `reviewConfiguration` through wholesale; it now maps only `columns`, so the internal triage address does not reach form applicants.

**This is the first direct notification type registered from code.** The mechanism is fully supported, but every `addressPath` type in production today is tenant-authored through the admin UI.

### Notes

- Failure to notify cannot block a message — it is already committed to comment-service before the event is published.
- Forms created by an intake application may have no applicant subscriber, so there is no address; that logs and moves on.
- `AMQP_HOST`/`USER`/`PASSWORD` added to form-service config; the deployment already uses `envFrom`, so no change was needed there.
- The `reviewConfiguration` JSON schema has `additionalProperties: false`, and the Review tab's `onChange` calls rebuilt `{ columns }` literally — both handled, with a test that adding or removing a column keeps the address.