### PR TITLE
fix(form-admin-app, form-app): CS-5355 stop a posted message showing twice

### DIFF
--- a/apps/form-admin-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.spec.ts
@@ -126,6 +126,17 @@ describe('commentReducer', () => {
       expect(state.comments.results.map((r) => r.id)).toEqual([11, 10]);
     });
 
+    // Posting waits on the subscription call, so the refresh the comment-created event triggers
+    // usually gets the comment into the list first.
+    it('should not add the comment a refresh has already brought in', () => {
+      const state = commentReducer(
+        loadedState(topicA, [comment(11, 'new'), comment(10, 'from form A')]),
+        addComment.fulfilled(comment(11, 'new'), 'req', { topic: topicA, comment: { content: 'new' } }),
+      );
+
+      expect(state.comments.results.map((r) => r.id)).toEqual([11, 10]);
+    });
+
     it('should not add the comment to a list of another topic', () => {
       const state = commentReducer(
         loadedState(topicA, [comment(10, 'from form A')]),

--- a/apps/form-admin-app/src/app/state/comment.slice.ts
+++ b/apps/form-admin-app/src/app/state/comment.slice.ts
@@ -464,7 +464,13 @@ const commentSlice = createSlice({
       })
       .addCase(addComment.fulfilled, (state, { payload, meta }) => {
         state.busy.executing = false;
-        if (state.comments.topicId === meta.arg.topic?.id) {
+        // The comment-created event refreshes the list, and that refresh can land first, so the
+        // comment posted may already be held. Adding it again showed the poster's own message
+        // twice, and nothing replaced the list afterwards to take the second copy away.
+        if (
+          state.comments.topicId === meta.arg.topic?.id &&
+          !state.comments.results.some(({ id }) => id === payload.id)
+        ) {
           state.comments.results.unshift(payload);
         }
         state.draft = { title: null, content: null };

--- a/apps/form-app/src/app/state/comment.slice.spec.ts
+++ b/apps/form-app/src/app/state/comment.slice.spec.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import axios from 'axios';
 import { io } from 'socket.io-client';
 import {
+  addComment,
   commentReducer,
   connectStream,
   loadComments,
@@ -254,6 +255,38 @@ describe('comment slice messages', () => {
     });
 
     expect(paged.comments.results.map((r) => r.id)).toEqual([9, 8]);
+  });
+
+  // The refresh the comment-created event triggers can land before the post resolves, and the
+  // message was then held twice with nothing to take the second copy away.
+  it('does not add a posted comment the refresh already brought in', () => {
+    const loaded = commentReducer(stateWithTopic, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 9, content: 'mine' }], page: {} },
+      meta: { arg: { topic: TOPIC } },
+    });
+
+    const posted = commentReducer(loaded, {
+      type: addComment.fulfilled.type,
+      payload: { id: 9, content: 'mine' },
+    });
+
+    expect(posted.comments.results.map((r) => r.id)).toEqual([9]);
+  });
+
+  it('adds a posted comment the refresh has not brought in', () => {
+    const loaded = commentReducer(stateWithTopic, {
+      type: loadComments.fulfilled.type,
+      payload: { results: [{ id: 8, content: 'theirs' }], page: {} },
+      meta: { arg: { topic: TOPIC } },
+    });
+
+    const posted = commentReducer(loaded, {
+      type: addComment.fulfilled.type,
+      payload: { id: 9, content: 'mine' },
+    });
+
+    expect(posted.comments.results.map((r) => r.id)).toEqual([9, 8]);
   });
 
   // Comments loaded into the drawer are what the next open marks as read.

--- a/apps/form-app/src/app/state/comment.slice.ts
+++ b/apps/form-app/src/app/state/comment.slice.ts
@@ -446,7 +446,11 @@ const commentSlice = createSlice({
       })
       .addCase(addComment.fulfilled, (state, { payload }) => {
         state.busy.executing = false;
-        state.comments.results.unshift(payload);
+        // The comment-created event refreshes the list, and that refresh can land first, so the
+        // comment posted may already be held; adding it again shows the message twice.
+        if (!state.comments.results.some(({ id }) => id === payload.id)) {
+          state.comments.results.unshift(payload);
+        }
         state.draft = { title: null, content: null };
         state.messages.latestCommentId = latestOf(state.messages.latestCommentId, [payload]);
       })


### PR DESCRIPTION
Fixes [CS-5355](https://goa-dio.atlassian.net/browse/CS-5355).

`addComment` unshifted the comment it posted whether or not the list already held it. The `comment-created` event refreshes that list, and in the admin app the refresh wins the race, since posting waits on the reviewer subscription call added by CS-5330 before it resolves. Nothing replaces the list afterwards — re-entering the workspace doesn't reload a topic that is already selected — so the second copy stayed until the page was reloaded.

Only add a comment that isn't already held, in both apps. CS-5353 fixed the other half of this, where a cursorless refresh appended onto the page already on screen.
