### PR TITLE
fix(jsonforms-components): CS-5347 let a host change the navigation target after mount

### DIFF
--- a/apps/sandbox-app/src/app/components/SandboxTenant.tsx
+++ b/apps/sandbox-app/src/app/components/SandboxTenant.tsx
@@ -35,6 +35,7 @@ import { ConfigurationServiceMain } from './services/ConfigurationServiceMain';
 import { FeedbackCSSLeak } from './services/feedback/FeedbackCSSLeak';
 import { JsonformsExampleOne } from './services/jsonforms/JsonformsExampleOne';
 import { JsonformsExternalNavigation } from './services/jsonforms/JsonformsExternalNavigation';
+import { JsonformsReviewNavigation } from './services/jsonforms/JsonformsReviewNavigation';
 import { DesignSystemsMain } from './services/DesignSystemsMain';
 import { DesignSystemsExampleOne } from './services/design-systems/DesignSystemsExampleOne';
 import { FeedbackNotification } from './FeedbackNotification';
@@ -105,6 +106,7 @@ export const SandBoxTenant = () => {
                 <Route path="/services/jsonforms" element={<JsonformsMain tenantName={tenantName} />} />
                 <Route path="/services/jsonforms/example1/:definitionId" element={<JsonformsExampleOne />} />
                 <Route path="/services/jsonforms/external-navigation" element={<JsonformsExternalNavigation />} />
+                <Route path="/services/jsonforms/review-navigation" element={<JsonformsReviewNavigation />} />
 
                 <Route path="/services/notification" element={<NotificationServiceMain tenantName={tenantName} />} />
                 <Route path="/services/pdf" element={<PDFServiceMain tenantName={tenantName} />} />

--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigation.spec.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigation.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { JsonformsReviewNavigation } from './JsonformsReviewNavigation';
+
+// Captures what the page hands the two providers, so a Change click and the form's answer can both
+// be driven without rendering the form itself.
+const wiring: {
+  onReviewChange?: (stepId: number | undefined, scope: string) => void;
+  navigationTarget?: { pageId?: string; scope?: string };
+  onNavigationChange?: (outcome: { status: string; pageId: string }) => void;
+} = {};
+
+jest.mock('@abgov/jsonforms-components', () => ({
+  ContextProviderFactory:
+    () =>
+    ({
+      children,
+      navigationTarget,
+      onNavigationChange,
+    }: {
+      children: React.ReactNode;
+      navigationTarget?: { pageId?: string; scope?: string };
+      onNavigationChange?: (outcome: { status: string; pageId: string }) => void;
+    }) => {
+      // The page renders two of these; only the one wrapping the form carries the navigation wiring.
+      if (onNavigationChange) {
+        wiring.navigationTarget = navigationTarget;
+        wiring.onNavigationChange = onNavigationChange;
+      }
+      return <div>{children}</div>;
+    },
+  ReviewRenderProvider: ({
+    children,
+    onReviewChange,
+  }: {
+    children: React.ReactNode;
+    onReviewChange: (stepId: number | undefined, scope: string) => void;
+  }) => {
+    wiring.onReviewChange = onReviewChange;
+    return <div data-testid="review-provider">{children}</div>;
+  },
+  createDefaultAjv: () => ({}),
+  getNavigationTargets: (uischema: { elements: { label?: string }[] }) =>
+    uischema.elements.map((element, index) => ({
+      pageId: `page-${index + 1}`,
+      label: element.label,
+      authored: false,
+      index,
+      fields: [],
+    })),
+  GoAReviewRenderers: [],
+  GoARenderers: [],
+  GoACells: [],
+}));
+
+jest.mock('@jsonforms/react', () => ({
+  JsonForms: () => <div data-testid="json-forms" />,
+}));
+
+jest.mock('../../styled-components', () => ({
+  ServiceContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@abgov/react-components', () => ({
+  GoabContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  GoabText: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  GoabCallout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  GoabButtonGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  GoabTable: ({ children }: { children: React.ReactNode }) => <table>{children}</table>,
+  GoabButton: ({ children, testId, onClick }: { children: React.ReactNode; testId: string; onClick: () => void }) => (
+    <button data-testid={testId} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('JsonformsReviewNavigation', () => {
+  beforeEach(() => {
+    wiring.onReviewChange = undefined;
+    wiring.navigationTarget = undefined;
+    wiring.onNavigationChange = undefined;
+  });
+
+  it('lists every page the definition lets a host address', () => {
+    render(<JsonformsReviewNavigation />);
+
+    expect(screen.getByTestId('navigation-target-page-1')).toHaveTextContent('What is your dispute about?');
+    expect(screen.getByTestId('navigation-target-page-13')).toHaveTextContent('Add optional supporting documents');
+  });
+
+  it('turns a reported step into a page target for the form', () => {
+    render(<JsonformsReviewNavigation />);
+
+    act(() => {
+      wiring.onReviewChange?.(2, '#/properties/applicantContactDetails/properties/firstName');
+    });
+
+    expect(wiring.navigationTarget).toEqual({
+      pageId: 'page-3',
+      scope: '#/properties/applicantContactDetails/properties/firstName',
+    });
+  });
+
+  it('passes a scope on its own when the review reports no step', () => {
+    render(<JsonformsReviewNavigation />);
+
+    act(() => {
+      wiring.onReviewChange?.(undefined, '#/properties/addSupportingDocuments');
+    });
+
+    expect(wiring.navigationTarget).toEqual({ pageId: undefined, scope: '#/properties/addSupportingDocuments' });
+  });
+
+  it('clears the target once the form has answered, so the same Change works again', () => {
+    render(<JsonformsReviewNavigation />);
+
+    act(() => {
+      wiring.onReviewChange?.(2, '#/properties/applicantContactDetails/properties/firstName');
+    });
+    act(() => {
+      wiring.onNavigationChange?.({ status: 'navigated', pageId: 'page-3' });
+    });
+
+    expect(wiring.navigationTarget).toBeUndefined();
+  });
+
+  it('logs what the review reported and what the form made of it', () => {
+    render(<JsonformsReviewNavigation />);
+
+    act(() => {
+      wiring.onReviewChange?.(2, '#/properties/applicantContactDetails/properties/firstName');
+    });
+    act(() => {
+      wiring.onNavigationChange?.({ status: 'navigated', pageId: 'page-3' });
+    });
+
+    const rows = screen.getAllByTestId('review-change-log-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('#/properties/applicantContactDetails/properties/firstName');
+    expect(rows[0]).toHaveTextContent('navigated to page-3');
+  });
+
+  it('empties the log when reset', () => {
+    render(<JsonformsReviewNavigation />);
+
+    act(() => {
+      wiring.onReviewChange?.(0, '#/properties/whichOfThemApplies');
+    });
+    expect(screen.getAllByTestId('review-change-log-row')).toHaveLength(1);
+
+    fireEvent.click(screen.getByTestId('reset-review-navigation'));
+
+    expect(screen.queryAllByTestId('review-change-log-row')).toHaveLength(0);
+  });
+});

--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigation.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigation.tsx
@@ -1,0 +1,252 @@
+// clean-code-ignore: RULE-19 — covered by ./JsonformsReviewNavigation.spec.tsx.
+//
+// Reproduction page for "the review's Change button does not go to the step/page".
+//
+// It runs the real CDRT application schemas (./condoTribunal) in the two shapes that matter, side
+// by side against one shared data object:
+//
+//   the form     — the pages stepper, including its own last-page review summary. Change there has
+//                  a stepper in context, so it moves the page directly.
+//   the review   — the same summary rendered on its own, the way a host application shows it. There
+//                  is no stepper in context, so the only thing a Change click can do is report
+//                  itself through onReviewChange; this page turns that report into a navigation
+//                  target and hands it to the form above.
+//
+// Every click is logged with what the review reported and what the form resolved it to, so a click
+// that goes nowhere can be attributed to one side or the other rather than guessed at.
+import { useCallback, useMemo, useState } from 'react';
+import { GoabButton, GoabButtonGroup, GoabCallout, GoabContainer, GoabTable, GoabText } from '@abgov/react-components';
+import {
+  ContextProviderFactory,
+  createDefaultAjv,
+  getNavigationTargets,
+  GoACells,
+  GoARenderers,
+  GoAReviewRenderers,
+  NavigationOutcome,
+  NavigationTarget,
+  ReviewRenderProvider,
+} from '@abgov/jsonforms-components';
+import { JsonForms } from '@jsonforms/react';
+import { ServiceContainer } from '../../styled-components';
+import { condoTribunalDataSchema, condoTribunalUiSchema } from './condoTribunal';
+
+const ContextProvider = ContextProviderFactory();
+
+interface ClickLogEntry {
+  at: string;
+  reported: { stepId: number | undefined; scope: string };
+  outcome?: NavigationOutcome;
+}
+
+const describeOutcome = (outcome?: NavigationOutcome): string => {
+  if (!outcome) {
+    return 'form has not answered yet';
+  }
+
+  switch (outcome.status) {
+    case 'navigated':
+      return `navigated to ${outcome.pageId}`;
+    case 'unavailable':
+      return `${outcome.pageId} unavailable (${outcome.reason})`;
+    default:
+      return `unknown target ${JSON.stringify(outcome.requested)}`;
+  }
+};
+
+// Sample answers, so the summary has something to render and every page reports a status. Kept to
+// the fields the review shows a Change button for — filling the whole application is not the point.
+const SAMPLE_DATA: Record<string, unknown> = {
+  whichOfThemApplies: ['Access to condominium documents'],
+  disputeAlreadyTakenToCourt: 'No, there are no other applications',
+  fillingApplicationOnbehalf: 'No',
+  applicantContactDetails: {
+    firstName: 'Dana',
+    lastName: 'Okafor',
+    email: 'dana.okafor@example.com',
+    telephone: '780-555-0134',
+    applicantPhysicalAddress: {
+      addressLine1: '10611 98 Ave NW',
+      city: 'Edmonton',
+      provinceState: 'Alberta',
+      country: 'Canada',
+      postalCodeZip: 'T5K 2P7',
+    },
+  },
+  otherPartyDisputeDetails: {
+    otherPartyPrimaryFirstName: 'Riley',
+    otherPartyPrimaryLastName: 'Chen',
+    otherPartyPrimaryCondoCorporationName: 'Condominium Corporation No. 012 3456',
+  },
+  whenDidIssueHappen: {
+    whenWasIssueDate: '2026-04-17',
+  },
+  describeDispute: {
+    disputeDescription: 'The corporation has not provided the approved AGM minutes after three written requests.',
+    resultOfApplication: 'An order requiring the corporation to release the requested records.',
+  },
+  addSupportingDocuments: 'No, not right now',
+};
+
+export const JsonformsReviewNavigation = (): JSX.Element => {
+  const ajv = useMemo(() => createDefaultAjv(), []);
+  const [formData, setFormData] = useState<Record<string, unknown>>(SAMPLE_DATA);
+  const [navigationTarget, setNavigationTarget] = useState<NavigationTarget>();
+  const [log, setLog] = useState<ClickLogEntry[]>([]);
+
+  // What the definition says a host is allowed to address. Rendering it here makes the page ids the
+  // review is reporting against visible, rather than something to infer from the behaviour.
+  const navigationTargets = useMemo(() => getNavigationTargets(condoTribunalUiSchema), []);
+
+  const handleFormChange = useCallback(({ data }: { data: Record<string, unknown> }) => setFormData(data), []);
+
+  // The host half: a Change click arrives as a step index and a scope, and becomes a target the
+  // form is asked to honour. A page id is used where the review knew the step, so the case where
+  // only the scope survives is still exercised by the fields the review reports without one.
+  const handleReviewChange = useCallback(
+    (stepId: number | undefined, scope: string) => {
+      const pageId = stepId === undefined ? undefined : navigationTargets[stepId]?.pageId;
+      setLog((entries) => [{ at: new Date().toLocaleTimeString(), reported: { stepId, scope } }, ...entries]);
+      setNavigationTarget({ pageId, scope });
+    },
+    [navigationTargets],
+  );
+
+  // The request is cleared once the form has answered it. A target left standing is treated as
+  // already applied, so without this a second click on the same Change button — after the user has
+  // walked back to the overview themselves — would be indistinguishable from a re-render and would
+  // go nowhere.
+  const handleNavigationChange = useCallback((outcome: NavigationOutcome) => {
+    setLog((entries) => (entries.length === 0 ? entries : [{ ...entries[0], outcome }, ...entries.slice(1)]));
+    setNavigationTarget(undefined);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setFormData(SAMPLE_DATA);
+    setNavigationTarget(undefined);
+    setLog([]);
+  }, []);
+
+  return (
+    <ServiceContainer>
+      <GoabContainer
+        accent="thick"
+        type="non-interactive"
+        width="full"
+        testId="JsonformsReviewNavigationContainer"
+        heading="Review change navigation (CDRT application)"
+      >
+        <GoabText size="body-m">
+          The condominium tribunal application, in the two shapes a Change button has to work in. The form below is the
+          pages stepper; the summary further down is the same review rendered on its own, as a host application shows
+          it. Both read and write the same data, so a change made in either is visible in the other.
+        </GoabText>
+
+        <GoabCallout type="information" heading="What to watch" mt="m" mb="m">
+          A Change click in the standalone summary reports a step index and a scope. Nothing else about it reaches the
+          form — the log at the bottom shows what was reported and what the form resolved it to.
+        </GoabCallout>
+
+        <GoabButtonGroup alignment="start" mb="l">
+          <GoabButton type="secondary" testId="reset-review-navigation" onClick={handleReset}>
+            Reset the data and log
+          </GoabButton>
+        </GoabButtonGroup>
+
+        <h3>The form</h3>
+        <ContextProvider
+          showChangeButtons={true}
+          navigationTarget={navigationTarget}
+          onNavigationChange={handleNavigationChange}
+        >
+          <JsonForms
+            ajv={ajv}
+            schema={condoTribunalDataSchema}
+            uischema={condoTribunalUiSchema}
+            data={formData}
+            validationMode="ValidateAndShow"
+            renderers={GoARenderers}
+            cells={GoACells}
+            onChange={handleFormChange}
+          />
+        </ContextProvider>
+
+        <h3>The review, rendered on its own</h3>
+        <GoabText size="body-m" mb="m">
+          No stepper is in context here, so a Change button has nothing of its own to move. Everything it can do is in
+          the report it makes.
+        </GoabText>
+        <ContextProvider showChangeButtons={true}>
+          <ReviewRenderProvider onReviewChange={handleReviewChange}>
+            <JsonForms
+              readonly={true}
+              ajv={ajv}
+              schema={condoTribunalDataSchema}
+              uischema={condoTribunalUiSchema}
+              data={formData}
+              validationMode="NoValidation"
+              renderers={GoAReviewRenderers}
+              cells={GoACells}
+            />
+          </ReviewRenderProvider>
+        </ContextProvider>
+
+        <h3>What the definition offers a host</h3>
+        <GoabText size="body-m" mb="m">
+          The pages a link can address, in the order the review reports them by index. None of this form's pages carry
+          an authored <code>options.id</code>, so every one of them is addressed positionally.
+        </GoabText>
+        <GoabTable width="100%" mb="l">
+          <thead>
+            <tr>
+              <th>Index</th>
+              <th>Page id</th>
+              <th>Label</th>
+            </tr>
+          </thead>
+          <tbody>
+            {navigationTargets.map(({ index, pageId, label }) => (
+              <tr key={pageId} data-testid={`navigation-target-${pageId}`}>
+                <td>{index}</td>
+                <td>
+                  <code>{pageId}</code>
+                </td>
+                <td>{label ?? '(no label)'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </GoabTable>
+
+        <h3>Change clicks</h3>
+        {log.length === 0 ? (
+          <GoabText size="body-m" mb="l">
+            Nothing yet. Click a Change button in the standalone summary.
+          </GoabText>
+        ) : (
+          <GoabTable width="100%" mb="l">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Reported step</th>
+                <th>Reported scope</th>
+                <th>Form outcome</th>
+              </tr>
+            </thead>
+            <tbody>
+              {log.map((entry, index) => (
+                <tr key={`${entry.at}-${index}`} data-testid="review-change-log-row">
+                  <td>{entry.at}</td>
+                  <td>{entry.reported.stepId === undefined ? '(none)' : entry.reported.stepId}</td>
+                  <td>
+                    <code>{entry.reported.scope || '(none)'}</code>
+                  </td>
+                  <td>{describeOutcome(entry.outcome)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabTable>
+        )}
+      </GoabContainer>
+    </ServiceContainer>
+  );
+};

--- a/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/applicationDataSchema.ts
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/applicationDataSchema.ts
@@ -1,0 +1,497 @@
+// clean-code-ignore: RULE-19 — a verbatim copy, exercised through the page it feeds. Asserting its
+// contents here would only restate the copy.
+// Copied from libs/condo-tribunal-common/src/schemas/versions/v1/applicationDataSchema.ts in
+// GovAlta-EMU/adsp-applications. Kept verbatim so the sandbox reproduces the real CDRT form rather
+// than a simplified stand-in; see ./locations.ts for the one part that had to be recreated.
+import { countries, provinceStates, mailingCountries, mailingProvinceStates } from './locations';
+import { JsonSchema7 } from '@jsonforms/core';
+
+export const dataSchema: JsonSchema7 = {
+  type: 'object',
+  properties: {
+    whichOfThemApplies: {
+      type: 'array',
+      default: [],
+      items: {
+        type: 'string',
+        oneOf: [
+          {
+            const: 'Monetary sanctions imposed by a corporation, including the process in applying that sanction',
+            title: 'Monetary sanctions imposed by a corporation, including the process in applying that sanction',
+            description: 'For example: Receiving a monetary sanction for not following a rule in the bylaws',
+          },
+          {
+            const: 'Access to condominium documents',
+            title: 'Access to condominium documents',
+            description: 'For example: Getting access to the approved minutes of the AGM or the annual budget',
+          },
+          {
+            const: 'General meetings and special general meetings of a corporation or its board',
+            title: 'General meetings and special general meetings of a corporation or its board',
+            description: 'For example: The AGM was not held within 15 months of the previous AGM',
+          },
+        ],
+        uniqueItems: true,
+      },
+      minItems: 1,
+      errorMessage: {
+        minItems: 'Choose all that apply is required',
+      },
+    },
+    disputeAlreadyTakenToCourt: {
+      type: 'string',
+      enum: [
+        'No, there are no other applications',
+        'Yes, I have filed an application with the courts',
+        'Yes, I have been served with an application by the courts',
+        "I'm not sure",
+      ],
+    },
+    fillingApplicationOnbehalf: {
+      type: 'string',
+      enum: ['No', 'Yes - lawyer', 'Yes - I have a personal representative'],
+    },
+    whichOfThemAppliesOther: {
+      type: 'string',
+      title: 'Describe your dispute in a few words',
+    },
+    readyToApply: {
+      type: 'object',
+      properties: {
+        hasDisputeTakenCareOff: {
+          type: 'string',
+          title: 'Has this dispute already been taken to court?',
+          enum: [
+            'No, there are no other applications',
+            'Yes, I have filed an application with the courts',
+            'Yes, I have been served with an application from the courts',
+            "I'm not sure",
+          ],
+        },
+      },
+    },
+    representativeContactInformation: {
+      type: 'object',
+      properties: {
+        primaryFirstName: {
+          type: 'string',
+        },
+        primaryLastName: {
+          type: 'string',
+        },
+        primaryOrganizationBusinessName: {
+          type: 'string',
+        },
+        primaryTitle: {
+          type: 'string',
+        },
+        primaryEmail: {
+          type: 'string',
+          pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+          errorMessage: {
+            pattern: 'Email is in a incorrect format',
+          },
+        },
+        primaryPhone: {
+          type: 'string',
+          pattern: '^[+\\-0-9]+$',
+          errorMessage: {
+            pattern: 'Telephone can only contain digits, hyphens and/or plus symbol',
+          },
+        },
+        alternateFirstName: {
+          type: 'string',
+        },
+        alternateLastName: {
+          type: 'string',
+        },
+        alternateOrganizationBusinessName: {
+          type: 'string',
+        },
+        alternateContact: {
+          type: 'array',
+          items: {
+            type: 'object',
+            title: 'Contact',
+            properties: {
+              alternateFirstName: {
+                type: 'string',
+              },
+              alternateLastName: {
+                type: 'string',
+              },
+              alternateOrganizationBusinessName: {
+                type: 'string',
+              },
+              alternateTitle: {
+                type: 'string',
+              },
+              alternateEmail: {
+                type: 'string',
+                pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+                errorMessage: {
+                  pattern: 'Email is in a incorrect format',
+                },
+              },
+              alternateTelephone: {
+                type: 'string',
+                pattern: '^[+\\-0-9]+$',
+                errorMessage: {
+                  pattern: 'Telephone can only contain digits, hyphens and/or plus symbol',
+                },
+              },
+              makePrimaryContact: {
+                type: 'boolean',
+                allOf: [
+                  {
+                    enum: [true],
+                  },
+                ],
+              },
+            },
+            required: [
+              'alternateFirstName',
+              'alternateLastName',
+              'alternateOrganizationBusinessName',
+              'alternateTitle',
+              'alternateTelephone',
+              'alternateEmail',
+            ],
+          },
+        },
+      },
+      required: ['primaryFirstName', 'primaryLastName', 'primaryEmail', 'primaryPhone'],
+    },
+
+    representatitiveMailAddress: {
+      type: 'object',
+      properties: {
+        addressLine1: {
+          type: 'string',
+        },
+        addressLine2: {
+          type: 'string',
+        },
+        city: {
+          type: 'string',
+        },
+        provinceState: {
+          type: 'string',
+          enum: provinceStates,
+        },
+        country: {
+          type: 'string',
+          enum: countries,
+        },
+        postalCodeZip: {
+          type: 'string',
+        },
+      },
+      required: ['addressLine1', 'city', 'provinceState', 'country', 'postalCodeZip'],
+    },
+    primaryDetailMailingAddress: {
+      type: 'object',
+      properties: {
+        primaryMailingAddressLine1: {
+          type: 'string',
+        },
+        primaryMailingAddressLine2: {
+          type: 'string',
+        },
+        primaryMailingCityTown: {
+          type: 'string',
+        },
+        primaryMailingProvinceState: {
+          type: 'string',
+          enum: mailingProvinceStates,
+        },
+        primaryMailingCountry: {
+          type: 'string',
+        },
+        primaryMailingPostalCodeZip: {
+          type: 'string',
+        },
+      },
+      required: [
+        'primaryMailingAddressLine1',
+        'primaryMailingCityTown',
+        'primaryMailingProvinceState',
+        'primaryMailingCountry',
+        'primaryMailingPostalCodeZip',
+      ],
+    },
+
+    applicantContactDetails: {
+      type: 'object',
+      properties: {
+        firstName: {
+          type: 'string',
+        },
+        middleName: {
+          type: 'string',
+        },
+        lastName: {
+          type: 'string',
+        },
+        condoCorporationName: { type: 'string' },
+        email: {
+          type: 'string',
+          pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+          errorMessage: {
+            pattern: 'Email is in a incorrect format',
+          },
+        },
+        telephone: {
+          type: 'string',
+          pattern: '^[+\\-0-9]+$',
+          errorMessage: {
+            pattern: 'Telephone can only contain digits, hyphens and/or plus symbol',
+          },
+        },
+        additionalApplicants: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              alternateFirstName: {
+                type: 'string',
+              },
+              alternateLastName: {
+                type: 'string',
+              },
+              alternateOrganizationBusinessName: {
+                type: 'string',
+              },
+              alternateEmail: {
+                type: 'string',
+                pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+                errorMessage: {
+                  pattern: 'Email is in a incorrect format',
+                },
+              },
+              alternateTelephone: {
+                type: 'string',
+                pattern: '^[+\\-0-9]+$',
+                errorMessage: {
+                  pattern: 'Telephone can only contain digits, hyphens and/or plus symbol',
+                },
+              },
+              confirmPrimaryContact: {
+                type: 'boolean',
+                allOf: [
+                  {
+                    enum: [true],
+                  },
+                ],
+              },
+            },
+            required: ['alternateFirstName', 'alternateLastName', 'alternateEmail', 'alternateTelephone'],
+          },
+        },
+        additionalMailAddress: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              addressLine1: {
+                type: 'string',
+              },
+              addressLine2: {
+                type: 'string',
+              },
+              city: {
+                type: 'string',
+              },
+              provinceState: {
+                type: 'string',
+                enum: mailingProvinceStates,
+              },
+              country: {
+                type: 'string',
+                enum: mailingCountries,
+              },
+              postalCodeZip: {
+                type: 'string',
+              },
+            },
+            required: ['addressLine1', 'city', 'provinceState', 'country', 'postalCodeZip'],
+          },
+        },
+        fillingMailingAddress: {
+          type: 'boolean',
+          allOf: [
+            {
+              enum: [true],
+            },
+          ],
+        },
+        applicantPhysicalAddress: {
+          type: 'object',
+          properties: {
+            addressLine1: {
+              type: 'string',
+            },
+            addressLine2: {
+              type: 'string',
+            },
+            city: {
+              type: 'string',
+            },
+            provinceState: {
+              type: 'string',
+              enum: provinceStates,
+            },
+
+            country: {
+              type: 'string',
+              enum: countries,
+            },
+            postalCodeZip: {
+              type: 'string',
+            },
+          },
+          required: ['addressLine1', 'city', 'provinceState', 'country', 'postalCodeZip'],
+        },
+      },
+      required: ['firstName', 'lastName', 'email', 'telephone'],
+    },
+    otherPartyDisputeDetails: {
+      type: 'object',
+      properties: {
+        otherPartyPrimaryFirstName: {
+          type: 'string',
+        },
+        otherPartyPrimaryLastName: {
+          type: 'string',
+        },
+        otherPartyPrimaryCondoCorporationName: {
+          type: 'string',
+        },
+        otherPartyPrimaryEmail: {
+          type: 'string',
+        },
+        otherPartyPrimaryTelephone: {
+          type: 'string',
+          pattern: '^[+\\-0-9]+$',
+          errorMessage: {
+            pattern: 'Telephone can only contain digits, hyphens and/or plus symbol',
+          },
+        },
+
+        additionalRespondents: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              respondentFirstName: {
+                type: 'string',
+              },
+              respondentLastName: {
+                type: 'string',
+              },
+              respondentCondoCorpName: {
+                type: 'string',
+              },
+              respondentEmail: {
+                type: 'string',
+                pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+                errorMessage: {
+                  pattern: 'Email is in a incorrect format',
+                },
+              },
+              respondentTelephone: {
+                type: 'string',
+                pattern: '^[+\\-0-9]+$',
+                errorMessage: {
+                  pattern: 'Telephone can only contain digits, hyphens and/or plus symbol',
+                },
+              },
+            },
+            required: ['respondentFirstName'],
+          },
+        },
+      },
+      required: ['otherPartyPrimaryFirstName'],
+    },
+
+    primaryRespondentMailAddress: {
+      type: 'object',
+      properties: {
+        addressLine1: {
+          type: 'string',
+        },
+        addressLine2: {
+          type: 'string',
+        },
+        city: {
+          type: 'string',
+        },
+        provinceState: {
+          type: 'string',
+          enum: mailingProvinceStates,
+        },
+        country: {
+          type: 'string',
+          enum: mailingCountries,
+        },
+        postalCodeZip: {
+          type: 'string',
+        },
+      },
+      required: [],
+    },
+    whenDidIssueHappen: {
+      type: 'object',
+      properties: {
+        whenWasIssueDate: {
+          type: 'string',
+          format: 'date',
+        },
+      },
+      required: ['whenWasIssueDate'],
+    },
+    isIssueStillHappening: {
+      type: 'string',
+      enum: ['Yes, it is still happening', 'No, it happened in the past'],
+    },
+    describeDispute: {
+      type: 'object',
+      properties: {
+        disputeDescription: {
+          type: 'string',
+        },
+        resultOfApplication: {
+          type: 'string',
+        },
+      },
+      required: ['disputeDescription', 'resultOfApplication'],
+    },
+    addSupportingDocuments: {
+      type: 'string',
+      enum: ['Yes, I would like to add optional supporting documents', 'No, not right now'],
+    },
+  },
+  allOf: [
+    {
+      if: {
+        properties: {
+          fillingApplicationOnbehalf: {
+            enum: ['Yes - lawyer', 'Yes - I have a personal representative'],
+          },
+        },
+        required: ['fillingApplicationOnbehalf'],
+      },
+      then: {
+        required: ['representativeContactInformation', 'representatitiveMailAddress'],
+      },
+    },
+  ],
+  required: [
+    'whichOfThemApplies',
+    'whenDidIssueHappen',
+    'describeDispute',
+    'disputeAlreadyTakenToCourt',
+    'fillingApplicationOnbehalf',
+    'addSupportingDocuments',
+  ],
+};

--- a/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/applicationUiSchema.ts
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/applicationUiSchema.ts
@@ -1,0 +1,1213 @@
+// clean-code-ignore: RULE-19 — a verbatim copy, exercised through the page it feeds. Asserting its
+// contents here would only restate the copy.
+// Copied from libs/condo-tribunal-common/src/schemas/versions/v1/applicationUiSchema.ts in
+// GovAlta-EMU/adsp-applications. Kept verbatim — the point of the sandbox page is to reproduce the
+// real CDRT form's navigation behaviour, so nothing here is simplified or reordered.
+export const uiSchema = {
+  type: 'Categorization',
+  options: {
+    variant: 'pages',
+    title: 'Step 1: Complete application form',
+    subtitle: '',
+    toAppOverviewLabel: 'Back to application overview',
+    hideSubmit: true,
+    hideSummary: false,
+    hideProgress: true,
+  },
+  elements: [
+    {
+      type: 'Category',
+      label: 'What is your dispute about?',
+      options: {
+        sectionTitle: 'Before you continue',
+        showInTaskList: true,
+      },
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['## What is your dispute about?', '<br/>'],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/whichOfThemApplies',
+              label: 'Choose all options that best apply',
+              options: {
+                format: 'checkbox',
+                componentProps: {
+                  orientation: 'vertical',
+                },
+              },
+            },
+            {
+              type: 'Callout',
+              options: {
+                componentProps: {
+                  type: 'important',
+                  maxWidth: '800px',
+                  heading: 'Not sure if your dispute is about a monetary sanction or a chargeback?',
+                  message:
+                    'The CDRT can hear disputes about monetary sanctions, but not about chargebacks. If your dispute is only about a chargeback, the CDRT may refuse your application. Monetary sanctions are enforcement tools, such as fines, used by condominium corporations for non-compliance with bylaws. Chargebacks are fees billed back to recover costs paid by a condominium corporation.',
+                },
+              },
+              rule: {
+                effect: 'SHOW',
+                condition: {
+                  scope: '#/properties/whichOfThemApplies',
+                  schema: {
+                    contains: {
+                      const:
+                        'Monetary sanctions imposed by a corporation, including the process in applying that sanction',
+                    },
+                  },
+                  failWhenUndefined: true,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      label: 'Has this dispute already been taken to court?',
+      options: {
+        sectionTitle: 'Before you continue',
+        showInTaskList: true,
+      },
+      elements: [
+        {
+          type: 'HelpContent',
+          options: {
+            markdown: true,
+            help: ['## Has this dispute already been taken to court?', '<br/>'],
+          },
+        },
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/disputeAlreadyTakenToCourt',
+              label: 'Choose the option that best applies.',
+              options: {
+                format: 'radio',
+              },
+            },
+            {
+              type: 'Callout',
+              options: {
+                componentProps: {
+                  type: 'important',
+                  maxWidth: '700px',
+                  emphasis: 'low',
+                  message:
+                    'If there is already an application with the court about this dispute, you should follow up on that one instead.',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: true,
+      },
+      label: 'Who is the person involved in the dispute?',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  '## Who is the person involved in the dispute?',
+                  '<br/>',
+                  '### Please enter the contact information of the applicant (owner or condominium corporation)',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/firstName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/middleName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/lastName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/condoCorporationName',
+              label: 'Corporation name, if applicable',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/email',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/telephone',
+              options: {
+                help: 'Enter a domestic or international phone number.',
+                componentProps: {
+                  type: 'tel',
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'ListWithDetail',
+              scope: '#/properties/applicantContactDetails/properties/additionalApplicants',
+              options: {
+                addButtonType: 'secondary',
+                itemLabel: 'Applicant',
+                noDataMessage: '',
+                addButtonUIProps: {
+                  leadingIcon: 'Add',
+                },
+                componentProps: {
+                  withLeftTab: true,
+                },
+                detail: {
+                  type: 'VerticalLayout',
+                  elements: [
+                    {
+                      type: 'VerticalLayout',
+                      elements: [
+                        {
+                          type: 'Control',
+                          scope: '#/properties/alternateFirstName',
+                          label: 'First name',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/alternateLastName',
+                          label: 'Last name',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/alternateOrganizationBusinessName',
+                          label: 'Organization or business name',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/alternateEmail',
+                          label: 'Email',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/alternateTelephone',
+                          label: 'Telephone',
+                          options: {
+                            componentProps: {
+                              leadingContent: '1+',
+                              width: '45ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Callout',
+                          options: {
+                            componentProps: {
+                              type: 'important',
+                              emphasis: 'low',
+                              message:
+                                'In a situation where a group of people are making an application, all individuals listed must agree on one person being the primary contact person. This person will be the primary contact for the application. You will be required to provide proof that your group has agreed with who the primary contact will be.',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      label: 'What is the physical address of the condominium unit involved in the dispute?',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: true,
+      },
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['##  What is the physical address of the condominium unit involved in the dispute?', '<br/>'],
+              },
+            },
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['### Enter the address on the property title.', '<br/>'],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/applicantPhysicalAddress/properties/addressLine1',
+              label: 'Address line 1',
+              options: {
+                help: 'For example, house number and street name',
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/applicantPhysicalAddress/properties/addressLine2',
+              label: 'Address line 2',
+              options: {
+                help: 'For example, apartment, suite, unit, building, floor, etc.',
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/applicantPhysicalAddress/properties/city',
+              label: 'City',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope:
+                '#/properties/applicantContactDetails/properties/applicantPhysicalAddress/properties/provinceState',
+              label: 'Province',
+              options: {
+                componentProps: {
+                  width: '53ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/applicantContactDetails/properties/applicantPhysicalAddress/properties/country',
+              label: 'Country',
+              options: {
+                componentProps: {
+                  width: '53ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope:
+                '#/properties/applicantContactDetails/properties/applicantPhysicalAddress/properties/postalCodeZip',
+              label: 'Postal code',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  '<br/>',
+                  '###  Mailing address of the person involved in the dispute (if different from physical address)',
+                  'Where the applicant receives mail',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'ListWithDetail',
+              label: 'Mailing address',
+              scope: '#/properties/applicantContactDetails/properties/additionalMailAddress',
+              options: {
+                addButtonText: 'Add mailing address',
+                addButtonType: 'secondary',
+                itemLabel: 'Address',
+                noDataMessage: '',
+                addButtonUIProps: {
+                  leadingIcon: 'Add',
+                },
+                componentProps: {
+                  withLeftTab: true,
+                },
+                detail: {
+                  type: 'VerticalLayout',
+                  maxItems: 1,
+                  elements: [
+                    {
+                      type: 'VerticalLayout',
+                      elements: [
+                        {
+                          type: 'Control',
+                          scope: '#/properties/addressLine1',
+                          label: 'Address line 1',
+                          options: {
+                            help: 'For example, house number and street name',
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/addressLine2',
+                          label: 'Address line 2',
+                          options: {
+                            help: 'For example, apartment, suite, unit, building, floor, etc.',
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/city',
+                          label: 'City',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/provinceState',
+                          label: 'Province',
+                          options: {
+                            componentProps: {
+                              width: '53ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/country',
+                          label: 'Country',
+                          options: {
+                            componentProps: {
+                              width: '53ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/postalCodeZip',
+                          label: 'Postal or zip code',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: true,
+      },
+      label: 'Who is the dispute with?',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  '## Enter the contact information of the person or condominium corporation the dispute is with.',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Control',
+              label: 'First name',
+              scope: '#/properties/otherPartyDisputeDetails/properties/otherPartyPrimaryFirstName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              label: 'Last name',
+              scope: '#/properties/otherPartyDisputeDetails/properties/otherPartyPrimaryLastName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              label: 'Condominium corporation name',
+              scope: '#/properties/otherPartyDisputeDetails/properties/otherPartyPrimaryCondoCorporationName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              label: 'Email',
+              scope: '#/properties/otherPartyDisputeDetails/properties/otherPartyPrimaryEmail',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              label: 'Telephone',
+              scope: '#/properties/otherPartyDisputeDetails/properties/otherPartyPrimaryTelephone',
+              options: {
+                componentProps: {
+                  type: 'tel',
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'ListWithDetail',
+              scope: '#/properties/otherPartyDisputeDetails/properties/additionalRespondents',
+              label: 'Additional respondents',
+              options: {
+                addButtonType: 'secondary',
+                noDataMessage: '',
+                itemLabel: 'Respondent',
+                addButtonUIProps: {
+                  leadingIcon: 'Add',
+                },
+                componentProps: {
+                  withLeftTab: true,
+                },
+                detail: {
+                  type: 'VerticalLayout',
+                  elements: [
+                    {
+                      type: 'VerticalLayout',
+                      elements: [
+                        {
+                          type: 'Control',
+                          scope: '#/properties/respondentFirstName',
+                          label: 'First Name',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/respondentLastName',
+                          label: 'Last Name',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/respondentCondoCorpName',
+                          label: 'Organization or business name',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/respondentEmail',
+                          label: 'Email',
+                          options: {
+                            componentProps: {
+                              width: '50ch',
+                            },
+                          },
+                        },
+                        {
+                          type: 'Control',
+                          scope: '#/properties/respondentTelephone',
+                          label: 'Telephone',
+                          options: {
+                            componentProps: {
+                              type: 'tel',
+                              width: '50ch',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: true,
+      },
+      label: "What is the mailing address of the person or organization you're having the dispute with?",
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  "## What is the mailing address of the person or organization you're having the dispute with?",
+                  '<br/>',
+                  '### Please include as much information as you can.',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/primaryRespondentMailAddress/properties/addressLine1',
+              options: {
+                help: 'For example, house number and street name',
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/primaryRespondentMailAddress/properties/addressLine2',
+              options: {
+                help: 'For example, apartment, suite, unit, building, floor, etc.',
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/primaryRespondentMailAddress/properties/city',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/primaryRespondentMailAddress/properties/provinceState',
+              label: 'Province or state',
+              options: {
+                componentProps: {
+                  width: '40ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/primaryRespondentMailAddress/properties/country',
+              options: {
+                componentProps: {
+                  width: '40ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/primaryRespondentMailAddress/properties/postalCodeZip',
+              label: 'Postal or zip code',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: true,
+      },
+      label: 'Does the applicant have a representative?',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  '## Does the applicant have a representative?',
+                  '<br/>',
+                  '### Applicants can apply on their own or with a lawyer or representative. A lawyer or representative is not required to apply or take part in this process.',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/fillingApplicationOnbehalf',
+              label: ' ',
+              options: {
+                format: 'radio',
+                componentProps: {
+                  orientation: 'vertical',
+                },
+              },
+            },
+            {
+              type: 'Callout',
+              options: {
+                componentProps: {
+                  type: 'important',
+                  maxWidth: '800px',
+                  emphasis: 'low',
+                  message:
+                    'If you are a personal representative applying on behalf of the applicant, please sign and upload this form as part of the application.',
+                },
+              },
+              rule: {
+                effect: 'SHOW',
+                condition: {
+                  scope: '#/properties/fillingApplicationOnbehalf',
+                  schema: {
+                    enum: ['Yes - I have a personal representative'],
+                  },
+                },
+              },
+            },
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  '[Download authorization form for personal representative](http://cfr.forms.gov.ab.ca/Form/CD15071)',
+                  '<br/>',
+                ],
+              },
+              rule: {
+                effect: 'SHOW',
+                condition: {
+                  scope: '#/properties/fillingApplicationOnbehalf',
+                  schema: {
+                    enum: ['Yes - I have a personal representative'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      label: 'What are their contact details?',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: false,
+      },
+      rule: {
+        effect: 'HIDE',
+        condition: {
+          scope: '#/properties/fillingApplicationOnbehalf',
+          schema: {
+            not: {
+              enum: ['Yes - lawyer', 'Yes - I have a personal representative'],
+            },
+            required: ['representativeContactInformation'],
+          },
+        },
+      },
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['## What are the representative’s contact details?', '<br/>'],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representativeContactInformation/properties/primaryFirstName',
+              label: 'First name',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              label: 'Last name',
+              scope: '#/properties/representativeContactInformation/properties/primaryLastName',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representativeContactInformation/properties/primaryOrganizationBusinessName',
+              label: 'Organization or business name',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representativeContactInformation/properties/primaryEmail',
+              label: 'Email',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              label: 'Phone',
+              scope: '#/properties/representativeContactInformation/properties/primaryPhone',
+              options: {
+                componentProps: {
+                  type: 'tel',
+                  placeholder: '',
+                  width: '50ch',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      label: 'What is their mailing address?',
+      options: {
+        sectionTitle: 'The parties',
+        showInTaskList: false,
+      },
+      rule: {
+        effect: 'HIDE',
+        condition: {
+          scope: '#/properties/fillingApplicationOnbehalf',
+          schema: {
+            not: {
+              enum: ['Yes - lawyer', 'Yes - I have a personal representative'],
+            },
+          },
+        },
+      },
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['## What is the representative’s mailing address', '<br/>'],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representatitiveMailAddress/properties/addressLine1',
+              label: 'Address line 1',
+              options: {
+                help: 'For example, house number and street name',
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representatitiveMailAddress/properties/addressLine2',
+              label: 'Address line 2',
+              options: {
+                help: 'For example, apartment, suite, unit, building, floor, etc.',
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representatitiveMailAddress/properties/city',
+              label: 'City',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representatitiveMailAddress/properties/provinceState',
+              label: 'Province',
+              options: {
+                componentProps: {
+                  width: '54ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representatitiveMailAddress/properties/country',
+              label: 'Country',
+              options: {
+                componentProps: {
+                  width: '54ch',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/representatitiveMailAddress/properties/postalCodeZip',
+              label: 'Postal or zip code',
+              options: {
+                componentProps: {
+                  width: '50ch',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'Describe the dispute',
+        showInTaskList: true,
+      },
+      label: 'When did the applicant first become aware of this dispute?',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['## When did the applicant first become aware of this dispute?', '<br/>'],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/whenDidIssueHappen/properties/whenWasIssueDate',
+              label: 'Dispute date',
+              options: {
+                componentProps: {
+                  width: '20ch',
+                  mb: 'm',
+                },
+              },
+            },
+            //Commenting this out as it needed for now.
+            // {
+            //   type: 'Control',
+            //   scope: '#/properties/isIssueStillHappening',
+            //   label: 'Is the dispute still happening?',
+            //   options: {
+            //     format: 'radio',
+            //     componentProps: {
+            //       orientation: 'vertical',
+            //     },
+            //   },
+            // },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'Describe the dispute',
+        showInTaskList: true,
+      },
+      label: 'What are the details of the dispute?',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['## What are the details of the dispute?', '<br/>'],
+              },
+            },
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  'Details of the dispute may include: ',
+                  '- A description of what happened, <strong>including dates and times</strong>',
+                  "- Any steps you've already taken to resolve the dispute",
+                  '- The names of any individuals involved who are not already listed in the application',
+                  '- Any other information you think is relevant',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/describeDispute/properties/disputeDescription',
+              label: 'Dispute description.',
+              options: {
+                multi: true,
+                componentProps: {
+                  rows: 10,
+                  cols: 100,
+                  countBy: 'character',
+                  maxCount: 2000,
+                  width: '75ch',
+                },
+              },
+            },
+            {
+              type: 'Callout',
+              options: {
+                componentProps: {
+                  type: 'information',
+                  maxWidth: '575px',
+                  emphasis: 'low',
+                  message:
+                    'If you have more information to share. You can upload a detailed description later in the application.',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'Describe the dispute',
+        showInTaskList: true,
+      },
+      label: 'What is the desired outcome?',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  '## What is the desired outcome?',
+                  '<br/>',
+                  'Briefly tell us the desired outcome or agreement. You may also upload an explanation in the documents section.',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/describeDispute/properties/resultOfApplication',
+              label: 'Desired outcome.',
+              options: {
+                multi: true,
+                componentProps: {
+                  rows: 10,
+                  cols: 100,
+                  countBy: 'character',
+                  maxCount: 500,
+                  width: '75ch',
+                },
+              },
+            },
+            {
+              type: 'Callout',
+              options: {
+                componentProps: {
+                  type: 'information',
+                  maxWidth: '575px',
+                  emphasis: 'low',
+                  message:
+                    'If you have more information to share. You can upload a detailed description later in the application.',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'Category',
+      options: {
+        sectionTitle: 'Describe the dispute',
+        showInTaskList: true,
+      },
+      label: 'Add optional supporting documents',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: ['## Add optional supporting documents', '<br/>'],
+              },
+            },
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  'Please upload any documents or files that help explain your side of the dispute, and how they support the issues you selected. Your dispute application will be reviewed by CDRT Administration to ensure it is complete and that the CDRT has the authority to accept it. Your ability to upload documents may be paused during that time.',
+                  '<br/>',
+                  'If you are uploading a description of your dispute please label it as "Dispute Description".',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'HelpContent',
+              options: {
+                markdown: true,
+                help: [
+                  'Supporting documents and files might include things like:',
+                  '> - Letters or emails',
+                  '> - Photos or videos',
+                  '> - Meeting notes',
+                  '> - Invoices or receipts',
+                  '> - Relevant rules, bylaws, or policies',
+                  '<br/>',
+                ],
+              },
+            },
+            {
+              type: 'Callout',
+              options: {
+                componentProps: {
+                  type: 'important',
+                  maxWidth: '700px',
+                  heading: 'Make sure your application is complete and accurate',
+                  message:
+                    'When submitting your application, it is your responsibility to ensure the information and documents you provide are complete and accurate. For the full requirements and responsibilities when making an application, refer to the <a href="https://www.alberta.ca/condominium-dispute-resolution-tribunal">CDRT\'s policies and procedures</a>.',
+                },
+              },
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/addSupportingDocuments',
+              label: 'Would you like to add documents now?',
+              options: {
+                format: 'radio',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/index.ts
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/index.ts
@@ -1,0 +1,3 @@
+// clean-code-ignore: RULE-19 — re-exports only.
+export { dataSchema as condoTribunalDataSchema } from './applicationDataSchema';
+export { uiSchema as condoTribunalUiSchema } from './applicationUiSchema';

--- a/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/locations.ts
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/locations.ts
@@ -1,0 +1,58 @@
+// clean-code-ignore: RULE-19 — enum fodder for the address dropdowns, with no behaviour of its own.
+// Stand-in for libs/condo-tribunal-common/src/schemas/locations.ts in GovAlta-EMU/adsp-applications.
+// That repository is not reachable from this one, and the lists are only enum fodder for the
+// dropdowns — nothing about page navigation depends on their contents, so a faithful shape is
+// enough to reproduce the form.
+export const provinceStates = [
+  'Alberta',
+  'British Columbia',
+  'Manitoba',
+  'New Brunswick',
+  'Newfoundland and Labrador',
+  'Northwest Territories',
+  'Nova Scotia',
+  'Nunavut',
+  'Ontario',
+  'Prince Edward Island',
+  'Quebec',
+  'Saskatchewan',
+  'Yukon',
+];
+
+export const countries = ['Canada'];
+
+// The mailing variants are the wider lists: a respondent or a representative can be outside Canada.
+export const mailingProvinceStates = [
+  ...provinceStates,
+  'Alabama',
+  'Alaska',
+  'Arizona',
+  'California',
+  'Colorado',
+  'Florida',
+  'Hawaii',
+  'Idaho',
+  'Illinois',
+  'Michigan',
+  'Minnesota',
+  'Montana',
+  'Nevada',
+  'New York',
+  'North Dakota',
+  'Oregon',
+  'Texas',
+  'Washington',
+];
+
+export const mailingCountries = [
+  'Canada',
+  'United States',
+  'United Kingdom',
+  'Australia',
+  'France',
+  'Germany',
+  'India',
+  'Mexico',
+  'Philippines',
+  'Other',
+];

--- a/apps/sandbox-app/src/app/utils/servicePageUtils.spec.ts
+++ b/apps/sandbox-app/src/app/utils/servicePageUtils.spec.ts
@@ -24,6 +24,12 @@ describe('servicePageUtils', () => {
           url: '/testTenant/services/jsonforms/external-navigation',
           testId: 'jsonformsExternalNavigation',
         },
+        {
+          id: 'jsonformsReviewNavigation',
+          name: 'Review change navigation (CDRT application)',
+          url: '/testTenant/services/jsonforms/review-navigation',
+          testId: 'jsonformsReviewNavigation',
+        },
       ]);
     });
 
@@ -48,6 +54,12 @@ describe('servicePageUtils', () => {
           name: 'External form navigation',
           url: '//services/jsonforms/external-navigation',
           testId: 'jsonformsExternalNavigation',
+        },
+        {
+          id: 'jsonformsReviewNavigation',
+          name: 'Review change navigation (CDRT application)',
+          url: '//services/jsonforms/review-navigation',
+          testId: 'jsonformsReviewNavigation',
         },
       ]);
     });

--- a/apps/sandbox-app/src/app/utils/servicePageUtils.ts
+++ b/apps/sandbox-app/src/app/utils/servicePageUtils.ts
@@ -15,6 +15,12 @@ export const addJsonformsPages = (tenantName: string) => {
       url: `${prefix}/external-navigation`,
       testId: 'jsonformsExternalNavigation',
     },
+    {
+      id: 'jsonformsReviewNavigation',
+      name: 'Review change navigation (CDRT application)',
+      url: `${prefix}/review-navigation`,
+      testId: 'jsonformsReviewNavigation',
+    },
   ];
 
   return jsonformsPages;

--- a/docs/tutorials/form-service/external-navigation.md
+++ b/docs/tutorials/form-service/external-navigation.md
@@ -61,6 +61,8 @@ const handleReviewChange = (stepId: number | undefined, scope: string) => {
 
 Both routes above end here. The provider applies a target once and reports what happened; it will not pull the user back to the requested page after they navigate away themselves.
 
+Treat the target as a request rather than a setting, and clear it once the form has answered - whatever the answer was. A target left standing has already been applied, so a second Change click on the same field is indistinguishable from a re-render and goes nowhere. That second click is a real path: open a field, walk back to the overview, and click the same Change again.
+
 ```javascript
 import { ContextProviderFactory, GoACells, GoARenderers } from '@abgov/jsonforms-components';
 
@@ -70,9 +72,7 @@ const ContextProvider = ContextProviderFactory();
   navigationTarget={navigationTarget}
   onNavigationChange={(outcome) => {
     // 'navigated' | 'unavailable' (hidden, disabled, not-yet-reachable) | 'unknown'
-    if (outcome.status !== 'navigated') {
-      setNavigationTarget(undefined);
-    }
+    setNavigationTarget(undefined);
   }}
 >
   <JsonForms
@@ -124,4 +124,4 @@ import { GoACells, GoAReviewRenderers, ReviewRenderProvider } from '@abgov/jsonf
 </ContextProvider>
 ```
 
-**NOTE**: Every control reports, including the composite ones. Address, full name, full name with date of birth, contact information and list controls report through `onReviewChange` exactly like a plain text field does. If a Change button appears to do nothing, check that `ReviewRenderProvider` is above the `JsonForms` element rather than beside it, and that the category carries the `options.id` you are matching on.
+**NOTE**: Every control reports, including the composite ones. Address, full name, full name with date of birth, contact information and list controls report through `onReviewChange` exactly like a plain text field does. If a Change button appears to do nothing, check that `ReviewRenderProvider` is above the `JsonForms` element rather than beside it, that the category carries the `options.id` you are matching on, and that the previous target was cleared in `onNavigationChange`.

--- a/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
+++ b/libs/jsonforms-components/src/lib/Context/ContextProvider.tsx
@@ -72,6 +72,22 @@ type Props = ExternalNavigationProps & {
   formId?: string;
 };
 
+// clean-code-ignore: RULE-19 — see the file-header note; ./context.spec.tsx covers this.
+// A shared empty default: a fresh [] on every render would read as a change and hand consumers a
+// new context value for nothing.
+const NO_AUTO_POPULATED_DATA: AutoPopulatedValue[] = [];
+
+// The props a host can change after mount. See the note where they are applied.
+const HOST_CONTROLLED_KEYS = [
+  'formUrl',
+  'isFormSubmitted',
+  'showChangeButtons',
+  'autoPopulatedData',
+  'formId',
+  'navigationTarget',
+  'onNavigationChange',
+] as const;
+
 export class ContextProviderClass {
   selfProps: Props | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -189,15 +205,28 @@ export class ContextProviderClass {
     if (!props.children) {
       return null;
     }
-    if (props.formUrl) {
-      this.baseEnumerator.formUrl = props.formUrl;
+    // Everything below is a value a host can change while the form is mounted, so it is applied by
+    // replacing the enumerator rather than by writing into it. The consumers all sit behind
+    // JsonForms' memoised renderers, which re-render only when the form's own state changes — React
+    // reaches past that memoisation for a context consumer, but only when the provider's value is a
+    // different object. Mutating the enumerator in place left every one of these stale until
+    // something else happened to re-render the form: a navigation target a host set on a Change
+    // click was simply never seen.
+    const next = {
+      ...this.baseEnumerator,
+      formUrl: props.formUrl || this.baseEnumerator.formUrl,
+      isFormSubmitted: props.isFormSubmitted ?? false,
+      showChangeButtons: props.showChangeButtons ?? true,
+      autoPopulatedData: props.autoPopulatedData ?? NO_AUTO_POPULATED_DATA,
+      formId: props.formId,
+      navigationTarget: props.navigationTarget,
+      onNavigationChange: props.onNavigationChange,
+    };
+
+    if (HOST_CONTROLLED_KEYS.some((key) => next[key] !== this.baseEnumerator[key])) {
+      this.baseEnumerator = next;
     }
-    this.baseEnumerator.isFormSubmitted = props.isFormSubmitted ?? false;
-    this.baseEnumerator.showChangeButtons = props.showChangeButtons ?? true;
-    this.baseEnumerator.autoPopulatedData = props.autoPopulatedData ?? [];
-    this.baseEnumerator.formId = props.formId;
-    this.baseEnumerator.navigationTarget = props.navigationTarget;
-    this.baseEnumerator.onNavigationChange = props.onNavigationChange;
+
     return <JsonFormContext.Provider value={this.baseEnumerator}>{this.selfProps?.children}</JsonFormContext.Provider>;
   };
 

--- a/libs/jsonforms-components/src/lib/Context/context.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Context/context.spec.tsx
@@ -178,6 +178,61 @@ describe('contextProvider', () => {
     expect(component.getByTestId('navigation-target').textContent).toBe('{"pageId":"contact-details"}');
   });
 
+  it('reaches a memoised form tree with a navigation target set after mount', () => {
+    // Arrange
+    // JsonForms memoises its renderers on the form's own state, so the stepper is not re-rendered
+    // by the host changing a target. Reaching it depends entirely on the provider handing out a
+    // different value, which is what mutating the enumerator in place used to prevent.
+    const Probe = () => {
+      const ctx = useContext(JsonFormContext);
+      return <div data-testid="navigation-target">{JSON.stringify(ctx.navigationTarget ?? null)}</div>;
+    };
+    const MemoisedTree = React.memo(() => <Probe />);
+    MemoisedTree.displayName = 'MemoisedTree';
+
+    const component = render(
+      <ContextProvider>
+        <MemoisedTree />
+      </ContextProvider>,
+    );
+    expect(component.getByTestId('navigation-target').textContent).toBe('null');
+
+    // Act
+    component.rerender(
+      <ContextProvider navigationTarget={{ pageId: 'contact-details' }}>
+        <MemoisedTree />
+      </ContextProvider>,
+    );
+
+    // Assert
+    expect(component.getByTestId('navigation-target').textContent).toBe('{"pageId":"contact-details"}');
+  });
+
+  it('leaves the context value alone when nothing a host controls has changed', () => {
+    // Arrange
+    const seen: unknown[] = [];
+    const Probe = () => {
+      seen.push(useContext(JsonFormContext));
+      return null;
+    };
+
+    // Act
+    const component = render(
+      <ContextProvider showChangeButtons={false}>
+        <Probe />
+      </ContextProvider>,
+    );
+    component.rerender(
+      <ContextProvider showChangeButtons={false}>
+        <Probe />
+      </ContextProvider>,
+    );
+
+    // Assert
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+  });
+
   it('exposes the navigation outcome callback to the form tree', () => {
     // Arrange
     const onNavigationChange = jest.fn();

--- a/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/FormStepper/context/StepperContext.spec.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 import { JsonFormsStepperContextProvider, JsonFormsStepperContext, JsonFormsStepperContextProps } from './index';
 import { CategorizationStepperLayoutRendererProps } from '../types';
 import Ajv from 'ajv';
-import { JsonFormContext } from '../../../Context';
+import { ContextProviderFactory, JsonFormContext } from '../../../Context';
 import { getCategoryStatus, PageStatus } from '../CategoryStatus';
 
 describe('JsonFormsStepperContext', () => {
@@ -206,6 +206,49 @@ describe('JsonFormsStepperContext', () => {
 
       // Assert
       expect(saveForm).toHaveBeenCalledWith({ firstName: 'Alex' });
+    });
+
+    // The other tests here hand the stepper a fresh context object, which is not what a host does.
+    // A host renders ContextProviderFactory's provider and changes navigationTarget on it, and the
+    // stepper sits inside JsonForms' memoised renderers — so the target only arrives if the
+    // provider hands out a different value. It used to hand out the same mutated object, and a
+    // target set on a Change click went nowhere.
+    test('applies a target the host sets after the form has mounted', () => {
+      // Arrange
+      const ContextProvider = ContextProviderFactory();
+      const MemoisedStepper = React.memo(() => (
+        <JsonFormsStepperContextProvider
+          StepperProps={
+            {
+              ...stepperBaseProps,
+              uischema: navigationUischema,
+              data: { firstName: 'Alex' },
+              customDispatch: mockDispatch,
+            } as unknown as CategorizationStepperLayoutRendererProps
+          }
+        >
+          <div />
+        </JsonFormsStepperContextProvider>
+      ));
+      MemoisedStepper.displayName = 'MemoisedStepper';
+
+      const tree = (navigationTarget?: { pageId: string }) => (
+        <ContextProvider navigationTarget={navigationTarget}>
+          <MemoisedStepper />
+        </ContextProvider>
+      );
+
+      const { rerender } = render(tree());
+      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'page/to/index' }));
+
+      // Act
+      rerender(tree({ pageId: 'contact-details' }));
+
+      // Assert
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'page/to/index',
+        payload: { id: 1, targetScope: undefined },
+      });
     });
 
     test('reports an unknown page without dispatching navigation', () => {


### PR DESCRIPTION
A review Change click that a host relays into `navigationTarget` never moved the form. `ContextProviderFactory` mutates one enumerator object and hands it to `JsonFormContext.Provider` every render, so its identity never changes and React does not propagate the update past JsonForms' memoised renderers. A target present at mount worked — which is why form-app, reading it from the URL, was fine — and a target set later was invisible. The provider now replaces the enumerator when a host-controlled prop changes.

Once that worked, a second Change click on the same field went nowhere after the user walked back to the overview themselves: the stepper keys "already applied" on the target's value. Loosening that guard would pull users back mid-typing, so the fix is the host contract — clear the target in `onNavigationChange`. The guide's example did the opposite and now says so.

The sandbox gains `services/jsonforms/review-navigation`, running the real CDRT application schemas as both the pages stepper and a standalone host summary over one data object, logging what each Change reported and what the form resolved it to.

`locations.ts` is a recreated stand-in — GovAlta-EMU/adsp-applications is not reachable from this account. Nothing about navigation depends on the enum values.

Both regression tests fail with the provider fix reverted.