### PR TITLE
refactor(status-service): CS-5215 remove status repo dependencies from WebhookRepo

### DIFF
--- a/apps/status-service/src/app/router/WebhookRepo.ts
+++ b/apps/status-service/src/app/router/WebhookRepo.ts
@@ -1,35 +1,17 @@
-import { AdspId, ServiceDirectory, TokenProvider, ConfigurationService } from '@abgov/adsp-service-sdk';
+import { AdspId, TokenProvider, ConfigurationService } from '@abgov/adsp-service-sdk';
 
-import { EndpointStatusEntryRepository } from '../repository/endpointStatusEntry';
-import { ServiceStatusRepository } from '../repository/serviceStatus';
 import { Webhooks } from '../model';
 
 /**
- * Applications are stored in both the status-repository (for
- * dynamic, status data) and the configuration-service f(or
- * static information).
+ * Webhooks are stored in the push-service configuration; this repo is a
+ * read-only accessor for them and holds no status-service concerns.
  */
 
 export class WebhookRepo {
-  #repository: ServiceStatusRepository;
-  #endpointStatusEntryRepository: EndpointStatusEntryRepository;
-  #serviceId: AdspId;
-  #directoryService: ServiceDirectory;
   #tokenProvider: TokenProvider;
   #configurationService: ConfigurationService;
-  constructor(
-    repository: ServiceStatusRepository,
-    endpointStatusEntryRepository: EndpointStatusEntryRepository,
-    serviceId: AdspId,
-    directoryService: ServiceDirectory,
-    tokenProvider: TokenProvider,
-    configurationService: ConfigurationService
-  ) {
-    this.#repository = repository;
-    this.#serviceId = serviceId;
-    this.#directoryService = directoryService;
+  constructor(tokenProvider: TokenProvider, configurationService: ConfigurationService) {
     this.#tokenProvider = tokenProvider;
-    this.#endpointStatusEntryRepository = endpointStatusEntryRepository;
     this.#configurationService = configurationService;
   }
 

--- a/apps/status-service/src/app/router/serviceStatus.ts
+++ b/apps/status-service/src/app/router/serviceStatus.ts
@@ -388,14 +388,7 @@ export function createServiceStatusRouter({
     configurationService,
   );
 
-  const webhookRepo = new WebhookRepo(
-    serviceStatusRepository,
-    endpointStatusEntryRepository,
-    serviceId,
-    directory,
-    tokenProvider,
-    configurationService,
-  );
+  const webhookRepo = new WebhookRepo(tokenProvider, configurationService);
 
   // Get the service for the tenant
   router.get('/applications', assertAuthenticatedHandler, getApplications(logger, applicationRepo));

--- a/apps/status-service/src/app/router/spec/webhookRepo.spec.ts
+++ b/apps/status-service/src/app/router/spec/webhookRepo.spec.ts
@@ -1,0 +1,65 @@
+import { adspId, ConfigurationService } from '@abgov/adsp-service-sdk';
+import { WebhookRepo } from '../WebhookRepo';
+
+describe('WebhookRepo', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const tenantId = adspId`urn:ads:platform:tenant-service:v2:/tenants/test`;
+
+  const tokenProviderMock = {
+    getAccessToken: jest.fn(() => Promise.resolve('Toot!')),
+  };
+
+  const configurationServiceMock = {
+    getConfiguration: jest.fn(),
+    getServiceConfiguration: jest.fn(),
+  };
+
+  const webhook = {
+    id: 'hook-1',
+    url: 'http://localhost/hook',
+    name: 'Test hook',
+    targetId: 'test-app',
+    intervalMinutes: 1,
+    eventTypes: [{ id: 'status-service:monitored-service-down' }],
+    description: 'A test hook',
+    appCurrentlyUp: true,
+  };
+
+  const repo = new WebhookRepo(tokenProviderMock, configurationServiceMock as unknown as ConfigurationService);
+
+  describe('getWebhooks', () => {
+    it('returns push service webhooks with the tenant id applied', async () => {
+      configurationServiceMock.getConfiguration.mockResolvedValueOnce({ webhooks: { 'hook-1': webhook } });
+
+      const webhooks = await repo.getWebhooks(tenantId);
+
+      expect(webhooks).toEqual({ 'hook-1': { ...webhook, tenantId } });
+      expect(configurationServiceMock.getConfiguration).toHaveBeenCalledWith(
+        expect.objectContaining({ service: 'push-service' }),
+        'Toot!',
+        tenantId,
+      );
+    });
+  });
+
+  describe('getWebhook', () => {
+    it('returns the webhook matching the id', async () => {
+      configurationServiceMock.getConfiguration.mockResolvedValueOnce({ webhooks: { 'hook-1': webhook } });
+
+      const result = await repo.getWebhook('hook-1', tenantId);
+
+      expect(result).toEqual({ ...webhook, tenantId });
+    });
+
+    it('returns undefined when no webhook matches the id', async () => {
+      configurationServiceMock.getConfiguration.mockResolvedValueOnce({ webhooks: { 'hook-1': webhook } });
+
+      const result = await repo.getWebhook('not-a-hook', tenantId);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## CS-5215 — Remove status-service dependency from webhooks

`WebhookRepo` took `ServiceStatusRepository`, `EndpointStatusEntryRepository`, the status service id and the service directory, but only ever used the token provider and configuration service to read push-service webhook configuration. The four extra parameters were assigned in the constructor and never read anywhere in the class.

The constructor is now `(tokenProvider, configurationService)`, making it a pure configuration-backed webhook accessor with no status persistence concerns. Endpoint status history is untouched and stays on the `ApplicationRepo` / status router path.

### Behaviour

No runtime change. The removed fields had zero reads, and the `getWebhook` / `getWebhooks` bodies are byte-identical to before. The only consumer is `GET /webhook/:id/test/:eventName` (the admin "test webhook" action); webhook delivery itself runs in push-service and never touches this class.

### Tests

New `webhookRepo.spec.ts` covering webhook lookup by id, tenant id decoration, and the no-match case. Status-service router specs 21/21 pass and `tsc --noEmit` is clean.

https://goa-dio.atlassian.net/browse/CS-5215
