### PR TITLE
fix(tenant-management-api): assign adsp-cli-admin to the adsp-cli client; allow prod tenant creation from adsp-cli

### DIFF
--- a/apps/tenant-management-api/src/keycloak/configuration.ts
+++ b/apps/tenant-management-api/src/keycloak/configuration.ts
@@ -119,8 +119,9 @@ export const createAdspCliPublicClientConfig = (id: string): ClientRepresentatio
 };
 
 /**
- * The OIDC scope object itself — not granted by default (see optionalClientScopes above), only included in a
- * token when a login request explicitly asks for it (scope=... adsp-cli-admin), with its own consent-screen line.
+ * The OIDC scope object itself — assigned to the adsp-cli client as an OPTIONAL scope by keycloak.ts's
+ * createAdspCliAdminScope, so it is only included in a token when a login request explicitly asks for it
+ * (scope=... adsp-cli-admin), with its own consent-screen line.
  * Requesting it doesn't grant manage-clients/manage-users to a user who doesn't already have them — it only makes
  * an existing grant visible/usable through this client. ClientScopeRepresentation has no field for role scope
  * mappings; that's wired up separately in keycloak.ts's grantAdspCliAdminScopeMapping after realm creation.

--- a/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.spec.ts
@@ -41,7 +41,6 @@ describe('KeycloakRealmService', () => {
       create: jest.fn(),
       findOneByName: jest.fn(),
       addClientScopeMappings: jest.fn(),
-      addDefaultOptionalClientScope: jest.fn(),
     },
     roles: {
       createComposite: jest.fn(),
@@ -82,7 +81,6 @@ describe('KeycloakRealmService', () => {
     keycloakClientMock.clientScopes.create.mockReset();
     keycloakClientMock.clientScopes.findOneByName.mockReset();
     keycloakClientMock.clientScopes.addClientScopeMappings.mockReset();
-    keycloakClientMock.clientScopes.addDefaultOptionalClientScope.mockReset();
 
     keycloakClientMock.users.create.mockReset();
     keycloakClientMock.users.addClientRoleMappings.mockReset();
@@ -183,6 +181,8 @@ describe('KeycloakRealmService', () => {
 
       keycloakClientMock.clients.find
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
+        // createAdspCliAdminScope looks up adsp-cli before createTenantAdminComposite runs
+        .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         // grantAdspCliClientScopeMappings: adsp-cli, config-service, agent-service (not in realm → []), directory-service
@@ -211,7 +211,7 @@ describe('KeycloakRealmService', () => {
       keycloakClientMock.clientScopes.findOneByName
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' })
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' });
-      keycloakClientMock.clientScopes.addDefaultOptionalClientScope.mockResolvedValueOnce(undefined);
+      keycloakClientMock.clients.addOptionalClientScope.mockResolvedValueOnce(undefined);
       keycloakClientMock.clients.getServiceAccountUser.mockResolvedValueOnce({ id: 'ci-service-account-user-123' });
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });
@@ -256,6 +256,13 @@ describe('KeycloakRealmService', () => {
       expect(keycloakClientMock.clientScopes.findOneByName).toHaveBeenCalledWith(
         expect.objectContaining({ realm, name: 'adsp-cli-admin' }),
       );
+      // Must target the adsp-cli CLIENT. A realm-level optional scope only seeds clients created after it,
+      // and adsp-cli is created earlier in the realm payload, so it would silently never get the scope.
+      expect(keycloakClientMock.clients.addOptionalClientScope).toHaveBeenCalledWith({
+        realm,
+        id: 'adsp-cli-client-123',
+        clientScopeId: 'adsp-cli-admin-scope-123',
+      });
       expect(keycloakClientMock.clientScopes.addClientScopeMappings).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'adsp-cli-admin-scope-123', client: 'realm-management-client-123' }),
         expect.arrayContaining([
@@ -315,6 +322,8 @@ describe('KeycloakRealmService', () => {
 
       keycloakClientMock.clients.find
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
+        // createAdspCliAdminScope looks up adsp-cli before createTenantAdminComposite runs
+        .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
@@ -341,7 +350,7 @@ describe('KeycloakRealmService', () => {
       keycloakClientMock.clientScopes.findOneByName
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' })
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' });
-      keycloakClientMock.clientScopes.addDefaultOptionalClientScope.mockResolvedValueOnce(undefined);
+      keycloakClientMock.clients.addOptionalClientScope.mockResolvedValueOnce(undefined);
       keycloakClientMock.clients.getServiceAccountUser.mockResolvedValueOnce({ id: 'ci-service-account-user-123' });
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });
@@ -369,6 +378,8 @@ describe('KeycloakRealmService', () => {
 
       keycloakClientMock.clients.find
         .mockResolvedValueOnce([{ id: 'tenant-service-client-123' }])
+        // createAdspCliAdminScope looks up adsp-cli before createTenantAdminComposite runs
+        .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
         .mockResolvedValueOnce([{ id: 'test-service-client-123' }])
         .mockResolvedValueOnce([{ id: 'realm-management-client-123' }])
         .mockResolvedValueOnce([{ id: 'adsp-cli-client-123' }])
@@ -395,7 +406,7 @@ describe('KeycloakRealmService', () => {
       keycloakClientMock.clientScopes.findOneByName
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' })
         .mockResolvedValueOnce({ id: 'adsp-cli-admin-scope-123' });
-      keycloakClientMock.clientScopes.addDefaultOptionalClientScope.mockResolvedValueOnce(undefined);
+      keycloakClientMock.clients.addOptionalClientScope.mockResolvedValueOnce(undefined);
       keycloakClientMock.clients.getServiceAccountUser.mockResolvedValueOnce({ id: 'ci-service-account-user-123' });
 
       keycloakClientMock.users.create.mockResolvedValueOnce({ id: 'admin-user-123' });

--- a/apps/tenant-management-api/src/keycloak/keycloak.ts
+++ b/apps/tenant-management-api/src/keycloak/keycloak.ts
@@ -212,9 +212,8 @@ export class KeycloakRealmServiceImpl implements RealmService {
   /**
    * Explicitly adds the ADSP_CLI_CLIENT_SCOPE_MAPPINGS role restrictions to the adsp-cli client via
    * the scope-mappings API. The clientScopeMappings key in the realm creation JSON sets the same
-   * restriction declaratively but KC 24 does not apply it — same pattern as the addOptionalClientScope
-   * regression fixed in createAdspCliAdminScope. Source clients absent from the realm are skipped so
-   * a not-yet-registered optional service does not break realm creation.
+   * restriction declaratively but KC 24 does not apply it. Source clients absent from the realm are
+   * skipped so a not-yet-registered optional service does not break realm creation.
    */
   private async grantAdspCliClientScopeMappings(client: KeycloakAdminClient, realm: string): Promise<void> {
     this.logger.debug(`Granting client scope mappings to 'adsp-cli' in realm '${realm}'...`, LOG_CONTEXT);
@@ -259,18 +258,30 @@ export class KeycloakRealmServiceImpl implements RealmService {
     this.logger.info(`Granted service account roles to '${ADSP_CLI_CI_CLIENT_ID}' in realm '${realm}'.`, LOG_CONTEXT);
   }
 
+  /**
+   * Creates the adsp-cli-admin client scope and assigns it to the adsp-cli client as an optional scope.
+   *
+   * The assignment must be per-client. The realm-level alternative (clientScopes.addDefaultOptionalClientScope)
+   * only seeds the optional scopes of clients created AFTER it runs — verified against KC 24.0.5 — and adsp-cli
+   * is created earlier, inside the realm creation payload, so it would never pick the scope up. Declaring
+   * optionalClientScopes on the client representation instead is also wrong: supplying either scope list
+   * suppresses KC's realm-default scope assignment entirely, stripping email/profile/roles from the client
+   * (that is the bug PR #5646 fixed by moving to this imperative call in the first place).
+   */
   private async createAdspCliAdminScope(client: KeycloakAdminClient, realm: string): Promise<void> {
     await client.clientScopes.create({ realm, ...createAdspCliAdminClientScopeConfig() });
 
     const adminScope = await client.clientScopes.findOneByName({ realm, name: ADSP_CLI_ADMIN_CLIENT_SCOPE_NAME });
+    const adspCliClient = (await client.clients.find({ realm, clientId: 'adsp-cli' }))[0];
 
-    // KC 24 deprecated per-client optional scope assignment for scopes that may be treated as realm-level.
-    // Use the realm-level optional scope endpoint instead — equivalent effect for adsp-cli since it is a
-    // client within this realm and will pick up realm-level optional scopes.
-    await client.clientScopes.addDefaultOptionalClientScope({ realm, id: adminScope.id });
+    await client.clients.addOptionalClientScope({
+      realm,
+      id: adspCliClient.id,
+      clientScopeId: adminScope.id,
+    });
 
     this.logger.debug(
-      `Created '${ADSP_CLI_ADMIN_CLIENT_SCOPE_NAME}' client scope and added as realm optional scope.`,
+      `Created '${ADSP_CLI_ADMIN_CLIENT_SCOPE_NAME}' client scope and assigned to adsp-cli as optional.`,
       LOG_CONTEXT,
     );
   }

--- a/libs/adsp-cli/README.md
+++ b/libs/adsp-cli/README.md
@@ -92,7 +92,7 @@ To enable it: log in to the Keycloak admin console for your realm → Clients �
 ## Creating a new tenant
 
 When the no-args `login` mode prompts you to pick a tenant, it also offers a `+ Create a new tenant` choice —
-but only in `dev`/`test` (never `prod`), and only for an account that can actually create one: your core-realm
+in every environment including `prod`, but only for an account that can actually create one: your core-realm
 roles must include `beta-tester` or `tenant-service-admin` (the same roles tenant-management-api's `POST
 /tenants` requires), and — unless you're a `tenant-service-admin` — you must not already own a tenant (the
 tenant service allows only one per admin email). Picking it prompts for a name (letters, numbers, spaces, and

--- a/libs/adsp-cli/src/login.spec.ts
+++ b/libs/adsp-cli/src/login.spec.ts
@@ -558,7 +558,7 @@ describe('login', () => {
         return call?.[0].choices ?? [];
       }
 
-      it('adds a create-tenant entry when logging into a pre-prod env with no owned tenant and the beta-tester role', async () => {
+      it('adds a create-tenant entry for a caller with no owned tenant and the beta-tester role', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
         mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
@@ -574,7 +574,7 @@ describe('login', () => {
         expect(autocompleteChoices()).toContainEqual({ name: '__create_tenant__', message: '+ Create a new tenant' });
       });
 
-      it('never adds a create-tenant entry when logging into prod, even with no owned tenant and the beta-tester role', async () => {
+      it('adds a create-tenant entry when logging into prod with no owned tenant and the beta-tester role', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
         mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
@@ -587,10 +587,10 @@ describe('login', () => {
         lastCallbackHandler()({ query: { code: 'tenant-auth-code' } }, { send: jest.fn() });
         await loginPromise;
 
-        expect(autocompleteChoices()).toEqual(['tenant-a']);
+        expect(autocompleteChoices()).toContainEqual({ name: '__create_tenant__', message: '+ Create a new tenant' });
       });
 
-      it('never adds a create-tenant entry in pre-prod for a caller with no owned tenant but neither the beta-tester nor tenant-service-admin role', async () => {
+      it('never adds a create-tenant entry for a caller with no owned tenant but neither the beta-tester nor tenant-service-admin role', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'someone.else@example.com' }]);
         mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: [] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
@@ -608,7 +608,7 @@ describe('login', () => {
         );
       });
 
-      it('never adds a create-tenant entry in pre-prod for a non-admin beta-tester who already owns a tenant', async () => {
+      it('never adds a create-tenant entry for a non-admin beta-tester who already owns a tenant', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' }]);
         mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['beta-tester'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });
@@ -626,7 +626,7 @@ describe('login', () => {
         );
       });
 
-      it('still adds a create-tenant entry in pre-prod for a tenant-service-admin who already owns a tenant', async () => {
+      it('still adds a create-tenant entry for a tenant-service-admin who already owns a tenant', async () => {
         mockListTenants.mockResolvedValue([{ name: 'tenant-a', realm: 'realm-a', adminEmail: 'me@example.com' }]);
         mockJwtDecode.mockReturnValue({ email: 'me@example.com', realm_access: { roles: ['tenant-service-admin'] } });
         mockPrompt.mockResolvedValue({ tenant: 'tenant-a' });

--- a/libs/adsp-cli/src/login.ts
+++ b/libs/adsp-cli/src/login.ts
@@ -334,14 +334,16 @@ async function createTenantInteractive(directoryServiceUrl: string, coreToken: s
   }
 }
 
-async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string, preProd: boolean): Promise<Tenant> {
+async function promptForTenantRealm(directoryServiceUrl: string, coreToken: string): Promise<Tenant> {
   const tenants = await listTenants(directoryServiceUrl, coreToken);
 
   const email = decodeEmail(coreToken);
   const byName = (a: Tenant, b: Tenant) => a.name.localeCompare(b.name);
   const owned = tenants.filter((t) => email && t.adminEmail === email).sort(byName);
   const rest = tenants.filter((t) => !(email && t.adminEmail === email)).sort(byName);
-  const showCreateOption = preProd && canCreateTenant(coreToken) && (owned.length === 0 || isTenantServiceAdmin(coreToken));
+  // Offered in every environment, prod included — the roles below (mirroring POST /tenants' own guard) are
+  // the only gate, so a caller who can create a tenant through the API can create one through the CLI too.
+  const showCreateOption = canCreateTenant(coreToken) && (owned.length === 0 || isTenantServiceAdmin(coreToken));
 
   if (tenants.length === 0 && !showCreateOption) {
     throw new Error('No tenants found.');
@@ -451,8 +453,7 @@ export async function loginInteractive(
     // doesn't have (and doesn't need) scopes like adsp-cli-admin registered; that scope is only
     // meaningful on the tenant-realm login below, once a realm is actually known.
     const core = await getOrLogin(accessServiceUrl, CORE_REALM, ['email']);
-    const preProd = resolveEnvironmentName(options.env) !== 'prod';
-    const picked = await promptForTenantRealm(directoryServiceUrl, core.token, preProd);
+    const picked = await promptForTenantRealm(directoryServiceUrl, core.token);
     realm = picked.realm;
     tenantName = picked.name;
   }


### PR DESCRIPTION
## Summary

Two related changes to the `adsp-cli` provisioning path.

**1. `adsp-cli-admin` was never assigned to the `adsp-cli` client.** `createAdspCliAdminScope` called `clientScopes.addDefaultOptionalClientScope`, which registers the scope as a **realm** default optional scope. That only seeds clients created *afterwards*, and `adsp-cli` is created earlier inside the realm creation payload — so it never received it. Symptom: the scope appears under the realm's client-scope list while the `adsp-cli` client's own optional scopes stay empty, and `adsp login --scope adsp-cli-admin` cannot be granted. Side effect: every client created in the realm *after* provisioning silently inherited `adsp-cli-admin` instead. Restores the per-client `clients.addOptionalClientScope` call.

**2. Tenant creation is now offered in prod.** `promptForTenantRealm` hid the `+ Create a new tenant` choice behind a `preProd` flag. That gate was presentation-only — `POST /tenants` has no environment gate and is guarded solely by `requireBetaTesterOrAdmin`, so prod tenants were still creatable via the API and the admin webapp. `delete-tenant` had no prod gate either, so the CLI blocked *creating* a prod tenant while permitting *deleting* one. Role checks are now the only gate, matching the API.

## Why #5700's premise was wrong

#5700 replaced the per-client call after attributing a tenant creation failure to it. Verified against the **KC 24.0.5** admin API in dev:

| test | result |
|---|---|
| `PUT /clients/{id}/optional-client-scopes/{scopeId}` (raw REST) | **204**, assignment sticks |
| same via `@keycloak/keycloak-admin-client` 23.0.7, replaying the original call sequence | every step OK |
| repeat PUT | **204**, idempotent |
| client created *before* realm-default registration | does **not** inherit the scope |
| client created *after* | inherits it |

The failure was real but belonged to **`adsp-cli-ci`**, and #5698 had already fixed it an hour earlier. `"Network response was not OK."` is thrown by the admin client's `fetchWithError` for every non-2xx from *any* call, so it identified nothing — which is how it got misattributed.

Also measured and rejected the declarative alternative: supplying `optionalClientScopes` on the client representation suppresses KC's realm-default scope assignment entirely and strips `email`/`profile`/`roles`/`web-origins`. That is the bug #5646 fixed by moving to this imperative call in the first place.

## Test plan

- [x] `keycloak.spec.ts` 13/13 pass
- [x] `adsp-cli` 144/144 pass
- [x] Mutation-tested the new assertion — flipping the code back to the realm-level call fails all three `createRealm` tests
- [x] Per-client assignment verified against live KC 24.0.5 (see table)
- [ ] **Provision a new tenant and confirm `adsp-cli-admin` appears on the `adsp-cli` client's own optional-scope list** (not just the realm's client-scope list — that is the check #5700's plan got wrong)
- [ ] `adsp login --scope adsp-cli-admin` against a newly provisioned realm returns a token carrying the scope
- [ ] `adsp login` against prod offers `+ Create a new tenant` for a `beta-tester`/`tenant-service-admin` account

## Not included

- **No backfill.** Realms provisioned since 2026-07-31 still have `adsp-cli-admin` missing from `adsp-cli` and left as a stray realm-default optional scope. This only corrects new provisioning; existing realms need a repair step (there is no repair path on `KeycloakRealmServiceImpl` today).
- The original UAT failure's true root cause is still unconfirmed. The `responseData` logging added by #5700 is in place, so the next failure will report the actual HTTP body.
- #5698's own premise — that `addOptionalClientScope` fails for a service-account-only client — remains unverified. It does not affect this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
