### PR TITLE
feat(jsonforms-components): add reusable pattern masks for form inputs

### DIFF
--- a/docs/tutorials/form-service/cheat-sheet.md
+++ b/docs/tutorials/form-service/cheat-sheet.md
@@ -411,6 +411,44 @@ The date control supports these options to restrict date selection:
   </tr>
 </table>
 
+#### Text Input Control Options
+
+The text input control supports a <code>formatPattern</code> option that auto-formats the entered value when the field loses focus (on blur). The <code>formatPattern</code> is a mask template: a <code>#</code> character consumes one character from the input, and every other character is inserted as a literal. Formatting is applied only; validation continues to be driven by the JSON schema <code>pattern</code>.
+
+<table>
+  <tr>
+    <th>Option</th>
+    <th>Behavior</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><code>formatPattern</code></td>
+    <td>A mask template applied to the value on blur, e.g. <code>(###) ###-####</code>. When set, the entered value is reformatted to match the mask. When empty or not set, no formatting is applied.</td>
+    <td>Not set</td>
+  </tr>
+</table>
+
+##### Text Input Format Examples
+
+| Mask (`formatPattern`) | User enters  | Formatted on blur |
+| ---------------------- | ------------ | ----------------- |
+| `(###) ###-####`       | `7801234567` | `(780) 123-4567`  |
+| `######-###`           | `123456789`  | `123456-789`      |
+| `### ###`              | `A1A1A1`     | `A1A 1A1`         |
+| `### ### ###`          | `123456789`  | `123 456 789`     |
+
+The user only needs to enter the raw characters; the field applies the mask automatically. The JSON schema <code>pattern</code> is used solely to validate the value for errors.
+
+```json
+{
+  "type": "Control",
+  "scope": "#/properties/phone",
+  "options": {
+    "formatPattern": "(###) ###-####"
+  }
+}
+```
+
 #### Calculation Control
 
 The calculation control is rendered when the JSON schema field uses <code>"format": "computed"</code>. The expression is defined in <code>schema.description</code>, evaluated against current form data, and the result is written back to the control path automatically. The rendered field is read-only.

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputNumberControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputNumberControl.spec.tsx
@@ -3,12 +3,12 @@ import { fireEvent, render } from '@testing-library/react';
 import { act } from 'react';
 import '@testing-library/jest-dom';
 
-import { formatSin } from './InputTextControl';
 import { ControlElement, ControlProps } from '@jsonforms/core';
 import { JsonFormsContext } from '@jsonforms/react';
 
 import { validateSinWithLuhn, checkFieldValidity, isValidDate } from '../../util/stringUtils';
 import { GoANumberInput, GoANumberControl, GoAInputNumberProps } from './InputNumberControl';
+import { DEFAULT_PATTERNS, formatWithPattern, filterAllowedKeys } from '../../util/patternForm';
 
 const mockContextValue = {
   errors: [],
@@ -249,45 +249,35 @@ describe('Input Text Control tests', () => {
       expect(validateSinWithLuhn('123456879')).toBe(false);
     });
     it('should return 9 digits for invalid SIN Number with more than 16 digits', () => {
-      expect(formatSin('123456879123456789999')).toBe('123-456-879');
+      expect(formatWithPattern('123456879123456789999', DEFAULT_PATTERNS.sin.mask)).toBe('123 456 879');
     });
   });
 
