### PR TITLE
fix(comment-service): CS-5330 let a service read back its own topic's comments

### DIFF
--- a/apps/comment-service/src/comment/model/topic.spec.ts
+++ b/apps/comment-service/src/comment/model/topic.spec.ts
@@ -114,6 +114,21 @@ describe('TopicEntity', () => {
       const result = entity.canRead({ ...user, roles: [] } as User);
       expect(result).toBe(false);
     });
+
+    it('can return true for core service that sets topics', () => {
+      const result = entity.canRead({
+        ...user,
+        tenantId: null,
+        isCore: true,
+        roles: [ServiceRoles.TopicSetter],
+      } as User);
+      expect(result).toBe(true);
+    });
+
+    it('can return false for core service that does not set topics', () => {
+      const result = entity.canRead({ ...user, tenantId: null, isCore: true, roles: [] } as User);
+      expect(result).toBe(false);
+    });
   });
 
   describe('canComment', () => {
@@ -278,6 +293,28 @@ describe('TopicEntity', () => {
 
     it('can fail for user without role', async () => {
       await expect(entity.getComment({ ...user, roles: [] } as User, 1)).rejects.toThrow(UnauthorizedUserError);
+    });
+
+    it('can return comment for core service that sets topics', async () => {
+      const comment = {
+        id: 123,
+        content: 'test',
+        createdBy: {
+          id: user.id,
+          name: user.name,
+        },
+        lastUpdatedBy: {
+          id: user.id,
+          name: user.name,
+        },
+      };
+      repositoryMock.getComment.mockResolvedValueOnce(comment);
+
+      const result = await entity.getComment(
+        { ...user, tenantId: null, isCore: true, roles: [ServiceRoles.TopicSetter] } as User,
+        1
+      );
+      expect(result).toEqual(expect.objectContaining(comment));
     });
 
     it('can return anonymized comment for commenter', async () => {

--- a/apps/comment-service/src/comment/model/topic.ts
+++ b/apps/comment-service/src/comment/model/topic.ts
@@ -1,4 +1,4 @@
-import { AdspId, AssertRole, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
+import { AdspId, AssertRole, UnauthorizedUserError, User, isAllowedUser } from '@abgov/adsp-service-sdk';
 import { New, Results } from '@core-services/core-common';
 import { TopicRepository } from '../repository';
 import { Comment, CommentCriteria, Topic } from '../types';
@@ -102,8 +102,22 @@ export class TopicEntity implements Topic {
     return user && this.commenters.includes(user.id);
   }
 
+  /**
+   * Gets a flag indicating if the user is a platform service acting on a topic it set up.
+   * Services authenticate as core users, so they can never satisfy the tenant scoped type roles;
+   * the topic router already admits them, and comments have to follow or a service can create a
+   * topic it is unable to read back.
+   *
+   * @param {User} user
+   * @returns {boolean}
+   * @memberof TopicEntity
+   */
+  private isTopicSetter(user: User): boolean {
+    return isAllowedUser(user, this.tenantId, [ServiceRoles.Admin, ServiceRoles.TopicSetter], true);
+  }
+
   public canRead(user: User): boolean {
-    return this.type?.canRead(user) || this.isCommenter(user);
+    return this.type?.canRead(user) || this.isCommenter(user) || this.isTopicSetter(user);
   }
 
   public canComment(user: User): boolean {


### PR DESCRIPTION
Follow-up to CS-5330 (#5818). Without this, the reviewer half of the form messaging feature does not work.

## The bug

When an applicant posts a form message and no reviewer is subscribed, form-service forwards the message to the definition's `questionsEmail`. To do that it has to read the message back, because the `comment-created` event carries only metadata, not content. That read fails:

```
error: Failed to read comment 41 of topic 31: User service-account-urn:ads:platform:form-service
       (ID: 774c1562-...) not permitted to read comment.
warn:  Unable to read message 41 for form 24690927-...; no notification sent.
```

A platform service authenticates as a **core** user, so `isAllowedUser(user, tenantId, roles)` fails its tenant check no matter which roles it holds — no role grant can fix it. The service is also not in the topic's `commenters`, since `createSupportTopic` sets only `commenters: [form.createdBy.id]`.

The inconsistency is that the router already admits these callers. `getTopic` (`router/topic.ts:420`) checks `isAllowedUser(user, tenantId, [ServiceRoles.TopicSetter, ...roles], true)` — note `allowCore: true` — and `TopicEntity.create` carries `@AssertRole(..., allowCore = true)`, which is why form-service can create the support topic in the first place. Only `canRead` disagreed, so a service could create a topic it was then unable to read back.

## The change

```ts
private isTopicSetter(user: User): boolean {
  return isAllowedUser(user, this.tenantId, [ServiceRoles.Admin, ServiceRoles.TopicSetter], true);
}

public canRead(user: User): boolean {
  return this.type?.canRead(user) || this.isCommenter(user) || this.isTopicSetter(user);
}
```

`canComment` is deliberately **unchanged** — this grants read-back only, not the ability to post as a service.

Scope worth a reviewer's eye: this lets any platform service holding `comment-service:topic-setter` read comments on topics in any tenant, not only the ones it created. Narrowing it to the creating service is not possible today, because `TopicEntity` does not record which service set a topic up; that would need a new owner field on the topic.

## Verification

- `comment-service`: 6 suites, 135 tests pass
- Three new tests: a core topic-setter passes `canRead` and can `getComment`; a core user without the role still cannot

Note this only unblocks the code path. Deploying it also needs the `form-service` RabbitMQ account and the `AMQP_USER`/`AMQP_PASSWORD` Secret keys in each environment, per `docs/platform/deployment.md`.