### PR TITLE
fix(agent-service): CS-5342 bump @mastra/core to fix tool schema conversion

### DIFF
--- a/apps/agent-service/src/agent/processors/file.ts
+++ b/apps/agent-service/src/agent/processors/file.ts
@@ -1,5 +1,5 @@
 import { AdspId, ServiceDirectory, TokenProvider } from '@abgov/adsp-service-sdk';
-import { convertUint8ArrayToBase64, FilePart, ImagePart, TextPart } from '@ai-sdk/provider-utils-v5';
+import { convertUint8ArrayToBase64, FilePart, ImagePart, TextPart } from '@ai-sdk/provider-utils'; // clean-code-ignore: RULE-19
 import type { CoreUserMessage } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
 import { Logger } from 'winston';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@ai-sdk/provider-utils": "^4.0.50",
         "@azure/storage-blob": "^12.9.0",
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.1",
@@ -319,11 +320,11 @@
         "yaml": "^2.4.2"
       }
     },
-    "node_modules/@a2a-js/sdk": {
+    "node_modules/@a2a-js/sdk-v0_3": {
+      "name": "@a2a-js/sdk",
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.14.tgz",
       "integrity": "sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^11.1.0"
       },
@@ -345,6 +346,43 @@
         "express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@a2a-js/sdk-v1": {
+      "name": "@a2a-js/sdk",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==",
+      "dependencies": {
+        "jose": "^6.2.3",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@a2a-js/sdk-v1/node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@abgov/adsp-cli": {
@@ -588,10 +626,9 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
-      "license": "Apache-2.0",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
+      "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -599,19 +636,18 @@
         "node": ">=18"
       }
     },
-    "node_modules/@ai-sdk/provider-utils-v5": {
-      "name": "@ai-sdk/provider-utils",
-      "version": "3.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.30.tgz",
-      "integrity": "sha512-NCJ9JKow5ENAgEZxzvEvF20thwDiH+hutvzmrUDbloRX0azpJHNst8+7pZIVryYhLM9wgpT5/ShTSjPTFhkxEQ==",
-      "license": "Apache-2.0",
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.50",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.50.tgz",
+      "integrity": "sha512-YAcB+7M1JhAYsHorTrWyldCyZihjCKr/QRXH2vFrara/+lwqNE7q5KzoucKLZ7ktFiUonhnhFhRoiymsq/2K2Q==",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
+        "@ai-sdk/provider": "3.0.15",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^6.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.17"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -9913,13 +9949,12 @@
       }
     },
     "node_modules/@mastra/core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@mastra/core/-/core-1.57.0.tgz",
-      "integrity": "sha512-2ud56Ow5wwyAFegxXkkOHcQfCG0W9Sz1ex2qVf3y/704zwwYZl/RBZXZV/7277RIxWFk8Bnw8pmGtGQ4tZVWEg==",
-      "license": "Apache-2.0",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@mastra/core/-/core-1.64.0.tgz",
+      "integrity": "sha512-+fuvDeORYWIb+SJrGQlXQi6r1JCxd05g3SNCDepnO910j4uqxMWf5s22Ta0sRSR5zbKRx2NUZoWPAfQt2xF4hQ==",
       "dependencies": {
-        "@a2a-js/sdk": "~0.3.14",
-        "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.30",
+        "@a2a-js/sdk-v0_3": "npm:@a2a-js/sdk@~0.3.14",
+        "@a2a-js/sdk-v1": "npm:@a2a-js/sdk@~1.0.1",
         "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.40",
         "@ai-sdk/provider-utils-v7": "npm:@ai-sdk/provider-utils@5.0.13",
         "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3",
@@ -9927,8 +9962,8 @@
         "@ai-sdk/provider-v7": "npm:@ai-sdk/provider@4.0.4",
         "@isaacs/ttlcache": "^2.1.5",
         "@lukeed/uuid": "^2.0.1",
-        "@mastra/schema-compat": "1.3.5",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@mastra/schema-compat": "1.3.8",
+        "@modelcontextprotocol/server": "2.0.0",
         "@sindresorhus/slugify": "^2.2.1",
         "@standard-schema/spec": "^1.1.0",
         "ajv": "^8.20.0",
@@ -9945,7 +9980,7 @@
         "p-map": "^7.0.4",
         "p-retry": "^7.1.1",
         "picomatch": "^4.0.3",
-        "posthog-node": "^5.37.0",
+        "posthog-node": "^5.46.1",
         "tokenx": "^1.3.0",
         "ws": "^8.21.0",
         "xxhash-wasm": "^1.1.0"
@@ -9958,15 +9993,12 @@
       }
     },
     "node_modules/@mastra/core/node_modules/@mastra/schema-compat": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.3.5.tgz",
-      "integrity": "sha512-9CdBZZ2Fb8q6Ms4r6hs0msH8MTmVn99Zrc+i8BnNNuqKlIrywIoH3BghmPr5VsvkBUx7u/GjdYAsJ6i9nPcZZA==",
-      "license": "Apache-2.0",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.3.8.tgz",
+      "integrity": "sha512-uGGQlb/QAIgghHf/FQLfnpHbUMXWWJDFlv0FQ/p0K6TjT8OVdWC9uNPdwQmFYu8Fzut4Z+LmzNkJ5S378/41Ew==",
       "dependencies": {
         "json-schema-to-zod": "^2.7.0",
-        "zod-from-json-schema": "^0.5.2",
-        "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
-        "zod-to-json-schema": "^3.25.1"
+        "zod-from-json-schema": "^0.5.2"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -10755,6 +10787,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@modelcontextprotocol/ext-apps": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.2.tgz",
@@ -11040,6 +11091,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@monaco-editor/loader": {
@@ -66465,7 +66536,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -68981,16 +69051,6 @@
       "license": "MIT",
       "dependencies": {
         "zod": "^4.0.17"
-      }
-    },
-    "node_modules/zod-from-json-schema-v3": {
-      "name": "zod-from-json-schema",
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/zod-from-json-schema/-/zod-from-json-schema-0.0.5.tgz",
-      "integrity": "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^3.24.2"
       }
     },
     "node_modules/zod-from-json-schema/node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "private": true,
   "dependencies": {
+    "@ai-sdk/provider-utils": "^4.0.50",
     "@azure/storage-blob": "^12.9.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",


### PR DESCRIPTION
## CS-5342

Agent calls were failing with `(0 , zod_to_json_schema.default) is not a function` whenever a tool's Zod schema was converted for an OpenAI-compatible model.

`@mastra/core` 1.57.0 bundles its own copy of `@mastra/schema-compat` 1.3.5, which reaches `zod-to-json-schema` through a broken build-tool interop wrapper. Refreshing `@mastra/core` to 1.64.0 (already inside the existing `^1.12.0` range) brings schema-compat 1.3.8, which vendors the converter and drops that dependency entirely.

1.64.0 also stops hoisting the `@ai-sdk/provider-utils-v5` alias that `processors/file.ts` was resolving through, which broke the build, so `@ai-sdk/provider-utils` is now a declared dependency and the import points at it.

Verified: `nx build`, `nx test` (347 passed) and `nx lint` for agent-service all pass.