-  describe('formatSin', () => {
-    it('formats a valid SIN number correctly', () => {
-      const input = '123456789';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
+  describe('SIN masking', () => {
+    const sinMask = DEFAULT_PATTERNS.sin.mask;
+
+    it('formats a valid SIN number with spaces', () => {
+      expect(formatWithPattern('123456789', sinMask)).toBe('123 456 789');
     });
 
-    it('handles input with existing hyphens correctly', () => {
-      const input = '123-456-789';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
-    });
-
-    it('rejects alphabet characters', () => {
-      const input = 'abc123456def';
-      const expected = '';
-      expect(formatSin(input)).toBe(expected);
+    it('re-formats an already formatted value', () => {
+      expect(formatWithPattern('123 456 789', sinMask)).toBe('123 456 789');
     });
 
     it('truncates input longer than 9 digits', () => {
-      const input = '123456789012345';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('123456789012345', sinMask)).toBe('123 456 789');
     });
 
     it('formats input with fewer than 9 digits', () => {
-      const input = '12345';
-      const expected = '123-45';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('12345', sinMask)).toBe('123 45');
+    });
+
+    it('strips non-digit characters via allowedKeys', () => {
+      expect(filterAllowedKeys('abc123456def', DEFAULT_PATTERNS.sin.allowedKeys)).toBe('123456');
     });
 
     it('returns an empty string for empty input', () => {
-      const input = '';
-      const expected = '';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('', sinMask)).toBe('');
     });
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.test.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { GoAInputTextProps, GoAInputText, formatSin } from './InputTextControl';
+import { GoAInputTextProps, GoAInputText } from './InputTextControl';
 import { ControlElement, ControlProps, JsonSchema7 } from '@jsonforms/core';
+import { DEFAULT_PATTERNS, formatWithPattern, filterAllowedKeys } from '../../util/patternForm';
 
 import { validateSinWithLuhn, checkFieldValidity, isValidDate } from '../../util/stringUtils';
 import { JsonFormsContext } from '@jsonforms/react';
@@ -306,7 +307,7 @@ describe('Input Text Control tests', () => {
       });
 
       expect(handleChangeMock).not.toHaveBeenCalledWith('', expect.stringContaining('a'));
-      expect((firstNameInput as HTMLElement & { value: string }).value).toBe('1324567');
+      expect((firstNameInput as HTMLElement & { value: string }).value).toBe('123');
     });
 
     it('prevents alphabet key presses for SIN input', async () => {
@@ -317,14 +318,13 @@ describe('Input Text Control tests', () => {
         </JsonFormsContext.Provider>,
       );
       const firstNameInput = baseElement.querySelector("goa-input[testId='firstName-input']");
-      const keyDownEvent = new KeyboardEvent('keydown', {
+      const keyPressEvent = new CustomEvent('_keyPress', {
         cancelable: true,
-        bubbles: true,
-        key: 'a',
+        detail: { key: 'a', value: '123a' },
       });
-      const preventDefaultSpy = jest.spyOn(keyDownEvent, 'preventDefault');
+      const preventDefaultSpy = jest.spyOn(keyPressEvent, 'preventDefault');
 
-      fireEvent(firstNameInput!, keyDownEvent);
+      fireEvent(firstNameInput!, keyPressEvent);
 
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
@@ -406,7 +406,7 @@ describe('Input Text Control tests', () => {
       expect(preventDefaultSpy).not.toHaveBeenCalled();
     });
 
-    it('prevents invalid pasted text for SIN input', async () => {
+    it('strips invalid characters entered into SIN input', async () => {
       const props = { ...sinProps, handleChange: handleChangeMock };
       const { baseElement } = render(
         <JsonFormsContext.Provider value={mockContextValue}>
@@ -414,17 +414,22 @@ describe('Input Text Control tests', () => {
         </JsonFormsContext.Provider>,
       );
       const firstNameInput = baseElement.querySelector("goa-input[testId='firstName-input']");
-      const pasteEvent = new Event('paste', { cancelable: true, bubbles: true });
-      Object.defineProperty(pasteEvent, 'clipboardData', {
-        value: {
-          getData: () => '123a',
-        },
+      handleChangeMock.mockClear();
+      (firstNameInput as HTMLElement & { value: string }).value = '123a456';
+
+      await fireEvent(
+        firstNameInput!,
+        new CustomEvent('_change', {
+          detail: { value: '123a456' },
+        }),
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
       });
-      const preventDefaultSpy = jest.spyOn(pasteEvent, 'preventDefault');
 
-      fireEvent(firstNameInput!, pasteEvent);
-
-      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(handleChangeMock).not.toHaveBeenCalledWith('', expect.stringContaining('a'));
+      expect((firstNameInput as HTMLElement & { value: string }).value).toBe('123 456');
     });
 
     it('allows valid pasted text for SIN input', async () => {
@@ -573,45 +578,35 @@ describe('Input Text Control tests', () => {
       expect(validateSinWithLuhn('123456879')).toBe(false);
     });
     it('should return 9 digits for invalid SIN Number with more than 16 digits', () => {
-      expect(formatSin('123456879123456789999')).toBe('123-456-879');
+      expect(formatWithPattern('123456879123456789999', DEFAULT_PATTERNS.sin.mask)).toBe('123 456 879');
     });
   });
 
-  describe('formatSin', () => {
-    it('formats a valid SIN number correctly', () => {
-      const input = '123456789';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
+  describe('SIN masking', () => {
+    const sinMask = DEFAULT_PATTERNS.sin.mask;
+
+    it('formats a valid SIN number with spaces', () => {
+      expect(formatWithPattern('123456789', sinMask)).toBe('123 456 789');
     });
 
-    it('handles input with existing hyphens correctly', () => {
-      const input = '123-456-789';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
-    });
-
-    it('rejects alphabet characters', () => {
-      const input = 'abc123456def';
-      const expected = '';
-      expect(formatSin(input)).toBe(expected);
+    it('re-formats an already formatted value', () => {
+      expect(formatWithPattern('123 456 789', sinMask)).toBe('123 456 789');
     });
 
     it('truncates input longer than 9 digits', () => {
-      const input = '123456789012345';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('123456789012345', sinMask)).toBe('123 456 789');
     });
 
     it('formats input with fewer than 9 digits', () => {
-      const input = '12345';
-      const expected = '123-45';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('12345', sinMask)).toBe('123 45');
+    });
+
+    it('strips non-digit characters via allowedKeys', () => {
+      expect(filterAllowedKeys('abc123456def', DEFAULT_PATTERNS.sin.allowedKeys)).toBe('123456');
     });
 
     it('returns an empty string for empty input', () => {
-      const input = '';
-      const expected = '';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('', DEFAULT_PATTERNS.sin.mask)).toBe('');
     });
   });
 

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
@@ -7,7 +7,20 @@ import { WithInputProps } from './type';
 import { GoAInputBaseControl } from './InputBaseControl';
 import { JsonFormRegisterProvider, RegisterDataType } from '../../Context/register';
 import { JsonFormsRegisterContext, RegisterConfig } from '../../Context/register';
-import { onBlurForTextControl, onChangeForInputControl } from '../../util/inputControlUtils';
+import { applyFormatPattern, onBlurForTextControl, onChangeForInputControl } from '../../util/inputControlUtils';
+import {
+  DEFAULT_PATTERNS,
+  MaskPattern,
+  filterAllowedKeys,
+  formatWithPattern,
+  toMaskTemplate,
+  computeMaskEdit,
+  getMaskInputTarget,
+  applyInPlaceEdit,
+  isMaskFilled,
+  maskPlaceholder,
+  shouldBlockKey,
+} from '../../util/patternForm';
 import { sinTitle } from '../../common/Constants';
 import {
   GoabInputOnChangeDetail,
@@ -29,39 +42,6 @@ export function fetchRegisterConfigFromOptions(
   return config;
 }
 
-const formattedSinPattern = /^\d{3}-\d{3}-\d{3}$/;
-const allowedSinInputPattern = /^[\d-]*$/;
-const allowedSinKeyPattern = /^[\d-]$/;
-const allowedSinControlKeys = new Set([
-  'Backspace',
-  'Delete',
-  'Tab',
-  'Enter',
-  'Escape',
-  'ArrowLeft',
-  'ArrowRight',
-  'ArrowUp',
-  'ArrowDown',
-  'Home',
-  'End',
-]);
-
-const formatSinForDisplay = (value: string) => value.replace(/ /g, '-');
-const formatSinForSchema = (value: string) => value.replace(/-/g, ' ');
-
-export const formatSin = (value: string) => {
-  if (!allowedSinInputPattern.test(value)) {
-    return '';
-  }
-
-  if (formattedSinPattern.test(value)) {
-    return value;
-  }
-
-  const digits = value?.replace(/\D/g, '').slice(0, 9);
-  return digits?.match(/.{1,3}/g)?.join('-') ?? '';
-};
-
 const resetInputValue = (detail: GoabInputOnChangeDetail, value: string) => {
   const target = (detail as GoabInputOnChangeDetail & { event?: Event }).event?.target as
     | { value?: string }
@@ -70,6 +50,14 @@ const resetInputValue = (detail: GoabInputOnChangeDetail, value: string) => {
   if (target) {
     target.value = value;
   }
+};
+
+// Resolve the mask format for a field: schema.format must match a DEFAULT_PATTERNS key.
+const resolveFormatConfig = (schema: { format?: string; title?: string }): MaskPattern | undefined => {
+  if (schema.format && schema.format in DEFAULT_PATTERNS) {
+    return DEFAULT_PATTERNS[schema.format];
+  }
+  return schema.title === sinTitle ? DEFAULT_PATTERNS.sin : undefined;
 };
 
 export const GoAInputText = (props: GoAInputTextProps): JSX.Element => {
@@ -83,11 +71,31 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
   const { data, config, id, enabled, uischema, schema, label, path, handleChange, errors, isVisited, setIsVisited } =
     props;
 
-  const isSinField = schema.title === sinTitle;
+  // Detect the mask format from the JSON schema `format` (with the SIN title kept for backward compatibility).
+  const formatConfig = resolveFormatConfig(schema);
+  const mask = formatConfig?.mask ?? (uischema?.options?.mask as string | undefined);
+  const allowedKeys = formatConfig?.allowedKeys;
+  // In-place shows the fill-in template and keeps the caret in place while editing.
+  const inPlace = !!mask && uischema?.options?.inPlace === true;
 
-  const initialValue = isSinField && typeof data === 'string' ? formatSinForDisplay(data) : data;
+  const toDisplay = (value: unknown): string => {
+    if (!mask) {
+      return value as string;
+    }
+    const str = typeof value === 'string' ? value : '';
+    return inPlace ? toMaskTemplate(str, mask) : formatWithPattern(str, mask);
+  };
+
   const [manualInput, setManualInput] = useState<boolean>(false);
-  const [localValue, setLocalValue] = useState<string>(initialValue);
+  // In-place mounts empty then sets the template so the web component reflects it (a value change forces the paint).
+  const [localValue, setLocalValue] = useState<string>(inPlace ? '' : toDisplay(data));
+
+  useEffect(() => {
+    if (inPlace) {
+      setLocalValue(toDisplay(data));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const debouncedValue = useDebounce(localValue, 300);
 
@@ -98,8 +106,9 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
       return;
     }
 
-    setLocalValue(isSinField && typeof data === 'string' ? formatSinForDisplay(data) : data);
-  }, [data, isSinField]);
+    setLocalValue(toDisplay(data));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, mask]);
 
   useEffect(() => {
     if (typeof handleChange === 'function' && hasDefault && data === undefined && !manualInput) {
@@ -111,17 +120,19 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
 
   /* istanbul ignore next */
   useEffect(() => {
-    const dataForInput = isSinField && typeof data === 'string' ? formatSinForDisplay(data) : data;
+    const dataForInput = toDisplay(data);
     if (debouncedValue === dataForInput) return;
 
     // Only sync if debouncedValue differs from data and is not initial empty state
     if (debouncedValue !== dataForInput && (debouncedValue !== '' || data !== undefined)) {
       onChangeForInputControl({
         name: '',
-        value: isSinField ? formatSinForSchema(debouncedValue) : debouncedValue,
+        // Normalize to the clean value; for in-place this drops the unfilled template characters.
+        value: mask ? formatWithPattern(debouncedValue, mask) : debouncedValue,
         controlProps: props as ControlProps,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedValue]);
 
   const width = uischema?.options?.componentProps?.width ?? '100%';
@@ -179,45 +190,10 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
   const autoCapitalize =
     uischema?.options?.componentProps?.autoCapitalize === true || uischema?.options?.autoCapitalize === true;
   const readOnly = uischema?.options?.componentProps?.readOnly ?? false;
-
-  const preventInvalidSinKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (
-      !isSinField ||
-      allowedSinControlKeys.has(event.key) ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.altKey ||
-      allowedSinKeyPattern.test(event.key)
-    ) {
-      return;
-    }
-
-    event.preventDefault();
-  };
-
-  const preventInvalidSinBeforeInput = (event: React.FormEvent<HTMLDivElement>) => {
-    if (!isSinField) {
-      return;
-    }
-
-    const data = (event.nativeEvent as InputEvent).data;
-    if (data && !allowedSinInputPattern.test(data)) {
-      event.preventDefault();
-    }
-  };
-
-  const preventInvalidSinPaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
-    if (isSinField && !allowedSinInputPattern.test(event.clipboardData.getData('text'))) {
-      event.preventDefault();
-    }
-  };
+  const formatPattern = uischema?.options?.formatPattern as string | undefined;
 
   return (
-    <div
-      onKeyDownCapture={preventInvalidSinKey}
-      onBeforeInputCapture={preventInvalidSinBeforeInput}
-      onPasteCapture={preventInvalidSinPaste}
-    >
+    <div>
       {mergedOptions.length > 1 ? (
         <GoabDropdown
           name={`jsonforms-${path}-dropdown`}
@@ -242,22 +218,30 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
           value={localValue}
           width={width}
           readonly={readOnly}
-          maxLength={isSinField ? 11 : undefined}
-          placeholder={placeholder}
+          maxLength={inPlace ? undefined : mask ? mask.length : undefined}
+          placeholder={inPlace ? undefined : mask ? maskPlaceholder(mask) : placeholder}
           name={appliedUiSchemaOptions?.name || `${id || label}-input`}
           ariaLabel={appliedUiSchemaOptions?.name || `${id || label}-input`}
           testId={appliedUiSchemaOptions?.testId || `${id}-input`}
           {...uischema.options?.componentProps}
           onChange={(detail: GoabInputOnChangeDetail) => {
-            let formattedValue = detail.value;
-            if (isSinField && !allowedSinInputPattern.test(detail.value)) {
-              resetInputValue(detail, localValue);
-              return;
+            const cleaned = allowedKeys ? filterAllowedKeys(detail.value, allowedKeys) : detail.value;
+
+            if (inPlace && mask) {
+              const target = getMaskInputTarget(detail as GoabInputOnChangeDetail & { event?: Event });
+              const caretIndex = target?.selectionStart ?? cleaned.length;
+              const edit = computeMaskEdit(cleaned, caretIndex, mask);
+              applyInPlaceEdit(target, edit);
+              setLocalValue(edit.display);
+            } else {
+              const formattedValue = mask && cleaned !== '' ? formatWithPattern(cleaned, mask) : cleaned;
+              // If characters were rejected, force the input to show the cleaned value.
+              if (allowedKeys && cleaned !== detail.value) {
+                resetInputValue(detail, formattedValue);
+              }
+              setLocalValue(formattedValue);
             }
-            if (isSinField && detail.value !== '') {
-              formattedValue = formatSin(detail.value);
-            }
-            setLocalValue(formattedValue);
+
             setManualInput(true);
             if (isVisited === false && setIsVisited) {
               setIsVisited();
@@ -268,14 +252,27 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
               setIsVisited();
             }
 
+            const capitalizedValue = autoCapitalize ? detail.value.toUpperCase() : detail.value;
+
+            if (formatPattern) {
+              const formattedValue = applyFormatPattern(capitalizedValue, formatPattern);
+              setLocalValue(formattedValue);
+              handleChange(path, formattedValue);
+              return;
+            }
+
             onBlurForTextControl({
               name: detail.name,
               controlProps: props as ControlProps,
-              value: autoCapitalize ? detail.value.toUpperCase() : detail.value,
+              value: capitalizedValue,
             });
           }}
           onKeyPress={(detail: GoabInputOnKeyPressDetail) => {
-            if (isSinField && detail.key && !allowedSinKeyPattern.test(detail.key)) {
+            const blockDisallowed = shouldBlockKey(detail.key, allowedKeys);
+            // In-place has no length cap, so also block content keys once the template is full.
+            const blockOverflow =
+              inPlace && !!mask && /^[A-Za-z0-9]$/.test(detail.key) && isMaskFilled(localValue, mask);
+            if (blockDisallowed || blockOverflow) {
               (detail as GoabInputOnKeyPressDetail & { event?: Event }).event?.preventDefault();
             }
           }}

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
@@ -913,6 +913,30 @@ describe('Input Text Control tests', () => {
       expect(handleChange).toHaveBeenCalledWith('postalCode', 'T2P 1A1');
     });
 
+    it('formats a motor vehicle ID from schema format mvid', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'mvid',
+        id: 'mvid',
+        handleChange,
+        schema: { type: 'string', format: 'mvid' },
+        uischema: { type: 'Control', scope: '#/properties/mvid' } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='mvid-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456789' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('mvid', '1234-56789');
+    });
+
     it('formats a driver licence from schema format driverId', async () => {
       const handleChange = jest.fn();
       const props = {

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { GoAInputTextProps, GoAInputText, formatSin } from './InputTextControl';
+import { GoAInputTextProps, GoAInputText } from './InputTextControl';
 import { ControlElement, ControlProps, JsonSchema7 } from '@jsonforms/core';
+import { DEFAULT_PATTERNS, formatWithPattern, filterAllowedKeys } from '../../util/patternForm';
 
 import { validateSinWithLuhn, checkFieldValidity, isValidDate } from '../../util/stringUtils';
 import { JsonFormsContext } from '@jsonforms/react';
@@ -112,7 +113,7 @@ describe('Input Text Control tests', () => {
     const { baseElement } = render(
       <JsonFormsContext.Provider value={mockContextValue}>
         <GoAInputText {...props} />
-      </JsonFormsContext.Provider>
+      </JsonFormsContext.Provider>,
     );
     const input = baseElement.querySelector("goa-input[testId='firstName-input']");
 
@@ -176,7 +177,6 @@ describe('Input Text Control tests', () => {
       const baseControl = render(<GoAInputBaseControl {...props} input={GoAInputText} />);
       expect(baseControl).toBeDefined();
     });
-
   });
 
   describe('text control events', () => {
@@ -261,6 +261,60 @@ describe('Input Text Control tests', () => {
       expect(blurred).toBe(true);
     });
 
+    it('formats the value on blur when formatPattern is provided', () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'phone',
+        id: 'phone',
+        handleChange,
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/phone',
+          options: { formatPattern: '(###) ###-####' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = render(
+        <JsonFormsContext.Provider value={mockContextValue}>
+          <GoAInputText {...props} />
+        </JsonFormsContext.Provider>,
+      );
+      const input = baseElement.querySelector("goa-input[testId='phone-input']");
+
+      fireEvent(input!, new CustomEvent('_blur', { detail: { name: 'phone', value: '7801234567' } }));
+
+      expect(handleChange).toHaveBeenCalledWith('phone', '(780) 123-4567');
+    });
+
+    it('does not reformat on blur when formatPattern is absent', () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'phone',
+        id: 'phone',
+        required: false,
+        handleChange,
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/phone',
+        } as ControlElement,
+      };
+
+      const { baseElement } = render(
+        <JsonFormsContext.Provider value={mockContextValue}>
+          <GoAInputText {...props} />
+        </JsonFormsContext.Provider>,
+      );
+      const input = baseElement.querySelector("goa-input[testId='phone-input']");
+
+      fireEvent(input!, new CustomEvent('_blur', { detail: { name: 'phone', value: '7801234567' } }));
+
+      expect(handleChange).not.toHaveBeenCalledWith('phone', '(780) 123-4567');
+    });
+
     it('should format sin', async () => {
       const props = { ...sinProps, handleChange: handleChangeMock };
       const { baseElement } = render(
@@ -308,7 +362,7 @@ describe('Input Text Control tests', () => {
       });
 
       expect(handleChangeMock).not.toHaveBeenCalledWith('', expect.stringContaining('a'));
-      expect((firstNameInput as HTMLElement & { value: string }).value).toBe('1324567');
+      expect((firstNameInput as HTMLElement & { value: string }).value).toBe('123');
     });
 
     it('prevents alphabet key presses for SIN input', async () => {
@@ -319,14 +373,13 @@ describe('Input Text Control tests', () => {
         </JsonFormsContext.Provider>,
       );
       const firstNameInput = baseElement.querySelector("goa-input[testId='firstName-input']");
-      const keyDownEvent = new KeyboardEvent('keydown', {
+      const keyPressEvent = new CustomEvent('_keyPress', {
         cancelable: true,
-        bubbles: true,
-        key: 'a',
+        detail: { key: 'a', value: '123a' },
       });
-      const preventDefaultSpy = jest.spyOn(keyDownEvent, 'preventDefault');
+      const preventDefaultSpy = jest.spyOn(keyPressEvent, 'preventDefault');
 
-      fireEvent(firstNameInput!, keyDownEvent);
+      fireEvent(firstNameInput!, keyPressEvent);
 
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
@@ -408,7 +461,7 @@ describe('Input Text Control tests', () => {
       expect(preventDefaultSpy).not.toHaveBeenCalled();
     });
 
-    it('prevents invalid pasted text for SIN input', async () => {
+    it('strips invalid characters entered into SIN input', async () => {
       const props = { ...sinProps, handleChange: handleChangeMock };
       const { baseElement } = render(
         <JsonFormsContext.Provider value={mockContextValue}>
@@ -416,17 +469,22 @@ describe('Input Text Control tests', () => {
         </JsonFormsContext.Provider>,
       );
       const firstNameInput = baseElement.querySelector("goa-input[testId='firstName-input']");
-      const pasteEvent = new Event('paste', { cancelable: true, bubbles: true });
-      Object.defineProperty(pasteEvent, 'clipboardData', {
-        value: {
-          getData: () => '123a',
-        },
+      handleChangeMock.mockClear();
+      (firstNameInput as HTMLElement & { value: string }).value = '123a456';
+
+      await fireEvent(
+        firstNameInput!,
+        new CustomEvent('_change', {
+          detail: { value: '123a456' },
+        }),
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
       });
-      const preventDefaultSpy = jest.spyOn(pasteEvent, 'preventDefault');
 
-      fireEvent(firstNameInput!, pasteEvent);
-
-      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(handleChangeMock).not.toHaveBeenCalledWith('', expect.stringContaining('a'));
+      expect((firstNameInput as HTMLElement & { value: string }).value).toBe('123 456');
     });
 
     it('allows valid pasted text for SIN input', async () => {
@@ -575,45 +633,35 @@ describe('Input Text Control tests', () => {
       expect(validateSinWithLuhn('123456879')).toBe(false);
     });
     it('should return 9 digits for invalid SIN Number with more than 16 digits', () => {
-      expect(formatSin('123456879123456789999')).toBe('123-456-879');
+      expect(formatWithPattern('123456879123456789999', DEFAULT_PATTERNS.sin.mask)).toBe('123 456 879');
     });
   });
 
-  describe('formatSin', () => {
-    it('formats a valid SIN number correctly', () => {
-      const input = '123456789';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
+  describe('SIN masking', () => {
+    const sinMask = DEFAULT_PATTERNS.sin.mask;
+
+    it('formats a valid SIN number with spaces', () => {
+      expect(formatWithPattern('123456789', sinMask)).toBe('123 456 789');
     });
 
-    it('handles input with existing hyphens correctly', () => {
-      const input = '123-456-789';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
-    });
-
-    it('rejects alphabet characters', () => {
-      const input = 'abc123456def';
-      const expected = '';
-      expect(formatSin(input)).toBe(expected);
+    it('re-formats an already formatted value', () => {
+      expect(formatWithPattern('123 456 789', sinMask)).toBe('123 456 789');
     });
 
     it('truncates input longer than 9 digits', () => {
-      const input = '123456789012345';
-      const expected = '123-456-789';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('123456789012345', sinMask)).toBe('123 456 789');
     });
 
     it('formats input with fewer than 9 digits', () => {
-      const input = '12345';
-      const expected = '123-45';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('12345', sinMask)).toBe('123 45');
     });
 
     it('returns an empty string for empty input', () => {
-      const input = '';
-      const expected = '';
-      expect(formatSin(input)).toBe(expected);
+      expect(formatWithPattern('', sinMask)).toBe('');
+    });
+
+    it('strips non-digit characters via allowedKeys', () => {
+      expect(filterAllowedKeys('abc123456def', DEFAULT_PATTERNS.sin.allowedKeys)).toBe('123456');
     });
   });
 
@@ -831,5 +879,193 @@ describe('Input Text Control tests', () => {
     );
 
     expect(handleChangeMock).not.toHaveBeenCalled();
+  });
+
+  describe('schema format masks', () => {
+    const renderInput = (props: GoAInputTextProps & ControlProps) =>
+      render(
+        <JsonFormsContext.Provider value={mockContextValue}>
+          <GoAInputText {...props} />
+        </JsonFormsContext.Provider>,
+      );
+
+    it('formats a postal code from schema format postalCode', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'postalCode',
+        id: 'postalCode',
+        handleChange,
+        schema: { type: 'string', format: 'postalCode' },
+        uischema: { type: 'Control', scope: '#/properties/postalCode' } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='postalCode-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: 'T2P1A1' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('postalCode', 'T2P 1A1');
+    });
+
+    it('formats a driver licence from schema format driverId', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'driverId',
+        id: 'driverId',
+        handleChange,
+        schema: { type: 'string', format: 'driverId' },
+        uischema: { type: 'Control', scope: '#/properties/driverId' } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='driverId-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456789' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('driverId', '123456-789');
+    });
+
+    it('formats a SIN from schema format sin', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...sinProps,
+        data: '',
+        path: 'sin',
+        id: 'sin',
+        handleChange,
+        schema: { type: 'string', format: 'sin' },
+        uischema: { type: 'Control', scope: '#/properties/sin' } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='sin-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456789' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('sin', '123 456 789');
+    });
+
+    it('uses a custom mask from UI schema options', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        handleChange,
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '####-##' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('customMask', '1234-56');
+    });
+
+    it('shows the in-place template for a driver licence', () => {
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'driverId',
+        id: 'driverId',
+        schema: { type: 'string', format: 'driverId' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/driverId',
+          options: { inPlace: true },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='driverId-input']");
+
+      expect(input).toHaveAttribute('value', DEFAULT_PATTERNS.driverId.mask);
+    });
+
+    it('does not apply a mask for an unknown schema format', () => {
+      const props = {
+        ...staticProps,
+        data: 'plain text',
+        path: 'notes',
+        id: 'notes',
+        schema: { type: 'string', format: 'unknown-format' },
+        uischema: { type: 'Control', scope: '#/properties/notes' } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='notes-input']");
+
+      expect(input).toHaveAttribute('value', 'plain text');
+    });
+
+    it('blocks extra content keys when an in-place mask is full', () => {
+      const props = {
+        ...staticProps,
+        data: '123456-789',
+        path: 'driverId',
+        id: 'driverId',
+        schema: { type: 'string', format: 'driverId' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/driverId',
+          options: { inPlace: true },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='driverId-input']");
+      const keyPressEvent = new CustomEvent('_keyPress', {
+        cancelable: true,
+        detail: { key: '1', value: '123456-7891' },
+      });
+      const preventDefaultSpy = jest.spyOn(keyPressEvent, 'preventDefault');
+
+      fireEvent(input!, keyPressEvent);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('uses the mask placeholder when a format is detected', () => {
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'postalCode',
+        id: 'postalCode',
+        schema: { type: 'string', format: 'postalCode' },
+        uischema: { type: 'Control', scope: '#/properties/postalCode' } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='postalCode-input']");
+
+      expect(input).toHaveAttribute('placeholder', '000 000');
+    });
   });
 });

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/type.ts
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/type.ts
@@ -7,6 +7,18 @@ export interface WithInputProps {
 }
 
 /**
+ * UI schema options recognized by the text input control.
+ */
+export interface InputControlOptions {
+  /**
+   * Mask template applied to the value on blur, e.g. "(###) ###-####".
+   * '#' consumes one input character; every other character is inserted as a literal.
+   * Formatting only; validation is still driven by the JSON schema `pattern`.
+   */
+  formatPattern?: string;
+}
+
+/**
  * Base event control props to handle event controls
  */
 export interface EventControlProps {

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumber.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumber.spec.tsx
@@ -38,7 +38,7 @@ describe('PhoneNumberControl', () => {
       input,
       new CustomEvent('_change', {
         detail: { name: 'phoneNumber', value: '(403) 555-1212' },
-      })
+      }),
     );
 
     expect(mockHandleChange).toHaveBeenCalledWith('phoneNumber', '(403) 555-1212');
@@ -53,6 +53,67 @@ describe('PhoneNumberControl', () => {
 
     const formItem = container.querySelector('[testid="form-item-phoneNumber"]');
     expect(formItem).toHaveAttribute('error', 'Must be a valid 10-digit phone number in format (000) 000-0000');
+  });
+
+  it('uses a custom phoneMask from the UI schema', () => {
+    const props = {
+      ...defaultProps,
+      data: '',
+      uischema: {
+        ...defaultProps.uischema,
+        options: { phoneMask: '###-###-####' },
+      },
+    };
+
+    const { container } = render(<PhoneNumberControl {...props} />);
+    const input = container.querySelector('[testid="phone-input-phoneNumber"]');
+
+    fireEvent(input!, new CustomEvent('_change', { detail: { name: 'phoneNumber', value: '4035551212' } }));
+
+    expect(mockHandleChange).toHaveBeenCalledWith('phoneNumber', '403-555-1212');
+  });
+
+  it('shows the in-place phone template after mount', () => {
+    const props = {
+      ...defaultProps,
+      data: '',
+      uischema: {
+        ...defaultProps.uischema,
+        options: { inPlace: true },
+      },
+    };
+
+    const { container } = render(<PhoneNumberControl {...props} />);
+    const input = container.querySelector('[testid="phone-input-phoneNumber"]');
+
+    expect(input).toHaveAttribute('value', '(###) ###-####');
+  });
+
+  it('does not set maxLength when the phone field is in-place', () => {
+    const props = {
+      ...defaultProps,
+      data: '',
+      uischema: {
+        ...defaultProps.uischema,
+        options: { inPlace: true },
+      },
+    };
+
+    const { container } = render(<PhoneNumberControl {...props} />);
+    const input = container.querySelector('[testid="phone-input-phoneNumber"]');
+
+    expect(input?.getAttribute('maxlength')).toBeNull();
+  });
+
+  it('clears the error when the phone number becomes valid', () => {
+    const { container } = render(<PhoneNumberControl {...defaultProps} />);
+    const input = container.querySelector('[testid="phone-input-phoneNumber"]');
+
+    fireEvent(input!, new CustomEvent('_change', { detail: { name: 'phoneNumber', value: '123' } }));
+    fireEvent(input!, new CustomEvent('_change', { detail: { name: 'phoneNumber', value: '(403) 555-1212' } }));
+
+    const formItem = container.querySelector('[testid="form-item-phoneNumber"]');
+    expect(formItem).toHaveAttribute('error', '');
   });
 });
 

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberControl.tsx
@@ -3,22 +3,33 @@ import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { useState } from 'react';
 import { Visible } from '../../util';
-import { PHONE_REGEX } from './PhoneNumberWithTypeControl';
-import { GoabInputOnChangeDetail } from '@abgov/ui-components-common';
+import { DEFAULT_PATTERNS, maskPlaceholder } from '../../util/patternForm';
+import { useMaskedInput } from '../../util/useMaskedInput';
+import { GoabInputOnChangeDetail, GoabInputOnKeyPressDetail } from '@abgov/ui-components-common';
 type PhoneNumberControlProps = ControlProps;
 
 export const PhoneNumberControl = (props: PhoneNumberControlProps): JSX.Element => {
-  const { data, path, schema, handleChange, enabled, visible, required } = props;
+  const { data, path, schema, uischema, handleChange, enabled, visible, required } = props;
+  // Default mask can be overridden per field via the UI schema options.
+  const phoneMask = (uischema?.options?.phoneMask as string) || DEFAULT_PATTERNS.phone.mask;
+  // When in-place, the field shows the fill-in template and edits keep the caret in place.
+  const inPlace = uischema?.options?.inPlace === true;
+
   const [error, setError] = useState<string>('');
 
-  const handleInputChange = (name: string, value: string) => {
-    if (value && !PHONE_REGEX.test(value)) {
-      setError('Must be a valid 10-digit phone number in format (000) 000-0000');
-    } else {
-      setError('');
-    }
-    handleChange(path, value);
-  };
+  const {
+    value,
+    handleChange: handleMaskChange,
+    handleKeyPress,
+  } = useMaskedInput({
+    mask: phoneMask,
+    inPlace,
+    data,
+    onCommit: (stored) => {
+      setError(stored && !DEFAULT_PATTERNS.phone.pattern.test(stored) ? DEFAULT_PATTERNS.phone.error : '');
+      handleChange(path, stored);
+    },
+  });
 
   return (
     <Visible $visible={visible}>
@@ -34,9 +45,11 @@ export const PhoneNumberControl = (props: PhoneNumberControlProps): JSX.Element 
           disabled={!enabled}
           aria-label="phone number input"
           testId={`phone-input-${path}`}
-          value={data || ''}
-          onChange={(detail: GoabInputOnChangeDetail) => handleInputChange(detail.name, detail.value)}
-          placeholder="(000) 000-0000"
+          value={value}
+          maxLength={inPlace ? undefined : phoneMask.length}
+          placeholder={inPlace ? undefined : maskPlaceholder(phoneMask)}
+          onChange={(detail: GoabInputOnChangeDetail) => handleMaskChange(detail)}
+          onKeyPress={inPlace ? (detail: GoabInputOnKeyPressDetail) => handleKeyPress(detail) : undefined}
           width="100%"
         />
       </GoabFormItem>

--- a/libs/jsonforms-components/src/lib/common/Ajv.spec.ts
+++ b/libs/jsonforms-components/src/lib/common/Ajv.spec.ts
@@ -101,21 +101,24 @@ describe('Ajv tests', () => {
         sinByFormat: { type: 'string', format: 'sin' },
         postalCode: { type: 'string', format: 'postalCode' },
         driverId: { type: 'string', format: 'driverId' },
+        mvid: { type: 'string', format: 'mvid' },
       },
     };
 
     expect(ajv.validate(schema, {})).toBe(true);
-    expect(ajv.validate(schema, { sinByFormat: '', postalCode: '', driverId: '' })).toBe(true);
+    expect(ajv.validate(schema, { sinByFormat: '', postalCode: '', driverId: '', mvid: '' })).toBe(true);
     expect(
       ajv.validate(schema, {
         sinByFormat: '123 456 789',
         postalCode: 'T2P 1A1',
         driverId: '123456-789',
+        mvid: '1234-56789',
       }),
     ).toBe(true);
     expect(ajv.validate(schema, { sinByFormat: '123456789' })).toBe(false);
     expect(ajv.validate(schema, { postalCode: 'T2P1A1' })).toBe(false);
     expect(ajv.validate(schema, { driverId: '123456789' })).toBe(false);
+    expect(ajv.validate(schema, { mvid: '123456789' })).toBe(false);
   });
 
   describe('can generate inital data ', () => {

--- a/libs/jsonforms-components/src/lib/common/Ajv.spec.ts
+++ b/libs/jsonforms-components/src/lib/common/Ajv.spec.ts
@@ -63,7 +63,7 @@ describe('Ajv tests', () => {
       },
       {
         'file-urn': 'urn:ads:platfor:file-service:v1:/files/c7f1c6aa-3564-4541-a6f4-a0915dcb8906',
-      }
+      },
     );
     expect(valid).toBe(false);
     valid = ajv.validate(
@@ -75,7 +75,7 @@ describe('Ajv tests', () => {
       },
       {
         'file-urn': 'urn:ads:platform:file-service:v1:/files/c7f1c6aa-3564-4541-a6f4-a0915dcb8906',
-      }
+      },
     );
     expect(valid).toBe(true);
     valid = ajv.validate(
@@ -88,9 +88,34 @@ describe('Ajv tests', () => {
       {
         'file-urn':
           'urn:ads:platform:file-service:v1:/files/c7f1c6aa-3564-4541-a6f4-a0915dcb8906;urn:ads:platform:file-service:v1:/files/c7f1c6aa-3564-4541-a6f4-a0915dcb8906',
-      }
+      },
     );
     expect(valid).toBe(true);
+  });
+
+  it('accepts custom pattern formats without unknown-format warnings', () => {
+    const ajv = createDefaultAjv();
+    const schema = {
+      type: 'object',
+      properties: {
+        sinByFormat: { type: 'string', format: 'sin' },
+        postalCode: { type: 'string', format: 'postalCode' },
+        driverId: { type: 'string', format: 'driverId' },
+      },
+    };
+
+    expect(ajv.validate(schema, {})).toBe(true);
+    expect(ajv.validate(schema, { sinByFormat: '', postalCode: '', driverId: '' })).toBe(true);
+    expect(
+      ajv.validate(schema, {
+        sinByFormat: '123 456 789',
+        postalCode: 'T2P 1A1',
+        driverId: '123456-789',
+      }),
+    ).toBe(true);
+    expect(ajv.validate(schema, { sinByFormat: '123456789' })).toBe(false);
+    expect(ajv.validate(schema, { postalCode: 'T2P1A1' })).toBe(false);
+    expect(ajv.validate(schema, { driverId: '123456789' })).toBe(false);
   });
 
   describe('can generate inital data ', () => {

--- a/libs/jsonforms-components/src/lib/common/Ajv.ts
+++ b/libs/jsonforms-components/src/lib/common/Ajv.ts
@@ -2,17 +2,31 @@ import Ajv, { AnySchema } from 'ajv';
 import addErrors from 'ajv-errors';
 import addFormats from 'ajv-formats';
 import { PHONE_REGEX } from '../Controls';
+import { DEFAULT_PATTERNS } from '../util/patternForm';
 import { validateSinWithLuhn } from '../util';
 import { invalidSin } from './Constants';
 
+// Allow empty values so incomplete fields are not treated as format errors.
+const optionalFormat = (pattern: RegExp) => (input: string) => !input || pattern.test(input);
+
 export const createDefaultAjv = (...schemas: AnySchema[]) => {
-  const ajv = new Ajv({ allErrors: true, verbose: true, strict: 'log', strictRequired: false, useDefaults: true, multipleOfPrecision: 10 });
+  const ajv = new Ajv({
+    allErrors: true,
+    verbose: true,
+    strict: 'log',
+    strictRequired: false,
+    useDefaults: true,
+    multipleOfPrecision: 10,
+  });
   ajv.addSchema(schemas);
 
   addErrors(ajv);
   addFormats(ajv);
 
   ajv.addFormat('time', /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/);
+  Object.entries(DEFAULT_PATTERNS).forEach(([format, config]) => {
+    ajv.addFormat(format, optionalFormat(config.pattern));
+  });
   ajv.addFormat('phone', PHONE_REGEX);
   ajv.addFormat('computed', /^[a-zA-Z0-9._-]+$/);
   ajv.addFormat('file-urn', {

--- a/libs/jsonforms-components/src/lib/util/inputControlUtils.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/inputControlUtils.spec.ts
@@ -14,6 +14,7 @@ import {
   onChangeForDateTimeControl,
   isRequiredAndHasNoData,
   isNotKeyPressTabOrShift,
+  applyFormatPattern,
 } from './inputControlUtils';
 import { ControlProps } from '@jsonforms/core';
 
@@ -94,13 +95,13 @@ describe('onChangeForNumericControl', () => {
   });
 
   it('should clear numeric value when input is empty and data has a number', () => {
-  onChangeForNumericControl({
-    value: '',
-    controlProps: { ...baseControlProps, data: 50 } as ControlProps,
-  });
+    onChangeForNumericControl({
+      value: '',
+      controlProps: { ...baseControlProps, data: 50 } as ControlProps,
+    });
 
-  expect(mockHandleChange).toHaveBeenCalledWith('testPath', undefined);
-});
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', undefined);
+  });
 
   it('should NOT call handleChange when value is same as data', () => {
     onChangeForNumericControl({
@@ -118,14 +119,14 @@ describe('onChangeForNumericControl', () => {
     expect(mockHandleChange).toHaveBeenCalledWith('testPath', 0);
   });
 
-it('should not call handleChange when value is null and data is already undefined', () => {
-  onChangeForNumericControl({
-    value: null,
-    controlProps: { ...baseControlProps, data: undefined } as ControlProps,
-  });
+  it('should not call handleChange when value is null and data is already undefined', () => {
+    onChangeForNumericControl({
+      value: null,
+      controlProps: { ...baseControlProps, data: undefined } as ControlProps,
+    });
 
-  expect(mockHandleChange).not.toHaveBeenCalled();
-});
+    expect(mockHandleChange).not.toHaveBeenCalled();
+  });
 
   it('should handle negative numbers', () => {
     onChangeForNumericControl({
@@ -420,7 +421,7 @@ describe('onKeyPressForTimeControl', () => {
       key: 'Enter',
       controlProps: { ...baseControlProps } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 
   it('should handle time with seconds', () => {
@@ -469,7 +470,7 @@ describe('onKeyPressForDateControl', () => {
       key: 'Enter',
       controlProps: { ...baseControlProps } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 
   it('should call handleChange with empty string for empty date', () => {
@@ -478,7 +479,7 @@ describe('onKeyPressForDateControl', () => {
       key: 'Enter',
       controlProps: { ...baseControlProps } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 });
 
@@ -515,7 +516,7 @@ describe('onBlurForTextControl', () => {
       value: '',
       controlProps: { ...baseControlProps, required: true, data: '' } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 
   it('should not call handleChange when required but data already has value', () => {
@@ -613,7 +614,7 @@ describe('onBlurForDateControl', () => {
       value: 'invalid',
       controlProps: { ...baseControlProps, required: true, data: '' } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 
   it('should call handleChange with empty string for empty date when required and empty', () => {
@@ -621,7 +622,7 @@ describe('onBlurForDateControl', () => {
       value: '',
       controlProps: { ...baseControlProps, required: true, data: '' } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 });
 
@@ -658,7 +659,7 @@ describe('onBlurForTimeControl', () => {
       value: '',
       controlProps: { ...baseControlProps, required: true, data: '' } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 
   it('should call handleChange with invalid time value when required and empty', () => {
@@ -695,7 +696,7 @@ describe('onChangeForInputControl', () => {
       value: '',
       controlProps: { ...baseControlProps } as ControlProps,
     });
-    expect(mockHandleChange).toHaveBeenCalledWith('testPath', "");
+    expect(mockHandleChange).toHaveBeenCalledWith('testPath', '');
   });
 
   it('should handle special characters', () => {
@@ -855,5 +856,47 @@ describe('onChangeForDateTimeControl', () => {
       controlProps: { ...baseControlProps, data: 42 } as ControlProps,
     });
     expect(mockHandleChange).toHaveBeenCalledWith('testPath', undefined);
+  });
+});
+
+describe('applyFormatPattern', () => {
+  it('formats a phone number', () => {
+    expect(applyFormatPattern('7801234567', '(###) ###-####')).toBe('(780) 123-4567');
+  });
+
+  it('formats a motor vehicle id', () => {
+    expect(applyFormatPattern('123456789', '######-###')).toBe('123456-789');
+  });
+
+  it('formats a postal code', () => {
+    expect(applyFormatPattern('A1A1A1', '### ###')).toBe('A1A 1A1');
+  });
+
+  it('formats a social insurance number', () => {
+    expect(applyFormatPattern('123456789', '### ### ###')).toBe('123 456 789');
+  });
+
+  it('is idempotent when the value is already formatted', () => {
+    expect(applyFormatPattern('(780) 123-4567', '(###) ###-####')).toBe('(780) 123-4567');
+  });
+
+  it('returns the value unchanged when the mask is empty', () => {
+    expect(applyFormatPattern('7801234567', '')).toBe('7801234567');
+  });
+
+  it('returns the value unchanged when the mask is undefined', () => {
+    expect(applyFormatPattern('7801234567', undefined)).toBe('7801234567');
+  });
+
+  it('returns the value unchanged for an empty value', () => {
+    expect(applyFormatPattern('', '(###) ###-####')).toBe('');
+  });
+
+  it('passes through partial input without adding trailing literals', () => {
+    expect(applyFormatPattern('780123', '(###) ###-####')).toBe('(780) 123');
+  });
+
+  it('appends leftover content characters that do not fit the mask', () => {
+    expect(applyFormatPattern('12345678901234', '######-###')).toBe('123456-78901234');
   });
 });

--- a/libs/jsonforms-components/src/lib/util/inputControlUtils.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/inputControlUtils.spec.ts
@@ -864,8 +864,12 @@ describe('applyFormatPattern', () => {
     expect(applyFormatPattern('7801234567', '(###) ###-####')).toBe('(780) 123-4567');
   });
 
-  it('formats a motor vehicle id', () => {
+  it('formats a driver licence number', () => {
     expect(applyFormatPattern('123456789', '######-###')).toBe('123456-789');
+  });
+
+  it('formats a motor vehicle ID', () => {
+    expect(applyFormatPattern('123456789', '####-#####')).toBe('1234-56789');
   });
 
   it('formats a postal code', () => {

--- a/libs/jsonforms-components/src/lib/util/inputControlUtils.ts
+++ b/libs/jsonforms-components/src/lib/util/inputControlUtils.ts
@@ -81,6 +81,11 @@ export const onKeyPressForDateControl = (props: EventKeyPressControlProps) => {
 };
 
 /**
+ * Re-exported from ./patternForm to keep existing import paths stable.
+ */
+export { applyFormatPattern } from './patternForm';
+
+/**
  * Helper function to process onBlur events for text controls.
  * @param props - EventBlurControlProps
  */
@@ -192,7 +197,6 @@ const toNumericControlValue = (value: string | number | Date | null | undefined)
 
   return +value;
 };
-
 
 /**
  * Helper function to process onChange event for Number/Integer controls.

--- a/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
@@ -48,6 +48,14 @@ describe('DEFAULT_PATTERNS', () => {
   it('rejects a driver licence number without a dash', () => {
     expect(DEFAULT_PATTERNS.driverId.pattern.test('123456789')).toBe(false);
   });
+
+  it('accepts a formatted motor vehicle ID', () => {
+    expect(DEFAULT_PATTERNS.mvid.pattern.test('1234-56789')).toBe(true);
+  });
+
+  it('rejects a motor vehicle ID without a dash', () => {
+    expect(DEFAULT_PATTERNS.mvid.pattern.test('123456789')).toBe(false);
+  });
 });
 
 describe('shouldBlockKey', () => {
@@ -103,6 +111,10 @@ describe('formatWithPattern', () => {
 
   it('formats a driver licence number', () => {
     expect(formatWithPattern('123456789', DEFAULT_PATTERNS.driverId.mask)).toBe('123456-789');
+  });
+
+  it('formats a motor vehicle ID', () => {
+    expect(formatWithPattern('123456789', DEFAULT_PATTERNS.mvid.mask)).toBe('1234-56789');
   });
 
   it('formats a postal code', () => {

--- a/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
@@ -1,0 +1,223 @@
+import {
+  DEFAULT_PATTERNS,
+  MASK_CONTROL_KEYS,
+  MASK_PLACEHOLDERS,
+  applyFormatPattern,
+  applyInPlaceEdit,
+  caretAfterDigits,
+  computeMaskEdit,
+  filterAllowedKeys,
+  formatWithPattern,
+  getMaskInputTarget,
+  isMaskFilled,
+  maskDigitCount,
+  maskPlaceholder,
+  shouldBlockKey,
+  toMaskTemplate,
+} from './patternForm';
+
+describe('DEFAULT_PATTERNS', () => {
+  it('accepts a formatted phone number', () => {
+    expect(DEFAULT_PATTERNS.phone.pattern.test('(403) 555-1212')).toBe(true);
+  });
+
+  it('rejects an incomplete phone number', () => {
+    expect(DEFAULT_PATTERNS.phone.pattern.test('403555')).toBe(false);
+  });
+
+  it('accepts a spaced SIN', () => {
+    expect(DEFAULT_PATTERNS.sin.pattern.test('123 456 789')).toBe(true);
+  });
+
+  it('rejects a SIN without spaces', () => {
+    expect(DEFAULT_PATTERNS.sin.pattern.test('123456789')).toBe(false);
+  });
+
+  it('accepts a Canadian postal code', () => {
+    expect(DEFAULT_PATTERNS.postalCode.pattern.test('T2P 1A1')).toBe(true);
+  });
+
+  it('rejects a postal code without a space', () => {
+    expect(DEFAULT_PATTERNS.postalCode.pattern.test('T2P1A1')).toBe(false);
+  });
+
+  it('accepts an Alberta driver licence number', () => {
+    expect(DEFAULT_PATTERNS.driverId.pattern.test('123456-789')).toBe(true);
+  });
+
+  it('rejects a driver licence number without a dash', () => {
+    expect(DEFAULT_PATTERNS.driverId.pattern.test('123456789')).toBe(false);
+  });
+});
+
+describe('shouldBlockKey', () => {
+  it('blocks a letter when only digits are allowed', () => {
+    expect(shouldBlockKey('a', /[0-9]/)).toBe(true);
+  });
+
+  it('allows a digit when digits are allowed', () => {
+    expect(shouldBlockKey('5', /[0-9]/)).toBe(false);
+  });
+
+  it('allows Backspace even when input is restricted', () => {
+    expect(shouldBlockKey('Backspace', /[0-9]/)).toBe(false);
+  });
+
+  it('does not block keys when no restriction is set', () => {
+    expect(shouldBlockKey('a', undefined)).toBe(false);
+  });
+});
+
+describe('filterAllowedKeys', () => {
+  it('strips letters from a digit-only format', () => {
+    expect(filterAllowedKeys('12a3b', /[0-9]/)).toBe('123');
+  });
+
+  it('returns the original value when no restriction is set', () => {
+    expect(filterAllowedKeys('12a3b', undefined)).toBe('12a3b');
+  });
+
+  it('treats a missing value as empty', () => {
+    expect(filterAllowedKeys(undefined as unknown as string, /[0-9]/)).toBe('');
+  });
+});
+
+describe('maskDigitCount', () => {
+  it('counts placeholder characters in a phone mask', () => {
+    expect(maskDigitCount(DEFAULT_PATTERNS.phone.mask)).toBe(10);
+  });
+
+  it('counts placeholder characters in a driver licence mask', () => {
+    expect(maskDigitCount(DEFAULT_PATTERNS.driverId.mask)).toBe(9);
+  });
+});
+
+describe('formatWithPattern', () => {
+  it('formats a phone number as digits are entered', () => {
+    expect(formatWithPattern('4035551212', DEFAULT_PATTERNS.phone.mask)).toBe('(403) 555-1212');
+  });
+
+  it('stops at the last entered content character', () => {
+    expect(formatWithPattern('40355', DEFAULT_PATTERNS.phone.mask)).toBe('(403) 55');
+  });
+
+  it('formats a driver licence number', () => {
+    expect(formatWithPattern('123456789', DEFAULT_PATTERNS.driverId.mask)).toBe('123456-789');
+  });
+
+  it('formats a postal code', () => {
+    expect(formatWithPattern('T2P1A1', DEFAULT_PATTERNS.postalCode.mask)).toBe('T2P 1A1');
+  });
+
+  it('treats a missing value as empty', () => {
+    expect(formatWithPattern(undefined as unknown as string, DEFAULT_PATTERNS.phone.mask)).toBe('');
+  });
+});
+
+describe('toMaskTemplate', () => {
+  it('fills entered digits and leaves remaining placeholders', () => {
+    expect(toMaskTemplate('40355', DEFAULT_PATTERNS.phone.mask)).toBe('(403) 55#-####');
+  });
+
+  it('returns the full template when the value is empty', () => {
+    expect(toMaskTemplate('', DEFAULT_PATTERNS.driverId.mask)).toBe('######-###');
+  });
+});
+
+describe('caretAfterDigits', () => {
+  it('returns 0 when no content has been entered', () => {
+    expect(caretAfterDigits('(###) ###-####', 0)).toBe(0);
+  });
+
+  it('places the caret after the requested content character', () => {
+    expect(caretAfterDigits('(403) 55#-####', 5)).toBe(8);
+  });
+
+  it('returns the end of the display when more digits are requested than exist', () => {
+    expect(caretAfterDigits('(403)', 10)).toBe(5);
+  });
+});
+
+describe('computeMaskEdit', () => {
+  it('builds the in-place display, stored value, and caret for a partial phone number', () => {
+    const edit = computeMaskEdit('40355', 5, DEFAULT_PATTERNS.phone.mask);
+
+    expect(edit).toEqual({
+      display: '(403) 55#-####',
+      stored: '(403) 55',
+      caret: 8,
+    });
+  });
+});
+
+describe('isMaskFilled', () => {
+  it('is false until every placeholder is filled', () => {
+    expect(isMaskFilled('(403) 555-121', DEFAULT_PATTERNS.phone.mask)).toBe(false);
+  });
+
+  it('is true once every placeholder is filled', () => {
+    expect(isMaskFilled('(403) 555-1212', DEFAULT_PATTERNS.phone.mask)).toBe(true);
+  });
+});
+
+describe('maskPlaceholder', () => {
+  it('replaces placeholders with zeros for a phone mask', () => {
+    expect(maskPlaceholder(DEFAULT_PATTERNS.phone.mask)).toBe('(000) 000-0000');
+  });
+});
+
+describe('getMaskInputTarget', () => {
+  it('returns the event target when present', () => {
+    const target = document.createElement('input');
+    const detail = { event: { target } as unknown as Event };
+
+    expect(getMaskInputTarget(detail)).toBe(target);
+  });
+
+  it('returns undefined when the event has no target', () => {
+    expect(getMaskInputTarget({})).toBeUndefined();
+  });
+});
+
+describe('applyInPlaceEdit', () => {
+  it('does nothing when the target is missing', () => {
+    expect(() =>
+      applyInPlaceEdit(undefined, { display: '(403) 555-1212', stored: '(403) 555-1212', caret: 14 }),
+    ).not.toThrow();
+  });
+
+  it('writes the display value and restores the caret', () => {
+    const target = document.createElement('input');
+    const setSelectionRange = jest.fn();
+    target.setSelectionRange = setSelectionRange;
+    const animationFrame = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 0;
+    });
+
+    applyInPlaceEdit(target, { display: '(403) 55#-####', stored: '(403) 55', caret: 8 });
+
+    expect(target.value).toBe('(403) 55#-####');
+    expect(setSelectionRange).toHaveBeenCalledWith(8, 8);
+
+    animationFrame.mockRestore();
+  });
+});
+
+describe('applyFormatPattern', () => {
+  it('formats leftover content that does not fit the mask', () => {
+    expect(applyFormatPattern('12345678901234', DEFAULT_PATTERNS.driverId.mask)).toBe('123456-78901234');
+  });
+});
+
+describe('mask constants', () => {
+  it('treats hash, star, and underscore as placeholders', () => {
+    expect(MASK_PLACEHOLDERS.has('#')).toBe(true);
+    expect(MASK_PLACEHOLDERS.has('*')).toBe(true);
+    expect(MASK_PLACEHOLDERS.has('_')).toBe(true);
+  });
+
+  it('includes Backspace as a control key', () => {
+    expect(MASK_CONTROL_KEYS.has('Backspace')).toBe(true);
+  });
+});

--- a/libs/jsonforms-components/src/lib/util/patternForm.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.ts
@@ -1,0 +1,201 @@
+// A named format: the display mask, the validation pattern, the error shown when invalid,
+// and the characters this format allows to be typed (beyond the base control keys).
+export interface MaskPattern {
+  mask: string;
+  pattern: RegExp;
+  error: string;
+  allowedKeys?: RegExp;
+}
+
+// Default formats keyed by type; the mask can be overridden per field via UI schema options.
+export const DEFAULT_PATTERNS: Record<string, MaskPattern> = {
+  phone: {
+    mask: '(###) ###-####',
+    pattern: /^\(?\d{3}\)?[- ]?\d{3}[- ]?\d{4}$/,
+    error: 'Must be a valid 10-digit phone number in format (000) 000-0000',
+    allowedKeys: /[0-9]/,
+  },
+  sin: {
+    mask: '### ### ###',
+    pattern: /^\d{3} \d{3} \d{3}$/,
+    error: 'Must be three groups of three digits.',
+    allowedKeys: /[0-9]/,
+  },
+  postalCode: {
+    mask: '### ###',
+    pattern: /^[A-Za-z]\d[A-Za-z] \d[A-Za-z]\d$/,
+    error: 'Must be in A0A 0A0 capital letters and numbers format',
+    allowedKeys: /[A-Za-z0-9]/,
+  },
+  driverId: {
+    // Alberta driver's licence: six digits, a dash, then three digits.
+    mask: '######-###',
+    pattern: /^\d{6}-\d{3}$/,
+    error: "Must be a valid driver's licence number in format 000000-000",
+    allowedKeys: /[0-9]/,
+  },
+};
+
+// Mask placeholder characters; each consumes one input character. Any other mask character is treated as a literal.
+export const MASK_PLACEHOLDERS = new Set(['#', '*', '_']);
+const isPlaceholder = (char: string): boolean => MASK_PLACEHOLDERS.has(char);
+
+// Navigation/editing keys that keystroke filtering must always let through.
+export const MASK_CONTROL_KEYS = new Set([
+  'Backspace',
+  'Delete',
+  'Tab',
+  'Enter',
+  'Escape',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+]);
+
+// A single-character key should be blocked when the format restricts input and the key isn't allowed.
+export const shouldBlockKey = (key: string, allowedKeys?: RegExp): boolean =>
+  !!allowedKeys && key.length === 1 && !MASK_CONTROL_KEYS.has(key) && !allowedKeys.test(key);
+
+// Removes characters the format doesn't allow (e.g. letters from a digit-only field), for paste/programmatic input.
+export const filterAllowedKeys = (value: string, allowedKeys?: RegExp): string =>
+  allowedKeys ? [...(value ?? '')].filter((char) => allowedKeys.test(char)).join('') : (value ?? '');
+
+// A mask slot holds one content character (letter or digit); everything else in the value is a separator.
+const NON_CONTENT = /[^a-zA-Z0-9]/g;
+const IS_CONTENT = /[a-zA-Z0-9]/;
+
+// Number of fill slots in a mask (its placeholder characters).
+export const maskDigitCount = (mask: string): number => [...mask].filter(isPlaceholder).length;
+
+// Formats a value into a placeholder mask (e.g. '(###) ###-####'), filling only the content entered so far.
+// Placeholder characters consume one content character each; every other mask character is a literal.
+export const formatWithPattern = (value: string, mask: string): string => {
+  const maxContent = maskDigitCount(mask);
+  const content = (value ?? '').replace(NON_CONTENT, '').slice(0, maxContent);
+
+  let index = 0;
+  let formatted = '';
+  for (const maskChar of mask) {
+    if (index >= content.length) {
+      break;
+    }
+    formatted += isPlaceholder(maskChar) ? content[index++] : maskChar;
+  }
+  return formatted;
+};
+
+// Fills the mask with the value's content, leaving the placeholder character for positions not yet entered.
+export const toMaskTemplate = (value: string, mask: string): string => {
+  const maxContent = maskDigitCount(mask);
+  const content = (value ?? '').replace(NON_CONTENT, '').slice(0, maxContent);
+
+  let index = 0;
+  let display = '';
+  for (const maskChar of mask) {
+    display += isPlaceholder(maskChar) ? (index < content.length ? content[index++] : maskChar) : maskChar;
+  }
+  return display;
+};
+
+// Caret position just after the Nth content character within a rendered mask, so in-place edits keep the cursor in place.
+export const caretAfterDigits = (display: string, digitCount: number): number => {
+  if (digitCount <= 0) {
+    return 0;
+  }
+  let seen = 0;
+  for (let i = 0; i < display.length; i++) {
+    if (IS_CONTENT.test(display[i])) {
+      seen += 1;
+      if (seen === digitCount) {
+        return i + 1;
+      }
+    }
+  }
+  return display.length;
+};
+
+export interface MaskEdit {
+  display: string; // in-place template with placeholder characters for unfilled slots
+  stored: string; // clean formatted value without trailing template characters
+  caret: number; // caret position to restore within the display
+}
+
+// Computes an in-place masked edit from the raw input and caret index: what to show, what to store, where to put the caret.
+export const computeMaskEdit = (rawValue: string, caretIndex: number, mask: string): MaskEdit => {
+  const digitsBeforeCaret = rawValue.slice(0, caretIndex).replace(NON_CONTENT, '').length;
+  const display = toMaskTemplate(rawValue, mask);
+  const stored = formatWithPattern(rawValue, mask);
+  const caret = caretAfterDigits(display, Math.min(digitsBeforeCaret, maskDigitCount(mask)));
+  return { display, stored, caret };
+};
+
+// True once the value has as many content characters as the mask has fill slots.
+export const isMaskFilled = (value: string, mask: string): boolean =>
+  value.replace(NON_CONTENT, '').length >= maskDigitCount(mask);
+
+// A human placeholder for a mask, e.g. '(###) ###-####' -> '(000) 000-0000'.
+export const maskPlaceholder = (mask: string): string =>
+  [...mask].map((char) => (isPlaceholder(char) ? '0' : char)).join('');
+
+type MaskInputTarget = (HTMLInputElement & { setSelectionRange?: (start: number, end: number) => void }) | undefined;
+
+// Extracts the underlying input element from a GoA change/keypress detail, if available.
+export const getMaskInputTarget = (detail: { event?: Event }): MaskInputTarget =>
+  (detail.event?.target as MaskInputTarget) ?? undefined;
+
+// Applies an in-place edit to the DOM: forces the (fixed-length) value and restores the caret after React commits.
+export const applyInPlaceEdit = (target: MaskInputTarget, edit: MaskEdit): void => {
+  if (!target) {
+    return;
+  }
+  target.value = edit.display;
+  if (target.setSelectionRange) {
+    requestAnimationFrame(() => target.setSelectionRange?.(edit.caret, edit.caret));
+  }
+};
+
+/**
+ * Applies a mask template to a value, e.g. mask "(###) ###-####" turns "7801234567" into "(780) 123-4567".
+ * '#' consumes one content character from the input; every other character is a literal inserted into the output.
+ * The mask's literal characters are stripped from the input first so an already formatted value re-formats cleanly.
+ * Returns the original value unchanged when the mask is empty or no content characters remain.
+ * @param value - The raw input value
+ * @param mask - The mask template string
+ * @returns The masked value
+ */
+export const applyFormatPattern = (value: string, mask: string | undefined): string => {
+  if (!mask || !value) {
+    return value;
+  }
+
+  const literals = new Set(mask.split('').filter((char) => !isPlaceholder(char)));
+  const content = value.split('').filter((char) => !literals.has(char));
+
+  if (content.length === 0) {
+    return value;
+  }
+
+  let contentIndex = 0;
+  let result = '';
+  for (const maskChar of mask) {
+    if (contentIndex >= content.length) {
+      break;
+    }
+    if (isPlaceholder(maskChar)) {
+      result += content[contentIndex];
+      contentIndex += 1;
+    } else {
+      result += maskChar;
+    }
+  }
+
+  // Append any remaining content characters that did not fit the mask.
+  if (contentIndex < content.length) {
+    result += content.slice(contentIndex).join('');
+  }
+
+  return result;
+};

--- a/libs/jsonforms-components/src/lib/util/patternForm.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.ts
@@ -34,6 +34,13 @@ export const DEFAULT_PATTERNS: Record<string, MaskPattern> = {
     error: "Must be a valid driver's licence number in format 000000-000",
     allowedKeys: /[0-9]/,
   },
+  mvid: {
+    // Motor vehicle ID: four digits, a dash, then five digits.
+    mask: '####-#####',
+    pattern: /^\d{4}-\d{5}$/,
+    error: 'Must be a valid motor vehicle ID in format 0000-00000',
+    allowedKeys: /[0-9]/,
+  },
 };
 
 // Mask placeholder characters; each consumes one input character. Any other mask character is treated as a literal.

--- a/libs/jsonforms-components/src/lib/util/useMaskedInput.spec.tsx
+++ b/libs/jsonforms-components/src/lib/util/useMaskedInput.spec.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react';
+import { DEFAULT_PATTERNS } from './patternForm';
+import { useMaskedInput } from './useMaskedInput';
+
+describe('useMaskedInput', () => {
+  it('formats progressive input as the user types', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: false,
+        data: '',
+        onCommit,
+      }),
+    );
+
+    act(() => result.current.handleChange({ value: '4035551212' }));
+
+    expect(result.current.value).toBe('(403) 555-1212');
+  });
+
+  it('commits the formatted value in progressive mode', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: false,
+        data: '',
+        onCommit,
+      }),
+    );
+
+    act(() => result.current.handleChange({ value: '4035551212' }));
+
+    expect(onCommit).toHaveBeenCalledWith('(403) 555-1212');
+  });
+
+  it('shows the in-place template for empty data after mount', () => {
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: true,
+        data: '',
+        onCommit: jest.fn(),
+      }),
+    );
+
+    expect(result.current.value).toBe('(###) ###-####');
+  });
+
+  it('keeps the in-place template while editing a partial value', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: true,
+        data: '',
+        onCommit,
+      }),
+    );
+
+    act(() => result.current.handleChange({ value: '40355' }));
+
+    expect(result.current.value).toBe('(403) 55#-####');
+  });
+
+  it('commits the clean stored value in in-place mode', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: true,
+        data: '',
+        onCommit,
+      }),
+    );
+
+    act(() => result.current.handleChange({ value: '40355' }));
+
+    expect(onCommit).toHaveBeenCalledWith('(403) 55');
+  });
+
+  it('blocks extra content keys once the in-place mask is full', () => {
+    const preventDefault = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: true,
+        data: '(403) 555-1212',
+        onCommit: jest.fn(),
+      }),
+    );
+
+    act(() => result.current.handleKeyPress({ key: '9', event: { preventDefault } as unknown as Event }));
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not block content keys when the in-place mask is not full', () => {
+    const preventDefault = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: true,
+        data: '',
+        onCommit: jest.fn(),
+      }),
+    );
+
+    act(() => result.current.handleKeyPress({ key: '4', event: { preventDefault } as unknown as Event }));
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/libs/jsonforms-components/src/lib/util/useMaskedInput.ts
+++ b/libs/jsonforms-components/src/lib/util/useMaskedInput.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import {
+  applyInPlaceEdit,
+  computeMaskEdit,
+  formatWithPattern,
+  getMaskInputTarget,
+  isMaskFilled,
+  toMaskTemplate,
+} from './patternForm';
+
+interface MaskChangeDetail {
+  value: string;
+  event?: Event;
+}
+
+interface MaskKeyPressDetail {
+  key: string;
+  event?: Event;
+}
+
+interface UseMaskedInputOptions {
+  mask: string;
+  // When true the field shows the fill-in template and edits keep the caret in place.
+  inPlace: boolean;
+  data: unknown;
+  // Receives the clean formatted value whenever it changes.
+  onCommit: (stored: string) => void;
+}
+
+interface UseMaskedInputResult {
+  value: string;
+  handleChange: (detail: MaskChangeDetail) => void;
+  handleKeyPress: (detail: MaskKeyPressDetail) => void;
+}
+
+// Encapsulates masked-input state for a GoA input: display value, mount reflection, and change/keypress handling.
+export const useMaskedInput = ({ mask, inPlace, data, onCommit }: UseMaskedInputOptions): UseMaskedInputResult => {
+  const format = (value: string): string => (inPlace ? toMaskTemplate(value, mask) : formatWithPattern(value, mask));
+
+  const initialDisplay = format(typeof data === 'string' ? data : '');
+  // In-place mounts empty then sets the template so the web component reflects it (a value change forces the paint).
+  const [value, setValue] = useState<string>(inPlace ? '' : initialDisplay);
+
+  useEffect(() => {
+    if (inPlace) {
+      setValue(initialDisplay);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChange = (detail: MaskChangeDetail) => {
+    const rawValue = detail.value;
+
+    if (!inPlace) {
+      const stored = formatWithPattern(rawValue, mask);
+      setValue(stored);
+      onCommit(stored);
+      return;
+    }
+
+    const target = getMaskInputTarget(detail);
+    const caretIndex = target?.selectionStart ?? rawValue.length;
+    const edit = computeMaskEdit(rawValue, caretIndex, mask);
+
+    applyInPlaceEdit(target, edit);
+    setValue(edit.display);
+    onCommit(edit.stored);
+  };
+
+  // In-place mode has no native length cap, so block extra content characters at the source.
+  const handleKeyPress = (detail: MaskKeyPressDetail) => {
+    if (inPlace && /^[A-Za-z0-9]$/.test(detail.key) && isMaskFilled(value, mask)) {
+      detail.event?.preventDefault();
+    }
+  };
+
+  return { value, handleChange, handleKeyPress };
+};


### PR DESCRIPTION
CS-5312

Extract a shared patternForm module so phone, SIN, postal code, and driver licence fields use the same masking, validation, and in-place editing behaviour. Detect formats from schema.format keys that match DEFAULT_PATTERNS, keep the SIN title fallback, and register those formats with AJV so custom schema formats are no longer ignored.


<img width="1177" height="1192" alt="image" src="https://github.com/user-attachments/assets/f7863fd6-38a1-453d-8baa-e09a24e97a7a" />
