### PR TITLE
fix(jsonforms-components): reject extra characters on in-place masks

### DIFF
--- a/docs/tutorials/form-service/building-forms.md
+++ b/docs/tutorials/form-service/building-forms.md
@@ -32,6 +32,12 @@ Sometimes a specific answer to a question will influence the flow of the form. A
 
 Jsonforms automatically handles basic input validation, such as ensuring required fields are filled in, dates are formatted correctly, or that numbers are, indeed, numbers. More sophisticated validation is also possible; you can add [custom error messages](https://jsonforms.io/docs/validation/) or even [integrate a custom AJV validator](https://jsonforms.io/docs/validation/) to [harness the full power of AJV](https://ajv.js.org/), which gives you complete control over validation.
 
+### Text input format patterns
+
+Text fields can format values with a mask while the user types, or only on blur. Built-in named formats (`phone`, `sin`, `postalCode`, `driverId`, `mvid`) are selected with JSON schema `format`. For any other layout, add a custom `mask` on the UI schema control (and keep a JSON schema `pattern` for validation). Set `inPlace: true` to show the fill-in template in the field.
+
+See [Text Input Control Options](/adsp-monorepo/tutorials/form-service/cheat-sheet.html#text-input-control-options) for named formats, custom mask examples, in-place behaviour, and how to register a new named format in code.
+
 #### Required Fields
 
 There is a known issue in jsonforms that allows an empty string to satisfy the required validation rule. To work around this, you should also add a minimum length of 1 to required string fields, e.g.

--- a/docs/tutorials/form-service/cheat-sheet.md
+++ b/docs/tutorials/form-service/cheat-sheet.md
@@ -413,22 +413,109 @@ The date control supports these options to restrict date selection:
 
 #### Text Input Control Options
 
-The text input control supports a <code>formatPattern</code> option that auto-formats the entered value when the field loses focus (on blur). The <code>formatPattern</code> is a mask template: a <code>#</code> character consumes one character from the input, and every other character is inserted as a literal. Formatting is applied only; validation continues to be driven by the JSON schema <code>pattern</code>.
+Text inputs can format values with a mask. A mask is a template: placeholder characters (`#`, `*`, or `_`) each consume one letter or digit from the input, and every other character is inserted as a literal (spaces, dashes, parentheses).
+
+There are three ways to apply a mask. Use a built-in named format when one already matches the field. Use a custom `mask` when you need a different layout. Use `formatPattern` only when you want formatting on blur and not while the user is typing.
 
 <table>
   <tr>
     <th>Option</th>
+    <th>Location</th>
     <th>Behavior</th>
     <th>Default</th>
   </tr>
   <tr>
+    <td><code>format</code></td>
+    <td>JSON schema</td>
+    <td>Selects a built-in named format (<code>phone</code>, <code>sin</code>, <code>postalCode</code>, <code>driverId</code>, <code>mvid</code>). The control formats as the user types, restricts allowed keys, and validates against the named pattern.</td>
+    <td>Not set</td>
+  </tr>
+  <tr>
+    <td><code>mask</code></td>
+    <td>UI schema <code>options</code></td>
+    <td>A custom mask template applied while typing, e.g. <code>####-##</code>. Use this when the field is not one of the built-in formats. A named <code>schema.format</code> takes precedence over this option.</td>
+    <td>Not set</td>
+  </tr>
+  <tr>
+    <td><code>inPlace</code></td>
+    <td>UI schema <code>options</code></td>
+    <td>When <code>true</code> and a mask is present, the field shows the fill-in template (for example <code>(###) ###-####</code>) and keeps the caret in place. Extra characters are rejected once every placeholder is filled. In-place fields do not use <code>maxLength</code> because the template is already full length.</td>
+    <td><code>false</code></td>
+  </tr>
+  <tr>
     <td><code>formatPattern</code></td>
-    <td>A mask template applied to the value on blur, e.g. <code>(###) ###-####</code>. When set, the entered value is reformatted to match the mask. When empty or not set, no formatting is applied.</td>
+    <td>UI schema <code>options</code></td>
+    <td>A mask template applied only when the field loses focus (on blur), e.g. <code>(###) ###-####</code>. Formatting only; validation is still driven by the JSON schema <code>pattern</code>.</td>
     <td>Not set</td>
   </tr>
 </table>
 
-##### Text Input Format Examples
+##### Built-in named formats
+
+Set <code>format</code> on the JSON schema property. The control then uses the matching mask, allowed keys, and validation pattern.
+
+| `schema.format` | Mask             | Allowed input      | Example value    |
+| --------------- | ---------------- | ------------------ | ---------------- |
+| `phone`         | `(###) ###-####` | Digits             | `(403) 555-1212` |
+| `sin`           | `### ### ###`    | Digits             | `123 456 789`    |
+| `postalCode`    | `### ###`        | Letters and digits | `T2P 1A1`        |
+| `driverId`      | `######-###`     | Digits             | `123456-789`     |
+| `mvid`          | `####-#####`     | Digits             | `1234-56789`     |
+
+```json
+{
+  "driverLicence": {
+    "type": "string",
+    "format": "driverId"
+  }
+}
+```
+
+```json
+{
+  "type": "Control",
+  "scope": "#/properties/driverLicence",
+  "options": {
+    "inPlace": true
+  }
+}
+```
+
+##### Custom mask (not a built-in format)
+
+Add a <code>mask</code> on the UI schema control when the value should be formatted while typing but is not one of the named formats. Keep a JSON schema <code>pattern</code> (and optional <code>errorMessage</code>) so the formatted value is still validated.
+
+```json
+{
+  "accountNumber": {
+    "type": "string",
+    "pattern": "^[0-9]{4}-[0-9]{2}$",
+    "errorMessage": "Must be in format 0000-00"
+  }
+}
+```
+
+```json
+{
+  "type": "Control",
+  "scope": "#/properties/accountNumber",
+  "options": {
+    "mask": "####-##",
+    "inPlace": true
+  }
+}
+```
+
+Mask rules:
+
+- Placeholders `#`, `*`, and `_` each take one letter or digit.
+- Any other character in the mask is a literal separator.
+- Extra content beyond the number of placeholders is discarded (in-place fields restore the previous value instead of keeping the extra character).
+- Named formats also restrict keystrokes (digits only, or letters and digits for postal code). A custom `mask` without a named format does not restrict which characters can be typed; use `schema.pattern` for validation.
+
+##### Format on blur only
+
+Use <code>formatPattern</code> when the field should stay unformatted while typing and only apply the mask when it loses focus. Validation still comes from the JSON schema <code>pattern</code>.
 
 | Mask (`formatPattern`) | User enters  | Formatted on blur |
 | ---------------------- | ------------ | ----------------- |
@@ -436,8 +523,6 @@ The text input control supports a <code>formatPattern</code> option that auto-fo
 | `######-###`           | `123456789`  | `123456-789`      |
 | `### ###`              | `A1A1A1`     | `A1A 1A1`         |
 | `### ### ###`          | `123456789`  | `123 456 789`     |
-
-The user only needs to enter the raw characters; the field applies the mask automatically. The JSON schema <code>pattern</code> is used solely to validate the value for errors.
 
 ```json
 {
@@ -448,6 +533,24 @@ The user only needs to enter the raw characters; the field applies the mask auto
   }
 }
 ```
+
+##### Adding a new named format in code
+
+Form definitions can only use the built-in names above or a per-field <code>mask</code>. To register a new reusable named format for all forms, add it to <code>DEFAULT_PATTERNS</code> in <code>libs/jsonforms-components/src/lib/util/patternForm.ts</code>:
+
+```ts
+export const DEFAULT_PATTERNS: Record<string, MaskPattern> = {
+  // ...
+  accountNumber: {
+    mask: '####-##',
+    pattern: /^\d{4}-\d{2}$/,
+    error: 'Must be in format 0000-00',
+    allowedKeys: /[0-9]/,
+  },
+};
+```
+
+`createDefaultAjv` registers every `DEFAULT_PATTERNS` key as a JSON schema format automatically. After that, form definitions can set `"format": "accountNumber"` the same way as `phone` or `driverId`.
 
 #### Calculation Control
 

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
@@ -18,6 +18,7 @@ import {
   getMaskInputTarget,
   applyInPlaceEdit,
   isMaskFilled,
+  overflowMaskEdit,
   maskPlaceholder,
   shouldBlockKey,
 } from '../../util/patternForm';
@@ -230,6 +231,11 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
             if (inPlace && mask) {
               const target = getMaskInputTarget(detail as GoabInputOnChangeDetail & { event?: Event });
               const caretIndex = target?.selectionStart ?? cleaned.length;
+              const overflow = overflowMaskEdit(localValue, cleaned, caretIndex, mask);
+              if (overflow) {
+                applyInPlaceEdit(target, overflow);
+                return;
+              }
               const edit = computeMaskEdit(cleaned, caretIndex, mask);
               applyInPlaceEdit(target, edit);
               setLocalValue(edit.display);
@@ -268,12 +274,26 @@ export const InnerGoAInputText = (props: GoAInputTextProps): JSX.Element => {
             });
           }}
           onKeyPress={(detail: GoabInputOnKeyPressDetail) => {
+            const keyPressDetail = detail as GoabInputOnKeyPressDetail & { event?: Event };
             const blockDisallowed = shouldBlockKey(detail.key, allowedKeys);
-            // In-place has no length cap, so also block content keys once the template is full.
+            // In-place has no maxLength, and GoA keyPress fires on keyup after the character is inserted.
             const blockOverflow =
               inPlace && !!mask && /^[A-Za-z0-9]$/.test(detail.key) && isMaskFilled(localValue, mask);
             if (blockDisallowed || blockOverflow) {
-              (detail as GoabInputOnKeyPressDetail & { event?: Event }).event?.preventDefault();
+              keyPressDetail.event?.preventDefault();
+            }
+            if (blockOverflow && mask) {
+              const target = getMaskInputTarget(keyPressDetail);
+              const rawValue = target?.value ?? detail.value ?? localValue;
+              const overflow = overflowMaskEdit(
+                localValue,
+                rawValue,
+                target?.selectionStart ?? localValue.length,
+                mask,
+              );
+              if (overflow) {
+                applyInPlaceEdit(target, overflow);
+              }
             }
           }}
           {...uischema?.options?.componentProps}

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
@@ -1049,6 +1049,35 @@ describe('Input Text Control tests', () => {
       expect(input).toHaveAttribute('value', 'plain text');
     });
 
+    it('does not keep extra characters when an in-place mask is full', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '123456-789',
+        path: 'driverId',
+        id: 'driverId',
+        handleChange,
+        schema: { type: 'string', format: 'driverId' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/driverId',
+          options: { inPlace: true },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='driverId-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456-7890' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(input).toHaveAttribute('value', '123456-789');
+      expect(handleChange).not.toHaveBeenCalledWith('driverId', '123456-7890');
+    });
+
     it('blocks extra content keys when an in-place mask is full', () => {
       const props = {
         ...staticProps,

--- a/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
@@ -12,6 +12,7 @@ import {
   isMaskFilled,
   maskDigitCount,
   maskPlaceholder,
+  overflowMaskEdit,
   shouldBlockKey,
   toMaskTemplate,
 } from './patternForm';
@@ -188,6 +189,24 @@ describe('getMaskInputTarget', () => {
 
   it('returns undefined when the event has no target', () => {
     expect(getMaskInputTarget({})).toBeUndefined();
+  });
+});
+
+describe('overflowMaskEdit', () => {
+  it('rejects extra content once the in-place mask is full', () => {
+    expect(overflowMaskEdit('123456-789', '123456-7890', 11, DEFAULT_PATTERNS.driverId.mask)).toEqual({
+      display: '123456-789',
+      stored: '123456-789',
+      caret: 10,
+    });
+  });
+
+  it('allows edits while the in-place mask is not full', () => {
+    expect(overflowMaskEdit('123456-##', '1234567', 7, DEFAULT_PATTERNS.driverId.mask)).toBeUndefined();
+  });
+
+  it('allows replacement that does not add extra content', () => {
+    expect(overflowMaskEdit('123456-789', '123456-789', 10, DEFAULT_PATTERNS.driverId.mask)).toBeUndefined();
   });
 });
 

--- a/libs/jsonforms-components/src/lib/util/patternForm.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.ts
@@ -149,19 +149,59 @@ export const maskPlaceholder = (mask: string): string =>
 
 type MaskInputTarget = (HTMLInputElement & { setSelectionRange?: (start: number, end: number) => void }) | undefined;
 
-// Extracts the underlying input element from a GoA change/keypress detail, if available.
-export const getMaskInputTarget = (detail: { event?: Event }): MaskInputTarget =>
-  (detail.event?.target as MaskInputTarget) ?? undefined;
+// GoA retargets composed events to the host, so prefer the inner native input from the composed path.
+export const getMaskInputTarget = (detail: { event?: Event }): MaskInputTarget => {
+  const event = detail.event;
+  if (!event) {
+    return undefined;
+  }
 
-// Applies an in-place edit to the DOM: forces the (fixed-length) value and restores the caret after React commits.
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
+  const fromPath = path.find((node): node is HTMLInputElement => node instanceof HTMLInputElement);
+  if (fromPath) {
+    return fromPath;
+  }
+
+  const target = event.target as HTMLElement | undefined;
+  if (target instanceof HTMLInputElement) {
+    return target;
+  }
+
+  return (target?.shadowRoot?.querySelector('input') as MaskInputTarget) ?? undefined;
+};
+
+const applyMaskValue = (target: NonNullable<MaskInputTarget>, edit: MaskEdit): void => {
+  target.value = edit.display;
+  target.setSelectionRange?.(edit.caret, edit.caret);
+};
+
+// Applies an in-place edit to the inner input and re-applies after the web component paints.
 export const applyInPlaceEdit = (target: MaskInputTarget, edit: MaskEdit): void => {
   if (!target) {
     return;
   }
-  target.value = edit.display;
-  if (target.setSelectionRange) {
-    requestAnimationFrame(() => target.setSelectionRange?.(edit.caret, edit.caret));
+  applyMaskValue(target, edit);
+  requestAnimationFrame(() => applyMaskValue(target, edit));
+};
+
+// When the template is already filled, extra content characters must be rejected rather than shifting the value.
+export const overflowMaskEdit = (
+  previousDisplay: string,
+  rawValue: string,
+  caretIndex: number,
+  mask: string,
+): MaskEdit | undefined => {
+  if (!isMaskFilled(previousDisplay, mask)) {
+    return undefined;
   }
+  if ((rawValue ?? '').replace(NON_CONTENT, '').length <= maskDigitCount(mask)) {
+    return undefined;
+  }
+  return {
+    display: previousDisplay,
+    stored: formatWithPattern(previousDisplay, mask),
+    caret: Math.min(Math.max(caretIndex, 0), previousDisplay.length),
+  };
 };
 
 /**

--- a/libs/jsonforms-components/src/lib/util/useMaskedInput.spec.tsx
+++ b/libs/jsonforms-components/src/lib/util/useMaskedInput.spec.tsx
@@ -96,6 +96,23 @@ describe('useMaskedInput', () => {
     expect(preventDefault).toHaveBeenCalled();
   });
 
+  it('does not keep extra characters when an in-place mask is already full', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: true,
+        data: '(403) 555-1212',
+        onCommit,
+      }),
+    );
+
+    act(() => result.current.handleChange({ value: '(403) 555-12129' }));
+
+    expect(result.current.value).toBe('(403) 555-1212');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
   it('does not block content keys when the in-place mask is not full', () => {
     const preventDefault = jest.fn();
     const { result } = renderHook(() =>

--- a/libs/jsonforms-components/src/lib/util/useMaskedInput.ts
+++ b/libs/jsonforms-components/src/lib/util/useMaskedInput.ts
@@ -5,6 +5,7 @@ import {
   formatWithPattern,
   getMaskInputTarget,
   isMaskFilled,
+  overflowMaskEdit,
   toMaskTemplate,
 } from './patternForm';
 
@@ -60,6 +61,12 @@ export const useMaskedInput = ({ mask, inPlace, data, onCommit }: UseMaskedInput
 
     const target = getMaskInputTarget(detail);
     const caretIndex = target?.selectionStart ?? rawValue.length;
+    const overflow = overflowMaskEdit(value, rawValue, caretIndex, mask);
+    if (overflow) {
+      applyInPlaceEdit(target, overflow);
+      return;
+    }
+
     const edit = computeMaskEdit(rawValue, caretIndex, mask);
 
     applyInPlaceEdit(target, edit);
@@ -67,10 +74,18 @@ export const useMaskedInput = ({ mask, inPlace, data, onCommit }: UseMaskedInput
     onCommit(edit.stored);
   };
 
-  // In-place mode has no native length cap, so block extra content characters at the source.
+  // In-place has no maxLength (the template is already full length) and GoA keyPress is keyup, so restore on overflow.
   const handleKeyPress = (detail: MaskKeyPressDetail) => {
-    if (inPlace && /^[A-Za-z0-9]$/.test(detail.key) && isMaskFilled(value, mask)) {
-      detail.event?.preventDefault();
+    if (!inPlace || !/^[A-Za-z0-9]$/.test(detail.key) || !isMaskFilled(value, mask)) {
+      return;
+    }
+
+    detail.event?.preventDefault();
+    const target = getMaskInputTarget(detail);
+    const rawValue = target?.value ?? value;
+    const overflow = overflowMaskEdit(value, rawValue, target?.selectionStart ?? value.length, mask);
+    if (overflow) {
+      applyInPlaceEdit(target, overflow);
     }
   };
 


### PR DESCRIPTION
## Summary

- Stop in-place masked form fields from accepting extra characters once the template is full.
- Document named formats, custom `mask`, `inPlace`, and blur-only `formatPattern`.

## Why

In-place masks cannot use `maxLength` because the fill-in template is already full length. GoA `_keyPress` fires on `keyup`, so `preventDefault` is too late and extra characters stay in the inner input.

## Changes

### Masked input

- Restore the previous masked value when extra content is entered after the mask is full (`overflowMaskEdit`).
- Force the inner native input back to the previous display (GoA retargets composed events to the host).
- Apply this on change and keypress in `InputTextControl` and `useMaskedInput`.

### Docs

- Cheat sheet: named formats (`phone`, `sin`, `postalCode`, `driverId`, `mvid`), custom `mask`, `inPlace`, blur-only `formatPattern`, and how to register a new named format in `DEFAULT_PATTERNS`.
- Building forms: short pointer to those options.