### PR TITLE
fix(form-service, notification-service): CS-5330 route applicant messages to the reviewer

### DIFF
--- a/apps/form-service/src/form/notifications.spec.ts
+++ b/apps/form-service/src/form/notifications.spec.ts
@@ -8,6 +8,7 @@ import {
   FORM_MESSAGE_TO_REVIEWER,
 } from './events';
 import { adspId } from '@abgov/adsp-service-sdk';
+import { FormServiceRoles } from './roles';
 
 describe('form message notification types', () => {
   const apiId = adspId`urn:ads:platform:form-service:v1`;
@@ -52,6 +53,19 @@ describe('form message notification types', () => {
     it('is subscription based', () => {
       expect(FormMessageReviewerNotificationType.addressPath).toBeUndefined();
       expect(FormMessageReviewerNotificationType.events.map(({ name }) => name)).toEqual([FORM_MESSAGE_TO_REVIEWER]);
+    });
+
+    // Notification service only lets a user subscribe themselves when the type allows managed
+    // subscribe and admits one of their roles; otherwise the reviewer's subscribe is rejected and
+    // the applicant's messages fall through to the configured questions address forever.
+    it('lets the roles that can post on a form questions topic subscribe themselves', () => {
+      expect(FormMessageReviewerNotificationType.manageSubscribe).toBe(true);
+      expect(FormMessageReviewerNotificationType.subscriberRoles).toEqual(
+        expect.arrayContaining([
+          `urn:ads:platform:form-service:${FormServiceRoles.Admin}`,
+          `urn:ads:platform:form-service:${FormServiceRoles.Support}`,
+        ]),
+      );
     });
 
     it('does not include the message', () => {

--- a/apps/form-service/src/form/notifications.ts
+++ b/apps/form-service/src/form/notifications.ts
@@ -9,6 +9,7 @@ import {
   FORM_UNLOCKED,
   FORM_SET_TO_DRAFT,
 } from './events';
+import { FormServiceRoles } from './roles';
 
 const FORM_EVENT_NAMESPACE = 'form-service';
 
@@ -191,13 +192,19 @@ export const FormMessageNotificationType: NotificationType = {
 };
 
 // Reviewers aren't recorded against a form, so they make themselves reachable by subscribing when
-// they reply. That subscription is what makes a reviewer "known" for a conversation.
+// they reply. That subscription is what makes a reviewer "known" for a conversation, so the
+// reviewer roles that can post on a form questions topic have to be able to subscribe themselves;
+// without manageSubscribe notification service rejects a subscriber that isn't a subscription admin.
 export const FormMessageReviewerNotificationType: NotificationType = {
   name: 'form-message-reviewer-notifications',
   displayName: 'Form message notifications for reviewers',
   description: 'Provides notification to reviewers of messages sent by a form applicant.',
   publicSubscribe: false,
-  subscriberRoles: [],
+  manageSubscribe: true,
+  subscriberRoles: [
+    `urn:ads:platform:form-service:${FormServiceRoles.Admin}`,
+    `urn:ads:platform:form-service:${FormServiceRoles.Support}`,
+  ],
   channels: [Channel.email],
   events: [
     {

--- a/apps/form-service/src/notification.spec.ts
+++ b/apps/form-service/src/notification.spec.ts
@@ -215,6 +215,47 @@ describe('notification', () => {
       });
     });
 
+    describe('hasSubscribers', () => {
+      const notificationApiUrl = new URL('https://notification-service/notification/v1');
+      const correlationId = `${apiId}:/forms/test`;
+
+      // Notification service reads the subscription filter from the subscriptionMatch query
+      // parameter. Sending it under any other name is not an error; the filter is simply dropped
+      // and the first subscriber of any form comes back as a match.
+      it('can filter subscribers by correlation id', async () => {
+        directoryMock.getServiceUrl.mockResolvedValueOnce(notificationApiUrl);
+        axiosMock.get.mockResolvedValueOnce({ data: { results: [{ id: 'subscription' }] } });
+
+        const result = await service.hasSubscribers(tenantId, 'form-message-reviewer-notifications', correlationId);
+        expect(result).toBe(true);
+        expect(axiosMock.get).toHaveBeenCalledWith(
+          'https://notification-service/notification/v1/types/form-message-reviewer-notifications/subscriptions',
+          expect.objectContaining({
+            params: expect.objectContaining({
+              tenantId: tenantId.toString(),
+              subscriptionMatch: JSON.stringify({ correlationId }),
+            }),
+          }),
+        );
+      });
+
+      it('can return false for no subscribers', async () => {
+        directoryMock.getServiceUrl.mockResolvedValueOnce(notificationApiUrl);
+        axiosMock.get.mockResolvedValueOnce({ data: { results: [] } });
+
+        const result = await service.hasSubscribers(tenantId, 'form-message-reviewer-notifications', correlationId);
+        expect(result).toBe(false);
+      });
+
+      it('can return false for error', async () => {
+        directoryMock.getServiceUrl.mockResolvedValueOnce(notificationApiUrl);
+        axiosMock.get.mockRejectedValueOnce(new Error('oh noes!'));
+
+        const result = await service.hasSubscribers(tenantId, 'form-message-reviewer-notifications', correlationId);
+        expect(result).toBe(false);
+      });
+    });
+
     describe('sendCode', () => {
       it('can send code', async () => {
         directoryMock.getResourceUrl.mockResolvedValueOnce(subscriberUrl);

--- a/apps/form-service/src/notification.ts
+++ b/apps/form-service/src/notification.ts
@@ -168,7 +168,9 @@ class NotificationServiceImpl implements NotificationService {
         params: {
           tenantId: tenantId.toString(),
           top: 1,
-          criteria: JSON.stringify({ subscriptionMatch: { correlationId } }),
+          // Notification service reads the subscription filter from its own query parameter; a
+          // criteria parameter is ignored, which would match the first subscriber of any form.
+          subscriptionMatch: JSON.stringify({ correlationId }),
         },
       });
 

--- a/apps/notification-service/src/notification/model/subscription.spec.ts
+++ b/apps/notification-service/src/notification/model/subscription.spec.ts
@@ -392,6 +392,32 @@ describe('SubscriptionEntity', () => {
       expect(updated.criteria).toMatchObject(expect.arrayContaining([expect.any(Object), criteria]));
     });
 
+    // Subscribing is repeated to keep a subscription current; e.g. a form reviewer subscribes for
+    // the form on each message they send, and the criteria would otherwise grow without bound.
+    it('can skip an equivalent criteria', async () => {
+      const criteria = {
+        correlationId: 'test',
+        context: {
+          value: 'test',
+        },
+      };
+
+      const entity = new SubscriptionEntity(
+        repositoryMock as unknown as SubscriptionRepository,
+        {
+          tenantId,
+          typeId: 'test',
+          criteria: { ...criteria },
+          subscriberId: 'test',
+        },
+        type,
+        subscriber
+      );
+
+      const updated = await entity.updateCriteria(user, { description: 'Again.', ...criteria });
+      expect(updated.criteria).toEqual([criteria]);
+    });
+
     it('can updated criteria with empty criteria', async () => {
       const entity = new SubscriptionEntity(
         repositoryMock as unknown as SubscriptionRepository,

--- a/apps/notification-service/src/notification/model/subscription.ts
+++ b/apps/notification-service/src/notification/model/subscription.ts
@@ -71,6 +71,11 @@ export class SubscriptionEntity implements Subscription {
     }
   }
 
+  // Criteria match each other in both directions only when they select the same events.
+  private isSameCriteria(criteria: SubscriptionCriteria, other: SubscriptionCriteria): boolean {
+    return this.evaluateCriteria(criteria, other) && this.evaluateCriteria(other, criteria);
+  }
+
   private isEmptyCriteria(criteria: SubscriptionCriteria): boolean {
     return !criteria?.correlationId && Object.entries(criteria?.context || {}).length < 1;
   }
@@ -98,10 +103,13 @@ export class SubscriptionEntity implements Subscription {
     } else if (this.isEmptyCriteria(criteria)) {
       // Set empty criteria.
       this.criteria = [{}];
-    } else {
+    } else if (!this.criteria.find((item) => this.isSameCriteria(item, criteria))) {
       // Add the criteria. This means the subscription will send for events that meet the new criteria as well as other
       // pre-existing criteria. e.g. this is used in forms where a subscriber can be subscribed to notifications on multiple
       // specific forms.
+      //
+      // An equivalent criteria is skipped since subscribing is repeated to keep a subscription current; e.g. a form
+      // reviewer subscribes for the form each time they send a message.
       this.criteria.push({
         description: criteria.description,
         correlationId: criteria.correlationId,


### PR DESCRIPTION
Howard's QA on CS-5330: when a reviewer starts the conversation, the applicant's reply still went to the general questions address.

A reviewer becomes reachable by subscribing themselves when they reply, but `form-message-reviewer-notifications` did not allow managed subscribe and admitted no roles, so notification service rejected every reviewer and no reviewer was ever known. This admits the roles that can post on a form questions topic, sends the subscriber lookup filter under `subscriptionMatch` (the parameter notification service actually reads; as `criteria` it was dropped, which would have matched the first subscriber of any form), and skips re-adding an equivalent criteria so a reviewer's criteria array stops growing one entry per message.

Existing conversations do not heal retroactively: the reviewer has to send a message after this deploys for the subscription to be created.