### PR TITLE
feat(sandbox-app): CS-5347 demonstrate review navigation across two pages

### DIFF
--- a/apps/sandbox-app/src/app/components/SandboxTenant.tsx
+++ b/apps/sandbox-app/src/app/components/SandboxTenant.tsx
@@ -36,6 +36,7 @@ import { FeedbackCSSLeak } from './services/feedback/FeedbackCSSLeak';
 import { JsonformsExampleOne } from './services/jsonforms/JsonformsExampleOne';
 import { JsonformsExternalNavigation } from './services/jsonforms/JsonformsExternalNavigation';
 import { JsonformsReviewNavigation } from './services/jsonforms/JsonformsReviewNavigation';
+import { JsonformsReviewNavigationPages } from './services/jsonforms/JsonformsReviewNavigationPages';
 import { DesignSystemsMain } from './services/DesignSystemsMain';
 import { DesignSystemsExampleOne } from './services/design-systems/DesignSystemsExampleOne';
 import { FeedbackNotification } from './FeedbackNotification';
@@ -107,6 +108,10 @@ export const SandBoxTenant = () => {
                 <Route path="/services/jsonforms/example1/:definitionId" element={<JsonformsExampleOne />} />
                 <Route path="/services/jsonforms/external-navigation" element={<JsonformsExternalNavigation />} />
                 <Route path="/services/jsonforms/review-navigation" element={<JsonformsReviewNavigation />} />
+                <Route
+                  path="/services/jsonforms/review-navigation-pages/*"
+                  element={<JsonformsReviewNavigationPages />}
+                />
 
                 <Route path="/services/notification" element={<NotificationServiceMain tenantName={tenantName} />} />
                 <Route path="/services/pdf" element={<PDFServiceMain tenantName={tenantName} />} />

--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigation.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigation.tsx
@@ -29,7 +29,7 @@ import {
 } from '@abgov/jsonforms-components';
 import { JsonForms } from '@jsonforms/react';
 import { ServiceContainer } from '../../styled-components';
-import { condoTribunalDataSchema, condoTribunalUiSchema } from './condoTribunal';
+import { condoTribunalDataSchema, condoTribunalUiSchema, sampleApplication } from './condoTribunal';
 
 const ContextProvider = ContextProviderFactory();
 
@@ -54,43 +54,9 @@ const describeOutcome = (outcome?: NavigationOutcome): string => {
   }
 };
 
-// Sample answers, so the summary has something to render and every page reports a status. Kept to
-// the fields the review shows a Change button for — filling the whole application is not the point.
-const SAMPLE_DATA: Record<string, unknown> = {
-  whichOfThemApplies: ['Access to condominium documents'],
-  disputeAlreadyTakenToCourt: 'No, there are no other applications',
-  fillingApplicationOnbehalf: 'No',
-  applicantContactDetails: {
-    firstName: 'Dana',
-    lastName: 'Okafor',
-    email: 'dana.okafor@example.com',
-    telephone: '780-555-0134',
-    applicantPhysicalAddress: {
-      addressLine1: '10611 98 Ave NW',
-      city: 'Edmonton',
-      provinceState: 'Alberta',
-      country: 'Canada',
-      postalCodeZip: 'T5K 2P7',
-    },
-  },
-  otherPartyDisputeDetails: {
-    otherPartyPrimaryFirstName: 'Riley',
-    otherPartyPrimaryLastName: 'Chen',
-    otherPartyPrimaryCondoCorporationName: 'Condominium Corporation No. 012 3456',
-  },
-  whenDidIssueHappen: {
-    whenWasIssueDate: '2026-04-17',
-  },
-  describeDispute: {
-    disputeDescription: 'The corporation has not provided the approved AGM minutes after three written requests.',
-    resultOfApplication: 'An order requiring the corporation to release the requested records.',
-  },
-  addSupportingDocuments: 'No, not right now',
-};
-
 export const JsonformsReviewNavigation = (): JSX.Element => {
   const ajv = useMemo(() => createDefaultAjv(), []);
-  const [formData, setFormData] = useState<Record<string, unknown>>(SAMPLE_DATA);
+  const [formData, setFormData] = useState<Record<string, unknown>>(sampleApplication);
   const [navigationTarget, setNavigationTarget] = useState<NavigationTarget>();
   const [log, setLog] = useState<ClickLogEntry[]>([]);
 
@@ -122,7 +88,7 @@ export const JsonformsReviewNavigation = (): JSX.Element => {
   }, []);
 
   const handleReset = useCallback(() => {
-    setFormData(SAMPLE_DATA);
+    setFormData(sampleApplication);
     setNavigationTarget(undefined);
     setLog([]);
   }, []);

