### PR TITLE
fix(form-admin-app, form-app, app-common): CS-5395 drop the label above the message draft field

### DIFF
--- a/apps/form-admin-app/src/app/containers/CommentsViewer.spec.tsx
+++ b/apps/form-admin-app/src/app/containers/CommentsViewer.spec.tsx
@@ -35,11 +35,14 @@ jest.mock('../state', () => ({
 const { CommentsViewer } = require('./CommentsViewer');
 
 describe('form-admin-app CommentsViewer', () => {
-  it('labels the send button "Send" while the draft field keeps its own label', () => {
+  // The heading and the field placeholder already say what the field is for, so the label above it
+  // was only taking height from the conversation.
+  it('labels the send button "Send" and drops the label above the draft field', () => {
     render(<CommentsViewer />);
 
     expect(capturedProps.addCommentButtonLabel).toBe('Send');
-    expect(capturedProps.addCommentLabel).toBe('Add response');
+    expect(capturedProps.hideAddCommentLabel).toBe(true);
+    expect(capturedProps.addCommentLabel).toBeUndefined();
   });
 
   it('renders the review conversation with the messaging layout', () => {

--- a/apps/form-admin-app/src/app/containers/CommentsViewer.tsx
+++ b/apps/form-admin-app/src/app/containers/CommentsViewer.tsx
@@ -34,7 +34,7 @@ export const CommentsViewer: FunctionComponent = () => {
       heading=" "
       $commentsHeight={'30vh'}
       messaging={true}
-      addCommentLabel="Add response"
+      hideAddCommentLabel={true}
       addCommentButtonLabel="Send"
       comments={results}
       canComment={canComment}

--- a/apps/form-app/src/app/containers/CommentsViewer.spec.tsx
+++ b/apps/form-app/src/app/containers/CommentsViewer.spec.tsx
@@ -33,11 +33,21 @@ jest.mock('../state', () => ({
 const { CommentsViewer } = require('./CommentsViewer');
 
 describe('form-app CommentsViewer', () => {
-  it('labels the send button "Send" while the draft field keeps its own label', () => {
+  // The Questions heading and the field placeholder already say what the field is for, so the label
+  // above it was only taking height from the conversation.
+  it('labels the send button "Send" and drops the label above the draft field', () => {
     render(<CommentsViewer />);
 
     expect(capturedProps.addCommentButtonLabel).toBe('Send');
-    expect(capturedProps.addCommentLabel).toBe('Add question');
+    expect(capturedProps.hideAddCommentLabel).toBe(true);
+    expect(capturedProps.addCommentLabel).toBeUndefined();
+  });
+
+  // With no label, the placeholder is what tells the applicant the field is for a question.
+  it('asks for a question in the draft field placeholder', () => {
+    render(<CommentsViewer />);
+
+    expect(capturedProps.draftPlaceholder).toBe('Write your question...');
   });
 
   it('renders the questions conversation with the messaging layout', () => {

--- a/apps/form-app/src/app/containers/CommentsViewer.tsx
+++ b/apps/form-app/src/app/containers/CommentsViewer.tsx
@@ -28,7 +28,8 @@ export const CommentsViewer: FunctionComponent = () => {
     <CommentsViewerComponent
       heading="Questions"
       messaging={true}
-      addCommentLabel="Add question"
+      hideAddCommentLabel={true}
+      draftPlaceholder="Write your question..."
       addCommentButtonLabel="Send"
       anonymousName="Support"
       comments={results}

--- a/libs/app-common/src/components/CommentsViewer.spec.tsx
+++ b/libs/app-common/src/components/CommentsViewer.spec.tsx
@@ -42,16 +42,19 @@ jest.mock('@abgov/react-components', () => ({
   GoabTextArea: ({
     value,
     disabled,
+    placeholder,
     onChange,
   }: {
     value: string;
     disabled?: boolean;
+    placeholder?: string;
     onChange: (detail: { value: string }) => void;
   }) => (
     <textarea
       data-testid="comment-textarea"
       value={value}
       disabled={disabled}
+      placeholder={placeholder}
       onChange={(event) => onChange({ value: event.target.value })}
     />
   ),
@@ -458,6 +461,41 @@ describe('CommentsViewer', () => {
     expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
     expect(screen.getByText('Add response')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Add response' })).not.toBeInTheDocument();
+  });
+
+  test('renders no label above the draft field when the label is hidden', () => {
+    // Arrange
+    const props = createProps({
+      draft: { content: 'Draft text' },
+      hideAddCommentLabel: true,
+      addCommentButtonLabel: 'Send',
+    });
+
+    // Act
+    const { baseElement } = render(<CommentsViewer {...props} />);
+
+    // Assert no label is left behind, including the 'Add comment' default, and no empty one in the
+    // space it occupied.
+    expect(screen.queryByText('Add comment')).not.toBeInTheDocument();
+    expect(baseElement.querySelector('form label')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
+  });
+
+  test('uses the draft placeholder given by the caller, and a comment one otherwise', () => {
+    // Arrange
+    const props = createProps({ draft: { content: '' }, draftPlaceholder: 'Write your question...' });
+
+    // Act
+    const { rerender } = render(<CommentsViewer {...props} />);
+
+    // Assert
+    expect(screen.getByTestId('comment-textarea')).toHaveAttribute('placeholder', 'Write your question...');
+
+    // Act
+    rerender(<CommentsViewer {...createProps({ draft: { content: '' } })} />);
+
+    // Assert
+    expect(screen.getByTestId('comment-textarea')).toHaveAttribute('placeholder', 'Write your comment...');
   });
 
   test('falls back to addCommentLabel for the button when no button label is provided', () => {

--- a/libs/app-common/src/components/CommentsViewer.tsx
+++ b/libs/app-common/src/components/CommentsViewer.tsx
@@ -32,6 +32,11 @@ interface CommentsViewerProps {
   className?: string;
   heading?: string;
   addCommentLabel?: string;
+  // Drops the label above the draft field, for a pane where the placeholder and the surrounding
+  // heading already say what the field is for. The space it occupied goes to the conversation.
+  hideAddCommentLabel?: boolean;
+  // Placeholder for the draft field, which carries the sense of the field once the label is hidden.
+  draftPlaceholder?: string;
   // Label for the submit button. Defaults to addCommentLabel, which also labels the draft field.
   addCommentButtonLabel?: string;
   anonymousName?: string;
@@ -73,6 +78,8 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
   className,
   heading,
   addCommentLabel,
+  hideAddCommentLabel,
+  draftPlaceholder,
   addCommentButtonLabel,
   anonymousName,
   canComment,
@@ -94,7 +101,19 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
   addCommentLabel = addCommentLabel || 'Add comment';
   addCommentButtonLabel = addCommentButtonLabel || addCommentLabel;
   anonymousName = anonymousName || 'Commenter';
+  draftPlaceholder = draftPlaceholder || 'Write your comment...';
   const [deleting, setDeleting] = useState<Comment>(null);
+
+  const draftField = (
+    <GoabTextArea
+      name="comment"
+      value={draft.content || ''}
+      disabled={!canComment}
+      onChange={(detail: GoabTextAreaOnChangeDetail) => onUpdateDraft({ title: draft.title, content: detail.value })}
+      placeholder={draftPlaceholder}
+      width="100%"
+    />
+  );
 
   return (
     <div className={className}>
@@ -149,18 +168,11 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
         )}
       </div>
       <form>
-        <GoabFormItem label={addCommentLabel}>
-          <GoabTextArea
-            name="comment"
-            value={draft.content || ''}
-            disabled={!canComment}
-            onChange={(detail: GoabTextAreaOnChangeDetail) =>
-              onUpdateDraft({ title: draft.title, content: detail.value })
-            }
-            placeholder={'Write your comment...'}
-            width="100%"
-          />
-        </GoabFormItem>
+        {/*
+          The label is dropped rather than emptied, so no blank row is left behind where it was;
+          the styled wrapper hands that height to the conversation instead.
+        */}
+        {hideAddCommentLabel ? draftField : <GoabFormItem label={addCommentLabel}>{draftField}</GoabFormItem>}
         <GoabButtonGroup alignment="start" mt="l">
           <GoabButton
             size="compact"
@@ -350,7 +362,37 @@ const messagingLayout = css`
   }
 `;
 
-export const CommentsViewer = styled(CommentsViewerComponent)<{ $commentsHeight?: string; messaging?: boolean }>`
+// With no label to separate the draft field from the conversation above it, the field needs a bit
+// more room over it than the label left behind.
+const HIDDEN_LABEL_SPACE = 'var(--goa-space-m)';
+
+// Dropping the label shortens the form by the label line and the padding under it. What is left
+// after the space above the field goes to the conversation, so the pane is the size it was.
+function commentsHeight({
+  $commentsHeight,
+  hideAddCommentLabel,
+}: {
+  $commentsHeight?: string;
+  hideAddCommentLabel?: boolean;
+}) {
+  if (!$commentsHeight) {
+    return 'auto';
+  }
+
+  return hideAddCommentLabel
+    ? `calc(${$commentsHeight} + var(--goa-line-height-4) + var(--goa-form-item-label-padding-bottom) - ${HIDDEN_LABEL_SPACE})`
+    : $commentsHeight;
+}
+
+function draftPaddingTop({ hideAddCommentLabel }: { hideAddCommentLabel?: boolean }) {
+  return hideAddCommentLabel ? `calc(var(--goa-space-s) + ${HIDDEN_LABEL_SPACE})` : 'var(--goa-space-s)';
+}
+
+export const CommentsViewer = styled(CommentsViewerComponent)<{
+  $commentsHeight?: string;
+  messaging?: boolean;
+  hideAddCommentLabel?: boolean;
+}>`
   display: flex;
   flex-direction: column;
 
@@ -366,10 +408,10 @@ export const CommentsViewer = styled(CommentsViewerComponent)<{ $commentsHeight?
     flex-grow: 0;
     max-height: 40vh;
     padding: var(--goa-space-l);
-    padding-top: var(--goa-space-s);
+    padding-top: ${draftPaddingTop};
   }
   & > .comments {
-    height: ${({ $commentsHeight }) => ($commentsHeight ? `${$commentsHeight}` : 'auto')};
+    height: ${commentsHeight};
     overflow-y: scroll;
     flex-direction: column-reverse;
     padding-left: var(--goa-space-l);


### PR DESCRIPTION
FORM APP

<img width="607" height="300" alt="image" src="https://github.com/user-attachments/assets/0d0661ed-05fe-49f3-8bb3-1f54134cf3fc" />


FORM ADMIN APP

<img width="824" height="287" alt="image" src="https://github.com/user-attachments/assets/50bb7dd1-3932-4b85-a44c-245ecc366dc1" />



Removes the "Add response" label above the message draft field in the form admin response pane
and the "Add question" label in the form app questions pane. Each pane's heading and field
placeholder already say what the field is for.

`CommentsViewer` now takes `hideAddCommentLabel` so a caller can drop the label rather than pass
an empty one, leaving no blank form item behind, and the height the label occupied goes to the
message list so the admin pane is the size it was. A new `draftPlaceholder` lets the form app ask
for a question, which with no label is what says what the field is for. Hiding is opt-in because
the 'Add comment' default also feeds the submit button label, which task-app relies on.

Resolves CS-5395.
