### PR TITLE
fix(deps): CS-5342 drop the vulnerable image-size package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10623,19 +10623,19 @@
       }
     },
     "node_modules/@mastra/memory": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@mastra/memory/-/memory-1.20.0.tgz",
-      "integrity": "sha512-pcPjRwTmKslQ97s2t4KoFGQh0BV+gQ/WAIYI8f7LTnsLzfS4PzLO8ZfIob1mJHZrlYDI7TTyM4Gnust43gYr4A==",
-      "license": "Apache-2.0",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@mastra/memory/-/memory-1.28.1.tgz",
+      "integrity": "sha512-ZMKblBgsr7mVBVqsZTT2DYZ7yzCQq7Zc9iEsHrDDSFSa8s9k4ysS7fXNNWUzLzzr7jOiHtvrg6fmfH32snEy5w==",
       "dependencies": {
-        "@mastra/schema-compat": "1.2.10",
+        "@mastra/schema-compat": "1.3.7",
         "async-mutex": "^0.5.0",
-        "image-size": "^2.0.2",
+        "diff": "^8.0.3",
         "json-schema": "^0.4.0",
         "lru-cache": "^11.2.7",
         "probe-image-size": "^7.2.3",
         "tokenx": "^1.3.0",
-        "xxhash-wasm": "^1.1.0"
+        "xxhash-wasm": "^1.1.0",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -10644,16 +10644,12 @@
         "@mastra/core": ">=1.4.1-0 <2.0.0-0"
       }
     },
-    "node_modules/@mastra/memory/node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
+    "node_modules/@mastra/memory/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "engines": {
-        "node": ">=16.x"
+        "node": ">=0.3.1"
       }
     },
     "node_modules/@mastra/memory/node_modules/lru-cache": {
@@ -10663,6 +10659,14 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/@mastra/memory/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@mastra/pg": {
@@ -10683,15 +10687,12 @@
       }
     },
     "node_modules/@mastra/schema-compat": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.2.10.tgz",
-      "integrity": "sha512-8Fg8PeO7GsRPOrEZAzc5udZgsF9ZDxih5JSoxjgnR79d0ImjKffhcoysPW6wIYXPEZ5i6/QDNR7rCazZZSD5Tg==",
-      "license": "Apache-2.0",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.3.7.tgz",
+      "integrity": "sha512-06WfY+j9rulYnDp8CM7pL7JIyrntkMolqmyyb1VJNEzlYTQCIcJcY0SwQiubZv2tztmoYGikszDiRVyXp0E9gA==",
       "dependencies": {
         "json-schema-to-zod": "^2.7.0",
-        "zod-from-json-schema": "^0.5.2",
-        "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
-        "zod-to-json-schema": "^3.25.1"
+        "zod-from-json-schema": "^0.5.2"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -28574,13 +28575,15 @@
       "license": "MIT"
     },
     "node_modules/copy-anything": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
-      "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "is-what": "^3.14.1"
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
@@ -36594,20 +36597,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -37731,11 +37720,16 @@
       }
     },
     "node_modules/is-what": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -42376,30 +42370,27 @@
       }
     },
     "node_modules/less": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.5.1.tgz",
-      "integrity": "sha512-UKgI3/KON4u6ngSsnDADsUERqhZknsVZbnuzlRZXLQCmfC/MDld42fTydUE9B+Mla1AL6SJ/Pp6SlEFi/AVGfw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.8.1.tgz",
+      "integrity": "sha512-jQ3lRIo1aUtiWVYXZ7mk4+V4BjCGswF3IxTLJ+4RUta8ZiHh8lhkig2G8dya2eCcyR1dYUvzuV46EkJN8PSwww==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "copy-anything": "^2.0.1",
-        "parse-node-version": "^1.0.1",
-        "tslib": "^2.3.0"
+        "copy-anything": "^3.0.5",
+        "parse-node-version": "^1.0.1"
       },
       "bin": {
         "lessc": "bin/lessc"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "errno": "^0.1.1",
         "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
+        "make-dir": "^5.1.0",
         "mime": "^1.4.1",
         "needle": "^3.1.0",
+        "probe-image-size": "^7.2.3",
         "source-map": "~0.6.0"
       }
     },
