### PR TITLE
fix(value-service): CS-5318 widen the monthly aggregate refresh window

### DIFF
--- a/apps/value-service/migrations/20260827120000_create_metric_continuous_aggregates.js
+++ b/apps/value-service/migrations/20260827120000_create_metric_continuous_aggregates.js
@@ -1,4 +1,7 @@
 /* eslint-disable no-undef */
+// clean-code-ignore: RULE-19 - covered by src/timescale/metric-continuous-aggregates-migration.spec.ts.
+// The test cannot be colocated: knex loads every .js in this directory as a migration, so a test file
+// here fails the migration run at startup.
 
 const aggregates = [
   {
@@ -18,12 +21,18 @@ const aggregates = [
   { name: 'metrics_hourly_continuous', bucket: '1 hour', schedule: '15 minutes', start: '3 hours', end: '1 hour' },
   { name: 'metrics_daily_continuous', bucket: '1 day', schedule: '1 hour', start: '3 days', end: '1 day' },
   { name: 'metrics_weekly_continuous', bucket: '1 week', schedule: '1 day', start: '3 weeks', end: '1 week' },
-  { name: 'metrics_monthly_continuous', bucket: '1 month', schedule: '1 day', start: '3 months', end: '1 month' },
+  // A month is a variable-width bucket, so Timescale requires the refresh window to span more than two
+  // of them rather than the exactly-two the fixed-width buckets above get away with; '3 months' here
+  // is rejected with 'policy refresh window too small'.
+  { name: 'metrics_monthly_continuous', bucket: '1 month', schedule: '1 day', start: '4 months', end: '1 month' },
 ];
 
+// Timescale cannot create continuous aggregates inside a transaction, so this migration runs unwrapped
+// (see exports.config below) and every statement has to be safe to re-run: a failure part way through
+// leaves the earlier statements applied, and knex will start again from the top on the next boot.
 const createAggregate = (knex, aggregate) =>
   knex.schema.raw(
-    `CREATE MATERIALIZED VIEW ${aggregate.name} ` +
+    `CREATE MATERIALIZED VIEW IF NOT EXISTS ${aggregate.name} ` +
       'WITH (timescaledb.continuous) AS ' +
       'SELECT namespace, name, tenant, metric, ' +
       `time_bucket(INTERVAL '${aggregate.bucket}', timestamp) AS bucket, ` +
@@ -31,22 +40,30 @@ const createAggregate = (knex, aggregate) =>
       'FROM metrics GROUP BY namespace, name, tenant, metric, bucket WITH NO DATA;',
   );
 
+// IF NOT EXISTS above skips an aggregate left behind by an earlier attempt, which would otherwise keep
+// whatever settings that attempt created it with. Set them explicitly so the end state is the same
+// whether the view is new or pre-existing.
+const setAggregateOptions = (knex, aggregate) =>
+  knex.schema.raw(`ALTER MATERIALIZED VIEW ${aggregate.name} SET (timescaledb.materialized_only = false);`);
+
 const addRefreshPolicy = (knex, aggregate) =>
   knex.schema.raw(
     `SELECT add_continuous_aggregate_policy('${aggregate.name}', ` +
       `start_offset => INTERVAL '${aggregate.start}', ` +
       `end_offset => INTERVAL '${aggregate.end}', ` +
-      `schedule_interval => INTERVAL '${aggregate.schedule}');`,
+      `schedule_interval => INTERVAL '${aggregate.schedule}', ` +
+      'if_not_exists => TRUE);',
   );
 
 exports.up = async function (knex) {
   for (const aggregate of aggregates) {
     await createAggregate(knex, aggregate);
+    await setAggregateOptions(knex, aggregate);
     await addRefreshPolicy(knex, aggregate);
   }
 
   await knex.schema.raw(`
-    CREATE TABLE metric_continuous_aggregate_backfills (
+    CREATE TABLE IF NOT EXISTS metric_continuous_aggregate_backfills (
       aggregate_name TEXT NOT NULL,
       window_start TIMESTAMPTZ NOT NULL,
       window_end TIMESTAMPTZ NOT NULL,
@@ -54,7 +71,7 @@ exports.up = async function (knex) {
       PRIMARY KEY (aggregate_name, window_start, window_end)
     );
 
-    CREATE PROCEDURE backfill_metric_continuous_aggregate(
+    CREATE OR REPLACE PROCEDURE backfill_metric_continuous_aggregate(
       p_aggregate REGCLASS,
       p_window_start TIMESTAMPTZ,
       p_window_end TIMESTAMPTZ
@@ -105,11 +122,13 @@ exports.up = async function (knex) {
 };
 
 exports.down = async function (knex) {
-  await knex.schema.raw('DROP PROCEDURE backfill_metric_continuous_aggregate(REGCLASS, TIMESTAMPTZ, TIMESTAMPTZ);');
-  await knex.schema.raw('DROP TABLE metric_continuous_aggregate_backfills;');
+  await knex.schema.raw(
+    'DROP PROCEDURE IF EXISTS backfill_metric_continuous_aggregate(REGCLASS, TIMESTAMPTZ, TIMESTAMPTZ);',
+  );
+  await knex.schema.raw('DROP TABLE IF EXISTS metric_continuous_aggregate_backfills;');
 
   for (const aggregate of [...aggregates].reverse()) {
-    await knex.schema.raw(`DROP MATERIALIZED VIEW ${aggregate.name};`);
+    await knex.schema.raw(`DROP MATERIALIZED VIEW IF EXISTS ${aggregate.name};`);
   }
 };
 

--- a/apps/value-service/src/timescale/metric-continuous-aggregates-migration.spec.ts
+++ b/apps/value-service/src/timescale/metric-continuous-aggregates-migration.spec.ts
@@ -33,20 +33,61 @@ describe('metric continuous aggregate migration', () => {
 
     const sql = statements.join('\n');
     aggregateNames.forEach((name) => {
-      expect(sql).toContain(`CREATE MATERIALIZED VIEW ${name}`);
+      expect(sql).toContain(`CREATE MATERIALIZED VIEW IF NOT EXISTS ${name}`);
       expect(sql).toContain(`add_continuous_aggregate_policy('${name}'`);
     });
     expect(sql).toContain('WITH (timescaledb.continuous) AS');
-    expect(sql).not.toContain('timescaledb.materialized_only');
     expect(sql.match(/WITH NO DATA/g)).toHaveLength(aggregateNames.length);
     expect(sql).toContain('SUM(value) AS sum');
     expect(sql).toContain('COUNT(value) AS count');
     expect(sql).not.toContain('AVG(value)');
     expect(sql).toContain("time_bucket(INTERVAL '1 month', timestamp)");
-    expect(sql).toContain('CREATE PROCEDURE backfill_metric_continuous_aggregate');
+    expect(sql).toContain('CREATE OR REPLACE PROCEDURE backfill_metric_continuous_aggregate');
     expect(sql).toContain("p_window_end - p_window_start > INTERVAL '31 days'");
     expect(sql).toContain('FROM metric_continuous_aggregate_backfills backfill');
     expect(sql).toContain('CALL refresh_continuous_aggregate(p_aggregate, p_window_start, p_window_end)');
+  });
+
+  // The migration runs unwrapped, so a failure part way through leaves earlier statements applied and
+  // knex replays the whole thing on the next boot. Every statement has to tolerate that replay.
+  it('only issues statements that are safe to re-run', async () => {
+    const { knex, statements } = createKnex();
+
+    await migration.up(knex);
+
+    statements.forEach((statement) => {
+      expect(statement).not.toMatch(/CREATE MATERIALIZED VIEW(?! IF NOT EXISTS)/);
+      expect(statement).not.toMatch(/CREATE TABLE(?! IF NOT EXISTS)/);
+      expect(statement).not.toMatch(/CREATE PROCEDURE/);
+    });
+
+    const sql = statements.join('\n');
+    expect(sql.match(/if_not_exists => TRUE/g)).toHaveLength(aggregateNames.length);
+  });
+
+  // A month is a variable-width bucket, so Timescale rejects the exactly-two-bucket window the
+  // fixed-width aggregates use: 3 months - 1 month fails with 'policy refresh window too small'.
+  it('gives the monthly aggregate a refresh window wider than two buckets', async () => {
+    const { knex, statements } = createKnex();
+
+    await migration.up(knex);
+
+    const monthly = statements.find((statement) =>
+      statement.includes("add_continuous_aggregate_policy('metrics_monthly_continuous'"),
+    );
+    expect(monthly).toContain("start_offset => INTERVAL '4 months'");
+    expect(monthly).toContain("end_offset => INTERVAL '1 month'");
+  });
+
+  it('sets aggregate options explicitly so a pre-existing view converges', async () => {
+    const { knex, statements } = createKnex();
+
+    await migration.up(knex);
+
+    const sql = statements.join('\n');
+    aggregateNames.forEach((name) => {
+      expect(sql).toContain(`ALTER MATERIALIZED VIEW ${name} SET (timescaledb.materialized_only = false);`);
+    });
   });
 
   it('removes backfill support before dropping aggregates in reverse order', async () => {
@@ -54,9 +95,11 @@ describe('metric continuous aggregate migration', () => {
 
     await migration.down(knex);
 
-    expect(statements[0]).toContain('DROP PROCEDURE backfill_metric_continuous_aggregate');
-    expect(statements[1]).toContain('DROP TABLE metric_continuous_aggregate_backfills');
-    expect(statements.slice(2)).toEqual([...aggregateNames].reverse().map((name) => `DROP MATERIALIZED VIEW ${name};`));
+    expect(statements[0]).toContain('DROP PROCEDURE IF EXISTS backfill_metric_continuous_aggregate');
+    expect(statements[1]).toContain('DROP TABLE IF EXISTS metric_continuous_aggregate_backfills');
+    expect(statements.slice(2)).toEqual(
+      [...aggregateNames].reverse().map((name) => `DROP MATERIALIZED VIEW IF EXISTS ${name};`),
+    );
   });
 
   it('runs outside a transaction', () => {


### PR DESCRIPTION
`add_continuous_aggregate_policy` rejected the monthly aggregate with `policy refresh window too small`: a month is a variable-width bucket, so Timescale needs the window to span more than two of them, and `3 months - 1 month` is exactly two. That left six views and five policies behind with the migration unrecorded, and since Timescale cannot create continuous aggregates in a transaction, every later boot replayed the migration and died on the leftover views — holding value-service readiness down and stalling `deployDev` since #5851.

Widens the monthly window to 4 months and makes each statement re-runnable (`IF NOT EXISTS` / `OR REPLACE`, `if_not_exists => TRUE`) so the half-applied state converges instead of blocking forever.

Verified against TimescaleDB 2.8.0: the original migration reproduces the error and the exact partial state; the fixed one applies cleanly on a fresh database and recovers a database left in that state.