### PR TITLE
feat(tenant-management-webapp): CS-5316 mark reports as alpha

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.spec.tsx
@@ -8,9 +8,9 @@ describe('Reports', () => {
 
     expect(getByTestId('reports-title')).toHaveTextContent('Reports');
   });
-  it('marks the page as beta', () => {
-    const { getByAltText } = render(<Reports />);
+  it('marks the page as alpha', () => {
+    const { getByText } = render(<Reports />);
 
-    expect(getByAltText('Reports beta')).toBeInTheDocument();
+    expect(getByText('Alpha')).toBeInTheDocument();
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/reports/reports.tsx
@@ -1,8 +1,8 @@
 import { Main } from '@components/Html';
-import BetaBadge from '@icons/beta-badge.svg';
 import React, { FunctionComponent } from 'react';
 import { ServiceColumnLayoutWithMargin } from '../../admin';
 import { HeadingDiv } from '../services/styled-components';
+import { alphaBadge } from '../sidebar';
 
 export const Reports: FunctionComponent = () => {
   return (
@@ -10,7 +10,7 @@ export const Reports: FunctionComponent = () => {
       <ServiceColumnLayoutWithMargin>
         <HeadingDiv>
           <h1 data-testid="reports-title">Reports</h1>
-          <img src={BetaBadge} alt="Reports beta" />
+          {alphaBadge()}
         </HeadingDiv>
       </ServiceColumnLayoutWithMargin>
     </Main>

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.spec.tsx
@@ -75,10 +75,10 @@ describe('Sidebar', () => {
 
     expect(() => fireEvent.click(getByTestId('menu-task'))).not.toThrow();
   });
-  it('marks the reports menu item as beta', () => {
+  it('marks the reports menu item as alpha', () => {
     const { getByTestId } = renderSidebar();
 
-    expect(getByTestId('menu-reports').querySelector('img')).toHaveAttribute('alt', 'Reports beta');
+    expect(getByTestId('menu-reports')).toHaveTextContent('Alpha');
   });
 
   it('names the service each beta badge belongs to', () => {

--- a/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/sidebar.tsx
@@ -92,7 +92,7 @@ const Sidebar = ({ type }: SidebarProps) => {
                     data-testid="menu-reports"
                   >
                     <span>Reports</span>
-                    {betaBadge('Reports')}
+                    {alphaBadge()}
                   </NavLink>
                   <NavLink
                     to="/admin"


### PR DESCRIPTION
Swaps the Reports beta badge for the alpha badge, on both the sidebar menu item and the page heading. Reuses the existing `alphaBadge` helper rather than the beta SVG, so Reports matches how other alpha services are marked.

Tests updated to assert the Alpha badge in both places.