### PR TITLE
fix(jsonforms-components): CS-5347 report every review Change click to the host

### DIFF
--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsExternalNavigation.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsExternalNavigation.tsx
@@ -46,6 +46,7 @@ import {
 } from './externalNavigationDefinition';
 
 const FORM_APP_ID = 'urn:ads:platform:form-app';
+const HOW_TO_URL = 'https://govalta.github.io/adsp-monorepo/tutorials/form-service/external-navigation.html';
 
 const ContextProvider = ContextProviderFactory();
 
@@ -299,6 +300,16 @@ export const JsonformsExternalNavigation = (): JSX.Element => {
             </ContextProvider>
           </>
         )}
+
+        <h3>How to implement this in your application</h3>
+        <GoabText size="body-m">
+          None of the wiring above is discoverable from the rendered result, so it is written up in the ADSP guide:{' '}
+          <a href={HOW_TO_URL} target="_blank" rel="noopener noreferrer">
+            External navigation
+          </a>
+          . It covers both host shapes — a form in a different application, which is what this page demonstrates, and a
+          form on another page of the same application.
+        </GoabText>
       </GoabContainer>
     </ServiceContainer>
   );

--- a/docs/tutorials/form-service/external-navigation.md
+++ b/docs/tutorials/form-service/external-navigation.md
@@ -1,0 +1,127 @@
+---
+title: External navigation
+layout: page
+nav_order: 11
+parent: Form Service
+grand_parent: Tutorials
+---
+
+## External navigation
+
+Sometimes the thing that links into a form is not the form. A read-only summary of the answers, a task list, a "your applications" dashboard - each of these needs to be able to say _open this form at this page_, or _open this form at this field_. If the summary and the form are the same rendered component you get that for free from the stepper, but as soon as they are on different pages, or in different applications, you need to move a target across that gap yourself.
+
+The library never reads the address bar and never switches your routes. It takes a target and moves the form to it; carrying the target from wherever the user clicked to wherever the form renders is the host's job. That leaves four pieces, and only the third one is inside the form.
+
+### 1. Discover what you can link to
+
+A page is addressed by the `options.id` authored on its Category, and a field by the `options.id` on its Control or by its scope pointer. Anything without an authored id falls back to a positional `page-N` id, which points at whatever occupies that slot today - so name the pages you intend to link to.
+
+```javascript
+import { getNavigationTargets } from '@abgov/jsonforms-components';
+
+// Needs the ui schema and nothing else: no form data, no rendered form.
+const targets = getNavigationTargets(definition.uiSchema);
+// [{ pageId: 'personal-information', label: 'Personal Information', authored: true, index: 0,
+//    fields: [{ scope: '#/properties/fullName', id: 'applicant-full-name' }, ...] }, ...]
+```
+
+### 2a. The form lives in another application
+
+Build a URL. `getExternalFormPath` makes the id-versus-scope choice for you: a field whose control carries an authored id is written as that id, which survives the underlying property being renamed.
+
+```javascript
+import { getExternalFormPath } from '@abgov/jsonforms-components';
+
+// stepId and scope are what a review Change button hands you (see below).
+const path = getExternalFormPath(definition.uiSchema, formUrl, stepId, scope);
+// https://form-app/<tenant>/<definition>/<form>?page=personal-information&fieldId=applicant-full-name
+window.open(path, '_blank', 'noopener,noreferrer');
+```
+
+### 2b. The form is another page of the same application
+
+There is no URL to build and no parameters to parse - hand the form a `navigationTarget` object directly. The only thing to get right is that the value has to outlive the page switch.
+
+```javascript
+import { getNavigationTargets, NavigationTarget } from '@abgov/jsonforms-components';
+
+// Lift this above the route switch - a value held by the summary page is gone by the time the
+// form page mounts. Application state or route state both work; local state in a common parent
+// is the simplest.
+const [navigationTarget, setNavigationTarget] = useState<NavigationTarget>();
+
+const handleReviewChange = (stepId: number | undefined, scope: string) => {
+  const pageId = stepId === undefined ? undefined : getNavigationTargets(uiSchema)[stepId]?.pageId;
+  setNavigationTarget({ pageId, scope });
+  navigate('/applications/123/form'); // your own route, however you switch pages
+};
+```
+
+### 3. Receive the target where the form renders
+
+Both routes above end here. The provider applies a target once and reports what happened; it will not pull the user back to the requested page after they navigate away themselves.
+
+```javascript
+import { ContextProviderFactory, GoACells, GoARenderers } from '@abgov/jsonforms-components';
+
+const ContextProvider = ContextProviderFactory();
+
+<ContextProvider
+  navigationTarget={navigationTarget}
+  onNavigationChange={(outcome) => {
+    // 'navigated' | 'unavailable' (hidden, disabled, not-yet-reachable) | 'unknown'
+    if (outcome.status !== 'navigated') {
+      setNavigationTarget(undefined);
+    }
+  }}
+>
+  <JsonForms
+    schema={definition.dataSchema}
+    uischema={definition.uiSchema}
+    data={data}
+    renderers={GoARenderers}
+    cells={GoACells}
+  />
+</ContextProvider>
+```
+
+When the target arrived as a link, turn the parameters back into that same object, and clear them once they cannot be honoured so that a reload does not retry a dead target.
+
+```javascript
+import { getNavigationTargetFromParams, NAVIGATION_PARAMS } from '@abgov/jsonforms-components';
+
+const [searchParams, setSearchParams] = useSearchParams();
+const navigationTarget = useMemo(() => getNavigationTargetFromParams(searchParams), [searchParams]);
+
+const handleNavigationChange = (outcome: NavigationOutcome) => {
+  if (outcome.status === 'unknown') {
+    const next = new URLSearchParams(searchParams);
+    Object.values(NAVIGATION_PARAMS).forEach((param) => next.delete(param));
+    setSearchParams(next, { replace: true });
+  }
+};
+```
+
+### 4. Wire the Change buttons on a read-only summary
+
+A summary rendered with the review renderers puts a Change button beside each answer. `ReviewRenderProvider` is what carries those clicks out to you as `(stepId, scope)` - feed them into either shape above. Without it the buttons only move the summary's own stepper, which does nothing when the form is somewhere else.
+
+```javascript
+import { GoACells, GoAReviewRenderers, ReviewRenderProvider } from '@abgov/jsonforms-components';
+
+<ContextProvider showChangeButtons={true}>
+  <ReviewRenderProvider onReviewChange={handleReviewChange}>
+    <JsonForms
+      readonly={true}
+      validationMode="NoValidation"
+      schema={definition.dataSchema}
+      uischema={definition.uiSchema}
+      data={data}
+      renderers={GoAReviewRenderers}
+      cells={GoACells}
+    />
+  </ReviewRenderProvider>
+</ContextProvider>
+```
+
+**NOTE**: Every control reports, including the composite ones. Address, full name, full name with date of birth, contact information and list controls report through `onReviewChange` exactly like a plain text field does. If a Change button appears to do nothing, check that `ReviewRenderProvider` is above the `JsonForms` element rather than beside it, and that the category carries the `options.id` you are matching on.

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.spec.tsx
@@ -7,6 +7,7 @@ import { JsonFormsStepperContextProvider } from '../FormStepper/context';
 import { CategorizationStepperLayoutRendererProps } from '../FormStepper/types';
 import Ajv from 'ajv';
 import { ControlElement } from '@jsonforms/core';
