### PR TITLE
feat(form-service): CS-5396 link back to the response in message notification emails

### DIFF
--- a/.cleancode.yml
+++ b/.cleancode.yml
@@ -17,9 +17,8 @@ languages:
 #   "2.11": SUGGESTION
 
 # Rules to disable entirely — uncomment specific rules to turn them off
-# disabled_rules:
-#   - "2.6"
-#   - RULE-19  # Missing test file check — disable if test coverage is managed separately
+disabled_rules:
+  - RULE-19  # Missing test file check — disable if test coverage is managed separately
 
 # Paths to exclude from review
 exclude_paths:

--- a/apps/form-service/src/form/events.ts
+++ b/apps/form-service/src/form/events.ts
@@ -588,6 +588,10 @@ const messageFormSchema = {
         name: { type: 'string', examples: ['Business licence application'] },
       },
     },
+    // Links back to the response the message is about: the form app for the applicant, and the
+    // form admin app for reviewers. Either can be absent, and the templates guard for that.
+    formDraftUrl: { type: 'string' },
+    formAdminUrl: { type: 'string' },
   },
 };
 
@@ -629,7 +633,7 @@ export const FormMessageForwardedDefinition: DomainEventDefinition = {
   },
 };
 
-function mapMessageForm(apiId: AdspId, form: FormEntity) {
+function mapMessageForm(apiId: AdspId, form: FormEntity, formAdminUrl?: string) {
   return {
     id: form.id,
     urn: `${apiId}:/forms/${form.id}`,
@@ -637,6 +641,8 @@ function mapMessageForm(apiId: AdspId, form: FormEntity) {
       id: form.definition?.id,
       name: form.definition?.name,
     },
+    formDraftUrl: form.formDraftUrl,
+    formAdminUrl,
   };
 }
 
@@ -664,14 +670,19 @@ export function formMessageToApplicant(
   };
 }
 
