### PR TITLE
fix(jsonforms-components): default validSin to true for SIN fields

### DIFF
--- a/libs/jsonforms-components/src/lib/common/Ajv.spec.ts
+++ b/libs/jsonforms-components/src/lib/common/Ajv.spec.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { createDefaultAjv } from './Ajv';
+import { invalidSin } from './Constants';
 
 const testDefaultSchema = {
   type: 'object',
@@ -109,16 +110,50 @@ describe('Ajv tests', () => {
     expect(ajv.validate(schema, { sinByFormat: '', postalCode: '', driverId: '', mvid: '' })).toBe(true);
     expect(
       ajv.validate(schema, {
-        sinByFormat: '123 456 789',
+        sinByFormat: '046 454 286',
         postalCode: 'T2P 1A1',
         driverId: '123456-789',
         mvid: '1234-56789',
       }),
     ).toBe(true);
+    expect(ajv.validate(schema, { sinByFormat: '123 456 789' })).toBe(false);
     expect(ajv.validate(schema, { sinByFormat: '123456789' })).toBe(false);
     expect(ajv.validate(schema, { postalCode: 'T2P1A1' })).toBe(false);
     expect(ajv.validate(schema, { driverId: '123456789' })).toBe(false);
     expect(ajv.validate(schema, { mvid: '123456789' })).toBe(false);
+  });
+
+  it('runs Luhn validation as part of format sin', () => {
+    const ajv = createDefaultAjv();
+    const schema = { type: 'string', format: 'sin' };
+
+    expect(ajv.validate(schema, '046 454 286')).toBe(true);
+    expect(ajv.validate(schema, '123 111 111')).toBe(false);
+    expect(ajv.errors?.[0]?.message).toBe('must match format "sin"');
+  });
+
+  it('uses the validSin keyword for Luhn when format sin is not set', () => {
+    const ajv = createDefaultAjv();
+    const schema = {
+      type: 'string',
+      pattern: '^\\d{3} \\d{3} \\d{3}$',
+      validSin: true,
+    };
+
+    expect(ajv.validate(schema, '046 454 286')).toBe(true);
+    expect(ajv.validate(schema, '123 111 111')).toBe(false);
+    expect(ajv.errors?.[0]?.message).toBe(invalidSin);
+  });
+
+  it('skips the validSin keyword when it is false', () => {
+    const ajv = createDefaultAjv();
+    const schema = {
+      type: 'string',
+      pattern: '^\\d{3} \\d{3} \\d{3}$',
+      validSin: false,
+    };
+
+    expect(ajv.validate(schema, '123 111 111')).toBe(true);
   });
 
   describe('can generate inital data ', () => {

--- a/libs/jsonforms-components/src/lib/common/Ajv.ts
+++ b/libs/jsonforms-components/src/lib/common/Ajv.ts
@@ -9,6 +9,26 @@ import { invalidSin } from './Constants';
 // Allow empty values so incomplete fields are not treated as format errors.
 const optionalFormat = (pattern: RegExp) => (input: string) => !input || pattern.test(input);
 
+const optionalSinFormat = (input: string) => {
+  if (!input) {
+    return true;
+  }
+  if (!DEFAULT_PATTERNS.sin.pattern.test(input)) {
+    return false;
+  }
+  return validateSinWithLuhn(input);
+};
+
+const isValidSinWhenComplete = (data: unknown): boolean => {
+  if (typeof data !== 'string' || data.length === 0) {
+    return true;
+  }
+  if (!DEFAULT_PATTERNS.sin.pattern.test(data)) {
+    return true;
+  }
+  return validateSinWithLuhn(data);
+};
+
 export const createDefaultAjv = (...schemas: AnySchema[]) => {
   const ajv = new Ajv({
     allErrors: true,
@@ -25,7 +45,7 @@ export const createDefaultAjv = (...schemas: AnySchema[]) => {
 
   ajv.addFormat('time', /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/);
   Object.entries(DEFAULT_PATTERNS).forEach(([format, config]) => {
-    ajv.addFormat(format, optionalFormat(config.pattern));
+    ajv.addFormat(format, format === 'sin' ? optionalSinFormat : optionalFormat(config.pattern));
   });
   ajv.addFormat('phone', PHONE_REGEX);
   ajv.addFormat('computed', /^[a-zA-Z0-9._-]+$/);
@@ -48,17 +68,11 @@ export const createDefaultAjv = (...schemas: AnySchema[]) => {
     type: 'string',
     schemaType: 'boolean',
     validate: (shouldValidate: boolean, data: unknown) => {
-      if (!shouldValidate) return true;
-
-      if (typeof data !== 'string' || data.length === 0) {
+      if (shouldValidate === false) {
         return true;
       }
 
-      if (!/^\d{3} \d{3} \d{3}$/.test(data)) {
-        return true;
-      }
-
-      return validateSinWithLuhn(data);
+      return isValidSinWhenComplete(data);
     },
     error: {
       message: invalidSin,


### PR DESCRIPTION
Validate a complete SIN as part of format sin. Keep the validSin keyword for schemas that set it explicitly.