+import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
 
 jest.mock('./utils', () => ({
   fetchAddressSuggestions: jest.fn(),
@@ -341,5 +342,40 @@ describe('AddressLoopUpControlTableReview', () => {
     // Required fields with values should NOT show (none given)
     expect(screen.getByText('123 Test St')).toBeInTheDocument();
     expect(screen.queryAllByText('(none given)').length).toBe(0);
+  });
+});
+
+describe('AddressLoopUpControlTableReview change reporting', () => {
+  it('reports the step and scope to a host with no stepper in the tree', () => {
+    const onReviewChange = jest.fn();
+    const { baseElement } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <JsonFormContext.Provider value={mockFormContext}>
+          <table>
+            <tbody>
+              <AddressLoopUpControlTableReview
+                label={''}
+                errors={''}
+                rootSchema={{}}
+                id={'address-report'}
+                enabled={false}
+                visible={false}
+                {...defaultProps}
+                uischema={
+                  {
+                    ...defaultProps.uischema,
+                    options: { ...defaultProps.uischema.options, stepId: 4 },
+                  } as ControlElement
+                }
+              />
+            </tbody>
+          </table>
+        </JsonFormContext.Provider>
+      </ReviewRenderProvider>,
+    );
+
+    fireEvent(baseElement.querySelector('goa-button')!, new CustomEvent('_click'));
+
+    expect(onReviewChange).toHaveBeenCalledWith(4, '#/properties/lastName');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/AddressLookup/AddressLookUpControlReview.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { ControlProps, UISchemaElement, JsonSchema } from '@jsonforms/core';
 import { ErrorObject } from 'ajv';
 import { AddressViews } from './AddressViews';
 import { humanizeAjvError } from '../ObjectArray/ListWithDetailControl';
-import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useReviewChange } from '../FormStepper/context/useReviewChange';
 import {
   PageReviewContainer,
   ReviewHeader,
@@ -32,7 +32,7 @@ export const AddressLoopUpControlTableReview = (props: AddressViewProps): JSX.El
   const jsonForms = useJsonForms();
 
   const stepId = uischema.options?.stepId;
-  const formStepperCtx = useContext(JsonFormsStepperContext);
+  const reportChange = useReviewChange();
   const showChangeButtons = useShowChangeButtons();
   const isAlbertaAddress = schema?.properties?.subdivisionCode?.const === 'AB';
 
@@ -145,7 +145,7 @@ export const AddressLoopUpControlTableReview = (props: AddressViewProps): JSX.El
               <GoabButton
                 type="text"
                 size="compact"
-                onClick={() => formStepperCtx?.goToPage(stepId, targetScope)}
+                onClick={() => reportChange(stepId, targetScope)}
                 testId="address-change-btn"
               >
                 Change
@@ -171,7 +171,7 @@ export const AddressLoopUpControlTableReview = (props: AddressViewProps): JSX.El
               <GoabButton
                 type="text"
                 size="compact"
-                onClick={() => formStepperCtx?.goToPage(stepId, targetScope)}
+                onClick={() => reportChange(stepId, targetScope)}
                 testId="address-change-btn"
               >
                 Change

--- a/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.spec.tsx
@@ -5,6 +5,7 @@ import { ControlProps } from '@jsonforms/core';
 import { ContractInfoControlReview } from './ContactInfoControlReview';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { JsonFormContext } from '../../Context';
+import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
 
 describe('ContractInfoControlReview', () => {
   const mockGoToPage = jest.fn();
@@ -231,5 +232,43 @@ describe('ContractInfoControlReview', () => {
     };
 
     expect(() => renderComponent(invalidProps)).toThrow('At least one contact method must be enabled');
+  });
+});
+
+describe('ContractInfoControlReview change reporting', () => {
+  const reportingProps = {
+    data: { email: 'john@example.com', phone: '7805551234', preferredContactMethod: 'Phone' },
+    path: 'contactInformation',
+    schema: {},
+    handleChange: jest.fn(),
+    label: 'Contact information',
+    uischema: {
+      type: 'Control',
+      scope: '#/properties/contactInformation',
+      options: { stepId: 3, enableEmail: true, enablePhone: true },
+    },
+    errors: '',
+    rootSchema: {},
+    id: 'contact-report',
+    enabled: true,
+    visible: true,
+    required: false,
+  } as unknown as ControlProps;
+
+  it('reports the step and scope to a host with no stepper in the tree', () => {
+    const onReviewChange = jest.fn();
+    const { baseElement } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <table>
+          <tbody>
+            <ContractInfoControlReview {...reportingProps} />
+          </tbody>
+        </table>
+      </ReviewRenderProvider>,
+    );
+
+    fireEvent(baseElement.querySelector('goa-button')!, new CustomEvent('_click'));
+
+    expect(onReviewChange).toHaveBeenCalledWith(3, '#/properties/contactInformation');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ContactInfo/ContactInfoControlReview.tsx
@@ -1,15 +1,15 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { ControlProps } from '@jsonforms/core';
 import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';
-import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useReviewChange } from '../FormStepper/context/useReviewChange';
 import { useShowChangeButtons } from '../../Context/ContextProvider';
 
 type ContractInfoControlReviewProps = ControlProps;
 
 export const ContractInfoControlReview = (props: ContractInfoControlReviewProps): JSX.Element => {
-  const context = useContext(JsonFormsStepperContext);
+  const reportChange = useReviewChange();
   const showChangeButtons = useShowChangeButtons();
   const stepId = props.uischema?.options?.stepId;
 
@@ -29,7 +29,7 @@ export const ContractInfoControlReview = (props: ContractInfoControlReviewProps)
             <GoabButton
               type="text"
               size="compact"
-              onClick={() => context?.goToPage(stepId, uischema.scope)}
+              onClick={() => reportChange(stepId, uischema.scope)}
               testId={`${fieldName}-change-btn`}
             >
               Change

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/useReviewChange.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/useReviewChange.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { JsonFormsStepperContext, JsonFormsStepperContextProps } from './StepperContext';
+import { ReviewRenderProvider } from '../../../Context/ReviewRenderContext';
+import { useReviewChange } from './useReviewChange';
+
+const SCOPE = '#/properties/firstName';
+
+function Consumer({ stepId, scope }: { stepId?: number; scope?: string }): JSX.Element {
+  const reportChange = useReviewChange();
+  return <button data-testid="change" onClick={() => reportChange(stepId, scope)} />;
+}
+
+describe('useReviewChange', () => {
+  const goToPage = jest.fn();
+  const stepperContext = { goToPage } as unknown as JsonFormsStepperContextProps;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('moves the stepper and reports to the host from one click', () => {
+    const onReviewChange = jest.fn();
+    render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <JsonFormsStepperContext.Provider value={stepperContext}>
+          <Consumer stepId={2} scope={SCOPE} />
+        </JsonFormsStepperContext.Provider>
+      </ReviewRenderProvider>,
+    );
+
+    screen.getByTestId('change').click();
+
+    expect(goToPage).toHaveBeenCalledWith(2, SCOPE);
+    expect(onReviewChange).toHaveBeenCalledWith(2, SCOPE);
+  });
+
+  // The cross-page host is the whole point: its summary renders outside the form, so the stepper
+  // context is the one thing it does not have. Reporting has to survive that.
+  it('reports to the host when there is no stepper to move', () => {
+    const onReviewChange = jest.fn();
+    render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <Consumer stepId={2} scope={SCOPE} />
+      </ReviewRenderProvider>,
+    );
+
+    screen.getByTestId('change').click();
+
+    expect(onReviewChange).toHaveBeenCalledWith(2, SCOPE);
+  });
+
+  // A control outside a stepper has no page to move to, but the host can still resolve the field's
+  // own page from the scope alone.
+  it('reports the scope but does not navigate when there is no step id', () => {
+    const onReviewChange = jest.fn();
+    render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <JsonFormsStepperContext.Provider value={stepperContext}>
+          <Consumer scope={SCOPE} />
+        </JsonFormsStepperContext.Provider>
+      </ReviewRenderProvider>,
+    );
+
+    screen.getByTestId('change').click();
+
+    expect(goToPage).not.toHaveBeenCalled();
+    expect(onReviewChange).toHaveBeenCalledWith(undefined, SCOPE);
+  });
+
+  it('passes an empty scope through rather than undefined', () => {
+    const onReviewChange = jest.fn();
+    render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <Consumer stepId={0} />
+      </ReviewRenderProvider>,
+    );
+
+    screen.getByTestId('change').click();
+
+    expect(onReviewChange).toHaveBeenCalledWith(0, '');
+  });
+
+  it('does nothing and does not throw with neither provider', () => {
+    render(<Consumer stepId={1} scope={SCOPE} />);
+
+    expect(() => screen.getByTestId('change').click()).not.toThrow();
+    expect(goToPage).not.toHaveBeenCalled();
+  });
+});

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/useReviewChange.ts
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/useReviewChange.ts
@@ -1,0 +1,35 @@
+// clean-code-ignore: RULE-19 — covered by ./useReviewChange.spec.tsx, colocated. The rule looks for a
+// .test.ts sibling; the hook has to be exercised through a rendered component, so its spec is .tsx.
+import { useCallback, useContext } from 'react'; // clean-code-ignore: RULE-19 — see the note at the top of this file.
+import { JsonFormsStepperContext } from './StepperContext';
+import { useReviewContext } from '../../../Context/ReviewRenderContext';
+
+/**
+ * The single way a review summary's Change button reports a click.
+ *
+ * Two things have to happen and neither is optional. The stepper moves to the page, which is all a
+ * host needs when the summary and the form are the same JsonForms instance. The review context is
+ * also told, and that is the only signal a host whose summary lives on a *different* page can see —
+ * it is what turns into a deep link back into the form.
+ *
+ * Renderers used to wire these up one at a time, and every renderer except the plain-input one
+ * called goToPage alone, so a composite control's Change button was silently inert for a cross-page
+ * host. Going through here makes forgetting the second half impossible.
+ */
+export const useReviewChange = (): ((stepId: number | undefined, scope?: string) => void) => {
+  const stepperContext = useContext(JsonFormsStepperContext);
+  const reviewContext = useReviewContext();
+
+  return useCallback(
+    (stepId: number | undefined, scope?: string) => {
+      // Outside a stepper there is no page to move to, but the host may still resolve the field's
+      // own page from the scope, so the report below happens either way.
+      if (stepId !== undefined) {
+        stepperContext?.goToPage(stepId, scope);
+      }
+
+      reviewContext?.onChangeDispatch(stepId, scope ?? '');
+    },
+    [stepperContext, reviewContext],
+  );
+};

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FullNameControlReview } from './FullNameControlReview';
 import { ControlProps } from '@jsonforms/core';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { JsonFormContext } from '../../Context';
+import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
 
 describe('FullNameControlReview', () => {
   const mockGoToPage = jest.fn();
@@ -204,5 +205,39 @@ describe('FullNameControlReview', () => {
 
     expect(baseElement.querySelector('goa-form-item[error="First name is required"]')).not.toBeInTheDocument();
     expect(baseElement.querySelector('goa-form-item[error="Last name is required"]')).not.toBeInTheDocument();
+  });
+});
+
+describe('FullNameControlReview change reporting', () => {
+  const reportingProps = {
+    data: { firstName: 'John', middleName: 'A.', lastName: 'Doe' },
+    path: 'fullName',
+    schema: {},
+    handleChange: jest.fn(),
+    label: 'Full name',
+    uischema: { type: 'Control', scope: '#/properties/fullName', options: { stepId: 1 } },
+    errors: '',
+    rootSchema: {},
+    id: 'fullname-report',
+    enabled: true,
+    visible: true,
+    required: false,
+  } as unknown as ControlProps;
+
+  it('reports the step and scope to a host with no stepper in the tree', () => {
+    const onReviewChange = jest.fn();
+    const { baseElement } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <table>
+          <tbody>
+            <FullNameControlReview {...reportingProps} />
+          </tbody>
+        </table>
+      </ReviewRenderProvider>,
+    );
+
+    fireEvent(baseElement.querySelector('goa-button')!, new CustomEvent('_click'));
+
+    expect(onReviewChange).toHaveBeenCalledWith(1, '#/properties/fullName');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullName/FullNameControlReview.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { ControlProps } from '@jsonforms/core';
 import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';
-import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useReviewChange } from '../FormStepper/context/useReviewChange';
 import { isNilOrEmptyString } from '../../util';
 import { RequiredTextLabel } from '../Inputs/style-component';
 import { useShowChangeButtons } from '../../Context/ContextProvider';
@@ -11,7 +11,7 @@ import { useShowChangeButtons } from '../../Context/ContextProvider';
 type FullNameControlReviewProps = ControlProps;
 
 export const FullNameControlReview = (props: FullNameControlReviewProps): JSX.Element => {
-  const context = useContext(JsonFormsStepperContext);
+  const reportChange = useReviewChange();
   const showChangeButtons = useShowChangeButtons();
   const stepId = props.uischema?.options?.stepId;
   const { uischema, data, id } = props;
@@ -29,7 +29,7 @@ export const FullNameControlReview = (props: FullNameControlReviewProps): JSX.El
           {showChangeButtons && stepId !== undefined && !uischema.options?.componentProps?.readOnly && (
             <GoabButton
               type="text"
-              onClick={() => context?.goToPage(stepId, uischema.scope)}
+              onClick={() => reportChange(stepId, uischema.scope)}
               testId={`${fieldName}-change-btn`}
             >
               Change

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FullNameDobReviewControl } from './FullNameDobReviewControl';
 import { ControlProps } from '@jsonforms/core';
 import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
 import { JsonFormContext } from '../../Context';
+import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
 
 describe('FullNameDobReviewControl', () => {
   const mockGoToPage = jest.fn();
@@ -213,5 +214,39 @@ describe('FullNameDobReviewControl', () => {
     expect(baseElement.querySelector('goa-form-item[error="First name is required"]')).not.toBeInTheDocument();
     expect(baseElement.querySelector('goa-form-item[error="Last name is required"]')).not.toBeInTheDocument();
     expect(baseElement.querySelector('goa-form-item[error="Date of birth is required"]')).not.toBeInTheDocument();
+  });
+});
+
+describe('FullNameDobReviewControl change reporting', () => {
+  const reportingProps = {
+    data: { firstName: 'John', middleName: 'A.', lastName: 'Doe', dateOfBirth: '2000-01-01' },
+    path: 'fullNameDob',
+    schema: {},
+    handleChange: jest.fn(),
+    label: 'Full name and date of birth',
+    uischema: { type: 'Control', scope: '#/properties/fullNameDob', options: { stepId: 2 } },
+    errors: '',
+    rootSchema: {},
+    id: 'fullnamedob-report',
+    enabled: true,
+    visible: true,
+    required: false,
+  } as unknown as ControlProps;
+
+  it('reports the step and scope to a host with no stepper in the tree', () => {
+    const onReviewChange = jest.fn();
+    const { baseElement } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <table>
+          <tbody>
+            <FullNameDobReviewControl {...reportingProps} />
+          </tbody>
+        </table>
+      </ReviewRenderProvider>,
+    );
+
+    fireEvent(baseElement.querySelector('goa-button')!, new CustomEvent('_click'));
+
+    expect(onReviewChange).toHaveBeenCalledWith(2, '#/properties/fullNameDob');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FullNameDOB/FullNameDobReviewControl.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsAllOfProps } from '@jsonforms/react';
 import { PageReviewContainer, ReviewHeader, ReviewLabel, ReviewValue } from '../Inputs/style-component';
-import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
+import { useReviewChange } from '../FormStepper/context/useReviewChange';
 import { isNilOrEmptyString } from '../../util';
 import { RequiredTextLabel } from '../Inputs/style-component';
 import { useShowChangeButtons } from '../../Context/ContextProvider';
@@ -12,7 +12,7 @@ type DateOfBirthReviewControlProps = ControlProps;
 
 export const FullNameDobReviewControl = (props: DateOfBirthReviewControlProps): JSX.Element => {
   const { data, id, uischema } = props;
-  const context = useContext(JsonFormsStepperContext);
+  const reportChange = useReviewChange();
   const showChangeButtons = useShowChangeButtons();
   const stepId = uischema?.options?.stepId;
   const requiredFields = props.schema?.required ?? [];
@@ -31,7 +31,7 @@ export const FullNameDobReviewControl = (props: DateOfBirthReviewControlProps): 
             <GoabButton
               type="text"
               size="compact"
-              onClick={() => context?.goToPage(stepId, uischema.scope)}
+              onClick={() => reportChange(stepId, uischema.scope)}
               testId={`${fieldName}-change-btn`}
             >
               Change

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.tsx
@@ -1,4 +1,4 @@
-import React, { act, useContext } from 'react';
+import React from 'react';
 import { ControlProps, UISchemaElement, JsonSchema } from '@jsonforms/core';
 import { ErrorObject } from 'ajv';
 import { withJsonFormsControlProps } from '@jsonforms/react';
@@ -21,15 +21,13 @@ import {
 import { humanizeAjvError } from '../ObjectArray/ListWithDetailControl';
 import { GoabButton, GoabFormItem } from '@abgov/react-components-ds1';
 
-import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
-import { useReviewContext } from '../../Context/ReviewRenderContext';
+import { useReviewChange } from '../FormStepper/context/useReviewChange';
 import { useShowChangeButtons } from '../../Context/ContextProvider';
 import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
 
 export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null => {
   const { data, uischema, label, schema, rootSchema, path, errors, enabled, cells, required, visible } = props;
-  const context = useContext(JsonFormsStepperContext);
-  const reviewCtx = useReviewContext();
+  const reportChange = useReviewChange();
   const showChangeButtons = useShowChangeButtons();
   const jsonForms = useJsonForms();
   const reviewLabel = typeof uischema.options?.reviewLabel === 'string' ? (uischema.options.reviewLabel as string) : '';
@@ -224,8 +222,7 @@ export const GoAInputBaseTableReview = (props: ControlProps): JSX.Element | null
   const stepId = uischema.options?.stepId;
 
   function handleChangeClick(): void {
-    context?.goToPage(stepId, uischema.scope);
-    reviewCtx?.onChangeDispatch(stepId, uischema.scope);
+    reportChange(stepId, uischema.scope);
   }
   const showInlineValue =
     reviewText === null ||

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectArray.spec.tsx
@@ -4,6 +4,7 @@ import { ObjectArrayControl, NonEmptyCellComponent } from './ObjectListControl';
 import { ControlElement, ArrayTranslations } from '@jsonforms/core';
 import { JsonFormContext } from '../../Context';
 import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
+import { ReviewRenderProvider } from '../../Context/ReviewRenderContext';
 jest.mock('@jsonforms/react');
 
 const mockUISchema: ControlElement = {
@@ -240,5 +241,35 @@ describe('Object List component', () => {
     render(<NonEmptyCellComponent openDeleteDialog={() => {}} handleChange={() => {}} {...props} />);
 
     expect(JsonFormsDispatch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Object List change reporting', () => {
+  it('reports the step and scope to a host with no stepper in the tree', () => {
+    (useJsonForms as jest.Mock).mockReturnValue({
+      core: { schema: rootSchema, errors: [] },
+      cells: [],
+      renderers: [],
+    });
+
+    const onReviewChange = jest.fn();
+    const { baseElement } = render(
+      <ReviewRenderProvider onReviewChange={onReviewChange}>
+        <table>
+          <tbody>
+            <ObjectArrayControl
+              {...baseMockProps}
+              data={[{ date: '2026-01-01', message: 'Hi' }]}
+              isStepperReview={true}
+              uischema={{ ...mockUISchema, options: { stepId: 5 } }}
+            />
+          </tbody>
+        </table>
+      </ReviewRenderProvider>,
+    );
+
+    fireEvent(baseElement.querySelector('goa-button')!, new CustomEvent('_click'));
+
+    expect(onReviewChange).toHaveBeenCalledWith(5, '#/properties/comments');
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/ObjectArray/ObjectListControl.tsx
@@ -1,3 +1,5 @@
+// clean-code-ignore: RULE-19 — covered by ./ObjectArray.spec.tsx, colocated. The rule only looks
+// for a .test.tsx sibling; adding one would duplicate the existing suite.
 import {
   GoabButton,
   GoabCallout,
@@ -22,10 +24,8 @@ import { ErrorObject } from 'ajv';
 import isEmpty from 'lodash/isEmpty';
 import merge from 'lodash/merge';
 import range from 'lodash/range';
-import React, { useCallback, useContext, useEffect, useReducer, useState } from 'react';
-import { JsonFormsStepperContext } from '../FormStepper/context/StepperContext';
-// clean-code-ignore: RULE-19 — covered by ./ObjectArray.spec.tsx, colocated. The rule only looks
-// for a .test.tsx sibling; adding one would duplicate the existing suite.
+import React, { useCallback, useEffect, useReducer, useState } from 'react'; // clean-code-ignore: RULE-19 — see the note at the top of this file.
+import { useReviewChange } from '../FormStepper/context/useReviewChange';
 import { useShowChangeButtons } from '../../Context/ContextProvider';
 import { capitalizeFirstLetter, isEmptyBoolean, isEmptyNumber, Visible } from '../../util';
 import {
@@ -606,7 +606,7 @@ export const ObjectArrayControl = (props: ObjectArrayControlProps): JSX.Element 
   const [open, setOpen] = useState(false);
   const [rowData, setRowData] = useState<number>(0);
   const [maxItemsError, setMaxItemsError] = useState('');
-  const context = useContext(JsonFormsStepperContext);
+  const reportChange = useReviewChange();
   const showChangeButtons = useShowChangeButtons();
 
   const {
@@ -802,7 +802,7 @@ export const ObjectArrayControl = (props: ObjectArrayControlProps): JSX.Element 
                     <GoabButton
                       type="text"
                       size="compact"
-                      onClick={() => context?.goToPage(uischema.options?.stepId as number)}
+                      onClick={() => reportChange(uischema.options?.stepId as number, uischema.scope)}
                     >
                       Change
                     </GoabButton>


### PR DESCRIPTION
## Problem

A read-only review summary rendered on a different page from the form could not send the user to the step they clicked Change on — it always landed on the application overview.

`useReviewContext().onChangeDispatch` — the call that fires the host's `onReviewChange` — was made by exactly one renderer, `InputBaseTableReviewControl`. Every other Change button only called `goToPage`, which moves the *summary's own* stepper. On a separate host page that context isn't rendering the form, so the click was a no-op, the host never received `(stepId, scope)`, `getExternalFormPath` was never called, and the host fell back to the bare form URL.

That made it look intermittent: plain text/number/date/enum fields go through the one working renderer, so only composite controls failed, silently. The Mailing Address Change button on the sandbox external-navigation demo was already broken for this reason.

## Changes

- New `useReviewChange` hook — the single path a Change click takes. It moves the stepper *and* reports to the review context, so the second half can't be forgotten by the next renderer that adds a Change button.
- Routed all six call sites through it: `FullNameControlReview`, `FullNameDobReviewControl`, `ContactInfoControlReview`, `AddressLookUpControlReview` (both buttons), `ObjectListControl`, and `InputBaseTableReviewControl`.
- `ObjectListControl` was also dropping the scope, so it couldn't focus the field even in-page — it now passes `uischema.scope`.
- Removed a stray `act` import from `InputBaseTableReviewControl` (test-only API in production code, unused).

## Documentation

New tutorial page `docs/tutorials/form-service/external-navigation.md`, which publishes to the developer guide at https://govalta.github.io/adsp-monorepo/tutorials/form-service/external-navigation.html. It walks through the four pieces a host wires up: discovering targets with `getNavigationTargets`, building a URL with `getExternalFormPath` for the cross-*application* case, handing a `navigationTarget` object across a route switch for the same-application case — the one in this ticket, which had no worked example and so read as unsupported — and receiving both through `ContextProvider` / `ReviewRenderProvider`.

The sandbox external navigation page keeps the live demo and links out to that guide.

## Tests

`useReviewChange.spec.tsx` covers the hook, including reporting with no stepper in the tree (the cross-page case) and scope-only targets. Each of the five newly-wired renderers gained a regression test that renders with **no** stepper context and asserts `onReviewChange` fires.

`jsonforms-components` 99 suites / 1458 tests pass, `sandbox-app` 11 / 77 pass, lint clean (0 errors).

## Note for the reviewer

The AC asks for Storybook documentation. There is no Storybook in this repo — no `.storybook` directory and no `*.stories.*` files — so this puts the written guide in the developer guide and leaves the runnable example in the sandbox app. Say if a real Storybook was intended; that is a much larger piece of work.

Refs CS-5347.
