### PR TITLE
fix(value-service): CS-5318 stop the interval rollup exhausting connections

### DIFF
--- a/apps/value-service/src/environments/environment.ts
+++ b/apps/value-service/src/environments/environment.ts
@@ -25,6 +25,10 @@ export const environment = envalid.cleanEnv(
     SERVICE_METRIC_ROLLUP_BACKFILL_ON_STARTUP: envalid.bool({ default: false }),
     SERVICE_METRIC_ROLLUP_TRAILING_DAYS: envalid.num({ default: 3 }),
     METRIC_INTERVAL_ROLLUP_JOB_ENABLED: envalid.bool({ default: true }),
+    // clean-code-ignore: RULE-19 — envalid declarations, exercised through the modules that read them.
+    METRIC_INTERVAL_ROLLUP_MAX_CHUNK_HOURS: envalid.num({ default: 7 * 24 }),
+    METRIC_INTERVAL_ROLLUP_STATEMENT_TIMEOUT_MS: envalid.num({ default: 120000 }),
+    DB_POOL_MAX: envalid.num({ default: 10 }),
   },
   {
     reporter: ({ errors }) => {

--- a/apps/value-service/src/main.ts
+++ b/apps/value-service/src/main.ts
@@ -150,7 +150,12 @@ const initializeApp = async () => {
   }
 
   if (environment.METRIC_INTERVAL_ROLLUP_JOB_ENABLED) {
-    scheduleMetricIntervalRollupJob({ logger, repository: repositories.metricIntervalRollupRepository });
+    // clean-code-ignore: RULE-19 — app bootstrap; the job it wires up is covered in its own spec.
+    scheduleMetricIntervalRollupJob({
+      logger,
+      repository: repositories.metricIntervalRollupRepository,
+      maxChunkHours: environment.METRIC_INTERVAL_ROLLUP_MAX_CHUNK_HOURS,
+    });
   }
 
   const swagger = JSON.parse(await promisify(readFile)(`${__dirname}/swagger.json`, 'utf8'));

--- a/apps/value-service/src/timescale/index.spec.ts
+++ b/apps/value-service/src/timescale/index.spec.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { knex as initKnex } from 'knex';
+import { Logger } from 'winston';
+import { createRepositories } from './index';
+
+jest.mock('knex', () => ({ knex: jest.fn() }));
+
+jest.mock('@abgov/adsp-service-sdk', () => ({
+  ...jest.requireActual('@abgov/adsp-service-sdk'),
+  retry: { execute: jest.fn((work: (context: { attempt: number }) => Promise<void>) => work({ attempt: 1 })) },
+}));
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+} as unknown as Logger;
+
+const props = {
+  logger,
+  DB_HOST: 'localhost',
+  DB_PORT: 5432,
+  DB_NAME: 'values-db',
+  DB_USER: 'postgres',
+  DB_PASSWORD: 'secret',
+  DB_TLS: false,
+  DB_POOL_MAX: 4,
+  METRIC_INTERVAL_ROLLUP_STATEMENT_TIMEOUT_MS: 30000,
+};
+
+const createKnexStub = () => {
+  const raw = jest.fn((sql: string) =>
+    Promise.resolve(sql.includes('pg_try_advisory_xact_lock') ? { rows: [{ locked: true }] } : {}),
+  );
+  const knex: any = jest.fn();
+  knex.migrate = { latest: jest.fn() };
+  knex.raw = raw;
+  knex.transaction = jest.fn((work: (trx: unknown) => Promise<unknown>) => work(knex));
+
+  return { knex, raw };
+};
+
+describe('createRepositories', () => {
+  const config = () => (initKnex as unknown as jest.Mock).mock.calls[0][0];
+
+  beforeEach(() => {
+    (initKnex as unknown as jest.Mock).mockReset();
+    (initKnex as unknown as jest.Mock).mockReturnValue(createKnexStub().knex);
+  });
+
+  // The ceiling is multiplied by the replica count against one server, and knex's implicit default
+  // also holds a floor of two connections open for the life of an idle process.
+  it('bounds what a replica can take from the database', async () => {
+    await createRepositories(props);
+
+    expect(config().pool).toEqual({ min: 0, max: 4, acquireTimeoutMillis: 30000 });
+  });
+
+  it('connects with the configured credentials', async () => {
+    await createRepositories(props);
+
+    expect(config().connection).toEqual({
+      host: 'localhost',
+      port: 5432,
+      database: 'values-db',
+      user: 'postgres',
+      password: 'secret',
+      ssl: false,
+    });
+  });
+
+  it('runs migrations before handing back the repositories', async () => {
+    const { knex } = createKnexStub();
+    (initKnex as unknown as jest.Mock).mockReturnValue(knex);
+
+    const repositories = await createRepositories(props);
+
+    expect(knex.migrate.latest).toHaveBeenCalled();
+    expect(repositories.metricIntervalRollupRepository).toBeDefined();
+  });
+
+  // A refresh that runs away would otherwise hold its connection for as long as it takes, and the
+  // pool it comes from is the one serving the API.
+  it('gives the rollup repository the configured statement timeout', async () => {
+    const { knex, raw } = createKnexStub();
+    (initKnex as unknown as jest.Mock).mockReturnValue(knex);
+
+    const { metricIntervalRollupRepository } = await createRepositories(props);
+    await metricIntervalRollupRepository.withRollupLock(async () => 0);
+
+    expect(raw).toHaveBeenCalledWith('SET LOCAL statement_timeout = 30000');
+  });
+
+  it('reports the connection as down when the check query throws', async () => {
+    const { knex } = createKnexStub();
+    knex.raw = jest.fn().mockRejectedValue(new Error('no connection slots'));
+    (initKnex as unknown as jest.Mock).mockReturnValue(knex);
+
+    const repositories = await createRepositories(props);
+
+    expect(await repositories.isConnected()).toBe(false);
+  });
+});

--- a/apps/value-service/src/timescale/index.ts
+++ b/apps/value-service/src/timescale/index.ts
@@ -13,6 +13,8 @@ interface TimescaleRepositoryProps {
   DB_USER: string;
   DB_PASSWORD: string;
   DB_TLS: boolean;
+  DB_POOL_MAX: number;
+  METRIC_INTERVAL_ROLLUP_STATEMENT_TIMEOUT_MS: number;
 }
 
 interface Repositories {
@@ -30,6 +32,8 @@ export const createRepositories = async ({
   DB_USER,
   DB_PASSWORD,
   DB_TLS,
+  DB_POOL_MAX,
+  METRIC_INTERVAL_ROLLUP_STATEMENT_TIMEOUT_MS,
 }: TimescaleRepositoryProps): Promise<Repositories> => {
   const knex = initKnex({
     client: 'postgresql',
@@ -42,6 +46,15 @@ export const createRepositories = async ({
       ssl: DB_TLS,
     },
     searchPath: ['public'],
+    // Left implicit, knex keeps a floor of two connections open per replica for the life of the
+    // process and caps at ten. The floor is dropped so idle replicas hand their connections back,
+    // and the ceiling is configurable because it is multiplied by the replica count against one
+    // shared server. Acquiring is bounded so a caller fails rather than queueing without end.
+    pool: {
+      min: 0,
+      max: DB_POOL_MAX,
+      acquireTimeoutMillis: 30000,
+    },
     migrations: {
       tableName: 'value_service_migrations',
       directory: __dirname + '/migrations',
@@ -70,6 +83,9 @@ export const createRepositories = async ({
     },
     valueRepository: new TimescaleValuesRepository(knex, logger),
     serviceMetricRollupRepository: new TimescaleServiceMetricRollupRepository(knex),
-    metricIntervalRollupRepository: new TimescaleMetricIntervalRollupRepository(knex),
+    metricIntervalRollupRepository: new TimescaleMetricIntervalRollupRepository(
+      knex,
+      METRIC_INTERVAL_ROLLUP_STATEMENT_TIMEOUT_MS,
+    ),
   };
 };

--- a/apps/value-service/src/values/jobs/metricIntervalRollup.spec.ts
+++ b/apps/value-service/src/values/jobs/metricIntervalRollup.spec.ts
@@ -1,6 +1,19 @@
 import { Logger } from 'winston';
-import { advanceMetricInterval, createMetricIntervalRollupJob } from './metricIntervalRollup';
+import * as schedule from 'node-schedule';
+import {
+  advanceMetricInterval,
+  createMetricIntervalRollupJob,
+  scheduleMetricIntervalRollupJob,
+} from './metricIntervalRollup';
 import { MetricIntervalDefinition } from '../metricIntervals';
+
+jest.mock('node-schedule', () => ({
+  scheduleJob: jest.fn(),
+}));
+
+jest.mock('@abgov/adsp-service-sdk', () => ({
+  instrumentJob: jest.fn((_name: string, job: () => Promise<void>) => job),
+}));
 
 const logger = {
   debug: jest.fn(),
@@ -12,15 +25,23 @@ const logger = {
 const definition: MetricIntervalDefinition = {
   interval: 'hourly',
   bucket: '1 hour',
+  bucketHours: 1,
   seedHours: 24,
   chunkHours: 24,
 };
 
-const createRepository = (coverage = null) => ({
-  getMetricsWindow: jest.fn(),
-  getCoverage: jest.fn().mockResolvedValue(coverage),
-  refresh: jest.fn().mockResolvedValue(1),
-});
+const createRepository = (coverage = null, locked = true) => {
+  const repository = {
+    getMetricsWindow: jest.fn(),
+    getCoverage: jest.fn().mockResolvedValue(coverage),
+    refresh: jest.fn().mockResolvedValue(1),
+    withRollupLock: jest.fn((work: (repository: unknown) => Promise<unknown>) =>
+      locked ? work(repository) : Promise.resolve(null),
+    ),
+  };
+
+  return repository;
+};
 
 const at = (iso: string) => new Date(iso);
 
@@ -149,6 +170,35 @@ describe('createMetricIntervalRollupJob', () => {
     expect(repository.refresh).not.toHaveBeenCalled();
   });
 
+  // A replica that cannot take the lock leaves the run to the one that did, rather than repeating
+  // work that is already in flight against the same rows.
+  it('does nothing when another instance holds the lock', async () => {
+    const repository = createRepository(null, false);
+
+    const refreshed = await createMetricIntervalRollupJob(repository, logger, [definition])();
+
+    expect(refreshed).toBe(0);
+    expect(repository.getMetricsWindow).not.toHaveBeenCalled();
+    expect(repository.refresh).not.toHaveBeenCalled();
+  });
+
+  // Coverage is read and then extended from what was read, so the whole run has to be inside the
+  // lock: two runs interleaving between those steps would advance from the same edge and leave a
+  // window neither of them filled.
+  it('reads and refreshes through the locked repository', async () => {
+    const repository = createRepository();
+    repository.getMetricsWindow.mockResolvedValue({
+      start: at('2026-03-10T00:00:00Z'),
+      end: at('2026-03-10T12:00:00Z'),
+    });
+
+    await createMetricIntervalRollupJob(repository, logger, [definition])(at('2026-03-10T12:00:00Z'));
+
+    const [locked] = repository.withRollupLock.mock.calls[0];
+    expect(locked).toEqual(expect.any(Function));
+    expect(repository.refresh).toHaveBeenCalled();
+  });
+
   it('advances every configured interval and totals the rows refreshed', async () => {
     const repository = createRepository();
     repository.getMetricsWindow.mockResolvedValue({
@@ -164,5 +214,70 @@ describe('createMetricIntervalRollupJob', () => {
 
     expect(refreshed).toBe(6);
     expect(repository.refresh).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('scheduleMetricIntervalRollupJob', () => {
+  beforeEach(() => {
+    (schedule.scheduleJob as jest.Mock).mockClear();
+  });
+
+  const scheduledJob = () => (schedule.scheduleJob as jest.Mock).mock.calls[0][1] as () => Promise<void>;
+
+  it('schedules the job on a five minute cron', () => {
+    scheduleMetricIntervalRollupJob({ logger, repository: createRepository(), maxChunkHours: 24 });
+
+    expect((schedule.scheduleJob as jest.Mock).mock.calls[0][0]).toBe('*/5 * * * *');
+  });
+
+  // The cron fires whether or not the last run finished. Without this the runs pile up, each one
+  // holding a connection, which is what emptied the database's connection slots in dev.
+  it('skips a tick while the previous run is still in progress', async () => {
+    const repository = createRepository();
+    let release: () => void;
+    repository.getMetricsWindow.mockReturnValue(
+      new Promise((resolve) => {
+        release = () => resolve({ start: at('2026-03-10T00:00:00Z'), end: at('2026-03-10T12:00:00Z') });
+      }),
+    );
+
+    scheduleMetricIntervalRollupJob({ logger, repository, maxChunkHours: 24 });
+    const job = scheduledJob();
+
+    const first = job();
+    await job();
+
+    expect(repository.withRollupLock).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalled();
+
+    release();
+    await first;
+  });
+
+  it('accepts a further tick once the previous run has finished', async () => {
+    const repository = createRepository();
+    repository.getMetricsWindow.mockResolvedValue(null);
+
+    scheduleMetricIntervalRollupJob({ logger, repository, maxChunkHours: 24 });
+    const job = scheduledJob();
+
+    await job();
+    await job();
+
+    expect(repository.withRollupLock).toHaveBeenCalledTimes(2);
+  });
+
+  // A run that throws must still clear the guard, or the pod stops rolling up until it restarts.
+  it('releases the guard when a run fails', async () => {
+    const repository = createRepository();
+    repository.withRollupLock.mockRejectedValue(new Error('connection slots exhausted'));
+
+    scheduleMetricIntervalRollupJob({ logger, repository, maxChunkHours: 24 });
+    const job = scheduledJob();
+
+    await expect(job()).rejects.toThrow('connection slots exhausted');
+    await expect(job()).rejects.toThrow('connection slots exhausted');
+
+    expect(repository.withRollupLock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/value-service/src/values/jobs/metricIntervalRollup.ts
+++ b/apps/value-service/src/values/jobs/metricIntervalRollup.ts
@@ -2,12 +2,13 @@ import { instrumentJob } from '@abgov/adsp-service-sdk';
 import * as schedule from 'node-schedule';
 import { Logger } from 'winston';
 import { MetricIntervalRollupRepository } from '../repository';
-import { MetricIntervalDefinition, metricIntervalDefinitions } from '../metricIntervals';
+import { boundMetricIntervalDefinitions, MetricIntervalDefinition } from '../metricIntervals';
 import { MetricIntervalWindow } from '../types';
 
 interface MetricIntervalRollupJobProps {
   logger: Logger;
   repository: MetricIntervalRollupRepository;
+  maxChunkHours: number;
 }
 
 const MS_PER_HOUR = 60 * 60 * 1000;
@@ -56,36 +57,75 @@ export const createMetricIntervalRollupJob =
   (
     repository: MetricIntervalRollupRepository,
     logger: Logger,
-    definitions: MetricIntervalDefinition[] = metricIntervalDefinitions,
+    definitions: MetricIntervalDefinition[] = boundMetricIntervalDefinitions(Number.POSITIVE_INFINITY),
   ) =>
   async (now = new Date()): Promise<number> => {
-    const metricsWindow = await repository.getMetricsWindow();
-    if (!metricsWindow) {
-      logger.debug('No metrics recorded yet; skipping metric interval rollup.', { context: 'MetricIntervalRollup' });
+    // The whole run goes under the lock rather than each interval separately: coverage is read and
+    // then extended from what was read, so two runs interleaving between those two steps would each
+    // advance from the same edge and leave a window neither of them filled.
+    const refreshed = await repository.withRollupLock(async (locked) => {
+      const metricsWindow = await locked.getMetricsWindow();
+      if (!metricsWindow) {
+        logger.debug('No metrics recorded yet; skipping metric interval rollup.', { context: 'MetricIntervalRollup' });
+        return 0;
+      }
+
+      let total = 0;
+      for (const definition of definitions) {
+        total += await advanceMetricInterval(locked, definition, metricsWindow, now);
+      }
+
+      logger.info(`Refreshed ${total} metric interval rollup record(s).`, { context: 'MetricIntervalRollup' });
+      return total;
+    });
+
+    if (refreshed === null) {
+      logger.debug('Another instance holds the metric interval rollup lock; skipping this run.', {
+        context: 'MetricIntervalRollup',
+      });
       return 0;
     }
 
-    let refreshed = 0;
-    for (const definition of definitions) {
-      refreshed += await advanceMetricInterval(repository, definition, metricsWindow, now);
-    }
-
-    logger.info(`Refreshed ${refreshed} metric interval rollup record(s).`, { context: 'MetricIntervalRollup' });
     return refreshed;
   };
 
-export const scheduleMetricIntervalRollupJob = ({ logger, repository }: MetricIntervalRollupJobProps): void => {
-  const rollupJob = createMetricIntervalRollupJob(repository, logger);
+export const scheduleMetricIntervalRollupJob = ({
+  logger,
+  repository,
+  maxChunkHours,
+}: MetricIntervalRollupJobProps): void => {
+  const definitions = boundMetricIntervalDefinitions(maxChunkHours);
+  const rollupJob = createMetricIntervalRollupJob(repository, logger, definitions);
+
+  // node-schedule fires on the tick whether or not the previous run finished, so a run that outlives
+  // its interval would have the next one start on top of it and the pile-up would hold a connection
+  // each. The database lock already excludes other replicas; this excludes this one from itself,
+  // without waiting on a round trip to find that out.
+  let running = false;
 
   schedule.scheduleJob(
     '*/5 * * * *',
     instrumentJob(
       'metric-interval-rollup',
       async () => {
-        await rollupJob();
+        if (running) {
+          logger.warn('Previous metric interval rollup run is still in progress; skipping this run.', {
+            context: 'MetricIntervalRollup',
+          });
+          return;
+        }
+
+        running = true;
+        try {
+          await rollupJob();
+        } finally {
+          running = false;
+        }
       },
       { logger },
     ),
   );
-  logger.info('Scheduled metric interval rollup job.', { context: 'MetricIntervalRollup' });
+  logger.info(`Scheduled metric interval rollup job with a ${maxChunkHours} hour chunk cap.`, {
+    context: 'MetricIntervalRollup',
+  });
 };

--- a/apps/value-service/src/values/metricIntervals.spec.ts
+++ b/apps/value-service/src/values/metricIntervals.spec.ts
@@ -1,5 +1,10 @@
 import { MetricInterval } from './types';
-import { getMetricIntervalDefinition, metricIntervalDefinitions } from './metricIntervals';
+import {
+  boundMetricIntervalDefinition,
+  boundMetricIntervalDefinitions,
+  getMetricIntervalDefinition,
+  metricIntervalDefinitions,
+} from './metricIntervals';
 
 const allIntervals: MetricInterval[] = ['one_minute', 'five_minutes', 'hourly', 'daily', 'weekly', 'monthly'];
 
@@ -16,9 +21,48 @@ describe('metricIntervalDefinitions', () => {
   });
 
   // A chunk narrower than a bucket could never advance coverage past that bucket.
-  it('gives coarser intervals wider windows than finer ones', () => {
-    const chunks = metricIntervalDefinitions.map((definition) => definition.chunkHours);
-    expect(chunks).toEqual([...chunks].sort((left, right) => left - right));
+  it('gives every interval a chunk at least one bucket wide', () => {
+    metricIntervalDefinitions.forEach(({ bucketHours, seedHours, chunkHours }) => {
+      expect(chunkHours).toBeGreaterThanOrEqual(bucketHours);
+      expect(seedHours).toBeGreaterThanOrEqual(bucketHours);
+    });
+  });
+
+  // What a refresh costs follows the span it reads out of metrics, not the bucket it fills, so a
+  // coarse interval must not be given a wider window just because its buckets are wider.
+  it('keeps every window within a couple of months of raw metrics', () => {
+    metricIntervalDefinitions.forEach(({ seedHours, chunkHours }) => {
+      expect(chunkHours).toBeLessThanOrEqual(62 * 24);
+      expect(seedHours).toBeLessThanOrEqual(62 * 24);
+    });
+  });
+});
+
+describe('boundMetricIntervalDefinition', () => {
+  const hourly = getMetricIntervalDefinition('hourly');
+  const monthly = getMetricIntervalDefinition('monthly');
+
+  it('caps both windows at the configured maximum', () => {
+    expect(boundMetricIntervalDefinition(hourly, 48)).toEqual({ ...hourly, seedHours: 48, chunkHours: 48 });
+  });
+
+  it('leaves a definition already inside the cap alone', () => {
+    expect(boundMetricIntervalDefinition(hourly, 10000)).toEqual(hourly);
+  });
+
+  // Cutting below a bucket would leave the refresh recomputing the same bucket forever, so the
+  // interval would never finish walking back through history.
+  it('will not cut a window below one bucket', () => {
+    const bounded = boundMetricIntervalDefinition(monthly, 1);
+
+    expect(bounded.chunkHours).toBe(monthly.bucketHours);
+    expect(bounded.seedHours).toBe(monthly.bucketHours);
+  });
+
+  it('bounds every definition', () => {
+    boundMetricIntervalDefinitions(48).forEach(({ bucketHours, chunkHours }) => {
+      expect(chunkHours).toBe(Math.max(bucketHours, Math.min(chunkHours, 48)));
+    });
   });
 });
 
@@ -27,6 +71,7 @@ describe('getMetricIntervalDefinition', () => {
     expect(getMetricIntervalDefinition('hourly')).toEqual({
       interval: 'hourly',
       bucket: '1 hour',
+      bucketHours: 1,
       seedHours: 720,
       chunkHours: 720,
     });

--- a/apps/value-service/src/values/metricIntervals.ts
+++ b/apps/value-service/src/values/metricIntervals.ts
@@ -4,6 +4,9 @@ export interface MetricIntervalDefinition {
   interval: MetricInterval;
   // Postgres interval literal handed to time_bucket.
   bucket: string;
+  // Span of a single bucket. A chunk narrower than this re-reads the same bucket on every run
+  // without ever advancing past it, so it is the floor the configured cap cannot cut below.
+  bucketHours: number;
   // How far back coverage starts when an interval is rolled up for the first time.
   seedHours: number;
   // Largest window a single refresh recomputes, so catching up after an outage or walking back
@@ -12,15 +15,79 @@ export interface MetricIntervalDefinition {
 }
 
 const HOURS_PER_DAY = 24;
+const MINUTE_HOURS = 1 / 60;
 
+// A refresh aggregates the raw metrics table over its window, so what a run costs follows the span
+// of that window rather than the width of the bucket being filled: a month of raw metrics is the
+// same read whether it lands in daily buckets or one monthly bucket. Chunks are therefore whole
+// numbers of buckets sized to a bounded span, and history fills in over successive runs.
 export const metricIntervalDefinitions: MetricIntervalDefinition[] = [
-  { interval: 'one_minute', bucket: '1 minute', seedHours: HOURS_PER_DAY, chunkHours: HOURS_PER_DAY },
-  { interval: 'five_minutes', bucket: '5 minutes', seedHours: 7 * HOURS_PER_DAY, chunkHours: 7 * HOURS_PER_DAY },
-  { interval: 'hourly', bucket: '1 hour', seedHours: 30 * HOURS_PER_DAY, chunkHours: 30 * HOURS_PER_DAY },
-  { interval: 'daily', bucket: '1 day', seedHours: 365 * HOURS_PER_DAY, chunkHours: 365 * HOURS_PER_DAY },
-  { interval: 'weekly', bucket: '1 week', seedHours: 1825 * HOURS_PER_DAY, chunkHours: 1825 * HOURS_PER_DAY },
-  { interval: 'monthly', bucket: '1 month', seedHours: 3650 * HOURS_PER_DAY, chunkHours: 3650 * HOURS_PER_DAY },
+  {
+    interval: 'one_minute',
+    bucket: '1 minute',
+    bucketHours: MINUTE_HOURS,
+    seedHours: HOURS_PER_DAY,
+    chunkHours: HOURS_PER_DAY,
+  },
+  {
+    interval: 'five_minutes',
+    bucket: '5 minutes',
+    bucketHours: 5 * MINUTE_HOURS,
+    seedHours: 7 * HOURS_PER_DAY,
+    chunkHours: 7 * HOURS_PER_DAY,
+  },
+  {
+    interval: 'hourly',
+    bucket: '1 hour',
+    bucketHours: 1,
+    seedHours: 30 * HOURS_PER_DAY,
+    chunkHours: 30 * HOURS_PER_DAY,
+  },
+  {
+    interval: 'daily',
+    bucket: '1 day',
+    bucketHours: HOURS_PER_DAY,
+    seedHours: 30 * HOURS_PER_DAY,
+    chunkHours: 30 * HOURS_PER_DAY,
+  },
+  {
+    interval: 'weekly',
+    bucket: '1 week',
+    bucketHours: 7 * HOURS_PER_DAY,
+    seedHours: 28 * HOURS_PER_DAY,
+    chunkHours: 28 * HOURS_PER_DAY,
+  },
+  {
+    interval: 'monthly',
+    bucket: '1 month',
+    bucketHours: 31 * HOURS_PER_DAY,
+    seedHours: 31 * HOURS_PER_DAY,
+    chunkHours: 31 * HOURS_PER_DAY,
+  },
 ];
+
+/**
+ * Bound a definition's windows to what one statement is allowed to read.
+ *
+ * The cap is deployment configuration rather than a constant because how much raw history the
+ * database can absorb in a single statement depends on how much of it there is. It cannot cut
+ * below one bucket: a window narrower than the bucket it fills leaves coverage where it was, and
+ * the interval would never finish backfilling.
+ */
+export const boundMetricIntervalDefinition = (
+  definition: MetricIntervalDefinition,
+  maxChunkHours: number,
+): MetricIntervalDefinition => {
+  const bound = (hours: number) => Math.max(definition.bucketHours, Math.min(hours, maxChunkHours));
+
+  return { ...definition, seedHours: bound(definition.seedHours), chunkHours: bound(definition.chunkHours) };
+};
+
+export const boundMetricIntervalDefinitions = (
+  maxChunkHours: number,
+  definitions: MetricIntervalDefinition[] = metricIntervalDefinitions,
+): MetricIntervalDefinition[] =>
+  definitions.map((definition) => boundMetricIntervalDefinition(definition, maxChunkHours));
 
 export const getMetricIntervalDefinition = (interval: MetricInterval): MetricIntervalDefinition | undefined =>
   metricIntervalDefinitions.find((definition) => definition.interval === interval);

--- a/apps/value-service/src/values/repository/metricIntervalRollup.spec.ts
+++ b/apps/value-service/src/values/repository/metricIntervalRollup.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TimescaleMetricIntervalRollupRepository } from './metricIntervalRollup';
+import { METRIC_INTERVAL_ROLLUP_LOCK_KEY, TimescaleMetricIntervalRollupRepository } from './metricIntervalRollup';
 
 const createQueryStub = (result: unknown) => {
   const stub: any = {};
@@ -10,14 +10,18 @@ const createQueryStub = (result: unknown) => {
   return stub;
 };
 
-const createKnex = (result: unknown = undefined, rowCount = 2) => {
+const createKnex = (result: unknown = undefined, rowCount = 2, locked = true) => {
   const raws: { sql: string; bindings: unknown[] }[] = [];
   const query = createQueryStub(result);
   const knex: any = jest.fn(() => query);
   knex.raw = jest.fn((sql: string, bindings: unknown[] = []) => {
     raws.push({ sql, bindings });
-    return Promise.resolve({ rowCount });
+
+    return Promise.resolve(sql.includes('pg_try_advisory_xact_lock') ? { rows: [{ locked }] } : { rowCount });
   });
+  // The transaction is the lock's scope, so the stub hands the callback the same query surface
+  // rather than a separate one; the repository is expected to work through what it is given.
+  knex.transaction = jest.fn((work: (trx: unknown) => Promise<unknown>) => work(knex));
 
   return { knex, query, raws };
 };
@@ -63,6 +67,61 @@ describe('TimescaleMetricIntervalRollupRepository', () => {
       const { knex } = createKnex(undefined);
 
       expect(await new TimescaleMetricIntervalRollupRepository(knex).getCoverage('hourly')).toBeNull();
+    });
+  });
+
+  describe('withRollupLock', () => {
+    it('runs the work when the lock is free', async () => {
+      const { knex, raws } = createKnex();
+      const work = jest.fn().mockResolvedValue(4);
+
+      const result = await new TimescaleMetricIntervalRollupRepository(knex).withRollupLock(work);
+
+      expect(result).toBe(4);
+      expect(raws[0].sql).toContain('pg_try_advisory_xact_lock');
+      expect(raws[0].bindings).toEqual([METRIC_INTERVAL_ROLLUP_LOCK_KEY]);
+    });
+
+    // A replica that loses the race has to leave the run to the winner rather than repeating it.
+    it('skips the work and resolves null when another instance holds the lock', async () => {
+      const { knex } = createKnex(undefined, 2, false);
+      const work = jest.fn();
+
+      expect(await new TimescaleMetricIntervalRollupRepository(knex).withRollupLock(work)).toBeNull();
+      expect(work).not.toHaveBeenCalled();
+    });
+
+    // The work has to run on the connection holding the lock, so the callback gets a repository
+    // bound to the transaction rather than the one withRollupLock was called on.
+    it('hands the work a repository bound to the locked transaction', async () => {
+      const { knex } = createKnex();
+      let handed: unknown;
+
+      await new TimescaleMetricIntervalRollupRepository(knex).withRollupLock(async (repository) => {
+        handed = repository;
+        return 0;
+      });
+
+      expect(handed).toBeInstanceOf(TimescaleMetricIntervalRollupRepository);
+      expect(knex.transaction).toHaveBeenCalled();
+    });
+
+    // SET takes no bind parameter, so the value is interpolated; it is truncated rather than
+    // passed through, and SET LOCAL keeps it off the connection once it goes back to the pool.
+    it('applies a statement timeout to the locked connection only', async () => {
+      const { knex, raws } = createKnex();
+
+      await new TimescaleMetricIntervalRollupRepository(knex, 90000.7).withRollupLock(async () => 0);
+
+      expect(raws[1].sql).toBe('SET LOCAL statement_timeout = 90000');
+    });
+
+    it('leaves the timeout at the server default when none is configured', async () => {
+      const { knex, raws } = createKnex();
+
+      await new TimescaleMetricIntervalRollupRepository(knex).withRollupLock(async () => 0);
+
+      expect(raws.some(({ sql }) => sql.includes('statement_timeout'))).toBe(false);
     });
   });
 

--- a/apps/value-service/src/values/repository/metricIntervalRollup.ts
+++ b/apps/value-service/src/values/repository/metricIntervalRollup.ts
@@ -7,7 +7,15 @@ export interface MetricIntervalRollupRepository {
   // Callers must pass a window that touches or overlaps existing coverage; coverage is stored as a
   // single span, so a detached window would report the gap between them as rolled up.
   refresh(interval: MetricInterval, bucket: string, window: MetricIntervalWindow): Promise<number>;
+  // Runs work while holding the rollup lock, resolving to null without running it when another
+  // instance holds the lock. The repository handed to the callback is bound to the locked
+  // connection, so callers must use it rather than the one they called this on.
+  withRollupLock<T>(work: (repository: MetricIntervalRollupRepository) => Promise<T>): Promise<T | null>;
 }
+
+// Every replica has to ask for the same key for the lock to mean anything, so this is arbitrary but
+// has to stay stable. Advisory keys share one database-wide space; this one is the ticket number.
+export const METRIC_INTERVAL_ROLLUP_LOCK_KEY = 5318;
 
 type RangeRow = {
   start?: Date | string | null;
@@ -20,7 +28,46 @@ type CoverageRow = {
 };
 
 export class TimescaleMetricIntervalRollupRepository implements MetricIntervalRollupRepository {
-  constructor(private knex: Knex) {}
+  constructor(
+    private knex: Knex,
+    private statementTimeoutMs = 0,
+  ) {}
+
+  /**
+   * Hold the rollup lock for one run.
+   *
+   * Every replica schedules this job, and the cron tick fires whether or not the last run finished,
+   * so without a lock the same windows are recomputed several times over concurrently -- which is
+   * what exhausted the database's connection slots in dev.
+   *
+   * pg_try_advisory_xact_lock is scoped to the transaction: it is taken on that transaction's own
+   * connection and released when it ends, so the lock cannot be released onto a different pooled
+   * connection than the one that took it, nor outlive a run whose pod was killed. The try_ form
+   * rather than the blocking one, because a replica that loses the race should skip this tick
+   * instead of queueing up behind the winner and running the same work a moment later.
+   */
+  async withRollupLock<T>(work: (repository: MetricIntervalRollupRepository) => Promise<T>): Promise<T | null> {
+    return this.knex.transaction(async (trx) => {
+      const result = await trx.raw<{ rows: { locked: boolean }[] }>('SELECT pg_try_advisory_xact_lock(?) AS locked', [
+        METRIC_INTERVAL_ROLLUP_LOCK_KEY,
+      ]);
+
+      if (!result?.rows?.[0]?.locked) {
+        return null;
+      }
+
+      if (this.statementTimeoutMs > 0) {
+        // A refresh that runs away holds its connection for as long as it takes, and the pool is
+        // shared with the API. SET LOCAL so the timeout reverts when the transaction ends rather
+        // than sticking to a pooled connection that goes on to serve a request. The value is
+        // interpolated because SET does not take a bind parameter; it is truncated to an integer
+        // rather than passed through as given.
+        await trx.raw(`SET LOCAL statement_timeout = ${Math.trunc(this.statementTimeoutMs)}`);
+      }
+
+      return work(new TimescaleMetricIntervalRollupRepository(trx, this.statementTimeoutMs));
+    });
+  }
 
   async getMetricsWindow(): Promise<MetricIntervalWindow | null> {
     const row = await this.knex('metrics').min({ start: 'timestamp' }).max({ end: 'timestamp' }).first<RangeRow>();

--- a/docs/services/value-service.md
+++ b/docs/services/value-service.md
@@ -40,6 +40,10 @@ The job runs every five minutes and moves one interval's coverage by at most a c
 
 Reads consult that coverage. A request whose window falls entirely inside it is served from the rollups; anything reaching outside falls back to the `metrics_*` view, which aggregates on read and is always complete. Rollups can therefore be populated progressively without the API losing data in the meantime.
 
+A refresh reads the raw `metrics` table over its window, so what a run costs follows the span of that window rather than the width of the bucket being filled — a month of metrics is the same read whether it lands in daily buckets or one monthly bucket. `METRIC_INTERVAL_ROLLUP_MAX_CHUNK_HOURS` caps that span, defaulting to a week; it cannot cut a window below a single bucket, since an interval whose chunk is narrower than its bucket would never finish backfilling. Lower it where the table is large enough that a week is too much to read at once, at the cost of history filling in more slowly.
+
+Only one run happens at a time. The job takes a Postgres advisory lock for the run, so of the replicas that all schedule it, whichever gets the lock does the work and the rest skip that tick; within a replica, a tick arriving while the last run is still going is skipped as well. `METRIC_INTERVAL_ROLLUP_STATEMENT_TIMEOUT_MS` bounds how long a single refresh may hold its connection, and `DB_POOL_MAX` bounds how many connections a replica can hold at all — worth setting deliberately, since it is multiplied by the replica count against one database.
+
 Set `METRIC_INTERVAL_ROLLUP_JOB_ENABLED=false` to stop the job. Reads keep working — they fall back to the views — but the rollups stop advancing and stale coverage will gradually stop matching incoming requests.
 
 ```sql


### PR DESCRIPTION
The rollup job merged in #5862 is failing every run in dev with `remaining connection slots are reserved for roles with the SUPERUSER attribute`, and has never completed a run.

`seedHours == chunkHours` at 1825 and 3650 days meant the first run for `weekly` and `monthly` aggregated the entire `metrics` history in one statement, so it outlived its five minute tick. `node-schedule` fires on the tick regardless, on all three replicas, and the pile-up held a connection each until the server had none left.

- Chunks are whole numbers of buckets over a bounded raw span, capped by `METRIC_INTERVAL_ROLLUP_MAX_CHUNK_HOURS` (default a week) and floored at one bucket, since a window narrower than its bucket never advances coverage.
- A run holds `pg_try_advisory_xact_lock` for its duration, so one replica works and the others skip the tick. Transaction-scoped, so the lock cannot be released onto a different pooled connection or outlive a killed pod. The whole run is inside it, because coverage is read and then extended from what was read.
- A tick arriving while the previous run is still going is skipped rather than started on top of it.
- The knex pool is explicit (`DB_POOL_MAX`, no floor of two connections held per replica) and a refresh runs under `SET LOCAL statement_timeout`.

149 tests pass.