### PR TITLE
fix(jsonforms-components): restrict phone input to digits and cover c…

### DIFF
--- a/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/Inputs/inputTextControl.spec.tsx
@@ -1013,6 +1013,215 @@ describe('Input Text Control tests', () => {
       expect(handleChange).toHaveBeenCalledWith('customMask', '1234-56');
     });
 
+    it('formats a partial custom mask as characters are entered', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        handleChange,
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '####-##' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('customMask', '123');
+    });
+
+    it('truncates extra characters that do not fit a custom mask', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        handleChange,
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '####-##' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456789' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('customMask', '1234-56');
+    });
+
+    it('formats a custom star mask from UI schema options', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        handleChange,
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '**/**' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: 'AB12' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('customMask', 'AB/12');
+    });
+
+    it('formats a custom underscore mask from UI schema options', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        handleChange,
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '__-__' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '1234' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('customMask', '12-34');
+    });
+
+    it('shows the placeholder for a custom mask', () => {
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '####-##' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      expect(input).toHaveAttribute('placeholder', '0000-00');
+    });
+
+    it('shows the in-place template for a custom mask', () => {
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'customMask',
+        id: 'customMask',
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '####-##', inPlace: true },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      expect(input).toHaveAttribute('value', '####-##');
+    });
+
+    it('does not keep extra characters when a custom in-place mask is full', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '1234-56',
+        path: 'customMask',
+        id: 'customMask',
+        handleChange,
+        schema: { type: 'string' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/customMask',
+          options: { mask: '####-##', inPlace: true },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='customMask-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '1234-567' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(input).toHaveAttribute('value', '1234-56');
+      expect(handleChange).not.toHaveBeenCalledWith('customMask', '1234-567');
+    });
+
+    it('uses the named schema format instead of a custom UI mask', async () => {
+      const handleChange = jest.fn();
+      const props = {
+        ...staticProps,
+        data: '',
+        path: 'sin',
+        id: 'sin',
+        handleChange,
+        schema: { type: 'string', format: 'sin' },
+        uischema: {
+          type: 'Control',
+          scope: '#/properties/sin',
+          options: { mask: '####-##' },
+        } as ControlElement,
+      };
+
+      const { baseElement } = renderInput(props);
+      const input = baseElement.querySelector("goa-input[testId='sin-input']");
+
+      fireEvent(input!, new CustomEvent('_change', { detail: { value: '123456789' } }));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(handleChange).toHaveBeenCalledWith('sin', '123 456 789');
+    });
+
     it('shows the in-place template for a driver licence', () => {
       const props = {
         ...staticProps,

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumber.spec.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumber.spec.tsx
@@ -115,6 +115,34 @@ describe('PhoneNumberControl', () => {
     const formItem = container.querySelector('[testid="form-item-phoneNumber"]');
     expect(formItem).toHaveAttribute('error', '');
   });
+
+  it('strips letters from phone input', () => {
+    const { container } = render(<PhoneNumberControl {...defaultProps} data="" />);
+    const input = container.querySelector('[testid="phone-input-phoneNumber"]')!;
+
+    fireEvent(
+      input,
+      new CustomEvent('_change', {
+        detail: { name: 'phoneNumber', value: '403a5551212' },
+      }),
+    );
+
+    expect(mockHandleChange).toHaveBeenCalledWith('phoneNumber', '(403) 555-1212');
+  });
+
+  it('prevents alphabet key presses on phone input', () => {
+    const { container } = render(<PhoneNumberControl {...defaultProps} data="" />);
+    const input = container.querySelector('[testid="phone-input-phoneNumber"]')!;
+    const keyPressEvent = new CustomEvent('_keyPress', {
+      cancelable: true,
+      detail: { key: 'a', value: '403a' },
+    });
+    const preventDefaultSpy = jest.spyOn(keyPressEvent, 'preventDefault');
+
+    fireEvent(input, keyPressEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
 });
 
 describe('PhoneNumberReviewControl', () => {

--- a/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberControl.tsx
+++ b/libs/jsonforms-components/src/lib/Controls/PhoneNumber/PhoneNumberControl.tsx
@@ -25,6 +25,7 @@ export const PhoneNumberControl = (props: PhoneNumberControlProps): JSX.Element 
     mask: phoneMask,
     inPlace,
     data,
+    allowedKeys: DEFAULT_PATTERNS.phone.allowedKeys,
     onCommit: (stored) => {
       setError(stored && !DEFAULT_PATTERNS.phone.pattern.test(stored) ? DEFAULT_PATTERNS.phone.error : '');
       handleChange(path, stored);
@@ -49,7 +50,7 @@ export const PhoneNumberControl = (props: PhoneNumberControlProps): JSX.Element 
           maxLength={inPlace ? undefined : phoneMask.length}
           placeholder={inPlace ? undefined : maskPlaceholder(phoneMask)}
           onChange={(detail: GoabInputOnChangeDetail) => handleMaskChange(detail)}
-          onKeyPress={inPlace ? (detail: GoabInputOnKeyPressDetail) => handleKeyPress(detail) : undefined}
+          onKeyPress={(detail: GoabInputOnKeyPressDetail) => handleKeyPress(detail)}
           width="100%"
         />
       </GoabFormItem>

--- a/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
+++ b/libs/jsonforms-components/src/lib/util/patternForm.spec.ts
@@ -279,3 +279,86 @@ describe('mask constants', () => {
     expect(MASK_CONTROL_KEYS.has('Backspace')).toBe(true);
   });
 });
+
+describe('custom patternForm masks', () => {
+  const hashMask = '####-##';
+  const starMask = '**/**';
+  const underscoreMask = '__-__';
+  const prefixedMask = 'ID-####';
+
+  it('formats a custom hash mask as digits are entered', () => {
+    expect(formatWithPattern('123456', hashMask)).toBe('1234-56');
+  });
+
+  it('stops a custom hash mask at the last entered character', () => {
+    expect(formatWithPattern('123', hashMask)).toBe('123');
+  });
+
+  it('truncates a custom hash mask at the placeholder count', () => {
+    expect(formatWithPattern('123456789', hashMask)).toBe('1234-56');
+  });
+
+  it('formats a custom star mask', () => {
+    expect(formatWithPattern('AB12', starMask)).toBe('AB/12');
+  });
+
+  it('formats a custom underscore mask', () => {
+    expect(formatWithPattern('1234', underscoreMask)).toBe('12-34');
+  });
+
+  it('inserts leading literals from a custom mask', () => {
+    expect(formatWithPattern('1234', prefixedMask)).toBe('ID-1234');
+  });
+
+  it('keeps letters in a custom mask because they are content characters', () => {
+    expect(formatWithPattern('1234ab', hashMask)).toBe('1234-ab');
+  });
+
+  it('counts placeholders in a custom mask', () => {
+    expect(maskDigitCount(hashMask)).toBe(6);
+  });
+
+  it('builds a zero placeholder for a custom mask', () => {
+    expect(maskPlaceholder(hashMask)).toBe('0000-00');
+  });
+
+  it('fills a custom in-place template and leaves remaining placeholders', () => {
+    expect(toMaskTemplate('123', hashMask)).toBe('123#-##');
+  });
+
+  it('returns the full custom template when the value is empty', () => {
+    expect(toMaskTemplate('', hashMask)).toBe('####-##');
+  });
+
+  it('builds the in-place display, stored value, and caret for a custom mask', () => {
+    expect(computeMaskEdit('1234', 4, hashMask)).toEqual({
+      display: '1234-##',
+      stored: '1234',
+      caret: 4,
+    });
+  });
+
+  it('is false until every custom placeholder is filled', () => {
+    expect(isMaskFilled('1234-5', hashMask)).toBe(false);
+  });
+
+  it('is true once every custom placeholder is filled', () => {
+    expect(isMaskFilled('1234-56', hashMask)).toBe(true);
+  });
+
+  it('rejects extra content once a custom in-place mask is full', () => {
+    expect(overflowMaskEdit('1234-56', '1234-567', 8, hashMask)).toEqual({
+      display: '1234-56',
+      stored: '1234-56',
+      caret: 7,
+    });
+  });
+
+  it('allows custom in-place edits while the mask is not full', () => {
+    expect(overflowMaskEdit('1234-##', '12345', 5, hashMask)).toBeUndefined();
+  });
+
+  it('appends leftover content that does not fit a custom applyFormatPattern mask', () => {
+    expect(applyFormatPattern('123456789', hashMask)).toBe('1234-56789');
+  });
+});

--- a/libs/jsonforms-components/src/lib/util/useMaskedInput.spec.tsx
+++ b/libs/jsonforms-components/src/lib/util/useMaskedInput.spec.tsx
@@ -128,4 +128,39 @@ describe('useMaskedInput', () => {
 
     expect(preventDefault).not.toHaveBeenCalled();
   });
+
+  it('strips letters when allowedKeys is digits only', () => {
+    const onCommit = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: false,
+        data: '',
+        allowedKeys: DEFAULT_PATTERNS.phone.allowedKeys,
+        onCommit,
+      }),
+    );
+
+    act(() => result.current.handleChange({ value: '403a5551212' }));
+
+    expect(result.current.value).toBe('(403) 555-1212');
+    expect(onCommit).toHaveBeenCalledWith('(403) 555-1212');
+  });
+
+  it('blocks letter key presses when allowedKeys is digits only', () => {
+    const preventDefault = jest.fn();
+    const { result } = renderHook(() =>
+      useMaskedInput({
+        mask: DEFAULT_PATTERNS.phone.mask,
+        inPlace: false,
+        data: '',
+        allowedKeys: DEFAULT_PATTERNS.phone.allowedKeys,
+        onCommit: jest.fn(),
+      }),
+    );
+
+    act(() => result.current.handleKeyPress({ key: 'a', event: { preventDefault } as unknown as Event }));
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
 });

--- a/libs/jsonforms-components/src/lib/util/useMaskedInput.ts
+++ b/libs/jsonforms-components/src/lib/util/useMaskedInput.ts
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import {
   applyInPlaceEdit,
   computeMaskEdit,
+  filterAllowedKeys,
   formatWithPattern,
   getMaskInputTarget,
   isMaskFilled,
   overflowMaskEdit,
+  shouldBlockKey,
   toMaskTemplate,
 } from './patternForm';
 
@@ -24,6 +26,7 @@ interface UseMaskedInputOptions {
   // When true the field shows the fill-in template and edits keep the caret in place.
   inPlace: boolean;
   data: unknown;
+  allowedKeys?: RegExp;
   // Receives the clean formatted value whenever it changes.
   onCommit: (stored: string) => void;
 }
@@ -35,7 +38,20 @@ interface UseMaskedInputResult {
 }
 
 // Encapsulates masked-input state for a GoA input: display value, mount reflection, and change/keypress handling.
-export const useMaskedInput = ({ mask, inPlace, data, onCommit }: UseMaskedInputOptions): UseMaskedInputResult => {
+const resetMaskedValue = (detail: MaskChangeDetail, nextValue: string) => {
+  const target = getMaskInputTarget(detail);
+  if (target) {
+    target.value = nextValue;
+  }
+};
+
+export const useMaskedInput = ({
+  mask,
+  inPlace,
+  data,
+  allowedKeys,
+  onCommit,
+}: UseMaskedInputOptions): UseMaskedInputResult => {
   const format = (value: string): string => (inPlace ? toMaskTemplate(value, mask) : formatWithPattern(value, mask));
 
   const initialDisplay = format(typeof data === 'string' ? data : '');
@@ -51,23 +67,27 @@ export const useMaskedInput = ({ mask, inPlace, data, onCommit }: UseMaskedInput
 
   const handleChange = (detail: MaskChangeDetail) => {
     const rawValue = detail.value;
+    const cleaned = allowedKeys ? filterAllowedKeys(rawValue, allowedKeys) : rawValue;
 
     if (!inPlace) {
-      const stored = formatWithPattern(rawValue, mask);
+      const stored = cleaned === '' ? '' : formatWithPattern(cleaned, mask);
+      if (allowedKeys && cleaned !== rawValue) {
+        resetMaskedValue(detail, stored);
+      }
       setValue(stored);
       onCommit(stored);
       return;
     }
 
     const target = getMaskInputTarget(detail);
-    const caretIndex = target?.selectionStart ?? rawValue.length;
-    const overflow = overflowMaskEdit(value, rawValue, caretIndex, mask);
+    const caretIndex = target?.selectionStart ?? cleaned.length;
+    const overflow = overflowMaskEdit(value, cleaned, caretIndex, mask);
     if (overflow) {
       applyInPlaceEdit(target, overflow);
       return;
     }
 
-    const edit = computeMaskEdit(rawValue, caretIndex, mask);
+    const edit = computeMaskEdit(cleaned, caretIndex, mask);
 
     applyInPlaceEdit(target, edit);
     setValue(edit.display);
@@ -76,11 +96,17 @@ export const useMaskedInput = ({ mask, inPlace, data, onCommit }: UseMaskedInput
 
   // In-place has no maxLength (the template is already full length) and GoA keyPress is keyup, so restore on overflow.
   const handleKeyPress = (detail: MaskKeyPressDetail) => {
-    if (!inPlace || !/^[A-Za-z0-9]$/.test(detail.key) || !isMaskFilled(value, mask)) {
+    const blockDisallowed = shouldBlockKey(detail.key, allowedKeys);
+    const blockOverflow = inPlace && /^[A-Za-z0-9]$/.test(detail.key) && isMaskFilled(value, mask);
+    if (!blockDisallowed && !blockOverflow) {
       return;
     }
 
     detail.event?.preventDefault();
+    if (!blockOverflow) {
+      return;
+    }
+
     const target = getMaskInputTarget(detail);
     const rawValue = target?.value ?? value;
     const overflow = overflowMaskEdit(value, rawValue, target?.selectionStart ?? value.length, mask);


### PR DESCRIPTION

Wire phone allowedKeys through useMaskedInput so letters are stripped and blocked, matching InputTextControl. Add custom options.mask cases for formatting, in-place overflow, and named format precedence.