### PR TITLE
feat(tenant-management-webapp): add event log CSV export

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLog.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLog.tsx
@@ -10,6 +10,9 @@ import { GoabButton, GoabCallout } from '@abgov/react-components';
 import { EventSearchCriteria } from '@store/event/models';
 import { LoadMoreWrapper } from '@components/styled-components';
 import { ServiceColumnLayoutWithMargin } from '../../admin';
+import { exportEventLogEntries } from './exportEventLog';
+import { SmallButton } from './styled-components';
+import { ErrorNotification } from '@store/notifications/actions';
 
 export const EventLog: FunctionComponent = () => {
   const readerRole = 'value-reader';
@@ -18,8 +21,12 @@ export const EventLog: FunctionComponent = () => {
   );
   const [searched, setSearched] = useState(false);
   const [searchCriteria, setSearchCriteria] = useState(null);
+  const [isExporting, setIsExporting] = useState(false);
   const next = useSelector((state: RootState) => state.event.nextEntries);
+  const entries = useSelector((state: RootState) => state.event.entries);
   const isLoading = useSelector((state: RootState) => state.event.isLoading.log);
+  const valueServiceApiUrl = useSelector((state: RootState) => state.config.serviceUrls?.valueServiceApiUrl);
+  const token = useSelector((state: RootState) => state.session?.credentials?.token);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -49,6 +56,22 @@ export const EventLog: FunctionComponent = () => {
   const onNext = () => {
     searched ? dispatch(getEventLogEntries(next, searchCriteria)) : dispatch(getEventLogEntries(next));
   };
+  const hasSelectedEvent = Boolean(searchCriteria?.namespace && searchCriteria?.name);
+  const hasEntries = Boolean(entries?.length);
+  const onExport = async () => {
+    if (!hasReaderRole || !hasSelectedEvent || !hasEntries || !valueServiceApiUrl || !token) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const fileName = `${searchCriteria.namespace}-${searchCriteria.name}`;
+      await exportEventLogEntries(valueServiceApiUrl, token, fileName, searchCriteria || {});
+    } catch (error) {
+      dispatch(ErrorNotification({ message: 'Failed to export event log. Try narrowing your time range.', error }));
+    } finally {
+      setIsExporting(false);
+    }
+  };
   return (
     <Main>
       <ServiceColumnLayoutWithMargin>
@@ -60,8 +83,23 @@ export const EventLog: FunctionComponent = () => {
         <section>
           {hasReaderRole ? (
             <>
-              <EventSearchForm onSearch={(criteria) => onSearch(criteria)} onCancel={onSearchCancel} />
-              <br />
+              <EventSearchForm
+                onSearch={(criteria) => onSearch(criteria)}
+                onCancel={onSearchCancel}
+                leftAction={
+                  <SmallButton>
+                    <GoabButton
+                      size="compact"
+                      type="tertiary"
+                      disabled={isExporting || !hasSelectedEvent || !hasEntries}
+                      onClick={onExport}
+                      testId="export-event-log-csv"
+                    >
+                      {isExporting ? 'Exporting...' : 'Download CSV'}
+                    </GoabButton>
+                  </SmallButton>
+                }
+              />
               <EventLogEntries onSearch={onSearch} />
               {next && (
                 <LoadMoreWrapper>

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventSearchForm.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventSearchForm.tsx
@@ -5,7 +5,7 @@ import type { EventSearchCriteria } from '@store/event/models';
 import { distance } from 'fastest-levenshtein';
 import { getEventDefinitions } from '@store/event/actions';
 import { useSearchableDropdown } from '@core-services/app-common';
-import { SearchBox, DateTimeInput } from './styled-components';
+import { SearchBox, DateTimeInput, SearchActions } from './styled-components';
 import { validateEventKey } from './util';
 import { GoabButton, GoabIconButton, GoabButtonGroup, GoabGrid, GoabFormItem } from '@abgov/react-components';
 
@@ -36,9 +36,10 @@ interface EventSearchFormProps {
   initialValue?: EventSearchCriteria;
   onCancel?: () => void;
   onSearch?: (searchCriteria: EventSearchCriteria) => void;
+  leftAction?: React.ReactNode;
 }
 
-export const EventSearchForm: FunctionComponent<EventSearchFormProps> = ({ onCancel, onSearch }) => {
+export const EventSearchForm: FunctionComponent<EventSearchFormProps> = ({ onCancel, onSearch, leftAction }) => {
   const [searchCriteria, setSearchCriteria] = useState(() => defaultWeekCriteria());
   const [error, setError] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
@@ -190,6 +191,7 @@ export const EventSearchForm: FunctionComponent<EventSearchFormProps> = ({ onCan
       setSearchCriteria(resolved);
       dd.setOpen(false);
       dd.setQuery(`${resolved.namespace}:${resolved.name}`);
+      onSearch?.(resolved);
     },
   });
   useEffect(() => {
@@ -331,44 +333,49 @@ export const EventSearchForm: FunctionComponent<EventSearchFormProps> = ({ onCan
           />
         </GoabFormItem>
       </GoabGrid>
-      <GoabButtonGroup alignment="end">
-        <GoabButton size="compact"
-          type="secondary"
-          onClick={() => {
-            dd.reset();
-            setError(false);
-            setSearchCriteria(initCriteria);
-            onCancel?.();
-          }}
-        >
-          Reset
-        </GoabButton>
-        <GoabButton size="compact"
-          disabled={dd.query.indexOf(':') === -1}
-          onClick={() => {
-            dd.setOpen(false);
-            setError(false);
+      <SearchActions>
+        <div>{leftAction}</div>
+        <GoabButtonGroup alignment="end">
+          <GoabButton
+            size="compact"
+            type="secondary"
+            onClick={() => {
+              dd.reset();
+              setError(false);
+              setSearchCriteria(initCriteria);
+              onCancel?.();
+            }}
+          >
+            Reset
+          </GoabButton>
+          <GoabButton
+            size="compact"
+            disabled={dd.query.indexOf(':') === -1}
+            onClick={() => {
+              dd.setOpen(false);
+              setError(false);
 
-            const resolved = resolveCriteriaFromInput(dd.query);
-            if (!resolved) {
-              setError(true);
-              return;
-            }
-            const validEvent = validateEventKey(dd.query, eventKey);
-            if (!validEvent.ok) {
-              setError(true);
-              setMessage(validEvent.ok ? '' : validEvent.reason);
-            } else {
-              setSearchCriteria(resolved);
-              setMessage(defaultMessage);
-              dd.setQuery(`${resolved.namespace}:${resolved.name}`);
-              onSearch?.(resolved);
-            }
-          }}
-        >
-          Search
-        </GoabButton>
-      </GoabButtonGroup>
+              const resolved = resolveCriteriaFromInput(dd.query);
+              if (!resolved) {
+                setError(true);
+                return;
+              }
+              const validEvent = validateEventKey(dd.query, eventKey);
+              if (!validEvent.ok) {
+                setError(true);
+                setMessage(validEvent.ok ? '' : validEvent.reason);
+              } else {
+                setSearchCriteria(resolved);
+                setMessage(defaultMessage);
+                dd.setQuery(`${resolved.namespace}:${resolved.name}`);
+                onSearch?.(resolved);
+              }
+            }}
+          >
+            Search
+          </GoabButton>
+        </GoabButtonGroup>
+      </SearchActions>
     </div>
   );
 };

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.spec.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.spec.ts
@@ -1,0 +1,127 @@
+import axios from 'axios';
+import exportFromJSON from 'export-from-json';
+import { EXPORT_PAGE_SIZE, exportEventLogEntries, fetchAllEventLogEntries } from './exportEventLog';
+
+jest.mock('axios');
+jest.mock('export-from-json');
+
+const mockedAxiosGet = axios.get as jest.Mock;
+const mockedExport = exportFromJSON as unknown as jest.Mock;
+(mockedExport as unknown as { types: Record<string, string> }).types = { csv: 'csv' };
+
+const baseUrl = 'http://mock-value-service.com';
+const token = 'mock-token';
+
+// Raw value-service shape: namespace/name in `context`, event body in `value.payload`.
+const entry = (name: string) => ({
+  context: { namespace: 'test-service', name },
+  timestamp: '2026-01-01T00:00:00.000Z',
+  correlationId: `corr-${name}`,
+  value: { payload: { value: name } },
+});
+
+const pageResponse = (events: ReturnType<typeof entry>[], next?: string) => ({
+  data: { 'event-service': { event: events }, page: { next } },
+});
+
+describe('exportEventLog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchAllEventLogEntries', () => {
+    it('accumulates entries across pages, following page.next until falsy', async () => {
+      mockedAxiosGet
+        .mockResolvedValueOnce(pageResponse([entry('a')], 'cursor-1'))
+        .mockResolvedValueOnce(pageResponse([entry('b')], 'cursor-2'))
+        .mockResolvedValueOnce(pageResponse([entry('c')], undefined));
+
+      const entries = await fetchAllEventLogEntries(baseUrl, token, {});
+
+      expect(entries.map((e) => e.name)).toEqual(['a', 'b', 'c']);
+      expect(mockedAxiosGet).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles a trailing empty page when total is an exact multiple of the page size', async () => {
+      mockedAxiosGet
+        .mockResolvedValueOnce(pageResponse([entry('a')], 'cursor-1'))
+        .mockResolvedValueOnce(pageResponse([], undefined));
+
+      const entries = await fetchAllEventLogEntries(baseUrl, token, {});
+
+      expect(entries.map((e) => e.name)).toEqual(['a']);
+      expect(mockedAxiosGet).toHaveBeenCalledTimes(2);
+    });
+
+    it('requests the configured export page size and passes the bearer token', async () => {
+      mockedAxiosGet.mockResolvedValueOnce(pageResponse([entry('a')], undefined));
+
+      await fetchAllEventLogEntries(baseUrl, token, {});
+
+      const [url, options] = mockedAxiosGet.mock.calls[0];
+      expect(url).toContain(`top=${EXPORT_PAGE_SIZE}`);
+      expect(options.headers.Authorization).toBe(`Bearer ${token}`);
+    });
+
+    it('maps criteria to the context, timestamp and correlationId query params', async () => {
+      mockedAxiosGet.mockResolvedValueOnce(pageResponse([], undefined));
+
+      await fetchAllEventLogEntries(baseUrl, token, {
+        namespace: 'test-service',
+        name: 'test-event',
+        timestampMin: '2026-01-01T00:00:00.000Z',
+        timestampMax: '2026-01-31T00:00:00.000Z',
+        correlationId: 'abc',
+      });
+
+      const [url] = mockedAxiosGet.mock.calls[0];
+      expect(url).toContain(`context=${JSON.stringify({ namespace: 'test-service', name: 'test-event' })}`);
+      expect(url).toContain('timestampMin=2026-01-01T00:00:00.000Z');
+      expect(url).toContain('timestampMax=2026-01-31T00:00:00.000Z');
+      expect(url).toContain('correlationId=abc');
+    });
+
+    it('pins the same timestampMax across every page when the criteria leaves it open-ended', async () => {
+      mockedAxiosGet
+        .mockResolvedValueOnce(pageResponse([entry('a')], 'cursor-1'))
+        .mockResolvedValueOnce(pageResponse([entry('b')], undefined));
+
+      await fetchAllEventLogEntries(baseUrl, token, { namespace: 'test-service' });
+
+      const firstMax = new URL(mockedAxiosGet.mock.calls[0][0]).searchParams.get('timestampMax');
+      const secondMax = new URL(mockedAxiosGet.mock.calls[1][0]).searchParams.get('timestampMax');
+      expect(firstMax).toBeTruthy();
+      expect(secondMax).toBe(firstMax);
+    });
+  });
+
+  describe('exportEventLogEntries', () => {
+    it('exports transformed rows as CSV and returns the entry count', async () => {
+      mockedAxiosGet.mockResolvedValueOnce(pageResponse([entry('a')], undefined));
+
+      const count = await exportEventLogEntries(baseUrl, token, 'tenant-event-log', {});
+
+      expect(count).toBe(1);
+      const call = mockedExport.mock.calls[0][0];
+      expect(call.fileName).toBe('tenant-event-log');
+      expect(call.exportType).toBe('csv');
+      expect(call.data[0]).toEqual({
+        timestamp: new Date('2026-01-01T00:00:00.000Z').toLocaleString(),
+        namespace: 'test-service',
+        name: 'a',
+        correlationId: 'corr-a',
+        details: JSON.stringify({ value: 'a' }),
+      });
+    });
+
+    it('still produces a CSV export when there are no entries', async () => {
+      mockedAxiosGet.mockResolvedValueOnce(pageResponse([], undefined));
+
+      const count = await exportEventLogEntries(baseUrl, token, 'tenant-event-log', {});
+
+      expect(count).toBe(0);
+      expect(mockedExport).toHaveBeenCalledTimes(1);
+      expect(mockedExport.mock.calls[0][0].data).toEqual([{}]);
+    });
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.ts
@@ -1,0 +1,116 @@
+import axios from 'axios';
+import exportFromJSON from 'export-from-json';
+import { EventLogEntry, EventSearchCriteria } from '@store/event/models';
+
+// Event value payloads are unbounded jsonb, so pages are kept small to bound per-request cost.
+export const EXPORT_PAGE_SIZE = 1000;
+
+const REQUEST_TIMEOUT_MS = 30000;
+
+// Raw entry shape returned by value-service: namespace/name live in `context`, the event body in `value.payload`.
+interface RawEventValue {
+  context: Record<string, string>;
+  timestamp: string;
+  correlationId?: string;
+  value?: { payload?: Record<string, unknown> };
+}
+
+interface EventValueResponse {
+  'event-service'?: { event?: RawEventValue[] };
+  page?: { after?: string; next?: string };
+}
+
+const toEntry = (raw: RawEventValue): EventLogEntry => ({
+  namespace: raw.context?.namespace,
+  name: raw.context?.name,
+  timestamp: new Date(raw.timestamp),
+  correlationId: raw.correlationId,
+  details: raw.value?.payload,
+});
+
+const buildEventUrl = (baseUrl: string, criteria: EventSearchCriteria, after: string): string => {
+  let eventUrl = `${baseUrl}/value/v1/event-service/values/event?top=${EXPORT_PAGE_SIZE}&after=${after || ''}`;
+
+  let contextObj: Record<string, unknown> = {};
+  if (criteria.namespace) {
+    contextObj['namespace'] = criteria.namespace;
+  }
+  if (criteria.name) {
+    contextObj['name'] = criteria.name;
+  }
+  if (criteria.context) {
+    contextObj = { ...contextObj, ...criteria.context };
+  }
+  if (Object.entries(contextObj).length > 0) {
+    eventUrl = `${eventUrl}&context=${JSON.stringify(contextObj)}`;
+  }
+  if (criteria.timestampMax) {
+    eventUrl = `${eventUrl}&timestampMax=${new Date(criteria.timestampMax).toISOString()}`;
+  }
+  if (criteria.applications) {
+    eventUrl = `${eventUrl}&value=${criteria.applications}`;
+  }
+  if (criteria.url) {
+    eventUrl = `${eventUrl}&url=${criteria.url}`;
+  }
+  if (criteria.timestampMin) {
+    eventUrl = `${eventUrl}&timestampMin=${new Date(criteria.timestampMin).toISOString()}`;
+  }
+  if (criteria.correlationId) {
+    eventUrl = `${eventUrl}&correlationId=${criteria.correlationId}`;
+  }
+
+  return eventUrl;
+};
+
+const toCsvRow = (entry: EventLogEntry) => ({
+  timestamp: entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '',
+  namespace: entry.namespace ?? '',
+  name: entry.name ?? '',
+  correlationId: entry.correlationId ?? '',
+  details: JSON.stringify(entry.details ?? {}),
+});
+
+export const fetchAllEventLogEntries = async (
+  baseUrl: string,
+  token: string,
+  criteria: EventSearchCriteria,
+): Promise<EventLogEntry[]> => {
+  // Pin the upper bound so offset-based pagination sees a stable window across pages.
+  const pinnedCriteria: EventSearchCriteria = {
+    ...criteria,
+    timestampMax: criteria?.timestampMax ?? new Date().toISOString(),
+  };
+
+  const entries: EventLogEntry[] = [];
+  let after = '';
+  do {
+    const url = buildEventUrl(baseUrl, pinnedCriteria, after);
+    const { data } = await axios.get<EventValueResponse>(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    entries.push(...(data?.['event-service']?.event ?? []).map(toEntry));
+    after = data?.page?.next ?? '';
+  } while (after);
+
+  return entries;
+};
+
+export const exportEventLogEntries = async (
+  baseUrl: string,
+  token: string,
+  fileName: string,
+  criteria: EventSearchCriteria = {},
+): Promise<number> => {
+  const entries = await fetchAllEventLogEntries(baseUrl, token, criteria);
+  const rows = entries.map(toCsvRow);
+
+  exportFromJSON({
+    data: rows.length ? rows : [{}],
+    fileName,
+    exportType: exportFromJSON.types.csv,
+  });
+
+  return entries.length;
+};

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/styled-components.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/styled-components.ts
@@ -77,3 +77,18 @@ export const DateTimeInput = styled.input`
     outline: none;
   }
 `;
+
+export const SearchActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--goa-space-m);
+  margin: var(--goa-space-l) 0;
+`;
+
+export const SmallButton = styled.span`
+  display: inline-block;
+  transform: scale(0.85);
+  transform-origin: left center;
+`;
+


### PR DESCRIPTION
Add a Download CSV action to the event log that exports the selected event over the chosen time range. Paginates value-service client-side (top=1000, pinned timestampMax) and generates the CSV via export-from-json. Button is enabled only when a single event is selected and entries exist.