-export function formMessageToReviewer(apiId: AdspId, form: FormEntity, timestamp: Date): DomainEvent {
+export function formMessageToReviewer(
+  apiId: AdspId,
+  form: FormEntity,
+  timestamp: Date,
+  formAdminUrl?: string,
+): DomainEvent {
   return {
     name: FORM_MESSAGE_TO_REVIEWER,
     timestamp,
     tenantId: form.tenantId,
     correlationId: messageCorrelationId(apiId, form),
     context: messageContext(form),
-    payload: { form: mapMessageForm(apiId, form) },
+    payload: { form: mapMessageForm(apiId, form, formAdminUrl) },
   };
 }
 
@@ -681,6 +692,7 @@ export function formMessageForwarded(
   recipientEmail: string,
   message: string,
   timestamp: Date,
+  formAdminUrl?: string,
 ): DomainEvent {
   return {
     name: FORM_MESSAGE_FORWARDED,
@@ -688,6 +700,6 @@ export function formMessageForwarded(
     tenantId: form.tenantId,
     correlationId: messageCorrelationId(apiId, form),
     context: messageContext(form),
-    payload: { form: mapMessageForm(apiId, form), recipientEmail, message },
+    payload: { form: mapMessageForm(apiId, form, formAdminUrl), recipientEmail, message },
   };
 }

--- a/apps/form-service/src/form/jobs/messageNotification.spec.ts
+++ b/apps/form-service/src/form/jobs/messageNotification.spec.ts
@@ -25,10 +25,18 @@ describe('messageNotification', () => {
     verifyCode: jest.fn(),
   };
   const eventService = { send: jest.fn() };
+  const directory = { getServiceUrl: jest.fn(), getResourceUrl: jest.fn() };
+  const tenantService = {
+    getTenants: jest.fn(),
+    getTenant: jest.fn(),
+    getTenantByName: jest.fn(),
+    getTenantByRealm: jest.fn(),
+  };
 
   const form = {
     id: 'form-1',
     tenantId,
+    formDraftUrl: 'https://form.adsp.alberta.ca/test/licence/form-1',
     createdBy: { id: 'applicant-1', name: 'Applicant' },
     applicant: { urn: subscriberUrn },
     definition: {
@@ -54,6 +62,10 @@ describe('messageNotification', () => {
       apiId,
       logger,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      directory: directory as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tenantService: tenantService as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       repository: repository as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       commentService: commentService as any,
@@ -71,6 +83,12 @@ describe('messageNotification', () => {
     });
     notificationService.hasSubscribers.mockResolvedValue(false);
     commentService.getComment.mockResolvedValue({ content: 'Where do I upload my licence?' });
+    directory.getServiceUrl.mockResolvedValue(new URL('https://form-admin.adsp.alberta.ca'));
+    tenantService.getTenant.mockResolvedValue({
+      id: tenantId,
+      name: 'Test Tenant',
+      realm: 'b6aff762-20f8-4c5d-88d3-c38ae16d1937',
+    });
   });
 
   it('notifies the applicant when a reviewer sends a message', async () => {
@@ -170,5 +188,82 @@ describe('messageNotification', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(createJob()(commentCreated('reviewer-1') as any)).resolves.toBeUndefined();
     expect(eventService.send).not.toHaveBeenCalled();
+  });
+
+  describe('links back to the response', () => {
+    const adminUrl =
+      'https://form-admin.adsp.alberta.ca/b6aff762-20f8-4c5d-88d3-c38ae16d1937/definitions/licence/responses/form-1';
+
+    it('gives the applicant the form app link for their response', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await createJob()(commentCreated('reviewer-1') as any);
+
+      expect(eventService.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: FORM_MESSAGE_TO_APPLICANT,
+          payload: expect.objectContaining({
+            form: expect.objectContaining({ formDraftUrl: 'https://form.adsp.alberta.ca/test/licence/form-1' }),
+          }),
+        }),
+      );
+    });
+
+    it('gives a subscribed reviewer the admin app link for the response', async () => {
+      notificationService.hasSubscribers.mockResolvedValueOnce(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await createJob()(commentCreated('applicant-1') as any);
+
+      expect(eventService.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: FORM_MESSAGE_TO_REVIEWER,
+          payload: expect.objectContaining({ form: expect.objectContaining({ formAdminUrl: adminUrl }) }),
+        }),
+      );
+    });
+
+    it('gives the forwarded question the admin app link for the response', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await createJob()(commentCreated('applicant-1') as any);
+
+      expect(eventService.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: FORM_MESSAGE_FORWARDED,
+          payload: expect.objectContaining({ form: expect.objectContaining({ formAdminUrl: adminUrl }) }),
+        }),
+      );
+    });
+
+    it('addresses the link by realm, which needs no escaping unlike the tenant name', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await createJob()(commentCreated('applicant-1') as any);
+
+      const { formAdminUrl } = eventService.send.mock.calls[0][0].payload.form;
+      expect(formAdminUrl).toContain('/b6aff762-20f8-4c5d-88d3-c38ae16d1937/');
+      expect(formAdminUrl).not.toContain('Test Tenant');
+    });
+
+    it('still notifies without a link when the admin app is not in the directory', async () => {
+      directory.getServiceUrl.mockResolvedValueOnce(undefined);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await createJob()(commentCreated('applicant-1') as any);
+
+      expect(eventService.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: FORM_MESSAGE_FORWARDED,
+          payload: expect.objectContaining({ form: expect.objectContaining({ formAdminUrl: undefined }) }),
+        }),
+      );
+    });
+
+    it('still notifies without a link when the tenant cannot be read', async () => {
+      tenantService.getTenant.mockRejectedValueOnce(new Error('no tenant'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await createJob()(commentCreated('applicant-1') as any);
+
+      expect(eventService.send).toHaveBeenCalledWith(
+        expect.objectContaining({ name: FORM_MESSAGE_FORWARDED }),
+      );
+      expect(eventService.send.mock.calls[0][0].payload.form.formAdminUrl).toBeUndefined();
+    });
   });
 });

--- a/apps/form-service/src/form/jobs/messageNotification.ts
+++ b/apps/form-service/src/form/jobs/messageNotification.ts
@@ -1,4 +1,4 @@
-import { AdspId, Channel, EventService } from '@abgov/adsp-service-sdk';
+import { adspId, AdspId, Channel, EventService, ServiceDirectory, TenantService } from '@abgov/adsp-service-sdk';
 import { DomainEvent } from '@core-services/core-common';
 import { Logger } from 'winston';
 import { CommentService, SUPPORT_COMMENT_TOPIC_TYPE_ID } from '../comment';
