### PR TITLE
fix(jsonforms-components): show a SIN format example in validation

### DIFF
--- a/libs/data-exchange-standard/src/common.v1.schema.json
+++ b/libs/data-exchange-standard/src/common.v1.schema.json
@@ -218,7 +218,7 @@
       "pattern": "^\\d{3} \\d{3} \\d{3}$",
       "validSin": true,
       "errorMessage": {
-        "pattern": "Must be three groups of three digits."
+        "pattern": "Must be a valid social insurance number in format 000 000 000"
       }
     },
     "email": {

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputBaseTableReviewControl.spec.tsx
@@ -712,7 +712,7 @@ describe('InputBaseTableReviewControl', () => {
       pattern: '^\\d{3} \\d{3} \\d{3}$',
       validSin: true,
       errorMessage: {
-        pattern: 'Must be three groups of three digits.',
+        pattern: 'Must be a valid social insurance number in format 000 000 000',
       },
     };
 

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputNumberControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputNumberControl.spec.tsx
@@ -57,7 +57,10 @@ describe('Input Text Control tests', () => {
   };
   const sinProps: GoAInputNumberProps & ControlProps = {
     uischema: textBoxUiSchema,
-    schema: { title: 'Social insurance number', errorMessage: 'Must be three groups of three digits.' },
+    schema: {
+      title: 'Social insurance number',
+      errorMessage: 'Must be a valid social insurance number in format 000 000 000',
+    },
     rootSchema: {},
     handleChange: (path, value) => {},
     enabled: true,

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.test.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.test.tsx
@@ -63,7 +63,7 @@ describe('Input Text Control tests', () => {
     uischema: textBoxUiSchema,
     schema: {
       title: 'Social insurance number',
-      errorMessage: 'Must be three groups of three digits.',
+      errorMessage: 'Must be a valid social insurance number in format 000 000 000',
       default: '123456789',
     },
     rootSchema: {},

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/InputTextControl.tsx
@@ -9,8 +9,7 @@ import { JsonFormRegisterProvider, RegisterDataType } from '../../Context/regist
 import { JsonFormsRegisterContext, RegisterConfig } from '../../Context/register';
 import { applyFormatPattern, onBlurForTextControl, onChangeForInputControl } from '../../util/inputControlUtils';
 import {
-  DEFAULT_PATTERNS,
-  MaskPattern,
+  resolveFormatConfig,
   filterAllowedKeys,
   formatWithPattern,
   toMaskTemplate,
@@ -22,7 +21,6 @@ import {
   maskPlaceholder,
   shouldBlockKey,
 } from '../../util/patternForm';
-import { sinTitle } from '../../common/Constants';
 import {
   GoabInputOnChangeDetail,
   GoabInputOnBlurDetail,
@@ -51,14 +49,6 @@ const resetInputValue = (detail: GoabInputOnChangeDetail, value: string) => {
   if (target) {
     target.value = value;
   }
-};
-
-// Resolve the mask format for a field: schema.format must match a DEFAULT_PATTERNS key.
-const resolveFormatConfig = (schema: { format?: string; title?: string }): MaskPattern | undefined => {
-  if (schema.format && schema.format in DEFAULT_PATTERNS) {
-    return DEFAULT_PATTERNS[schema.format];
-  }
-  return schema.title === sinTitle ? DEFAULT_PATTERNS.sin : undefined;
 };
 
 export const GoAInputText = (props: GoAInputTextProps): JSX.Element => {

--- a/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
@@ -63,7 +63,7 @@ describe('Input Text Control tests', () => {
     uischema: textBoxUiSchema,
     schema: {
       title: 'Social insurance number',
-      errorMessage: 'Must be three groups of three digits.',
+      errorMessage: 'Must be a valid social insurance number in format 000 000 000',
       default: '123456789',
     },
     rootSchema: {},

--- a/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
@@ -8,11 +8,13 @@ import {
   computeMaskEdit,
   filterAllowedKeys,
   formatWithPattern,
+  getConfiguredFormatError,
   getMaskInputTarget,
   isMaskFilled,
   maskDigitCount,
   maskPlaceholder,
   overflowMaskEdit,
+  resolveFormatConfig,
   shouldBlockKey,
   toMaskTemplate,
 } from './patternForm';
@@ -32,6 +34,31 @@ describe('DEFAULT_PATTERNS', () => {
 
   it('rejects a SIN without spaces', () => {
     expect(DEFAULT_PATTERNS.sin.pattern.test('123456789')).toBe(false);
+  });
+
+  it('tells the user the correct SIN example format', () => {
+    expect(DEFAULT_PATTERNS.sin.error).toBe('Must be a valid social insurance number in format 000 000 000');
+  });
+
+  it('resolves SIN format config from the social insurance number title', () => {
+    expect(resolveFormatConfig({ title: 'Social insurance number' })).toBe(DEFAULT_PATTERNS.sin);
+  });
+
+  it('uses a schema errorMessage when one is provided', () => {
+    expect(
+      getConfiguredFormatError({
+        title: 'Social insurance number',
+        errorMessage: { pattern: 'Please enter valid SIN' },
+      }),
+    ).toBe('Please enter valid SIN');
+  });
+
+  it('uses the format config error when no schema errorMessage is provided', () => {
+    expect(getConfiguredFormatError({ title: 'Social insurance number' })).toBe(DEFAULT_PATTERNS.sin.error);
+  });
+
+  it('returns undefined when no format config or schema error is provided', () => {
+    expect(getConfiguredFormatError({ type: 'string' } as { format?: string; title?: string })).toBeUndefined();
   });
 
   it('accepts a Canadian postal code', () => {

--- a/libs/jsonforms-components/src/lib/util/patternForm.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.ts
@@ -1,3 +1,5 @@
+import { sinTitle } from '../common/Constants';
+
 // A named format: the display mask, the validation pattern, the error shown when invalid,
 // and the characters this format allows to be typed (beyond the base control keys).
 export interface MaskPattern {
@@ -18,7 +20,7 @@ export const DEFAULT_PATTERNS: Record<string, MaskPattern> = {
   sin: {
     mask: '### ### ###',
     pattern: /^\d{3} \d{3} \d{3}$/,
-    error: 'Must be three groups of three digits.',
+    error: 'Must be a valid social insurance number in format 000 000 000',
     allowedKeys: /[0-9]/,
   },
   postalCode: {
@@ -42,6 +44,42 @@ export const DEFAULT_PATTERNS: Record<string, MaskPattern> = {
     allowedKeys: /[0-9]/,
   },
 };
+
+// Resolve the mask format for a field: schema.format must match a DEFAULT_PATTERNS key.
+export const resolveFormatConfig = (schema?: { format?: string; title?: string }): MaskPattern | undefined => {
+  if (!schema) {
+    return undefined;
+  }
+  if (schema.format && schema.format in DEFAULT_PATTERNS) {
+    return DEFAULT_PATTERNS[schema.format];
+  }
+  return schema.title === sinTitle ? DEFAULT_PATTERNS.sin : undefined;
+};
+
+type SchemaErrorMessage = string | { pattern?: string; format?: string };
+
+type FormatSchema = {
+  format?: string;
+  title?: string;
+  errorMessage?: SchemaErrorMessage;
+};
+
+const getSchemaErrorMessage = (errorMessage?: SchemaErrorMessage): string | undefined => {
+  if (typeof errorMessage === 'string' && errorMessage.trim() !== '') {
+    return errorMessage;
+  }
+  if (errorMessage && typeof errorMessage === 'object') {
+    const configured = errorMessage.pattern || errorMessage.format;
+    if (typeof configured === 'string' && configured.trim() !== '') {
+      return configured;
+    }
+  }
+  return undefined;
+};
+
+// Prefer a schema or format-config error; callers fall back to AJV when this is empty.
+export const getConfiguredFormatError = (schema?: FormatSchema): string | undefined =>
+  getSchemaErrorMessage(schema?.errorMessage) || resolveFormatConfig(schema)?.error;
 
 // Mask placeholder characters; each consumes one input character. Any other mask character is treated as a literal.
 export const MASK_PLACEHOLDERS = new Set(['#', '*', '_']);

--- a/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.spec.ts
@@ -223,6 +223,53 @@ describe('stringUtils string tests', () => {
     expect(checkFieldValidity(props, {})).toBe('My First name is required');
   });
 
+  it('uses a configured SIN error instead of the AJV pattern message', () => {
+    const props = {
+      ...schemaIfThenProps,
+      data: '123 45',
+      schema: {
+        title: 'Social insurance number',
+        errorMessage: { pattern: 'Must be a valid social insurance number in format 000 000 000' },
+      },
+      errors: 'must match pattern "^\\d{3} \\d{3} \\d{3}$"',
+    } as ControlProps;
+
+    expect(checkFieldValidity(props, {})).toBe('Must be a valid social insurance number in format 000 000 000');
+  });
+
+  it('uses the format config SIN error when no schema errorMessage is provided', () => {
+    const props = {
+      ...schemaIfThenProps,
+      data: '123 45',
+      schema: { title: 'Social insurance number' },
+      errors: 'must match pattern "^\\d{3} \\d{3} \\d{3}$"',
+    } as ControlProps;
+
+    expect(checkFieldValidity(props, {})).toBe('Must be a valid social insurance number in format 000 000 000');
+  });
+
+  it('keeps the AJV Luhn error for an invalid SIN checksum', () => {
+    const props = {
+      ...schemaIfThenProps,
+      data: '123 111 111',
+      schema: { title: 'Social insurance number' },
+      errors: 'Social insurance number is invalid',
+    } as ControlProps;
+
+    expect(checkFieldValidity(props, {})).toBe('Social insurance number is invalid');
+  });
+
+  it('uses the AJV error when no configured format error exists', () => {
+    const props = {
+      ...schemaIfThenProps,
+      data: 'abc',
+      schema: { type: 'string' },
+      errors: 'must match pattern "^[0-9]+$"',
+    } as ControlProps;
+
+    expect(checkFieldValidity(props, {})).toBe('must match pattern "^[0-9]+$"');
+  });
+
   it('When allOf should have at least one If condition', () => {
     const schema = schemaAllOfIfThenProps.rootSchema as JsonSchema7;
     const ifConditions = schema.allOf?.filter((y) => y.if !== undefined);

--- a/libs/jsonforms-components/src/lib/util/stringUtils.ts
+++ b/libs/jsonforms-components/src/lib/util/stringUtils.ts
@@ -1,6 +1,7 @@
-import { ControlProps, JsonSchema, JsonSchema7, extractSchema } from '@jsonforms/core';
-import { invalidSin, sinTitle } from '../common/Constants';
+import { ControlProps, JsonSchema, JsonSchema7 } from '@jsonforms/core';
+import { invalidSin } from '../common/Constants';
 import { isRequiredBySchema } from './requiredUtil';
+import { getConfiguredFormatError } from './patternForm';
 
 /**
  * Sets the first word to be capitalized so that it is sentence cased.
@@ -144,10 +145,6 @@ export const validateSinWithLuhn = (input: string): boolean => {
   return sum % 10 === 0;
 };
 
-interface extractSchema {
-  errorMessage?: string;
-}
-
 /**
  * Gets the required fields in the If/Then/Else json schema condition.
  * @param props - ControlProps
@@ -229,7 +226,11 @@ export const checkFieldValidity = (props: ControlProps, rootData?: unknown): str
     return '';
   }
 
-  return ajvErrors;
+  if (!ajvErrors || ajvErrors === invalidSin) {
+    return ajvErrors;
+  }
+
+  return getConfiguredFormatError(schema) || ajvErrors;
 };
 
 /**


### PR DESCRIPTION

Prefer a configured format error on masked inputs, and keep the AJV Luhn message for invalid checksums.