### PR TITLE
fix(form-service): CS-5330 call the form a response, not a submission

### DIFF
--- a/apps/form-service/src/form/notifications.spec.ts
+++ b/apps/form-service/src/form/notifications.spec.ts
@@ -37,6 +37,17 @@ describe('form message notification types', () => {
       expect(FormMessageNotificationType.channels).toEqual([Channel.email]);
     });
 
+    // A message can be sent about a draft, not just a submitted form, and drafts and submissions
+    // were merged into 'responses'. Calling it a submission in the applicant's email is wrong for
+    // every draft conversation, so pin the word.
+    it('calls the form a response rather than a submission', () => {
+      const toApplicant = FormMessageNotificationType.events.find(({ name }) => name === FORM_MESSAGE_TO_APPLICANT);
+      const email = JSON.stringify(toApplicant.templates.email);
+
+      expect(email).toContain('response');
+      expect(email).not.toContain('submission');
+    });
+
     it('includes the message only when forwarding to the configured address', () => {
       const toApplicant = FormMessageNotificationType.events.find(({ name }) => name === FORM_MESSAGE_TO_APPLICANT);
       const forwarded = FormMessageNotificationType.events.find(({ name }) => name === FORM_MESSAGE_FORWARDED);

--- a/apps/form-service/src/form/notifications.ts
+++ b/apps/form-service/src/form/notifications.ts
@@ -156,16 +156,18 @@ export const FormMessageNotificationType: NotificationType = {
   addressPath: 'recipientEmail',
   events: [
     {
+      // Messages are available on a draft as well as a submitted form, and the two were merged into
+      // "responses", so this copy says response rather than submission.
       namespace: FORM_EVENT_NAMESPACE,
       name: FORM_MESSAGE_TO_APPLICANT,
       templates: {
         email: {
-          subject: 'New message about your {{ event.payload.form.definition.name }} submission',
+          subject: 'New message about your {{ event.payload.form.definition.name }} response',
           title: '{{ event.payload.form.definition.name }}',
           subtitle: 'You have a new message',
           body: `
 <section>
-  <p>You have received a message regarding your <b>{{ event.payload.form.definition.name }}</b> submission. Please log in to the form application to read your message and respond.</p>
+  <p>You have received a message regarding your <b>{{ event.payload.form.definition.name }}</b> response. Please log in to the form application to read your message and respond.</p>
 </section>`,
         },
       },


### PR DESCRIPTION
Addresses Howard's comment on [CS-5330](https://goa-dio.atlassian.net/browse/CS-5330).

## Change

The applicant's new-message email called the form a *submission*:

> New message about your **{{ definition.name }}** submission
> You have received a message regarding your **{{ definition.name }}** submission. Please log in to the form application to read your message and respond.

Both now say **response**. Howard's reasoning: messages are available on a draft as well as a submitted form, and drafts and submissions were merged into responses — so "submission" is wrong for every draft conversation.

Two lines in `FormMessageNotificationType` / `FORM_MESSAGE_TO_APPLICANT`, plus a comment recording why, so it does not get "corrected" back.

## Scope

Only the applicant template. The other two message templates never used the word:

- `FORM_MESSAGE_TO_REVIEWER` — "You have received a message from a … applicant"
- `FORM_MESSAGE_FORWARDED` — "The following message from a … applicant has been received"

The remaining `submission` occurrences in this file belong to `FormStatusNotificationType` (form created / locked / submitted), where the word is about an actual submission event and is still correct. No other messaging copy in `CommentsViewer` or the form apps uses it.

## Tests

Added `calls the form a response rather than a submission` to `notifications.spec.ts`, pinning the wording so it cannot drift back. `notifications.spec.ts` and `messageNotification.spec.ts` pass (15 tests); lint clean (0 errors).

Note that `nx test form-service` could not run in full locally — `MongoMemoryServer` fails to spawn `mongod` (`EFTYPE`), which blocks every spec in the project regardless of this change. The two specs above were run against the same transform with the mongo global setup skipped. CI covers the rest.

## Deploying

`FormMessageNotificationType` is registered by form-service at startup (`main.ts:153`), so the copy updates on deploy. A tenant that has overridden this template in configuration keeps its own wording.