--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigationPages.spec.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigationPages.spec.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { JsonformsReviewNavigationPages } from './JsonformsReviewNavigationPages';
+
+// This one renders the real renderers rather than mocking them: the whole question the page exists
+// to answer is whether a target survives a route switch and lands the form on the right page, and
+// a mocked JsonForms cannot answer it.
+window.matchMedia = jest.fn().mockImplementation((query) => ({
+  matches: true,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+}));
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+global.ResizeObserver = MockResizeObserver as never;
+Element.prototype.scrollIntoView = jest.fn();
+
+const BASE = '/autotest/services/jsonforms/review-navigation-pages';
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/:tenant/services/jsonforms/review-navigation-pages/*"
+          element={<JsonformsReviewNavigationPages />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+// The web components take a custom event, not a DOM click.
+const clickGoab = (element: Element) => fireEvent(element, new CustomEvent('_click'));
+
+// GoabButton renders a goa-button web component, whose testId lands on a `testid` attribute rather
+// than the `data-testid` getByTestId looks for.
+const goabButton = (root: Element, testId: string): Element => {
+  const button = root.querySelector(`goa-button[testid="${testId}"]`);
+  if (!button) {
+    throw new Error(`no goa-button with testid ${testId}`);
+  }
+  return button;
+};
+
+const changeButtons = (root: Element) =>
+  Array.from(root.querySelectorAll('goa-button')).filter((b) => b.textContent?.trim() === 'Change');
+
+const activePage = (root: Element): string | undefined =>
+  root.querySelector('[data-testid$="-content-pages"]')?.getAttribute('data-testid') ?? undefined;
+
+describe('JsonformsReviewNavigationPages', () => {
+  it('opens on the summary, with the form not mounted', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    expect(screen.getByTestId('summary-route')).toBeInTheDocument();
+    expect(screen.queryByTestId('form-route')).not.toBeInTheDocument();
+    expect(changeButtons(baseElement).length).toBeGreaterThan(0);
+  });
+
+  it('lands the form on the page owning the answer after the route switch', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    // The third Change belongs to the applicant's first name, on category index 2.
+    clickGoab(changeButtons(baseElement)[2]);
+
+    expect(screen.getByTestId('form-route')).toBeInTheDocument();
+    expect(activePage(baseElement)).toBe('step_2-content-pages');
+  });
+
+  it('records what was reported and what the form answered', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    clickGoab(changeButtons(baseElement)[2]);
+
+    const rows = screen.getAllByTestId('review-change-log-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('#/properties/applicantContactDetails/properties/firstName');
+    expect(rows[0]).toHaveTextContent('navigated to page-3');
+  });
+
+  it('opens the form on its task list when no target was set', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    clickGoab(goabButton(baseElement, 'goto-form'));
+
+    expect(screen.getByTestId('form-route')).toBeInTheDocument();
+    expect(activePage(baseElement)).toBeUndefined();
+  });
+
+  it('does not re-apply a spent target when the form is opened again', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    clickGoab(changeButtons(baseElement)[2]);
+    expect(activePage(baseElement)).toBe('step_2-content-pages');
+
+    clickGoab(goabButton(baseElement, 'goto-summary'));
+    clickGoab(goabButton(baseElement, 'goto-form'));
+
+    // Cleared in onNavigationChange, so the plain link is not hijacked by the earlier request.
+    expect(activePage(baseElement)).toBeUndefined();
+  });
+
+  it('honours the same Change a second time', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    clickGoab(changeButtons(baseElement)[2]);
+    expect(activePage(baseElement)).toBe('step_2-content-pages');
+
+    clickGoab(goabButton(baseElement, 'goto-summary'));
+    clickGoab(changeButtons(baseElement)[2]);
+
+    expect(activePage(baseElement)).toBe('step_2-content-pages');
+    expect(screen.getAllByTestId('review-change-log-row')).toHaveLength(2);
+  });
+
+  it('sends a different Change to a different page', () => {
+    const { baseElement } = renderAt(`${BASE}/summary`);
+
+    clickGoab(changeButtons(baseElement)[16]);
+
+    expect(activePage(baseElement)).toBe('step_4-content-pages');
+  });
+});

--- a/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigationPages.tsx
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/JsonformsReviewNavigationPages.tsx
@@ -1,0 +1,245 @@
+// clean-code-ignore: RULE-19 — covered by ./JsonformsReviewNavigationPages.spec.tsx.
+//
+// The other host shape: the summary and the form are separate routes of one application, so the
+// form is unmounted while the user is looking at the summary and mounts fresh when they arrive.
+//
+// The sibling page (./JsonformsReviewNavigation.tsx) keeps both in one tree. That difference is not
+// cosmetic, and it is the reason this page exists:
+//
+//   one tree     — the form is already mounted, so a Change click can only reach it through a
+//                  context value that changes identity. That is what CS-5347 fixed.
+//   two routes   — the form mounts with the target already in hand, so it never depended on that.
+//                  What it depends on instead is the target outliving the route switch, which is
+//                  why the state lives here, above the <Routes>, rather than on the summary page.
+//
+// Both end at the same `navigationTarget`, and the log below records what each click reported and
+// what the form made of it, so the two pages can be compared directly.
+import { useCallback, useMemo, useState } from 'react';
+import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import { GoabButton, GoabButtonGroup, GoabCallout, GoabContainer, GoabTable, GoabText } from '@abgov/react-components';
+import {
+  ContextProviderFactory,
+  createDefaultAjv,
+  getNavigationTargets,
+  GoACells,
+  GoARenderers,
+  GoAReviewRenderers,
+  NavigationOutcome,
+  NavigationTarget,
+  ReviewRenderProvider,
+} from '@abgov/jsonforms-components';
+import { JsonForms } from '@jsonforms/react';
+import { ServiceContainer } from '../../styled-components';
+import { condoTribunalDataSchema, condoTribunalUiSchema, sampleApplication } from './condoTribunal';
+
+const ContextProvider = ContextProviderFactory();
+
+interface ClickLogEntry {
+  at: string;
+  reported: { stepId: number | undefined; scope: string };
+  outcome?: NavigationOutcome;
+}
+
+const describeOutcome = (outcome?: NavigationOutcome): string => {
+  if (!outcome) {
+    return 'form has not answered yet';
+  }
+
+  switch (outcome.status) {
+    case 'navigated':
+      return `navigated to ${outcome.pageId}`;
+    case 'unavailable':
+      return `${outcome.pageId} unavailable (${outcome.reason})`;
+    default:
+      return `unknown target ${JSON.stringify(outcome.requested)}`;
+  }
+};
+
+interface PageProps {
+  data: Record<string, unknown>;
+  onDataChange: (data: Record<string, unknown>) => void;
+}
+
+const SummaryPage = ({
+  data,
+  onReviewChange,
+}: {
+  data: Record<string, unknown>;
+  onReviewChange: (stepId: number | undefined, scope: string) => void;
+}): JSX.Element => {
+  const ajv = useMemo(() => createDefaultAjv(), []);
+
+  return (
+    <div data-testid="summary-route">
+      <GoabText size="body-m" mb="m">
+        A read-only summary. The form is not mounted at all while you are here — a Change button has nothing in this
+        tree to move, so all it can do is report itself.
+      </GoabText>
+      <ContextProvider showChangeButtons={true}>
+        <ReviewRenderProvider onReviewChange={onReviewChange}>
+          <JsonForms
+            readonly={true}
+            ajv={ajv}
+            schema={condoTribunalDataSchema}
+            uischema={condoTribunalUiSchema}
+            data={data}
+            validationMode="NoValidation"
+            renderers={GoAReviewRenderers}
+            cells={GoACells}
+          />
+        </ReviewRenderProvider>
+      </ContextProvider>
+    </div>
+  );
+};
+
+const FormPage = ({
+  data,
+  onDataChange,
+  navigationTarget,
+  onNavigationChange,
+}: PageProps & {
+  navigationTarget?: NavigationTarget;
+  onNavigationChange: (outcome: NavigationOutcome) => void;
+}): JSX.Element => {
+  const ajv = useMemo(() => createDefaultAjv(), []);
+
+  return (
+    <div data-testid="form-route">
+      <ContextProvider
+        showChangeButtons={true}
+        navigationTarget={navigationTarget}
+        onNavigationChange={onNavigationChange}
+      >
+        <JsonForms
+          ajv={ajv}
+          schema={condoTribunalDataSchema}
+          uischema={condoTribunalUiSchema}
+          data={data}
+          validationMode="ValidateAndShow"
+          renderers={GoARenderers}
+          cells={GoACells}
+          onChange={({ data: next }) => onDataChange(next as Record<string, unknown>)}
+        />
+      </ContextProvider>
+    </div>
+  );
+};
+
+export const JsonformsReviewNavigationPages = (): JSX.Element => {
+  const { tenant } = useParams<{ tenant: string }>();
+  const navigate = useNavigate();
+  const basePath = `/${tenant}/services/jsonforms/review-navigation-pages`;
+
+  // Both of these live above the <Routes>. Held on the summary page they would be gone by the time
+  // the form page mounted, which is the failure the guide warns about for this shape.
+  const [formData, setFormData] = useState<Record<string, unknown>>(sampleApplication);
+  const [navigationTarget, setNavigationTarget] = useState<NavigationTarget>();
+  const [log, setLog] = useState<ClickLogEntry[]>([]);
+
+  const navigationTargets = useMemo(() => getNavigationTargets(condoTribunalUiSchema), []);
+
+  const handleReviewChange = useCallback(
+    (stepId: number | undefined, scope: string) => {
+      const pageId = stepId === undefined ? undefined : navigationTargets[stepId]?.pageId;
+      setLog((entries) => [{ at: new Date().toLocaleTimeString(), reported: { stepId, scope } }, ...entries]);
+      setNavigationTarget({ pageId, scope });
+      navigate(`${basePath}/form`);
+    },
+    [basePath, navigate, navigationTargets],
+  );
+
+  // Clearing matters more here than it looks. The form remounts on every visit, so it would honour
+  // whatever target is still standing — walk to the form by the link below with a stale one left
+  // set, and it would drop you on the page you last asked for rather than where you left off.
+  const handleNavigationChange = useCallback((outcome: NavigationOutcome) => {
+    setLog((entries) => (entries.length === 0 ? entries : [{ ...entries[0], outcome }, ...entries.slice(1)]));
+    setNavigationTarget(undefined);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setFormData(sampleApplication);
+    setNavigationTarget(undefined);
+    setLog([]);
+  }, []);
+
+  return (
+    <ServiceContainer>
+      <GoabContainer
+        accent="thick"
+        type="non-interactive"
+        width="full"
+        testId="JsonformsReviewNavigationPagesContainer"
+        heading="Review change navigation across pages (CDRT application)"
+      >
+        <GoabText size="body-m">
+          The same CDRT application as the single-page demo, split across two routes of this application. Clicking
+          Change on the summary sets a target and switches route; the form mounts with that target already in hand.
+        </GoabText>
+
+        <GoabCallout type="information" heading="What to watch" mt="m" mb="m">
+          Use the plain link to the form to see the difference: it carries no target, so it opens on the task list. A
+          Change click opens the page that owns the answer.
+        </GoabCallout>
+
+        <GoabButtonGroup alignment="start" mb="l">
+          <GoabButton type="secondary" testId="goto-summary" onClick={() => navigate(`${basePath}/summary`)}>
+            Summary
+          </GoabButton>
+          <GoabButton type="secondary" testId="goto-form" onClick={() => navigate(`${basePath}/form`)}>
+            The form, with no target
+          </GoabButton>
+          <GoabButton type="tertiary" testId="reset-review-navigation-pages" onClick={handleReset}>
+            Reset the data and log
+          </GoabButton>
+        </GoabButtonGroup>
+
+        <Routes>
+          <Route path="summary" element={<SummaryPage data={formData} onReviewChange={handleReviewChange} />} />
+          <Route
+            path="form"
+            element={
+              <FormPage
+                data={formData}
+                onDataChange={setFormData}
+                navigationTarget={navigationTarget}
+                onNavigationChange={handleNavigationChange}
+              />
+            }
+          />
+          <Route path="*" element={<Navigate to={`${basePath}/summary`} replace />} />
+        </Routes>
+
+        <h3>Change clicks</h3>
+        {log.length === 0 ? (
+          <GoabText size="body-m" mb="l">
+            Nothing yet. Click a Change button on the summary.
+          </GoabText>
+        ) : (
+          <GoabTable width="100%" mb="l">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Reported step</th>
+                <th>Reported scope</th>
+                <th>Form outcome</th>
+              </tr>
+            </thead>
+            <tbody>
+              {log.map((entry, index) => (
+                <tr key={`${entry.at}-${index}`} data-testid="review-change-log-row">
+                  <td>{entry.at}</td>
+                  <td>{entry.reported.stepId === undefined ? '(none)' : entry.reported.stepId}</td>
+                  <td>
+                    <code>{entry.reported.scope || '(none)'}</code>
+                  </td>
+                  <td>{describeOutcome(entry.outcome)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabTable>
+        )}
+      </GoabContainer>
+    </ServiceContainer>
+  );
+};

--- a/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/index.ts
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/index.ts
@@ -1,3 +1,4 @@
 // clean-code-ignore: RULE-19 — re-exports only.
 export { dataSchema as condoTribunalDataSchema } from './applicationDataSchema';
 export { uiSchema as condoTribunalUiSchema } from './applicationUiSchema';
+export { sampleApplication } from './sampleApplication';

--- a/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/sampleApplication.ts
+++ b/apps/sandbox-app/src/app/components/services/jsonforms/condoTribunal/sampleApplication.ts
@@ -1,0 +1,35 @@
+// clean-code-ignore: RULE-19 — a fixture, exercised through the pages that render it.
+// Enough of an application for the review to have something to show and for every page to report a
+// status. Kept to the fields the review puts a Change button beside; filling the whole form is not
+// the point of either demo.
+export const sampleApplication: Record<string, unknown> = {
+  whichOfThemApplies: ['Access to condominium documents'],
+  disputeAlreadyTakenToCourt: 'No, there are no other applications',
+  fillingApplicationOnbehalf: 'No',
+  applicantContactDetails: {
+    firstName: 'Dana',
+    lastName: 'Okafor',
+    email: 'dana.okafor@example.com',
+    telephone: '780-555-0134',
+    applicantPhysicalAddress: {
+      addressLine1: '10611 98 Ave NW',
+      city: 'Edmonton',
+      provinceState: 'Alberta',
+      country: 'Canada',
+      postalCodeZip: 'T5K 2P7',
+    },
+  },
+  otherPartyDisputeDetails: {
+    otherPartyPrimaryFirstName: 'Riley',
+    otherPartyPrimaryLastName: 'Chen',
+    otherPartyPrimaryCondoCorporationName: 'Condominium Corporation No. 012 3456',
+  },
+  whenDidIssueHappen: {
+    whenWasIssueDate: '2026-04-17',
+  },
+  describeDispute: {
+    disputeDescription: 'The corporation has not provided the approved AGM minutes after three written requests.',
+    resultOfApplication: 'An order requiring the corporation to release the requested records.',
+  },
+  addSupportingDocuments: 'No, not right now',
+};

--- a/apps/sandbox-app/src/app/utils/servicePageUtils.spec.ts
+++ b/apps/sandbox-app/src/app/utils/servicePageUtils.spec.ts
@@ -30,6 +30,12 @@ describe('servicePageUtils', () => {
           url: '/testTenant/services/jsonforms/review-navigation',
           testId: 'jsonformsReviewNavigation',
         },
+        {
+          id: 'jsonformsReviewNavigationPages',
+          name: 'Review change navigation across pages (CDRT application)',
+          url: '/testTenant/services/jsonforms/review-navigation-pages',
+          testId: 'jsonformsReviewNavigationPages',
+        },
       ]);
     });
 
@@ -60,6 +66,12 @@ describe('servicePageUtils', () => {
           name: 'Review change navigation (CDRT application)',
           url: '//services/jsonforms/review-navigation',
           testId: 'jsonformsReviewNavigation',
+        },
+        {
+          id: 'jsonformsReviewNavigationPages',
+          name: 'Review change navigation across pages (CDRT application)',
+          url: '//services/jsonforms/review-navigation-pages',
+          testId: 'jsonformsReviewNavigationPages',
         },
       ]);
     });

--- a/apps/sandbox-app/src/app/utils/servicePageUtils.ts
+++ b/apps/sandbox-app/src/app/utils/servicePageUtils.ts
@@ -21,6 +21,12 @@ export const addJsonformsPages = (tenantName: string) => {
       url: `${prefix}/review-navigation`,
       testId: 'jsonformsReviewNavigation',
     },
+    {
+      id: 'jsonformsReviewNavigationPages',
+      name: 'Review change navigation across pages (CDRT application)',
+      url: `${prefix}/review-navigation-pages`,
+      testId: 'jsonformsReviewNavigationPages',
+    },
   ];
 
   return jsonformsPages;


### PR DESCRIPTION
The existing demo keeps the summary and the form in one React tree. This adds the other host shape a real application uses: the summary and the form are separate routes, so the form is unmounted while the user is on the summary and mounts fresh when they arrive.

`services/jsonforms/review-navigation-pages` runs the same CDRT schemas across `/summary` and `/form`, with the navigation target and the form data lifted above the `<Routes>` so they outlive the switch — holding them on the summary page is the failure this shape is prone to. A plain link to the form sits beside the Change buttons so the difference is visible: no target, so it opens on the task list.

The spec drives the real renderers rather than mocking JsonForms, because the question is whether the target survives the route switch and lands the form on the right page, which a mocked form cannot answer. It also covers the two cases that are specific to remounting: a spent target must not hijack the plain link, and the same Change has to work a second time.

Worth recording: this spec passes against the pre-fix provider as well. The form mounts with the target already in hand, so this shape never depended on the context fix in #5845 — only the one-tree shape did. Anyone debugging a Change button that goes nowhere can use the two pages to tell which half they are in.

The sample application data moves to `condoTribunal/sampleApplication.ts`, shared by both demos.