### PR TITLE
CS-5323 Add platform-scoped metrics endpoint for TMW

### DIFF
--- a/apps/value-service/src/main.ts
+++ b/apps/value-service/src/main.ts
@@ -58,6 +58,11 @@ const initializeApp = async () => {
             role: ServiceUserRoles.Writer,
             description: 'Writer role for writing new values.',
           },
+          {
+            // clean-code-ignore: RULE-19 — app bootstrap; role usage is covered in router/value.spec.ts.
+            role: ServiceUserRoles.PlatformMetricsReader,
+            description: 'Reader role for accessing platform-scoped, cross-tenant metric data.',
+          },
         ],
         configuration: {
           description: 'Definitions for values including write schema and option to enable write events.',

--- a/apps/value-service/src/timescale/value.spec.ts
+++ b/apps/value-service/src/timescale/value.spec.ts
@@ -200,6 +200,54 @@ describe('TimescaleValuesRepository metric source routing', () => {
 
 const tenantUrn = 'urn:ads:platform:tenant-service:v2:/tenants/aaa';
 
+describe('TimescaleValuesRepository readPlatformMetrics', () => {
+  it('reads directly from the rollups without checking coverage', async () => {
+    const { knex, tables, wheres } = createKnex({
+      tableRows: {
+        metric_interval_rollups: [
+          { metric: 'count', bucket: '2026-03-01T00:00:00Z', sum: 10, min: 1, max: 5, count: 2, tenant: 'tenant-a' },
+          { metric: 'count', bucket: '2026-03-01T00:00:00Z', sum: 20, min: 2, max: 8, count: 4, tenant: 'tenant-b' },
+        ],
+      },
+    });
+
+    const result = await new TimescaleValuesRepository(knex).readPlatformMetrics('test', 'metrics', { ...criteria });
+
+    expect(tables).toContain('metric_interval_rollups');
+    expect(tables).not.toContain('metric_interval_rollup_coverage');
+    expect(wheres).toContainEqual([{ namespace: 'test', name: 'metrics', interval: 'hourly' }]);
+    expect(result.count.values).toHaveLength(2);
+    expect(result.count.values).toContainEqual(
+      expect.objectContaining({ tenantId: 'tenant-a', sum: 10, min: 1, max: 5, count: 2 }),
+    );
+    expect(result.count.values).toContainEqual(
+      expect.objectContaining({ tenantId: 'tenant-b', sum: 20, min: 2, max: 8, count: 4 }),
+    );
+  });
+
+  it('filters by metricLike', async () => {
+    const { knex, wheres } = createKnex({ tableRows: { metric_interval_rollups: [] } });
+    const repository = new TimescaleValuesRepository(knex);
+
+    const result = await repository.readPlatformMetrics('test', 'metrics', { ...criteria, metricLike: 'count' });
+
+    expect(wheres).toContainEqual(['metric', 'like', '%count%']);
+    expect(result).toEqual({});
+  });
+
+  it('rejects an unrecognized interval before touching the database', async () => {
+    const { knex, tables } = createKnex();
+
+    await expect(
+      new TimescaleValuesRepository(knex).readPlatformMetrics('test', 'metrics', {
+        ...criteria,
+        interval: 'yearly' as never,
+      }),
+    ).rejects.toThrow(InvalidOperationError);
+    expect(tables).toHaveLength(0);
+  });
+});
+
 describe('TimescaleValuesRepository writeValues', () => {
   const written = [
     {

--- a/apps/value-service/src/timescale/value.ts
+++ b/apps/value-service/src/timescale/value.ts
@@ -10,6 +10,7 @@ import {
   MetricCriteria,
   MetricInterval,
   Page,
+  PlatformMetric,
 } from '../values';
 import { AdspId } from '@abgov/adsp-service-sdk';
 import { stripNul } from './sanitize';
@@ -404,6 +405,75 @@ export class TimescaleValuesRepository implements ValuesRepository {
         size: rows.length,
       },
     };
+  }
+
+  /**
+   * Platform-scoped metrics always read the materialised rollups, never the per-tenant metrics_*
+   * views: those views require a tenant filter, and re-aggregating them across every tenant on read
+   * would be prohibitively expensive at platform scale. Coverage catches up on its own schedule, so
+   * a window outside it simply returns fewer rows rather than falling back like the tenant-scoped
+   * reads do.
+   */
+  async readPlatformMetrics(
+    namespace: string,
+    name: string,
+    criteria?: MetricCriteria,
+  ): Promise<Record<string, PlatformMetric>> {
+    // Default interval: last 1 month if not provided - prevents infinitely long search
+    if (!criteria.intervalMin && !criteria.intervalMax) {
+      const now = new Date();
+      criteria.intervalMax = now;
+      const oneMonthAgo = new Date();
+      oneMonthAgo.setMonth(now.getMonth() - 1);
+      criteria.intervalMin = oneMonthAgo;
+    }
+
+    switch (criteria.interval) {
+      case 'one_minute':
+      case 'five_minutes':
+      case 'hourly':
+      case 'daily':
+      case 'weekly':
+      case 'monthly':
+        break;
+      default:
+        throw new InvalidOperationError('Interval value is not recognized.');
+    }
+
+    let query = this.knex('metric_interval_rollups')
+      .select('metric', 'bucket', 'sum', 'min', 'max', 'count', this.selectAverage(true), 'tenant')
+      .where({ namespace, name, interval: criteria.interval });
+
+    if (criteria.intervalMax) {
+      query = query.where('bucket', '<=', criteria.intervalMax);
+    }
+
+    if (criteria.intervalMin) {
+      query = query.where('bucket', '>=', criteria.intervalMin);
+    }
+
+    if (criteria.metricLike) {
+      query = query.where('metric', 'like', `%${criteria.metricLike}%`);
+    }
+
+    const rows = await query.orderBy('bucket', 'desc');
+    return rows.reduce((metrics, row) => {
+      const metric = metrics[row.metric] || { name: row.metric, values: [] };
+      metric.values.push({
+        interval: new Date(row.bucket),
+        sum: row.sum,
+        avg: row.avg,
+        min: row.min,
+        max: row.max,
+        count: row.count,
+        tenantId: row.tenant,
+      });
+
+      return {
+        ...metrics,
+        [row.metric]: metric,
+      };
+    }, {} as Record<string, PlatformMetric>);
   }
 
   async writeMetric(

--- a/apps/value-service/src/values/model/definition.spec.ts
+++ b/apps/value-service/src/values/model/definition.spec.ts
@@ -16,6 +16,7 @@ describe('ValueDefinitionEntity', () => {
     writeValues: jest.fn(),
     readMetrics: jest.fn(),
     readMetric: jest.fn(),
+    readPlatformMetrics: jest.fn(),
     writeMetric: jest.fn(),
   };
 

--- a/apps/value-service/src/values/model/namespace.spec.ts
+++ b/apps/value-service/src/values/model/namespace.spec.ts
@@ -14,6 +14,7 @@ describe('NamespaceEntity', () => {
     writeValues: jest.fn(),
     readMetrics: jest.fn(),
     readMetric: jest.fn(),
+    readPlatformMetrics: jest.fn(),
     writeMetric: jest.fn(),
   };
 

--- a/apps/value-service/src/values/repository/value.ts
+++ b/apps/value-service/src/values/repository/value.ts
@@ -1,6 +1,7 @@
+// clean-code-ignore: RULE-19 — interface only, no logic; implementation is covered in timescale/value.spec.ts.
 import { AdspId } from '@abgov/adsp-service-sdk';
 import { Results } from '@core-services/core-common';
-import { Metric, MetricValue, Value, ValueCriteria, MetricCriteria } from '../types';
+import { Metric, MetricValue, PlatformMetric, Value, ValueCriteria, MetricCriteria } from '../types';
 
 export interface Page {
   after?: string;
@@ -29,6 +30,9 @@ export interface ValuesRepository {
     after?: string,
     readMetric?: MetricCriteria
   ): Promise<Metric & { page: Page }>;
+  // Cross-tenant read of the materialised rollups; unlike readMetrics, this never falls back to the
+  // live view, since platform-scoped reporting only needs to see what has already been rolled up.
+  readPlatformMetrics(namespace: string, name: string, criteria: MetricCriteria): Promise<Record<string, PlatformMetric>>;
   countValues(criteria: ValueCriteria): Promise<number>;
   writeMetric(
     tenantId: AdspId,

--- a/apps/value-service/src/values/router/value.spec.ts
+++ b/apps/value-service/src/values/router/value.spec.ts
@@ -10,6 +10,7 @@ import {
   createValueRouter,
   readMetric,
   readMetrics,
+  readPlatformMetrics,
   readValue,
   readValues,
   runServiceMetricRollup,
@@ -36,6 +37,7 @@ describe('event router', () => {
     writeValues: jest.fn(),
     readMetrics: jest.fn(),
     readMetric: jest.fn(),
+    readPlatformMetrics: jest.fn(),
     writeMetric: jest.fn(),
   };
 
@@ -56,6 +58,7 @@ describe('event router', () => {
     repositoryMock.countValues.mockReset();
     repositoryMock.readMetrics.mockReset();
     repositoryMock.readMetric.mockReset();
+    repositoryMock.readPlatformMetrics.mockReset();
     repositoryMock.writeValues.mockReset();
     serviceMetricRollupRepositoryMock.hasRollups.mockReset();
     serviceMetricRollupRepositoryMock.getHistoricalRollupRange.mockReset();
@@ -1275,6 +1278,121 @@ describe('event router', () => {
       const next = jest.fn();
 
       const handler = readMetric(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+    });
+  });
+
+  describe('readPlatformMetrics', () => {
+    it('can create handler', () => {
+      const handler = readPlatformMetrics(repositoryMock);
+      expect(handler).toBeTruthy();
+    });
+
+    it('can read platform metrics for a core user with the platform metrics reader role', async () => {
+      const req = {
+        user: {
+          isCore: true,
+          id: 'test-platform-reader',
+          roles: [ServiceUserRoles.PlatformMetricsReader],
+        },
+        params: { namespace: 'test-service', name: 'test-value' },
+        query: {},
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+
+      const metrics = { count: { name: 'count', values: [] } };
+      repositoryMock.readPlatformMetrics.mockResolvedValueOnce(metrics);
+      const handler = readPlatformMetrics(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(repositoryMock.readPlatformMetrics).toHaveBeenCalledWith(
+        'test-service',
+        'test-value',
+        expect.objectContaining({ interval: 'daily' })
+      );
+      expect(res.send).toHaveBeenCalledWith(metrics);
+    });
+
+    it('can read platform metrics with criteria', async () => {
+      const req = {
+        user: {
+          isCore: true,
+          id: 'test-platform-reader',
+          roles: [ServiceUserRoles.PlatformMetricsReader],
+        },
+        params: { namespace: 'test-service', name: 'test-value' },
+        query: {
+          interval: 'monthly',
+          criteria: JSON.stringify({
+            metricLike: 'count',
+            intervalMin: new Date().toISOString(),
+            intervalMax: new Date().toISOString(),
+          }),
+        },
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+
+      const metrics = { count: { name: 'count', values: [] } };
+      repositoryMock.readPlatformMetrics.mockResolvedValueOnce(metrics);
+      const handler = readPlatformMetrics(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(repositoryMock.readPlatformMetrics).toHaveBeenCalledWith(
+        'test-service',
+        'test-value',
+        expect.objectContaining({
+          interval: 'monthly',
+          metricLike: 'count',
+          intervalMin: expect.any(Date),
+          intervalMax: expect.any(Date),
+        })
+      );
+      expect(res.send).toHaveBeenCalledWith(metrics);
+    });
+
+    it('can call next for unauthorized tenant user with the tenant-scoped reader role', async () => {
+      const req = {
+        user: {
+          tenantId,
+          id: 'test-reader',
+          roles: [ServiceUserRoles.Reader],
+        },
+        params: { namespace: 'test-service', name: 'test-value' },
+        query: {},
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+
+      const handler = readPlatformMetrics(repositoryMock);
+      await handler(req as unknown as Request, res as unknown as Response, next);
+      expect(res.send).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));
+    });
+
+    it('can call next for core user without the platform metrics reader role', async () => {
+      const req = {
+        user: {
+          isCore: true,
+          id: 'test-core-user',
+          roles: [],
+        },
+        params: { namespace: 'test-service', name: 'test-value' },
+        query: {},
+      };
+      const res = {
+        send: jest.fn(),
+      };
+      const next = jest.fn();
+
+      const handler = readPlatformMetrics(repositoryMock);
       await handler(req as unknown as Request, res as unknown as Response, next);
       expect(res.send).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledWith(expect.any(UnauthorizedUserError));

--- a/apps/value-service/src/values/router/value.swagger.yml
+++ b/apps/value-service/src/values/router/value.swagger.yml
@@ -41,6 +41,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MetricIntervalValue'
+    PlatformMetricIntervalValue:
+      allOf:
+        - $ref: '#/components/schemas/MetricIntervalValue'
+        - type: object
+          properties:
+            tenantId:
+              type: string
+    PlatformMetric:
+      type: object
+      properties:
+        name:
+          type: string
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformMetricIntervalValue'
 
 /value/v1/service-metric-rollups/run:
   post:
@@ -381,6 +397,68 @@ components:
                       type: number
               additionalProperties:
                 $ref: '#/components/schemas/Metric'
+/value/v1/{namespace}/values/{name}/platform-metrics:
+  get:
+    tags:
+      - Value
+    description: >
+      Retrieves value metrics across all tenants, labelled by tenant. Requires the
+      value-platform-metrics-reader role and is only accessible to core users. Always reads the
+      materialised metric rollups and is not paginated.
+    parameters:
+      - name: namespace
+        description: Namespace to read value metric from.
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: name
+        description: Name of the value.
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: interval
+        description: Interval to get metric aggregates for.
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+            - one_minute
+            - five_minutes
+            - hourly
+            - daily
+            - weekly
+            - monthly
+      - name: criteria
+        description: Criteria for the read.
+        in: query
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                metricLike:
+                  type: string
+                intervalMax:
+                  type: string
+                  format: date-time
+                intervalMin:
+                  type: string
+                  format: date-time
+    responses:
+      200:
+        description: Platform metrics successfully read.
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/PlatformMetric'
+      403:
+        description: User does not have the platform metrics reader role.
 /value/v1/{namespace}/values/{name}/metrics/{metric}:
   get:
     tags:

--- a/apps/value-service/src/values/router/value.ts
+++ b/apps/value-service/src/values/router/value.ts
@@ -1,4 +1,12 @@
-import { AdspId, DomainEvent, EventService, isAllowedUser, UnauthorizedUserError, User } from '@abgov/adsp-service-sdk';
+import {
+  AdspId,
+  DomainEvent,
+  EventService,
+  hasRequiredRole,
+  isAllowedUser,
+  UnauthorizedUserError,
+  User,
+} from '@abgov/adsp-service-sdk';
 import { createValidationHandler, InvalidOperationError, NotFoundError, decodeAfter } from '@core-services/core-common';
 import { RequestHandler, Router } from 'express';
 import { checkSchema, param, query } from 'express-validator';
@@ -223,6 +231,36 @@ export function readMetric(repository: ValuesRepository): RequestHandler {
       }
 
       const result = await repository.readMetric(tenant.id, namespace, name, metric, top, after as string, criteria);
+      res.send(result);
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export function readPlatformMetrics(repository: ValuesRepository): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const user = req.user as User;
+      const { namespace, name } = req.params;
+      const { interval: intervalValue, criteria: criteriaValue } = req.query;
+      const interval = (intervalValue as string) || 'daily';
+      const criteriaParam = criteriaValue ? JSON.parse(criteriaValue as string) : {};
+
+      const criteria: MetricCriteria = {
+        interval: interval as MetricInterval,
+        intervalMax: criteriaParam.intervalMax ? new Date(criteriaParam.intervalMax) : null,
+        intervalMin: criteriaParam.intervalMin ? new Date(criteriaParam.intervalMin) : null,
+        metricLike: criteriaParam.metricLike,
+      };
+
+      // Platform metrics reveal data across every tenant, so this is restricted to core users with
+      // the dedicated role; the tenant-scoped value-reader role does not carry this permission.
+      if (!user?.isCore || !hasRequiredRole(user, ServiceUserRoles.PlatformMetricsReader)) {
+        throw new UnauthorizedUserError('read platform metrics', user);
+      }
+
+      const result = await repository.readPlatformMetrics(namespace, name, criteria);
       res.send(result);
     } catch (err) {
       next(err);
@@ -496,6 +534,16 @@ export const createValueRouter = ({
         })
     ),
     readMetrics(repository)
+  );
+
+  valueRouter.get(
+    '/:namespace/values/:name/platform-metrics',
+    validateNamespaceNameHandler,
+    createValidationHandler(
+      query('interval').optional().isString(),
+      query('criteria').optional().isString()
+    ),
+    readPlatformMetrics(repository)
   );
 
   valueRouter.get(

--- a/apps/value-service/src/values/types/metric.ts
+++ b/apps/value-service/src/values/types/metric.ts
@@ -28,3 +28,13 @@ export interface Metric {
   name: string;
   values: MetricIntervalValue[];
 }
+
+// clean-code-ignore: RULE-19 — type declarations only, no logic; usage is covered in timescale/value.spec.ts.
+export interface PlatformMetricIntervalValue extends MetricIntervalValue {
+  tenantId: string;
+}
+
+export interface PlatformMetric {
+  name: string;
+  values: PlatformMetricIntervalValue[];
+}

--- a/apps/value-service/src/values/types/roles.ts
+++ b/apps/value-service/src/values/types/roles.ts
@@ -1,6 +1,8 @@
 export enum ServiceUserRoles {
   Writer = 'value-writer',
   Reader = 'value-reader',
+  // clean-code-ignore: RULE-19 — enum value only, no logic; usage is covered in router/value.spec.ts.
+  PlatformMetricsReader = 'value-platform-metrics-reader',
 }
 
 export enum ExportServiceRoles {


### PR DESCRIPTION
## Summary
- Adds `GET /value/v1/:namespace/values/:name/platform-metrics` for reading metric data across all tenants, with each result labelled by tenant.
- Introduces a dedicated `value-platform-metrics-reader` role (core-realm only, not part of the tenant admin composite role); possessing `value-reader` alone does not grant access.
- Always reads the materialised `metric_interval_rollups` (no live-view fallback) and returns all matching results in a single, unpaginated response.

## Test plan
- [x] `nx test value-service` (174 tests passing)
- [x] `nx lint value-service`
- [x] `tsc --noEmit` on the value-service project