### PR TITLE
feat(tenant-management-webapp): CS-5335 add event log CSV export modal

### DIFF
--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLog.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLog.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EventLog } from './eventLog';
+
+jest.mock('./eventSearchForm', () => ({
+  EventSearchForm: ({
+    onSearch,
+    onCancel,
+    leftAction,
+  }: {
+    onSearch?: (criteria: { namespace: string; name: string }) => void;
+    onCancel?: () => void;
+    leftAction?: React.ReactNode;
+  }) => (
+    <div>
+      {leftAction}
+      <button
+        data-testid="event-log-search"
+        onClick={() => onSearch?.({ namespace: 'form-service', name: 'form-created' })}
+      >
+        Search
+      </button>
+      <button data-testid="event-log-reset" onClick={() => onCancel?.()}>
+        Reset
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('./eventLogEntries', () => ({
+  EventLogEntries: () => <div data-testid="event-log-entries" />,
+}));
+
+describe('EventLog', () => {
+  const mockStore = configureStore([]);
+
+  const createStore = () =>
+    mockStore({
+      event: {
+        entries: [
+          {
+            timestamp: '2026-01-01T00:00:00.000Z',
+            namespace: 'form-service',
+            name: 'form-created',
+            correlationId: 'corr-1',
+            details: {},
+          },
+        ],
+        nextEntries: null,
+        isLoading: { definitions: false, log: false },
+        definitions: {},
+      },
+      config: {
+        serviceUrls: {
+          valueServiceApiUrl: 'http://value-service',
+        },
+      },
+      session: {
+        credentials: { token: 'token' },
+        resourceAccess: {
+          'urn:ads:platform:value-service': { roles: ['value-reader'] },
+        },
+      },
+    });
+
+  it('loads the initial event log without a time range', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <EventLog />
+      </Provider>,
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter((action) => action.type === 'eventLog/FETCH_EVENT_LOG_ENTRIES_ACTION');
+    expect(fetchActions).toHaveLength(1);
+    expect(fetchActions[0].searchCriteria).toBeUndefined();
+  });
+
+  it('disables CSV download after reset', () => {
+    const store = createStore();
+    const { getByTestId, container } = render(
+      <Provider store={store}>
+        <EventLog />
+      </Provider>,
+    );
+
+    const csvButton = container.querySelector('goa-button[testid="export-event-log-csv"]');
+    expect(csvButton).toHaveAttribute('disabled');
+
+    fireEvent.click(getByTestId('event-log-search'));
+    expect(csvButton).not.toHaveAttribute('disabled');
+
+    fireEvent.click(getByTestId('event-log-reset'));
+    expect(csvButton).toHaveAttribute('disabled');
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLog.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLog.tsx
@@ -1,7 +1,7 @@
 import { Main } from '@components/Html';
 import { RootState } from '@store/index';
 import { getEventLogEntries, clearEventLogEntries } from '@store/event/actions';
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { EventLogEntries } from './eventLogEntries';
 import { EventSearchForm } from './eventSearchForm';
@@ -10,7 +10,8 @@ import { GoabButton, GoabCallout } from '@abgov/react-components';
 import { EventSearchCriteria } from '@store/event/models';
 import { LoadMoreWrapper } from '@components/styled-components';
 import { ServiceColumnLayoutWithMargin } from '../../admin';
-import { exportEventLogEntries } from './exportEventLog';
+import { exportEventLogEntries, isExportCanceled } from './exportEventLog';
+import { EventLogExportModal } from './eventLogExportModal';
 import { SmallButton } from './styled-components';
 import { ErrorNotification } from '@store/notifications/actions';
 
@@ -22,6 +23,9 @@ export const EventLog: FunctionComponent = () => {
   const [searched, setSearched] = useState(false);
   const [searchCriteria, setSearchCriteria] = useState(null);
   const [isExporting, setIsExporting] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
+  const [exportRowCount, setExportRowCount] = useState(0);
+  const exportAbortRef = useRef<AbortController | null>(null);
   const next = useSelector((state: RootState) => state.event.nextEntries);
   const entries = useSelector((state: RootState) => state.event.entries);
   const isLoading = useSelector((state: RootState) => state.event.isLoading.log);
@@ -37,6 +41,7 @@ export const EventLog: FunctionComponent = () => {
 
   useEffect(() => {
     return function clean() {
+      exportAbortRef.current?.abort();
       dispatch(clearEventLogEntries());
     };
   }, [dispatch]);
@@ -51,6 +56,7 @@ export const EventLog: FunctionComponent = () => {
   };
   const onSearchCancel = () => {
     setSearched(false);
+    setSearchCriteria(null);
     dispatch(getEventLogEntries());
   };
   const onNext = () => {
@@ -58,18 +64,43 @@ export const EventLog: FunctionComponent = () => {
   };
   const hasSelectedEvent = Boolean(searchCriteria?.namespace && searchCriteria?.name);
   const hasEntries = Boolean(entries?.length);
+  const closeExportModal = () => {
+    setExportOpen(false);
+    setIsExporting(false);
+    setExportRowCount(0);
+  };
+  const onCancelExport = () => {
+    exportAbortRef.current?.abort();
+    closeExportModal();
+  };
   const onExport = async () => {
     if (!hasReaderRole || !hasSelectedEvent || !hasEntries || !valueServiceApiUrl || !token) {
       return;
     }
+    const controller = new AbortController();
+    exportAbortRef.current = controller;
     setIsExporting(true);
+    setExportOpen(true);
+    setExportRowCount(0);
     try {
       const fileName = `${searchCriteria.namespace}-${searchCriteria.name}`;
-      await exportEventLogEntries(valueServiceApiUrl, token, fileName, searchCriteria || {});
+      const count = await exportEventLogEntries(
+        valueServiceApiUrl,
+        token,
+        fileName,
+        searchCriteria || {},
+        controller.signal,
+      );
+      setExportRowCount(count);
     } catch (error) {
+      if (isExportCanceled(error)) {
+        return;
+      }
+      closeExportModal();
       dispatch(ErrorNotification({ message: 'Failed to export event log. Try narrowing your time range.', error }));
     } finally {
       setIsExporting(false);
+      exportAbortRef.current = null;
     }
   };
   return (
@@ -95,10 +126,17 @@ export const EventLog: FunctionComponent = () => {
                       onClick={onExport}
                       testId="export-event-log-csv"
                     >
-                      {isExporting ? 'Exporting...' : 'Download CSV'}
+                      Download CSV
                     </GoabButton>
                   </SmallButton>
                 }
+              />
+              <EventLogExportModal
+                open={exportOpen}
+                isExporting={isExporting}
+                rowCount={exportRowCount}
+                onCancel={onCancelExport}
+                onClose={closeExportModal}
               />
               <EventLogEntries onSearch={onSearch} />
               {next && (

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLogExportModal.spec.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLogExportModal.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EventLogExportModal } from './eventLogExportModal';
+
+describe('EventLogExportModal', () => {
+  it('shows a loading spinner and cancel while exporting', () => {
+    const onCancel = jest.fn();
+    const { container, getByText } = render(
+      <EventLogExportModal open={true} isExporting={true} onCancel={onCancel} onClose={jest.fn()} />,
+    );
+
+    expect(container.querySelector('goa-modal[testid="export-event-log-modal"]')).toHaveAttribute('open');
+    expect(container.querySelector('goa-circular-progress')).not.toBeNull();
+    expect(getByText('Exporting event log...')).toBeInTheDocument();
+
+    fireEvent(
+      container.querySelector('goa-button[testid="export-event-log-cancel"]') as Element,
+      new CustomEvent('_click'),
+    );
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows close after export completes', () => {
+    const onClose = jest.fn();
+    const { container, getByText } = render(
+      <EventLogExportModal open={true} isExporting={false} rowCount={12} onCancel={jest.fn()} onClose={onClose} />,
+    );
+
+    expect(getByText('Export complete. 12 rows included in the CSV file.')).toBeInTheDocument();
+    fireEvent(
+      container.querySelector('goa-button[testid="export-event-log-close"]') as Element,
+      new CustomEvent('_click'),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses singular row wording for one exported item', () => {
+    const { getByText } = render(
+      <EventLogExportModal open={true} isExporting={false} rowCount={1} onCancel={jest.fn()} onClose={jest.fn()} />,
+    );
+
+    expect(getByText('Export complete. 1 row included in the CSV file.')).toBeInTheDocument();
+  });
+});

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLogExportModal.tsx
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/eventLogExportModal.tsx
@@ -1,0 +1,61 @@
+import React, { FunctionComponent } from 'react';
+import { GoabButton, GoabButtonGroup, GoabCircularProgress, GoabModal, GoabText } from '@abgov/react-components';
+import styled from 'styled-components';
+
+interface EventLogExportModalProps {
+  open: boolean;
+  isExporting: boolean;
+  rowCount?: number;
+  onCancel: () => void;
+  onClose: () => void;
+}
+
+export const EventLogExportModal: FunctionComponent<EventLogExportModalProps> = ({
+  open,
+  isExporting,
+  rowCount = 0,
+  onCancel,
+  onClose,
+}) => {
+  const rowLabel = rowCount === 1 ? 'row' : 'rows';
+  return (
+    <GoabModal
+      testId="export-event-log-modal"
+      open={open}
+      heading="Export event log"
+      actions={
+        <GoabButtonGroup alignment="end">
+          {isExporting ? (
+            <GoabButton size="compact" type="secondary" testId="export-event-log-cancel" onClick={onCancel}>
+              Cancel
+            </GoabButton>
+          ) : (
+            <GoabButton size="compact" type="primary" testId="export-event-log-close" onClick={onClose}>
+              Close
+            </GoabButton>
+          )}
+        </GoabButtonGroup>
+      }
+    >
+      {isExporting ? (
+        <ExportProgress>
+          <GoabCircularProgress visible={true} size="large" />
+          <GoabText size="body-m" mb="none">
+            Exporting event log...
+          </GoabText>
+        </ExportProgress>
+      ) : (
+        <GoabText size="body-m" mb="none">
+          Export complete. {rowCount} {rowLabel} included in the CSV file.
+        </GoabText>
+      )}
+    </GoabModal>
+  );
+};
+
+const ExportProgress = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+`;

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.spec.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import exportFromJSON from 'export-from-json';
-import { EXPORT_PAGE_SIZE, exportEventLogEntries, fetchAllEventLogEntries } from './exportEventLog';
+import { EXPORT_PAGE_SIZE, exportEventLogEntries, fetchAllEventLogEntries, isExportCanceled } from './exportEventLog';
 
 jest.mock('axios');
 jest.mock('export-from-json');
@@ -93,6 +93,15 @@ describe('exportEventLog', () => {
       expect(firstMax).toBeTruthy();
       expect(secondMax).toBe(firstMax);
     });
+
+    it('passes the abort signal to each page request', async () => {
+      mockedAxiosGet.mockResolvedValueOnce(pageResponse([entry('a')], undefined));
+      const controller = new AbortController();
+
+      await fetchAllEventLogEntries(baseUrl, token, {}, controller.signal);
+
+      expect(mockedAxiosGet.mock.calls[0][1].signal).toBe(controller.signal);
+    });
   });
 
   describe('exportEventLogEntries', () => {
@@ -122,6 +131,24 @@ describe('exportEventLog', () => {
       expect(count).toBe(0);
       expect(mockedExport).toHaveBeenCalledTimes(1);
       expect(mockedExport.mock.calls[0][0].data).toEqual([{}]);
+    });
+
+    it('does not write a CSV when the export is aborted after fetch', async () => {
+      mockedAxiosGet.mockResolvedValueOnce(pageResponse([entry('a')], undefined));
+      const controller = new AbortController();
+      controller.abort();
+
+      const count = await exportEventLogEntries(baseUrl, token, 'tenant-event-log', {}, controller.signal);
+
+      expect(count).toBe(0);
+      expect(mockedExport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isExportCanceled', () => {
+    it('recognizes an axios cancel error', () => {
+      (axios.isCancel as unknown as jest.Mock) = jest.fn().mockReturnValue(true);
+      expect(isExportCanceled({ message: 'canceled' })).toBe(true);
     });
   });
 });

--- a/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.ts
+++ b/apps/tenant-management-webapp/src/app/pages/admin/event-log/exportEventLog.ts
@@ -71,10 +71,14 @@ const toCsvRow = (entry: EventLogEntry) => ({
   details: JSON.stringify(entry.details ?? {}),
 });
 
+export const isExportCanceled = (error: unknown): boolean =>
+  axios.isCancel(error) || (error as { code?: string })?.code === 'ERR_CANCELED';
+
 export const fetchAllEventLogEntries = async (
   baseUrl: string,
   token: string,
   criteria: EventSearchCriteria,
+  signal?: AbortSignal,
 ): Promise<EventLogEntry[]> => {
   // Pin the upper bound so offset-based pagination sees a stable window across pages.
   const pinnedCriteria: EventSearchCriteria = {
@@ -89,6 +93,7 @@ export const fetchAllEventLogEntries = async (
     const { data } = await axios.get<EventValueResponse>(url, {
       headers: { Authorization: `Bearer ${token}` },
       timeout: REQUEST_TIMEOUT_MS,
+      signal,
     });
     entries.push(...(data?.['event-service']?.event ?? []).map(toEntry));
     after = data?.page?.next ?? '';
@@ -102,8 +107,12 @@ export const exportEventLogEntries = async (
   token: string,
   fileName: string,
   criteria: EventSearchCriteria = {},
+  signal?: AbortSignal,
 ): Promise<number> => {
-  const entries = await fetchAllEventLogEntries(baseUrl, token, criteria);
+  const entries = await fetchAllEventLogEntries(baseUrl, token, criteria, signal);
+  if (signal?.aborted) {
+    return 0;
+  }
   const rows = entries.map(toCsvRow);
 
   exportFromJSON({


### PR DESCRIPTION
## Summary
Adds a dedicated Event log CSV export modal and disables **Download CSV** after Reset when no event is selected.

## Changes
- Open an **Export event log** modal when **Download CSV** is clicked.
- Show a large loading indicator and **Cancel** while the export is in progress.
- On completion, show how many rows were included in the CSV, then **Close**.
- Keep the button label as **Download CSV**.
- Clear the selected event on **Reset**, so **Download CSV** is disabled until an event is selected again.
- Allow canceling an in-flight export via `AbortController`.

## Why
CSV export can take long enough that users need progress, cancel, and completion feedback. Reset previously left the last selected event in place, so Download CSV stayed enabled even though no event was selected.