### PR TITLE
fix(app-common): CS-5400 show timestamps for old messages in form comments

### DIFF
--- a/libs/app-common/src/components/CommentsViewer.spec.tsx
+++ b/libs/app-common/src/components/CommentsViewer.spec.tsx
@@ -581,6 +581,19 @@ describe('CommentsViewer', () => {
     expect(container.querySelectorAll('.comment')[1]).toHaveAttribute('data-continues', 'true');
   });
 
+  test('breaks a run across a day boundary so the earlier message keeps its own byline', () => {
+    const props = createProps({
+      comments: [
+        createComment({ id: 1, createdBy: { id: 'a', name: 'Abhishek' }, createdOn: new Date(2026, 7, 20, 9, 0, 0) }),
+        createComment({ id: 2, createdBy: { id: 'a', name: 'Abhishek' }, createdOn: new Date(2026, 7, 21, 9, 0, 0) }),
+      ],
+    });
+    const { container } = render(<CommentsViewer {...props} messaging={true} />);
+
+    expect(container.querySelectorAll('.byline')).toHaveLength(2);
+    expect(container.querySelectorAll('.comment')[1]).toHaveAttribute('data-continues', 'false');
+  });
+
   test('gives every comment its own byline without the messaging layout', () => {
     const props = createProps({
       comments: [

--- a/libs/app-common/src/components/CommentsViewer.tsx
+++ b/libs/app-common/src/components/CommentsViewer.tsx
@@ -122,9 +122,15 @@ const CommentsViewerComponent: FunctionComponent<CommentsViewerProps> = ({
       <div className="comments">
         {comments.map((result, index) => {
           // In a message thread a run of messages from the same person carries one byline,
-          // the way a phone's messaging app groups them.
+          // the way a phone's messaging app groups them. A run breaks across a day boundary too,
+          // so an old message doesn't read as having been sent today just because the next
+          // message from the same person was.
           const previous = comments[index - 1];
-          const continuesRun = !!messaging && !!previous && previous.createdBy.id === result.createdBy.id;
+          const continuesRun =
+            !!messaging &&
+            !!previous &&
+            previous.createdBy.id === result.createdBy.id &&
+            moment(previous.createdOn).isSame(result.createdOn, 'day');
 
           return (
             <div


### PR DESCRIPTION

<img width="560" height="263" alt="image" src="https://github.com/user-attachments/assets/b40b5dad-e8de-4d10-b060-32bf1057a1dc" />


## Summary
- Grouped-message bylines in `CommentsViewer` were keyed only on the sender, so an older message from the same person lost its timestamp once a newer message landed on a different day.
- Break the grouped run on a day boundary, not just a sender change, so each day's message keeps its own byline/timestamp.

## Test plan
- [x] `npx nx test app-common --testPathPattern=CommentsViewer` (54 passed)
- [x] Added a test covering a same-sender run split across two days