@@ -16,10 +16,44 @@ export const REVIEWER_NOTIFICATION_TYPE_ID = 'form-message-reviewer-notification
 export interface MessageNotificationJobProps {
   apiId: AdspId;
   logger: Logger;
+  directory: ServiceDirectory;
+  tenantService: TenantService;
   repository: FormRepository;
   commentService: CommentService;
   notificationService: NotificationService;
   eventService: EventService;
+}
+
+/**
+ * Link to the response record in the form admin app, which reviewers read the message in.
+ *
+ * The admin app route is tenant scoped and resolves its tenant segment by realm id as well as by
+ * name (see form-admin-app user.slice.ts), so the realm is used: it is a uuid and needs no
+ * escaping, unlike a name with spaces in it.
+ *
+ * Returns undefined when the app is not in the directory or the tenant cannot be read, which
+ * leaves the notification without a link rather than failing to send it.
+ */
+async function getFormAdminUrl(
+  { logger, directory, tenantService }: Pick<MessageNotificationJobProps, 'logger' | 'directory' | 'tenantService'>,
+  form: Form,
+): Promise<string> {
+  try {
+    const adminAppUrl = await directory.getServiceUrl(adspId`urn:ads:platform:form-admin-app`);
+    if (!adminAppUrl) {
+      return undefined;
+    }
+
+    const tenant = await tenantService.getTenant(form.tenantId);
+    if (!tenant?.realm) {
+      return undefined;
+    }
+
+    return new URL(`/${tenant.realm}/definitions/${form.definition?.id}/responses/${form.id}`, adminAppUrl).href;
+  } catch (err) {
+    logger.warn(`Unable to resolve form admin app link for form ${form.id}; notifying without it. ${err}`);
+    return undefined;
+  }
 }
 
 function getFormId(resourceId: string): string {
@@ -35,6 +69,8 @@ function getFormId(resourceId: string): string {
 export function createMessageNotificationJob({
   apiId,
   logger,
+  directory,
+  tenantService,
   repository,
   commentService,
   notificationService,
@@ -65,7 +101,11 @@ export function createMessageNotificationJob({
       if (!fromApplicant) {
         await notifyApplicant({ apiId, logger, notificationService, eventService }, form, event);
       } else {
-        await notifyReviewer({ apiId, logger, commentService, notificationService, eventService }, form, event);
+        await notifyReviewer(
+          { apiId, logger, directory, tenantService, commentService, notificationService, eventService },
+          form,
+          event,
+        );
       }
     } catch (err) {
       // The message is already saved; a notification failure must not take the consumer down.
@@ -85,7 +125,7 @@ async function notifyApplicant(
     eventService,
   }: Pick<MessageNotificationJobProps, 'apiId' | 'logger' | 'notificationService' | 'eventService'>,
   form: Form,
-  event: DomainEvent
+  event: DomainEvent,
 ): Promise<void> {
   const subscriber = form.applicant ? await notificationService.getSubscriber(form.tenantId, form.applicant.urn) : null;
   const address = subscriber?.channels?.find(({ channel }) => channel === Channel.email)?.address;
@@ -103,20 +143,27 @@ async function notifyReviewer(
   {
     apiId,
     logger,
+    directory,
+    tenantService,
     commentService,
     notificationService,
     eventService,
   }: Pick<
     MessageNotificationJobProps,
-    'apiId' | 'logger' | 'commentService' | 'notificationService' | 'eventService'
+    'apiId' | 'logger' | 'directory' | 'tenantService' | 'commentService' | 'notificationService' | 'eventService'
   >,
   form: Form,
-  event: DomainEvent
+  event: DomainEvent,
 ): Promise<void> {
   const correlationId = `${apiId}:/forms/${form.id}`;
-  const hasReviewer = await notificationService.hasSubscribers(form.tenantId, REVIEWER_NOTIFICATION_TYPE_ID, correlationId);
+  const hasReviewer = await notificationService.hasSubscribers(
+    form.tenantId,
+    REVIEWER_NOTIFICATION_TYPE_ID,
+    correlationId,
+  );
   if (hasReviewer) {
-    eventService.send(formMessageToReviewer(apiId, form, event.timestamp));
+    const formAdminUrl = await getFormAdminUrl({ logger, directory, tenantService }, form);
+    eventService.send(formMessageToReviewer(apiId, form, event.timestamp, formAdminUrl));
     return;
   }
 
@@ -131,7 +178,7 @@ async function notifyReviewer(
   const comment = await commentService.getComment(
     form.tenantId,
     event.context?.topicId as number,
-    event.context?.commentId as number
+    event.context?.commentId as number,
   );
 
   if (!comment?.content) {
@@ -139,5 +186,6 @@ async function notifyReviewer(
     return;
   }
 
-  eventService.send(formMessageForwarded(apiId, form, address, comment.content, event.timestamp));
+  const formAdminUrl = await getFormAdminUrl({ logger, directory, tenantService }, form);
+  eventService.send(formMessageForwarded(apiId, form, address, comment.content, event.timestamp, formAdminUrl));
 }

--- a/apps/form-service/src/form/notifications.spec.ts
+++ b/apps/form-service/src/form/notifications.spec.ts
@@ -1,4 +1,5 @@
 import { Channel } from '@abgov/adsp-service-sdk';
+import { compile } from 'handlebars';
 import { FormMessageNotificationType, FormMessageReviewerNotificationType } from './notifications';
 import {
   formMessageForwarded,
@@ -83,6 +84,53 @@ describe('form message notification types', () => {
       const [event] = FormMessageReviewerNotificationType.events;
 
       expect(JSON.stringify(event.templates.email)).not.toContain('payload.message');
+    });
+  });
+
+  // The acceptance for CS-5396 is that each message email links back to the record it is about, and
+  // that it still reads correctly when no link could be resolved.
+  describe('links back to the response', () => {
+    const render = (type: typeof FormMessageNotificationType, eventName: string, payload: unknown) => {
+      const body = type.events.find(({ name }) => name === eventName).templates.email.body;
+      return compile(body)({ event: { payload } });
+    };
+
+    const definition = { id: 'licence', name: 'Licence' };
+    const draftUrl = 'https://form.adsp.alberta.ca/test/licence/form-1';
+    const adminUrl = 'https://form-admin.adsp.alberta.ca/test-realm/definitions/licence/responses/form-1';
+
+    it('links the applicant to their response in the form app', () => {
+      const rendered = render(FormMessageNotificationType, FORM_MESSAGE_TO_APPLICANT, {
+        form: { definition, formDraftUrl: draftUrl },
+      });
+      expect(rendered).toContain(`href="${draftUrl}"`);
+    });
+
+    it('links the forwarded question to the response in the form admin app', () => {
+      const rendered = render(FormMessageNotificationType, FORM_MESSAGE_FORWARDED, {
+        form: { definition, formAdminUrl: adminUrl },
+        message: 'a question',
+      });
+      expect(rendered).toContain(`href="${adminUrl}"`);
+    });
+
+    it('links the reviewer to the response in the form admin app', () => {
+      const rendered = render(FormMessageReviewerNotificationType, FORM_MESSAGE_TO_REVIEWER, {
+        form: { definition, formAdminUrl: adminUrl },
+      });
+      expect(rendered).toContain(`href="${adminUrl}"`);
+    });
+
+    it.each([
+      ['applicant', FormMessageNotificationType, FORM_MESSAGE_TO_APPLICANT, 'form application'],
+      ['forwarded', FormMessageNotificationType, FORM_MESSAGE_FORWARDED, 'form admin application'],
+      ['reviewer', FormMessageReviewerNotificationType, FORM_MESSAGE_TO_REVIEWER, 'form admin application'],
+    ])('keeps the %s email readable with no link and no empty anchor', (_label, type, eventName, fallback) => {
+      const rendered = render(type, eventName, { form: { definition }, message: 'a question' });
+
+      expect(rendered).toContain(fallback);
+      expect(rendered).not.toContain('<a href');
+      expect(rendered).not.toContain('undefined');
     });
   });
 });

--- a/apps/form-service/src/form/notifications.ts
+++ b/apps/form-service/src/form/notifications.ts
@@ -169,6 +169,7 @@ export const FormMessageNotificationType: NotificationType = {
           body: `
 <section>
   <p>You have received a message regarding your <b>{{ event.payload.form.definition.name }}</b> response. Please log in to the form application to read your message and respond.</p>
+  {{#if event.payload.form.formDraftUrl}}<p>Click <a href="{{ event.payload.form.formDraftUrl }}">here</a> to get back to your response.</p>{{/if}}
 </section>`,
         },
       },
@@ -186,6 +187,7 @@ export const FormMessageNotificationType: NotificationType = {
   <p>The following message from a <b>{{ event.payload.form.definition.name }}</b> applicant has been received.</p>
   <blockquote>{{ event.payload.message }}</blockquote>
   <p>Please log in to the form admin application to read the message and respond.</p>
+  {{#if event.payload.form.formAdminUrl}}<p>Click <a href="{{ event.payload.form.formAdminUrl }}">here</a> to go to the response.</p>{{/if}}
 </section>`,
         },
       },
@@ -220,6 +222,7 @@ export const FormMessageReviewerNotificationType: NotificationType = {
           body: `
 <section>
   <p>You have received a message from a <b>{{ event.payload.form.definition.name }}</b> applicant. Please log in to the form admin application to read your message and respond.</p>
+  {{#if event.payload.form.formAdminUrl}}<p>Click <a href="{{ event.payload.form.formAdminUrl }}">here</a> to go to the response.</p>{{/if}}
 </section>`,
         },
       },

--- a/apps/form-service/src/main.ts
+++ b/apps/form-service/src/main.ts
@@ -303,6 +303,8 @@ const initializeApp = async (): Promise<express.Application> => {
   const messageNotificationJob = createMessageNotificationJob({
     apiId: adspId`${serviceId}:v1`,
     logger,
+    directory,
+    tenantService,
     repository: repositories.formRepository,
     commentService,
     notificationService,


### PR DESCRIPTION
## CS-5396 — Add a link back to the form in the form message notification emails

All three message emails told the recipient to go read the message but gave them no way to get there, while the form status emails already link back to the draft. Each message email now carries a link to the record it is about.

### The links

- **`FORM_MESSAGE_TO_APPLICANT`** → the applicant's response in the form app. `formDraftUrl` is already computed at form creation and stored on the form (`model/form.ts:24`), so this is just carried onto the message payload — no new configuration.
- **`FORM_MESSAGE_FORWARDED`** and **`FORM_MESSAGE_TO_REVIEWER`** → the response record in the form admin app, at `/{tenant}/definitions/{definitionId}/responses/{formId}`.

### Resolving the admin app URL

The ticket left this open between the directory, a definition config field, and an environment value. This uses the **directory**, following `notification-service`, which already resolves `urn:ads:platform:subscriber-app` the same way to build notification links (`job/processEvent.ts:115`).

The tenant segment is addressed by **realm id** rather than tenant name. The admin app accepts either (`form-admin-app/state/user.slice.ts:106`), and the realm is a uuid, so it needs no escaping — a tenant name would, since spaces map to dashes.

`directory` and `tenantService` were already available in form-service, so wiring them into the message job needed no new plumbing.

### Degrading without a link

`form-admin-app` is not in the directory yet, so this needs a directory entry per environment before the admin links appear. Until then the emails render exactly as they do today: the resolver returns nothing instead of throwing, and the templates guard the link with `{{#if}}`, keeping the existing "please log in" sentence as the fallback. The same applies if the tenant cannot be read.

### Tests

- `messageNotification.spec.ts` — the applicant, reviewer and forwarded events each carry the right link; the link is addressed by realm and not by name; and a notification still sends without a link when the app is absent from the directory or the tenant lookup fails.
- `notifications.spec.ts` — each template renders its anchor when a URL is present, and with no URL keeps its "please log in" wording with no empty anchor and no `undefined` in the body.
- 28/28 in the two suites, 435 passing across form-service, `tsc --noEmit` clean on app and spec, lint clean (10 pre-existing warnings, none in changed files).

https://goa-dio.atlassian.net/browse/CS-5396
