### PR TITLE
fix(form-admin-app): CS-5354 show a loading state when filtering definitions

### DIFF
--- a/apps/form-admin-app/src/app/containers/FormDefinitions.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/FormDefinitions.spec.tsx
@@ -24,10 +24,16 @@ const createState = ({
   definitionResults = [definitionId],
   totalDefinitions = 12,
   definitionCriteria = {},
+  searching = false,
+  loading = false,
+  next = null,
 }: {
   definitionResults?: string[];
   totalDefinitions?: number | null;
   definitionCriteria?: Record<string, unknown>;
+  searching?: boolean;
+  loading?: boolean;
+  next?: string | null;
 } = {}) => ({
   user: {
     user: {
@@ -40,7 +46,8 @@ const createState = ({
   form: {
     busy: {
       initializing: false,
-      loading: false,
+      loading,
+      searching,
       findPdf: false,
       executing: false,
       exporting: false,
@@ -72,7 +79,7 @@ const createState = ({
     formCriteria: {},
     submissionCriteria: {},
     next: {
-      definitions: null,
+      definitions: next,
       forms: null,
       submissions: null,
     },
@@ -151,6 +158,37 @@ describe('FormsDefinitions', () => {
     fireEvent(baseElement.querySelector("goa-icon-button[testId='load-definitions']"), new CustomEvent('_click'));
 
     expect(loadDefinitions).toHaveBeenCalledWith({ after: undefined, tag: 'urgent', criteria });
+  });
+
+  // The search replaces the whole listing, so leaving the previous results up with one skeleton row
+  // appended below them put the only feedback at the bottom of the list, out of sight.
+  it('should show a loading state in place of the results while searching', () => {
+    const { baseElement, queryByText } = renderDefinitions(createState({ searching: true, loading: true }));
+
+    expect(queryByText('Intake form')).toBeNull();
+    expect(baseElement.querySelectorAll('goa-skeleton').length).toBeGreaterThan(1);
+  });
+
+  it('should disable the tag filter while searching, so the filter shown is the one applied', () => {
+    const { baseElement } = renderDefinitions(createState({ searching: true, loading: true }));
+
+    expect(baseElement.querySelector("goa-dropdown[name='tag']").getAttribute('disabled')).toBe('true');
+  });
+
+  it('should leave the tag filter usable when not searching', () => {
+    const { baseElement } = renderDefinitions();
+
+    expect(baseElement.querySelector("goa-dropdown[name='tag']").getAttribute('disabled')).toBeFalsy();
+  });
+
+  // Paging keeps the results on screen, so that load keeps the trailing skeleton instead.
+  it('should keep the results and trail a skeleton while paging further into them', () => {
+    const { baseElement, queryByText } = renderDefinitions(
+      createState({ loading: true, searching: false, next: 'cursor' }),
+    );
+
+    expect(queryByText('Intake form')).toBeTruthy();
+    expect(baseElement.querySelectorAll('goa-skeleton').length).toBe(4);
   });
 
   it('should clear the filters from the header summary', () => {

--- a/apps/form-admin-app/src/app/containers/FormDefinitions.tsx
+++ b/apps/form-admin-app/src/app/containers/FormDefinitions.tsx
@@ -34,6 +34,10 @@ import { Tags } from './Tags';
 import { TagSearchFilter } from './TagSearchFilter';
 import { ResultsSummary } from '../components/ResultsSummary';
 
+// Enough rows for the loading state to read as a list rather than a stray row, without pushing the
+// results that replace them far down the page.
+const SEARCH_SKELETON_ROWS = [0, 1, 2, 3, 4];
+
 const FeatureBadge: FunctionComponent<{ feature: string; hasFeature?: boolean }> = ({ feature, hasFeature }) => {
   return hasFeature && <GoabBadge type="information" content={feature} mr="xs" mb="xs" emphasis="subtle" />;
 };
@@ -117,7 +121,11 @@ export const FormsDefinitions = () => {
                 onChangeFrom={(value) => updateCriteria({ ...criteria, createDateAfter: value })}
                 onChangeTo={(value) => updateCriteria({ ...criteria, createDateBefore: value })}
               />
-              <TagSearchFilter value={criteria.tag} onChange={(value) => updateCriteria({ ...criteria, tag: value })} />
+              <TagSearchFilter
+                value={criteria.tag}
+                disabled={busy.searching}
+                onChange={(value) => updateCriteria({ ...criteria, tag: value })}
+              />
               <SearchFormActionItem>
                 <GoabIconButton
                   icon="search"
@@ -158,16 +166,26 @@ export const FormsDefinitions = () => {
             </tr>
           </thead>
           <tbody>
-            {definitions.map((definition) => (
-              <FormDefinitionRow
-                key={definition.id}
-                navigate={navigate}
-                definition={definition}
-                onTag={() => setShowTagDefinition(definition)}
-              />
-            ))}
-            <RowSkeleton columns={4} show={busy.loading} />
-            <RowLoadMore columns={4} next={next} loading={busy.loading} onLoadMore={handleLoadDefinitions} />
+            {/*
+              A search replaces the whole listing, so the results it is replacing are cleared while
+              it runs. Leaving them up with a single skeleton row appended below meant the only
+              feedback was at the bottom of the list, out of sight on anything but a short one.
+            */}
+            {busy.searching
+              ? SEARCH_SKELETON_ROWS.map((row) => <RowSkeleton key={row} columns={4} show />)
+              : definitions.map((definition) => (
+                  <FormDefinitionRow
+                    key={definition.id}
+                    navigate={navigate}
+                    definition={definition}
+                    onTag={() => setShowTagDefinition(definition)}
+                  />
+                ))}
+            {/* Paging further into the results keeps them on screen, so that skeleton still trails them. */}
+            <RowSkeleton columns={4} show={busy.loading && !busy.searching} />
+            {!busy.searching && (
+              <RowLoadMore columns={4} next={next} loading={busy.loading} onLoadMore={handleLoadDefinitions} />
+            )}
           </tbody>
         </GoabTable>
       </ContentContainer>

--- a/apps/form-admin-app/src/app/containers/TagSearchFilter.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/TagSearchFilter.spec.tsx
@@ -1,0 +1,85 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { TagSearchFilter } from './TagSearchFilter';
+import { getTags } from '../state';
+
+jest.mock('../state', () => {
+  const actual = jest.requireActual('../state');
+  return {
+    ...actual,
+    getTags: jest.fn((payload) => ({ type: 'directory/get-tags', payload })),
+  };
+});
+
+const mockStore = configureStore();
+
+const createState = (tags: Record<string, { value: string; label: string }> = {}) => ({
+  directory: {
+    resources: {},
+    tags,
+    resourceTags: {},
+    tagResources: {},
+    results: [],
+    next: null,
+    busy: { loading: false, loadingResourceTags: {}, executing: false },
+  },
+});
+
+const renderFilter = (props: Partial<Parameters<typeof TagSearchFilter>[0]> = {}, state = createState()) => {
+  const store = mockStore(state);
+  const view = render(
+    <Provider store={store}>
+      <TagSearchFilter value={null} onChange={jest.fn()} {...props} />
+    </Provider>,
+  );
+
+  return { store, ...view };
+};
+
+describe('TagSearchFilter', () => {
+  beforeEach(() => {
+    (getTags as unknown as jest.Mock).mockClear();
+  });
+
+  it('should load the tags to filter by when none are held yet', () => {
+    renderFilter();
+
+    expect(getTags).toHaveBeenCalledWith({});
+  });
+
+  it('should not reload tags it already holds', () => {
+    renderFilter({}, createState({ urgent: { value: 'urgent', label: 'Urgent' } }));
+
+    expect(getTags).not.toHaveBeenCalled();
+  });
+
+  it('should offer every tag alongside the option to filter by none', () => {
+    const { baseElement } = renderFilter(
+      {},
+      createState({
+        urgent: { value: 'urgent', label: 'Urgent' },
+        howard: { value: 'howard', label: 'Howard' },
+      }),
+    );
+
+    const options = Array.from(baseElement.querySelectorAll('goa-dropdown-item')).map((item) =>
+      item.getAttribute('value'),
+    );
+    expect(options).toEqual(['', 'howard', 'urgent']);
+  });
+
+  // Changing the filter mid-search would leave a tag on screen that the results were not filtered
+  // by, so the listing disables it while a search runs.
+  it('should be disabled when asked', () => {
+    const { baseElement } = renderFilter({ disabled: true });
+
+    expect(baseElement.querySelector("goa-dropdown[name='tag']").getAttribute('disabled')).toBe('true');
+  });
+
+  it('should be enabled by default', () => {
+    const { baseElement } = renderFilter();
+
+    expect(baseElement.querySelector("goa-dropdown[name='tag']").getAttribute('disabled')).toBeFalsy();
+  });
+});

--- a/apps/form-admin-app/src/app/containers/TagSearchFilter.tsx
+++ b/apps/form-admin-app/src/app/containers/TagSearchFilter.tsx
@@ -6,10 +6,11 @@ import { GoabDropdownOnChangeDetail } from '@abgov/ui-components-common';
 
 interface TagSearchFilterProps {
   value: string;
+  disabled?: boolean;
   onChange: (value: string) => void;
 }
 
-export const TagSearchFilter: FunctionComponent<TagSearchFilterProps> = ({ value, onChange }) => {
+export const TagSearchFilter: FunctionComponent<TagSearchFilterProps> = ({ value, disabled, onChange }) => {
   const dispatch = useDispatch<AppDispatch>();
 
   const tags = useSelector(tagsSelector);
@@ -27,6 +28,7 @@ export const TagSearchFilter: FunctionComponent<TagSearchFilterProps> = ({ value
         size="compact"
         name="tag"
         value={value || ''}
+        disabled={disabled}
         onChange={(detail: GoabDropdownOnChangeDetail) => onChange(detail.value)}
       >
         <GoabDropdownItem value="" label="<No tag filter>" />

--- a/apps/form-admin-app/src/app/state/form.slice.ts
+++ b/apps/form-admin-app/src/app/state/form.slice.ts
@@ -80,10 +80,7 @@ export const countActiveFilters = (criteria: { dataCriteria?: Record<string, unk
 // Tag based searches resolve results via the directory service, which doesn't include a total in the page.
 // Carry the total across pages of the same search, but clear it when a new search comes back without one,
 // so the total of a previous search isn't reported against the current results.
-export const resolveResultTotal = (
-  current: number | null,
-  page: { after?: string; total?: number },
-): number | null => {
+export const resolveResultTotal = (current: number | null, page: { after?: string; total?: number }): number | null => {
   if (page.total !== undefined) {
     return page.total;
   }
@@ -110,6 +107,10 @@ export interface FormState {
   busy: {
     initializing: boolean;
     loading: boolean;
+    // A definition search starting from the first page, as opposed to paging further into the
+    // results of one. The stale results are still on screen while it runs, so this is what tells
+    // the listing to show a loading state in their place rather than a row appended below them.
+    searching: boolean;
     findPdf: boolean;
     executing: boolean;
     exporting: boolean;
@@ -146,6 +147,7 @@ export const initialFormState: FormState = {
   busy: {
     initializing: false,
     loading: false,
+    searching: false,
     findPdf: false,
     executing: false,
     exporting: false,
@@ -782,11 +784,13 @@ const formSlice = createSlice({
         state.selectedSubmission = meta.arg;
         state.dispositionDraft = initialFormState.dispositionDraft;
       })
-      .addCase(loadDefinitions.pending, (state) => {
+      .addCase(loadDefinitions.pending, (state, { meta }) => {
         state.busy.loading = true;
+        state.busy.searching = !meta.arg?.after;
       })
       .addCase(loadDefinitions.fulfilled, (state, { payload }) => {
         state.busy.loading = false;
+        state.busy.searching = false;
         state.definitions = payload.results.reduce(
           (definitions, definition) => ({ ...definitions, [definition.id]: definition }),
           state.definitions as Record<string, FormDefinition>,
@@ -801,6 +805,7 @@ const formSlice = createSlice({
       })
       .addCase(loadDefinitions.rejected, (state) => {
         state.busy.loading = false;
+        state.busy.searching = false;
       })
       .addCase(loadDefinition.pending, (state) => {
         state.busy.initializing = true;


### PR DESCRIPTION
Applying a tag filter on the definitions listing gave no sign anything was happening for several seconds. The only feedback was the search icon going disabled.

`busy.loading` was already set, and `RowSkeleton` was already wired to it — but a search replaces the whole listing while leaving the previous results on screen, and the skeleton was a single row appended *below* them. On any list longer than the viewport it was out of sight.

- The slice now distinguishes a search from paging: `loadDefinitions.pending` sets `busy.searching` from whether the request carries an `after` cursor.
- While searching, the stale results are replaced by skeleton rows, so the loading state appears where the results will. Paging keeps the results up and the trailing skeleton as before.
- The tag filter is disabled while searching, so the tag on screen when results arrive is the one they were filtered by.

127 tests pass, four of them new.