### PR TITLE
fix(deps): CS-5346 patch the reachable brace-expansion copies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25928,11 +25928,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -51749,11 +51748,10 @@
       }
     },
     "node_modules/nx/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -347,6 +347,8 @@
     "yaml": "^2.4.2"
   },
   "overrides": {
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@5": "5.0.9",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/core": "2.10.0",
     "nx": {


### PR DESCRIPTION
Closes CS-5346.

## What is actually in the tree

`brace-expansion` has **24 copies** in the dependency tree. 20 were already on patched versions (2.1.4 / 5.0.9). Four were in vulnerable ranges (`<=1.1.17 || 2.0.0 - 2.1.3 || 4.0.0 - 5.0.8`):

| Copy | Version | Source | Reachable by `overrides`? |
|---|---|---|---|
| `brace-expansion` | 1.1.13 | `minimatch@3` via `@eslint/eslintrc`, `serve-handler` | yes |
| `nx/node_modules/brace-expansion` | 5.0.8 | `nx` pins exactly `5.0.8` | yes |
| `npm/node_modules/brace-expansion` | 5.0.7 | bundled inside `npm@11.19.0` | no |
| `semantic-release/node_modules/npm/node_modules/brace-expansion` | 2.0.2 | bundled inside `npm@10.9.9` | no |

## Change

Two `overrides` entries, each staying **within its own major** so every consumer's declared range still holds:

```json
"brace-expansion@1": "1.1.18",
"brace-expansion@5": "5.0.9"
```

`minimatch@3`'s `^1.1.7` is satisfied by 1.1.18, and the `^5.0.5` consumers already resolve to 5.0.9. Total diff: 2 lines of `package.json`, 4 changed lockfile values.

## Why the other two are not fixed here

Both are inside the **vendored `npm` CLI**, which ships its dependencies as `bundleDependencies`, so `overrides` cannot rewrite them. The only way to move them is to replace the whole vendored tree:

- `npm@11.19.0` → `11.19.1` fixes one, at a **~47,000-line** lockfile diff
- additionally forcing `semantic-release`'s nested `@semantic-release/npm` 12 → 13 clears the last one, at a **61,316-line** diff, and forces a major plugin bump inside `semantic-release@24` — whose `^24.0.0` peer is pinned by GoA's own `@abgov/maven-semantic-release` and `@abgov/nx-release`

Both variants were built and verified as working, but neither seemed worth the churn and the release-tooling risk: these copies are dev-only release tooling that never ships to a service. This matches the ticket's own criteria — *"the ticket is blocked and retained for fixing when the upgrade is available"*. They should clear naturally when `semantic-release` is next upgraded deliberately.

## Two corrections to the ticket

- It says to upgrade to **2.1.2**. Current advisories cover `2.0.0 - 2.1.3`, so 2.1.2 is still vulnerable; **2.1.4** is the floor for the 2.x line.
- It attributes the package to **cypress-cucumber-preprocessor**. `@badeball/cypress-cucumber-preprocessor` is in the tree, but its `minimatch` already resolves to a patched 5.0.9. The real sources are the four listed above.

## Verification

- Vulnerable copies **4 → 2**; the two remaining are the unreachable vendored ones
- `nx run-many -t build --all` / `-t test --all` compared against a baseline run on `main`: **no new failures**. `tenant-management-webapp:test` failed once with a Windows jest transform-cache `EPERM` race in the shared temp dir, and passes in isolation (78 suites / 364 tests)
- Remaining failures (Python/Java/.NET SDK toolchains, Mongo-memory-server services, `cache-service`, `token-handler`, `pii-service`) all fail identically on unmodified `main` in this environment