### PR TITLE
fix(notification-service, form-service): CS-5330 let services check who is subscribed

### DIFF
--- a/apps/form-service/src/notification.ts
+++ b/apps/form-service/src/notification.ts
@@ -177,7 +177,9 @@ class NotificationServiceImpl implements NotificationService {
       return data?.results?.length > 0;
     } catch (err) {
       // Treated as nobody being subscribed, so the question still reaches the configured address.
-      this.logger.warn(`Error encountered checking subscribers of ${typeId} for ${correlationId}. ${err}`, {
+      // Logged as an error because that fallback silently misroutes every message to the configured
+      // address, which looks like working software until someone compares inboxes.
+      this.logger.error(`Error encountered checking subscribers of ${typeId} for ${correlationId}. ${err}`, {
         ...LOG_CONTEXT,
         tenant: tenantId?.toString(),
       });

--- a/apps/notification-service/src/notification/router/subscription.spec.ts
+++ b/apps/notification-service/src/notification/router/subscription.spec.ts
@@ -319,6 +319,50 @@ describe('subscription router', () => {
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ page: result.page }));
     });
 
+    // Services check whether anyone is subscribed before sending an event, and they hold
+    // subscription-app rather than the admin role.
+    it('can get subscriptions for service account with subscription app role', async () => {
+      const req = {
+        user: {
+          id: 'form-service',
+          tenantId,
+          name: 'Form service',
+          roles: [ServiceUserRoles.SubscriptionApp],
+        },
+        tenant: {
+          id: tenantId,
+        },
+        query: {},
+        notificationType: new NotificationTypeEntity(
+          loggerMock,
+          templateServiceMock,
+          attachmentServiceMock,
+          notificationType,
+          tenantId
+        ),
+        getConfiguration: jest.fn(),
+      };
+      const res = { send: jest.fn() };
+      const next = jest.fn();
+
+      req.getConfiguration.mockResolvedValueOnce(
+        new NotificationConfiguration(
+          loggerMock,
+          templateServiceMock,
+          attachmentServiceMock,
+          { test: notificationType },
+          {},
+          tenantId
+        )
+      );
+      repositoryMock.getSubscriptions.mockResolvedValueOnce({ results: [], page: {} });
+
+      const handler = getTypeSubscriptions(apiId, repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.send).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
     it('can call next for unauthorized user', async () => {
       const req = {
         user: {

--- a/apps/notification-service/src/notification/router/subscription.ts
+++ b/apps/notification-service/src/notification/router/subscription.ts
@@ -93,7 +93,12 @@ export function getTypeSubscriptions(apiId: AdspId, repository: SubscriptionRepo
       } = req.query;
       const top = topValue ? parseInt(topValue as string, 10) : 10;
 
-      if (!isAllowedUser(user, tenantId, ServiceUserRoles.SubscriptionAdmin, true)) {
+      // Service accounts hold subscription-app, which already permits creating and updating
+      // subscriptions. Reading back which of them exist for a type is less than that, and services
+      // like form service need it to know whether anyone is subscribed before sending an event.
+      if (
+        !isAllowedUser(user, tenantId, [ServiceUserRoles.SubscriptionAdmin, ServiceUserRoles.SubscriptionApp], true)
+      ) {
         throw new UnauthorizedUserError('get subscribers', user);
       }
 


### PR DESCRIPTION
## Why

Howard's QA on CS-5330: once a reviewer joins a conversation, the applicant's messages still went to the form definition's questions email (`support@…`) instead of the reviewer.

The event log shows the reviewer's `form-message-reviewer-notifications` subscription being created with the right `correlationId` seven seconds before the applicant's message, so the subscription was there — form service just could not see it.

`GET /types/{type}/subscriptions` required `subscription-admin`, while `getSubscriber` (which works, hence applicants get their emails) accepts `subscription-admin` **or** `subscription-app`. Form service's account holds `subscription-app`, so the lookup 403'd, `hasSubscribers` swallowed it and returned `false`, and every applicant message fell through to the questions email.

## What

- `getTypeSubscriptions` now accepts `subscription-app` alongside `subscription-admin`. That role already permits creating, updating and deleting subscriptions and reading any subscriber by id; reading back which subscriptions exist for a type is less than that. The admin-only checks on `getTypeSubscription` and `getSubscribers` are unchanged.
- Form service logs the failed subscribers check as an error rather than a warning. The `catch → return false` fallback is deliberate and stays, but it is why this looked like working software for two QA rounds.

## Testing

`subscription.spec.ts` (69 tests, including a new one covering a service account with `subscription-app`) and the form service notification suites (34 tests) pass.

Note for re-testing: existing conversations do not heal retroactively — a reviewer has to send a message after this deploys before the applicant's reply routes to them.
