### PR TITLE
fix(form-admin-app, form-app): CS-5351 label the message submit button "Send"

### DIFF
--- a/apps/form-admin-app/src/app/containers/CommentsViewer.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/CommentsViewer.spec.tsx
@@ -35,6 +35,13 @@ jest.mock('../state', () => ({
 const { CommentsViewer } = require('./CommentsViewer');
 
 describe('form-admin-app CommentsViewer', () => {
+  it('labels the send button "Send" while the draft field keeps its own label', () => {
+    render(<CommentsViewer />);
+
+    expect(capturedProps.addCommentButtonLabel).toBe('Send');
+    expect(capturedProps.addCommentLabel).toBe('Add response');
+  });
+
   it('renders the review conversation with the messaging layout', () => {
     const { getByTestId } = render(<CommentsViewer />);
 

--- a/apps/form-admin-app/src/app/containers/CommentsViewer.tsx
+++ b/apps/form-admin-app/src/app/containers/CommentsViewer.tsx
@@ -35,6 +35,7 @@ export const CommentsViewer: FunctionComponent = () => {
       $commentsHeight={'30vh'}
       messaging={true}
       addCommentLabel="Add response"
+      addCommentButtonLabel="Send"
       comments={results}
       canComment={canComment}
       canLoadMore={!!next}

--- a/apps/form-app/src/app/containers/CommentsViewer.spec.tsx
+++ b/apps/form-app/src/app/containers/CommentsViewer.spec.tsx
@@ -33,6 +33,13 @@ jest.mock('../state', () => ({
 const { CommentsViewer } = require('./CommentsViewer');
 
 describe('form-app CommentsViewer', () => {
+  it('labels the send button "Send" while the draft field keeps its own label', () => {
+    render(<CommentsViewer />);
+
+    expect(capturedProps.addCommentButtonLabel).toBe('Send');
+    expect(capturedProps.addCommentLabel).toBe('Add question');
+  });
+
   it('renders the questions conversation with the messaging layout', () => {
     const { getByTestId } = render(<CommentsViewer />);
 

--- a/apps/form-app/src/app/containers/CommentsViewer.tsx
+++ b/apps/form-app/src/app/containers/CommentsViewer.tsx
@@ -29,6 +29,7 @@ export const CommentsViewer: FunctionComponent = () => {
       heading="Questions"
       messaging={true}
       addCommentLabel="Add question"
+      addCommentButtonLabel="Send"
       anonymousName="Support"
       comments={results}
       canComment={canComment}

--- a/libs/app-common/src/components/CommentsViewer.spec.tsx
+++ b/libs/app-common/src/components/CommentsViewer.spec.tsx
@@ -443,6 +443,34 @@ describe('CommentsViewer', () => {
     // Assert
     expect(props.onAddComment).toHaveBeenCalledWith(draft);
   });
+  test('labels the add comment button with addCommentButtonLabel when one is provided', () => {
+    // Arrange
+    const props = createProps({
+      draft: { content: 'Draft text' },
+      addCommentLabel: 'Add response',
+      addCommentButtonLabel: 'Send',
+    });
+
+    // Act
+    render(<CommentsViewer {...props} />);
+
+    // Assert the field keeps its own descriptive label while the button reads 'Send'.
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
+    expect(screen.getByText('Add response')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add response' })).not.toBeInTheDocument();
+  });
+
+  test('falls back to addCommentLabel for the button when no button label is provided', () => {
+    // Arrange
+    const props = createProps({ draft: { content: 'Draft text' }, addCommentLabel: 'Post comment' });
+
+    // Act
+    render(<CommentsViewer {...props} />);
+
+    // Assert
+    expect(screen.getByRole('button', { name: 'Post comment' })).toBeInTheDocument();
+  });
+
   test('marks a comment from the current user so the messaging layout can position it', () => {
     const props = createProps({ comments: [createComment({ byCurrentUser: true })] });
     const { container } = render(<CommentsViewer {...props} messaging={true} />);

--- a/libs/app-common/src/components/CommentsViewer.tsx
+++ b/libs/app-common/src/components/CommentsViewer.tsx
@@ -32,6 +32,8 @@ interface CommentsViewerProps {
   className?: string;
   heading?: string;
   addCommentLabel?: string;
+  // Label for the submit button. Defaults to addCommentLabel, which also labels the draft field.
+  addCommentButtonLabel?: string;
   anonymousName?: string;
   userId?: string;
   canComment: boolean;
@@ -71,6 +73,7 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
   className,
   heading,
   addCommentLabel,
+  addCommentButtonLabel,
   anonymousName,
   canComment,
   canLoadMore,
@@ -89,6 +92,7 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
 }) => {
   heading = heading || 'Comments';
   addCommentLabel = addCommentLabel || 'Add comment';
+  addCommentButtonLabel = addCommentButtonLabel || addCommentLabel;
   anonymousName = anonymousName || 'Commenter';
   const [deleting, setDeleting] = useState<Comment>(null);
 
@@ -172,7 +176,7 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
             disabled={!draft.content || commenting}
             onClick={() => onAddComment(draft)}
           >
-            {addCommentLabel}
+            {addCommentButtonLabel}
           </GoabButton>
         </GoabButtonGroup>
       </form>


### PR DESCRIPTION
## CS-5351

The message threads labelled their submit button "Add response" (form admin app) and "Add question" (form app), which reads as confusing button text.

The shared `CommentsViewer` used a single `addCommentLabel` prop for two different things — the label on the draft textarea *and* the button text — so renaming the prop value alone would have put "Send" above the textarea as its field label. A new optional `addCommentButtonLabel` now carries the button text and falls back to `addCommentLabel` when absent, so existing callers are unchanged.

Both form apps pass `addCommentButtonLabel="Send"` and keep their field labels ("Add response" / "Add question") describing what is being written. The task app doesn't set either prop, so it still reads "Add comment" throughout.

Covers both entry points to these threads: `ReviewWorkspace` in the form admin app and `FormSupportPane` in the form app both render the containers that changed.

Verified: `nx test` for app-common, form-admin-app and form-app (242 passed), `nx lint` 0 errors, and both apps build.