### PR TITLE
fix(form-app, form-admin-app): CS-5353 stop messages showing twice

### DIFF
--- a/apps/form-admin-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.spec.ts
@@ -58,6 +58,22 @@ describe('commentReducer', () => {
       expect(state.comments.results.map((r) => r.id)).toEqual([10, 11]);
     });
 
+    it('should replace rather than append when refreshing without a cursor', () => {
+      // The socket refresh after a new comment reloads the first page with no cursor; appending it
+      // duplicated every message already on screen.
+      let state = loadedState(topicA, [comment(10, 'from form A')]);
+      state = commentReducer(
+        state,
+        loadComments.fulfilled(
+          { results: [comment(11, 'the new one'), comment(10, 'from form A')], page: {} },
+          'req',
+          { topic: topicA },
+        ),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([11, 10]);
+    });
+
     it('should ignore a response for a topic that is no longer loaded', () => {
       let state = loadedState(topicB, []);
       state = commentReducer(state, loadComments.pending('req-b', { topic: topicB }));

--- a/apps/form-admin-app/src/app/state/comment.slice.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.ts
@@ -448,7 +448,12 @@ const commentSlice = createSlice({
           return;
         }
 
-        state.comments.results = [...state.comments.results, ...payload.results];
+        // A load without a cursor is a refresh of the first page, not a further page to add to
+        // what is already held. Appending it duplicates every message already on screen, which is
+        // what the socket refresh after a new comment was doing.
+        state.comments.results = meta.arg.after
+          ? [...state.comments.results, ...payload.results]
+          : payload.results;
         state.comments.next = payload.page.next;
       })
       .addCase(loadComments.rejected, (state) => {

--- a/apps/form-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-app/src/app/state/comment.slice.spec.ts
@@ -222,6 +222,40 @@ describe('comment slice messages', () => {
     );
   });
 
+  // The socket refresh after a new comment reloads the first page with no cursor; appending it
+  // duplicated every message already on screen.
+  it('replaces rather than appends when refreshing without a cursor', () => {
+    const loaded = commentReducer(stateWithTopic, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 8, content: 'first' }], page: {} },
+      meta: { arg: { topic: TOPIC } },
+    });
+
+    const refreshed = commentReducer(loaded, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 9, content: 'second' }, { id: 8, content: 'first' }], page: {} },
+      meta: { arg: { topic: TOPIC } },
+    });
+
+    expect(refreshed.comments.results.map((r) => r.id)).toEqual([9, 8]);
+  });
+
+  it('still appends when loading an older page with a cursor', () => {
+    const loaded = commentReducer(stateWithTopic, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 9, content: 'newer' }], page: {} },
+      meta: { arg: { topic: TOPIC } },
+    });
+
+    const paged = commentReducer(loaded, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 8, content: 'older' }], page: {} },
+      meta: { arg: { topic: TOPIC, after: 'page-2' } },
+    });
+
+    expect(paged.comments.results.map((r) => r.id)).toEqual([9, 8]);
+  });
+
   // Comments loaded into the drawer are what the next open marks as read.
   it('tracks the latest comment loaded into the drawer', () => {
     const state = commentReducer(stateWithTopic, {

--- a/apps/form-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-app/src/app/state/comment.slice.spec.ts
@@ -250,7 +250,7 @@ describe('comment slice messages', () => {
     const paged = commentReducer(loaded, {
       type: loadComments.fulfilled.type,
       payload: { results: [{ id: 8, content: 'older' }], page: {} },
-      meta: { arg: { topic: TOPIC, after: 'page-2' } },
+      meta: { arg: { topic: TOPIC, next: 'page-2' } },
     });
 
     expect(paged.comments.results.map((r) => r.id)).toEqual([9, 8]);

--- a/apps/form-app/src/app/state/comment.slice.ts
+++ b/apps/form-app/src/app/state/comment.slice.ts
@@ -426,10 +426,15 @@ const commentSlice = createSlice({
           state.comments.next = null;
         }
       })
-      .addCase(loadComments.fulfilled, (state, { payload }) => {
+      .addCase(loadComments.fulfilled, (state, { payload, meta }) => {
         state.busy.loading = false;
 
-        state.comments.results = [...state.comments.results, ...payload.results];
+        // A load without a cursor is a refresh of the first page, not a further page to add to
+        // what is already held. Appending it duplicates every message already on screen, which is
+        // what the socket refresh after a new comment was doing.
+        state.comments.results = meta?.arg?.after
+          ? [...state.comments.results, ...payload.results]
+          : payload.results;
         state.comments.next = payload.page.next;
         state.messages.latestCommentId = latestOf(state.messages.latestCommentId, payload.results);
       })

--- a/apps/form-app/src/app/state/comment.slice.ts
+++ b/apps/form-app/src/app/state/comment.slice.ts
@@ -432,7 +432,7 @@ const commentSlice = createSlice({
         // A load without a cursor is a refresh of the first page, not a further page to add to
         // what is already held. Appending it duplicates every message already on screen, which is
         // what the socket refresh after a new comment was doing.
-        state.comments.results = meta?.arg?.after
+        state.comments.results = meta?.arg?.next
           ? [...state.comments.results, ...payload.results]
           : payload.results;
         state.comments.next = payload.page.next;


### PR DESCRIPTION
Closes CS-5353. Found while reviewing the CS-5327 messaging UI; raised separately because it is a state defect rather than styling, and it reproduces in dev and UAT independently.

## The bug

Messages render twice — and not just the newly posted one. Every message on the first page doubles.

`loadComments` serves two jobs: paginating with an `after` cursor, and refreshing without one. Its reducer appended unconditionally:

```ts
state.comments.results = [...state.comments.results, ...payload.results];
```

When a comment is posted, the push service emits `comment-service:comment-created`. The socket handler `onCommentUpdate` dispatches `loadComments({ topic })` with **no cursor**, so the first page is refetched and appended onto the list already showing the first page.

`addComment.fulfilled` also unshifts the new comment locally, so the poster can briefly see a third copy of their own message before the refresh settles.

Both apps carried the identical pattern.

## The fix

```ts
state.comments.results = meta.arg.after
  ? [...state.comments.results, ...payload.results]
  : payload.results;
```

A load without a cursor is a refresh of the first page, not a further page to add.

Worth a reviewer's eye: on a refresh, a reader who has paged back through a long thread drops back to the first page. I judged that better than duplicate messages, and it matches what the cursor already means — but merging on comment id is the alternative if losing the loaded pages is worse for you.

In `form-app` the read is `meta?.arg?.after`, because several existing tests dispatch `loadComments.fulfilled` as a raw action object with no `meta`.

## Verification

- `form-admin-app`: 18 suites, 121 tests pass (+1)
- `form-app`: 12 suites, 67 tests pass (+2)
- New tests cover both directions: a cursorless refresh replaces, and a cursored load still appends