@@ -42431,18 +42422,16 @@
       }
     },
     "node_modules/less/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-5.1.0.tgz",
+      "integrity": "sha512-IfpFq6UM39dUNiphpA6uDezNx/AvWyhwfICWPR3t1VspkgkMZrL+Rk1RbN1bx+aeNYwOrqGJgEgV3yotk+ZUVw==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/less/node_modules/mime": {
@@ -42457,28 +42446,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/less/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/less/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/less/node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -347,6 +347,7 @@
     "yaml": "^2.4.2"
   },
   "overrides": {
+    "less": "4.8.1",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/core": "2.10.0",
     "nx": {


### PR DESCRIPTION
Closes CS-5342.

## What was actually wrong

`image-size` has two unfixed advisories ([GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq)), both with an affected range of `*` — hence the ticket noting no patch exists.

The ticket asks us to swap `image-size` for something like `probe-image-size` in our own code, but **ADSP never imported it**. It has no `package.json` entry and no import under `apps/` or `libs/`. It arrived transitively by two routes:

| Route | Chain | Scope |
|---|---|---|
| A | `@nx/webpack` → `less@4.5.1` → *(optional)* `image-size@0.5.5` | dev |
| B | `@mastra/memory@1.20.0` → `image-size@^2.0.2` | prod (`agent-service`) |

Both upstreams have already made exactly the substitution the ticket describes — they moved to `probe-image-size`. `@mastra/memory` even documents why, citing these advisories. So this is a dependency-only change; no application code is touched.

## Changes

- `less` 4.5.1 → **4.8.1** (4.7.0 was the release that dropped `image-size`), via one `overrides` entry
- `@mastra/memory` 1.20.0 → **1.28.1**, in-range for the existing `^1.7.0`, so no `package.json` change
- Follow-on: `@mastra/schema-compat` 1.2.10 → 1.3.7, `less/make-dir` 2.1.0 → 5.1.0; drops `less/pify` and `less/semver@5`

`probe-image-size@7.2.3` was already in the tree (`@mastra/memory@1.20.0` declared both packages) and is now the sole path.

### Why an override rather than bumping nx

`@nx/webpack@23.1.1` declares `less >=4.1.3 <4.6.0`, which caps us below 4.7.0. `@nx/webpack@23.1.3` widens that, but the `@nx/*` packages exact-pin each other and four of them (`@nx/vite`, `@nx/vitest`, `@nx/docker`, `@nx/module-federation`) are reached only via `@abgov/nx-adsp` peers and are not declared at root — so bumping nx fails with `ERESOLVE` and only resolves after deleting the lockfile, which re-resolves all 4,458 packages for a **115,876-line** lockfile diff. That is unreviewable and risks version drift across every project, so the override keeps the change at 144 lines. Worth revisiting when nx is next upgraded deliberately.

Forcing `less` past its declared range is safe here: the repo contains **zero** `.less` files and no build config references `less-loader`, so `less` is never invoked.

## Verification

- `image-size` — **0 occurrences** in `package-lock.json`, no installs anywhere in the tree
- `npm audit` no longer lists `image-size` or `less` at all; remaining advisories are pre-existing and unrelated
- `nx run-many -t build --all` and `-t test --all`, compared against a baseline run on `main`: **no new failures**. The remaining ones (Python/Java/.NET SDK toolchains, `cache-service`, `token-handler`, `pii-service`) all fail identically on unmodified `main` in this environment
- `agent-service` — the only `@mastra/memory` consumer — builds and tests clean

Manual testing worth doing: observational memory is on by default (`AGENT_OBSERVATIONAL_MEMORY`, `apps/agent-service/src/environments/environment.ts:28`), and the swapped parser sits behind it in `measure-image-buffer`. Sending an agent PNG/JPEG/WebP image attachments through `apps/agent-service/src/agent/processors/file.ts` exercises the changed path.

## Out of scope

`npm audit` also reports separate high findings on `@mastra/core` (via `ajv`) and `@mastra/agentfs` with `fixAvailable: false`. Different advisories, not part of CS-5342.